### PR TITLE
feat(py/plugins/amazon-bedrock): add Converse non-streaming generate path

### DIFF
--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -4,7 +4,8 @@ Amazon Bedrock plugin for Genkit Python. Provides access to Bedrock-hosted
 models (Anthropic Claude, Amazon Nova, Meta Llama, Mistral, Cohere, and
 others), Titan/Cohere/Nova embedders, image generation, and Cohere reranking.
 
-> Status: scaffold. Feature slices are being ported from the mature Go plugin
+> Status: in progress. Non-streaming text generation (Converse) is available;
+> remaining feature slices are being ported from the mature Go plugin
 > ([genkit-ai/aws-bedrock-go-plugin](https://github.com/genkit-ai/aws-bedrock-go-plugin)).
 
 ## Installation
@@ -32,7 +33,9 @@ ai = Genkit(
 
 Credentials resolve through the standard AWS SDK chain (environment,
 `~/.aws/credentials`, instance metadata). Pass a pre-configured
-`boto3.session.Session` via `session=` for custom wiring.
+`boto3.session.Session` via `session=` for custom wiring. The region comes
+from `region=` or the SDK chain (`AWS_REGION`, `AWS_DEFAULT_REGION`,
+`~/.aws/config`); there is deliberately no default region.
 
 ## License
 

--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -6,8 +6,7 @@ Cohere, and others) through the Bedrock Converse API.
 
 > Status: in progress. Only non-streaming text generation (Converse) is
 > available so far. Streaming, embedders, image generation, and reranking are
-> still being ported from the mature Go plugin
-> ([genkit-ai/aws-bedrock-go-plugin](https://github.com/genkit-ai/aws-bedrock-go-plugin)).
+> still to come.
 
 ## Installation
 

--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -37,11 +37,36 @@ Credentials resolve through the standard AWS SDK chain (environment,
 from `region=` or the SDK chain (`AWS_REGION`, `AWS_DEFAULT_REGION`,
 `~/.aws/config`); there is deliberately no default region.
 
+### Client tuning
+
+`max_retries`, `read_timeout`, `connect_timeout` and `max_pool_connections`
+are unset by default, so your own AWS configuration wins and the package
+defaults (3 retries in standard mode, a 3600s read timeout, a 60s connect
+timeout and a pool of 50) fill in only where it is silent. Passing an argument
+explicitly overrides both.
+
+Which sources apply differs by knob, because botocore only reads some of them:
+
+- Retries come from `AWS_MAX_ATTEMPTS`, `AWS_RETRY_MODE`, the `max_attempts`
+  and `retry_mode` keys in `~/.aws/config`, or a session's default client
+  config. The attempt count and the mode are resolved separately, so setting
+  just one of them leaves the other at the package default.
+- The two timeouts and the pool size have no environment or config-file
+  equivalent in botocore. Their only external source is a `botocore.config.Config`
+  installed on a session you pass via `session=`.
+
+`total_timeout` (3600s, `None` to disable) is separate: it caps the whole
+call, including retries. The read timeout only bounds silence between two
+reads, so a connection that dribbles bytes never trips it. When the deadline
+fires the caller gets a `DEADLINE_EXCEEDED` error, though the boto3 call
+itself cannot be aborted and its worker thread runs until the socket timeouts
+end it.
+
 ### Config fields that are ignored
 
 `BedrockConfig` inherits the core `ModelConfig` fields, so the Dev UI offers
 `topK` and `version`. Converse has no equivalent parameters and both values
-are dropped, matching the Go plugin. Models that support a top-k knob take it
+are dropped. Models that support a top-k knob take it
 through `additionalModelRequestFields` instead:
 
 ```python

--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -1,11 +1,12 @@
 # Genkit Amazon Bedrock Plugin
 
-Amazon Bedrock plugin for Genkit Python. Provides access to Bedrock-hosted
-models (Anthropic Claude, Amazon Nova, Meta Llama, Mistral, Cohere, and
-others), Titan/Cohere/Nova embedders, image generation, and Cohere reranking.
+Amazon Bedrock plugin for Genkit Python. Provides text generation with
+Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama, Mistral,
+Cohere, and others) through the Bedrock Converse API.
 
-> Status: in progress. Non-streaming text generation (Converse) is available;
-> remaining feature slices are being ported from the mature Go plugin
+> Status: in progress. Only non-streaming text generation (Converse) is
+> available so far. Streaming, embedders, image generation, and reranking are
+> still being ported from the mature Go plugin
 > ([genkit-ai/aws-bedrock-go-plugin](https://github.com/genkit-ai/aws-bedrock-go-plugin)).
 
 ## Installation
@@ -36,6 +37,17 @@ Credentials resolve through the standard AWS SDK chain (environment,
 `boto3.session.Session` via `session=` for custom wiring. The region comes
 from `region=` or the SDK chain (`AWS_REGION`, `AWS_DEFAULT_REGION`,
 `~/.aws/config`); there is deliberately no default region.
+
+### Config fields that are ignored
+
+`BedrockConfig` inherits the core `ModelConfig` fields, so the Dev UI offers
+`topK` and `version`. Converse has no equivalent parameters and both values
+are dropped, matching the Go plugin. Models that support a top-k knob take it
+through `additionalModelRequestFields` instead:
+
+```python
+BedrockConfig(additional_model_request_fields={'top_k': 40})
+```
 
 ## License
 

--- a/py/packages/genkit-amazon-bedrock/pyproject.toml
+++ b/py/packages/genkit-amazon-bedrock/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
   "Typing :: Typed",
   "License :: OSI Approved :: Apache Software License",
 ]
-dependencies = ["genkit", "boto3>=1.36"]
+dependencies = ["genkit", "boto3>=1.37.24"]
 description = "Genkit Amazon Bedrock Plugin"
 keywords = [
   "genkit",

--- a/py/packages/genkit-amazon-bedrock/pyproject.toml
+++ b/py/packages/genkit-amazon-bedrock/pyproject.toml
@@ -37,7 +37,10 @@ classifiers = [
   "Typing :: Typed",
   "License :: OSI Approved :: Apache Software License",
 ]
-dependencies = ["genkit", "boto3>=1.37.24"]
+# botocore is imported directly (config, exceptions) and pins the floor that
+# keeps the manual AWS_REGION lookup in transport.py necessary: it did not read
+# AWS_REGION itself until 1.41.
+dependencies = ["genkit", "boto3>=1.37.24", "botocore>=1.37.24"]
 description = "Genkit Amazon Bedrock Plugin"
 keywords = [
   "genkit",

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/__init__.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/__init__.py
@@ -17,6 +17,7 @@
 """Amazon Bedrock plugin for Genkit."""
 
 from genkit_amazon_bedrock.config import BedrockConfig, ModelDefinition
+from genkit_amazon_bedrock.converters import cache_point_part
 from genkit_amazon_bedrock.plugin import Bedrock, bedrock_name
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     'BedrockConfig',
     'ModelDefinition',
     'bedrock_name',
+    'cache_point_part',
 ]

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
@@ -47,8 +47,8 @@ class BedrockConfig(ModelConfig):
     )
 
     max_tokens: int | None = None
-    """Maximum tokens to generate. When unset, the plugin leaves the field
-    unset except for Claude models, where Bedrock requires a value."""
+    """Maximum tokens to generate. When unset, the field is left unset and
+    the service applies its own default cap."""
 
     tool_choice: str | None = None
     """Tool choice mode: ``auto``, ``required``/``any``, ``none``, or a tool name."""

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
@@ -24,10 +24,14 @@ from pydantic.alias_generators import to_camel
 from genkit import ModelConfig
 
 DEFAULT_MAX_RETRIES = 3
-# Socket read timeout, not a whole-call deadline: Bedrock generations can
+# Socket read timeout: the gap botocore tolerates between two reads, which
+# resets on every byte received. Generous because Bedrock generations can
 # legitimately run for many minutes (Nova allows 60-minute inference).
 DEFAULT_READ_TIMEOUT = 3600.0
 DEFAULT_CONNECT_TIMEOUT = 60.0
+# Whole-call deadline. Unlike the read timeout this does not reset, so a
+# connection that dribbles a byte at a time still ends.
+DEFAULT_TOTAL_TIMEOUT = 3600.0
 # The botocore default of 10 pooled connections throttles LLM concurrency.
 DEFAULT_MAX_POOL_CONNECTIONS = 50
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
@@ -35,9 +35,8 @@ DEFAULT_MAX_POOL_CONNECTIONS = 50
 class BedrockConfig(ModelConfig):
     """Per-call configuration for Bedrock models.
 
-    Mirrors the Go plugin's ``Config`` surface. Unknown keys are tolerated for
-    forward compatibility but only the declared fields (and
-    ``additional_model_request_fields``) reach the Converse API.
+    Unknown keys are tolerated for forward compatibility, but only the declared
+    fields (and ``additional_model_request_fields``) reach the Converse API.
     """
 
     model_config = ConfigDict(

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
@@ -24,15 +24,20 @@ from pydantic.alias_generators import to_camel
 from genkit import ModelConfig
 
 DEFAULT_MAX_RETRIES = 3
-DEFAULT_REQUEST_TIMEOUT = 30.0
+# Socket read timeout, not a whole-call deadline: Bedrock generations can
+# legitimately run for many minutes (Nova allows 60-minute inference).
+DEFAULT_READ_TIMEOUT = 3600.0
+DEFAULT_CONNECT_TIMEOUT = 60.0
+# The botocore default of 10 pooled connections throttles LLM concurrency.
+DEFAULT_MAX_POOL_CONNECTIONS = 50
 
 
 class BedrockConfig(ModelConfig):
     """Per-call configuration for Bedrock models.
 
-    Mirrors the Go plugin's ``Config`` surface. Unknown keys are allowed and
-    forwarded so callers can use provider-specific options without a plugin
-    release.
+    Mirrors the Go plugin's ``Config`` surface. Unknown keys are tolerated for
+    forward compatibility but only the declared fields (and
+    ``additional_model_request_fields``) reach the Converse API.
     """
 
     model_config = ConfigDict(
@@ -40,6 +45,10 @@ class BedrockConfig(ModelConfig):
         populate_by_name=True,
         extra='allow',
     )
+
+    max_tokens: int | None = None
+    """Maximum tokens to generate. When unset, the plugin leaves the field
+    unset except for Claude models, where Bedrock requires a value."""
 
     tool_choice: str | None = None
     """Tool choice mode: ``auto``, ``required``/``any``, ``none``, or a tool name."""
@@ -58,5 +67,5 @@ class ModelDefinition(BaseModel):
     name: str
     """Bedrock model ID, e.g. ``anthropic.claude-sonnet-4-5-20250929-v1:0``."""
 
-    type: Literal['chat', 'image', 'embedding'] = 'chat'
+    type: Literal['chat', 'text', 'image', 'embedding'] = 'chat'
     """Routes generate calls: chat/text via Converse, image via InvokeModel."""

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
@@ -45,10 +45,6 @@ class BedrockConfig(ModelConfig):
         extra='allow',
     )
 
-    max_tokens: int | None = None
-    """Maximum tokens to generate. When unset, the field is left unset and
-    the service applies its own default cap."""
-
     tool_choice: str | None = None
     """Tool choice mode: ``auto``, ``required``/``any``, ``none``, or a tool name."""
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -57,18 +57,6 @@ REDACTED_CONTENT_METADATA_KEY = 'bedrockRedactedContent'
 CACHE_POINT_CUSTOM_KEY = 'bedrockCachePointType'
 DEFAULT_CACHE_POINT_TYPE = 'default'
 
-# Bedrock requires maxTokens for Claude models; newer families allow more.
-DEFAULT_CLAUDE_MAX_TOKENS = 4096
-DEFAULT_EXTENDED_CLAUDE_MAX_TOKENS = 8192
-EXTENDED_CLAUDE_MAX_TOKEN_PATTERNS = (
-    'claude-3-5',
-    'claude-3-7',
-    'claude-4',
-    'claude-haiku-4',
-    'claude-sonnet-4',
-    'claude-opus-4',
-)
-
 IMAGE_FORMATS = {
     'image/png': 'png',
     'image/jpeg': 'jpeg',
@@ -210,21 +198,6 @@ def _effective_max_tokens(config: BedrockConfig | None) -> int | None:
     if config.max_output_tokens is not None and config.max_output_tokens > 0:
         return int(config.max_output_tokens)
     return None
-
-
-def default_max_tokens_for_model(model_id: str) -> int | None:
-    """Default maxTokens for models that require one (Claude only).
-
-    Substring match on the full lowercased model ID so cross-region
-    inference-profile IDs (``us.anthropic.claude-...``) match too.
-    """
-    lowered = model_id.lower()
-    if 'claude' not in lowered:
-        return None
-    for pattern in EXTENDED_CLAUDE_MAX_TOKEN_PATTERNS:
-        if pattern in lowered:
-            return DEFAULT_EXTENDED_CLAUDE_MAX_TOKENS
-    return DEFAULT_CLAUDE_MAX_TOKENS
 
 
 def build_inference_config(config: BedrockConfig | None) -> dict[str, Any] | None:  # noqa: ANN401
@@ -540,14 +513,6 @@ def build_converse_request(model_id: str, request: ModelRequest[Any]) -> dict[st
         kwargs['system'] = system
 
     inference_config = build_inference_config(config)
-    max_tokens_set = bool(inference_config and 'maxTokens' in inference_config)
-    if not max_tokens_set:
-        # Bedrock requires maxTokens for Claude models; inject a default only
-        # when the caller didn't set one.
-        default_max_tokens = default_max_tokens_for_model(model_id)
-        if default_max_tokens is not None:
-            inference_config = dict(inference_config or {})
-            inference_config['maxTokens'] = default_max_tokens
     if inference_config:
         kwargs['inferenceConfig'] = inference_config
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -602,12 +602,9 @@ def _coerce_tool_input(name: str, value: Any, tools: list[ToolDefinition] | None
 def _reasoning_block_to_part(block: dict[str, Any]) -> Part | None:  # noqa: ANN401
     reasoning_text = block.get('reasoningText')
     if reasoning_text is not None:
-        # Both wire shapes occur: {'text': ...} and a bare string.
-        if isinstance(reasoning_text, str):
-            text, signature = reasoning_text, None
-        else:
-            text = reasoning_text.get('text') or ''
-            signature = reasoning_text.get('signature')
+        # A ReasoningTextBlock structure on the wire, so botocore parses it to a dict.
+        text = reasoning_text.get('text') or ''
+        signature = reasoning_text.get('signature')
         if not text and not signature:
             return None
         return _bedrock_reasoning_part(text, signature, None)

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -1,0 +1,755 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure conversion functions between Genkit types and the Bedrock Converse API.
+
+Ported from the Go plugin's ``generate.go``. Everything here is side-effect
+free and testable without AWS: request builders return the keyword arguments
+for ``client.converse(...)``, response parsers take the raw response dict.
+"""
+
+import base64
+import json
+from typing import Any
+
+from genkit import (
+    FinishReason,
+    Message,
+    ModelRequest,
+    ModelResponse,
+    ModelUsage,
+    Part,
+    ReasoningPart,
+    Role,
+    TextPart,
+    ToolDefinition,
+    ToolRequest,
+    ToolRequestPart,
+)
+from genkit.plugin_api import GenkitError
+from genkit_amazon_bedrock.config import BedrockConfig
+
+# Metadata keys used to round-trip Bedrock reasoning ("thinking") content back
+# into a follow-up request. Bedrock returns signed and sometimes redacted
+# reasoning that must be replayed verbatim on the next turn or the model
+# rejects it, so both are stashed on the part metadata: the signature verbatim
+# (it is a string on the wire), the redacted blob as a base64 string so the
+# part stays JSON-serializable. These keys are Bedrock-specific: a generic
+# reasoning part (without these) is intentionally NOT round-tripped, so
+# foreign reasoning can't corrupt a Bedrock conversation.
+REASONING_SIGNATURE_METADATA_KEY = 'bedrockReasoningSignature'
+REDACTED_CONTENT_METADATA_KEY = 'bedrockRedactedContent'
+
+# Custom-part key marking a prompt cache point, mirroring the Go plugin.
+CACHE_POINT_CUSTOM_KEY = 'bedrockCachePointType'
+DEFAULT_CACHE_POINT_TYPE = 'default'
+
+# Bedrock requires maxTokens for Claude models; newer families allow more.
+DEFAULT_CLAUDE_MAX_TOKENS = 4096
+DEFAULT_EXTENDED_CLAUDE_MAX_TOKENS = 8192
+EXTENDED_CLAUDE_MAX_TOKEN_PATTERNS = (
+    'claude-3-5',
+    'claude-3-7',
+    'claude-4',
+    'claude-haiku-4',
+    'claude-sonnet-4',
+    'claude-opus-4',
+)
+
+IMAGE_FORMATS = {
+    'image/png': 'png',
+    'image/jpeg': 'jpeg',
+    # Common alias; Bedrock's format enum has no "jpg".
+    'image/jpg': 'jpeg',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+}
+
+DOCUMENT_FORMATS = {
+    'application/pdf': 'pdf',
+    'text/html': 'html',
+    'text/plain': 'txt',
+    'text/markdown': 'md',
+    'text/csv': 'csv',
+    'application/msword': 'doc',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+    'application/vnd.ms-excel': 'xls',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+}
+
+# Bedrock stopReason values → Genkit finish reasons. Unknown values map to
+# OTHER instead of raising: AWS adds stop reasons without notice.
+STOP_REASON_MAP = {
+    'end_turn': FinishReason.STOP,
+    'stop_sequence': FinishReason.STOP,
+    # Genkit's core loop drives tool re-entry by inspecting parts, not the
+    # finish reason, so a tool-use turn is a normal stop.
+    'tool_use': FinishReason.STOP,
+    'max_tokens': FinishReason.LENGTH,
+    'model_context_window_exceeded': FinishReason.LENGTH,
+    'content_filtered': FinishReason.BLOCKED,
+    'guardrail_intervened': FinishReason.BLOCKED,
+    'malformed_model_output': FinishReason.OTHER,
+    'malformed_tool_use': FinishReason.OTHER,
+}
+
+
+def cache_point_part(cache_type: str = DEFAULT_CACHE_POINT_TYPE) -> Part:
+    """Builds a prompt cache-point part.
+
+    A cache point should be inserted after a big static prompt that is reused
+    across multiple requests.
+
+    Args:
+        cache_type: Bedrock cache-point type; only ``default`` exists today.
+
+    Returns:
+        A custom Part that converts to a Converse ``cachePoint`` block.
+    """
+    return Part.model_validate({'custom': {CACHE_POINT_CUSTOM_KEY: cache_type}})
+
+
+def _cache_point_type(root: Any) -> str | None:  # noqa: ANN401
+    custom = getattr(root, 'custom', None)
+    if not isinstance(custom, dict):
+        return None
+    value = custom.get(CACHE_POINT_CUSTOM_KEY)
+    # Compare by value: the marker arrives as a plain string after any JSON
+    # round-trip (resumed/serialized flows).
+    return value if isinstance(value, str) and value else None
+
+
+def _metadata_bytes(metadata: dict[str, Any] | None, key: str) -> bytes | None:  # noqa: ANN401
+    """Reads a bytes metadata value stored in its base64-string form.
+
+    Raw bytes are also tolerated for programmatically-built parts; invalid
+    base64 yields None.
+    """
+    if not metadata:
+        return None
+    value = metadata.get(key)
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return base64.b64decode(value, validate=True)
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+def _metadata_str(metadata: dict[str, Any] | None, key: str) -> str | None:  # noqa: ANN401
+    """Reads a string metadata value, tolerating a UTF-8 bytes form.
+
+    The reasoning signature is a string on the Converse wire and must be
+    replayed verbatim, never re-encoded.
+    """
+    if not metadata:
+        return None
+    value = metadata.get(key)
+    if isinstance(value, str) and value:
+        return value
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8') or None
+        except UnicodeDecodeError:
+            return None
+    return None
+
+
+def normalize_config(config: Any) -> BedrockConfig | None:  # noqa: ANN401
+    """Coerces the request config into a BedrockConfig.
+
+    Accepts a BedrockConfig, any pydantic model (e.g. the core ModelConfig the
+    framework validates configs into), or a plain dict — the historical shape
+    on resumed/serialized flows.
+
+    Args:
+        config: The raw ``request.config`` value.
+
+    Returns:
+        A BedrockConfig, or None when no config was given.
+
+    Raises:
+        GenkitError: INVALID_ARGUMENT for unsupported config types.
+    """
+    if config is None:
+        return None
+    if isinstance(config, BedrockConfig):
+        return config
+    if isinstance(config, dict):
+        return BedrockConfig.model_validate(config)
+    dump = getattr(config, 'model_dump', None)
+    if callable(dump):
+        return BedrockConfig.model_validate(dump(exclude_none=True))
+    raise GenkitError(
+        message=f'bedrock: unexpected config type {type(config).__name__}, want BedrockConfig, ModelConfig, or dict',
+        status='INVALID_ARGUMENT',
+    )
+
+
+def _effective_max_tokens(config: BedrockConfig | None) -> int | None:
+    if config is None:
+        return None
+    if config.max_tokens is not None and config.max_tokens > 0:
+        return config.max_tokens
+    # Legacy/common key from the core ModelConfig surface.
+    if config.max_output_tokens is not None and config.max_output_tokens > 0:
+        return int(config.max_output_tokens)
+    return None
+
+
+def default_max_tokens_for_model(model_id: str) -> int | None:
+    """Default maxTokens for models that require one (Claude only).
+
+    Substring match on the full lowercased model ID so cross-region
+    inference-profile IDs (``us.anthropic.claude-...``) match too.
+    """
+    lowered = model_id.lower()
+    if 'claude' not in lowered:
+        return None
+    for pattern in EXTENDED_CLAUDE_MAX_TOKEN_PATTERNS:
+        if pattern in lowered:
+            return DEFAULT_EXTENDED_CLAUDE_MAX_TOKENS
+    return DEFAULT_CLAUDE_MAX_TOKENS
+
+
+def build_inference_config(config: BedrockConfig | None) -> dict[str, Any] | None:  # noqa: ANN401
+    """Builds the Converse ``inferenceConfig`` member; None when empty."""
+    if config is None:
+        return None
+    inference_config: dict[str, Any] = {}
+    max_tokens = _effective_max_tokens(config)
+    if max_tokens is not None:
+        inference_config['maxTokens'] = max_tokens
+    if config.temperature is not None:
+        inference_config['temperature'] = config.temperature
+    if config.top_p is not None:
+        inference_config['topP'] = config.top_p
+    if config.stop_sequences:
+        inference_config['stopSequences'] = config.stop_sequences
+    return inference_config or None
+
+
+def to_bedrock_role(role: Role | str) -> str:
+    """Maps a Genkit role to a Converse role (only user/assistant exist).
+
+    Genkit's TOOL role becomes ``user``: tool results travel back to Bedrock
+    inside a user message.
+    """
+    if role in (Role.USER, Role.TOOL):
+        return 'user'
+    if role == Role.MODEL:
+        return 'assistant'
+    raise GenkitError(message=f'bedrock: unsupported role {role!r}', status='INVALID_ARGUMENT')
+
+
+def _media_mime(media: Any) -> str:  # noqa: ANN401
+    content_type = (getattr(media, 'content_type', None) or '').strip()
+    url = getattr(media, 'url', '') or ''
+    if not content_type and url.startswith('data:'):
+        header = url.split(',', 1)[0].removeprefix('data:')
+        content_type = header.split(';', 1)[0].strip()
+    if not content_type:
+        raise GenkitError(message='bedrock: media part has no content type', status='INVALID_ARGUMENT')
+    return content_type.split(';', 1)[0].strip().lower()
+
+
+def _decode_media_payload(url: str) -> bytes:
+    """Decodes media to raw bytes; boto3 base64-encodes them for the wire.
+
+    Accepts a ``data:<mime>;base64,...`` URL or a bare base64 string.
+    Double-encoding (sending the base64 string as bytes) is the classic bug.
+    """
+    data = (url or '').strip()
+    if not data:
+        raise GenkitError(message='bedrock: media part has empty data', status='INVALID_ARGUMENT')
+    # Substring search tolerates multi-parameter data-URL headers.
+    marker = data.find(';base64,')
+    if marker != -1:
+        payload = data[marker + len(';base64,') :].strip()
+    elif data.startswith('data:'):
+        raise GenkitError(
+            message="bedrock: data URL must be base64-encoded (use ';base64,' prefix)",
+            status='INVALID_ARGUMENT',
+        )
+    elif data.startswith(('http://', 'https://')):
+        raise GenkitError(
+            message='bedrock: remote URLs are not supported; use a data URL or base64-encoded data',
+            status='INVALID_ARGUMENT',
+        )
+    else:
+        payload = data
+    try:
+        return base64.b64decode(payload, validate=True)
+    except (ValueError, TypeError) as e:
+        raise GenkitError(message=f'bedrock: decode base64 media: {e}', status='INVALID_ARGUMENT') from e
+
+
+def media_to_block(root: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Converts a media part to an image or document content block."""
+    media = root.media
+    mime = _media_mime(media)
+    payload = _decode_media_payload(media.url)
+    # Document formats are checked before image formats, matching Go.
+    document_format = DOCUMENT_FORMATS.get(mime)
+    if document_format is not None:
+        return {
+            'document': {
+                'format': document_format,
+                'name': 'document',
+                'source': {'bytes': payload},
+            }
+        }
+    image_format = IMAGE_FORMATS.get(mime)
+    if image_format is not None:
+        return {'image': {'format': image_format, 'source': {'bytes': payload}}}
+    raise GenkitError(
+        message=(
+            f'bedrock: unsupported media MIME type {mime!r} '
+            '(must be png/jpeg/gif/webp or one of pdf/csv/doc/docx/xls/xlsx/html/txt/md)'
+        ),
+        status='INVALID_ARGUMENT',
+    )
+
+
+def _tool_response_text(output: Any) -> str:  # noqa: ANN401
+    if output is None:
+        return ''
+    if isinstance(output, str):
+        return output
+    try:
+        return json.dumps(output)
+    except (TypeError, ValueError) as e:
+        raise GenkitError(message=f'bedrock: marshal tool response: {e}', status='INVALID_ARGUMENT') from e
+
+
+def _reasoning_part_to_blocks(root: Any) -> list[dict[str, Any]]:  # noqa: ANN401
+    """Converts a reasoning part back to Converse reasoningContent blocks.
+
+    Only Bedrock-originated reasoning (carrying the signature and/or redacted
+    metadata) is emitted; a generic reasoning part produces no blocks so it
+    cannot corrupt the follow-up request.
+    """
+    metadata = getattr(root, 'metadata', None)
+    blocks: list[dict[str, Any]] = []
+    redacted = _metadata_bytes(metadata, REDACTED_CONTENT_METADATA_KEY)
+    if redacted:
+        blocks.append({'reasoningContent': {'redactedContent': redacted}})
+    signature = _metadata_str(metadata, REASONING_SIGNATURE_METADATA_KEY)
+    text = getattr(root, 'reasoning', None) or ''
+    if text and signature:
+        blocks.append({'reasoningContent': {'reasoningText': {'text': text, 'signature': signature}}})
+    return blocks
+
+
+def _tool_use_id(ref: str | None, label: str) -> str:
+    """Bedrock's toolUseId rejects empty strings, so a missing ref cannot be sent."""
+    if not ref:
+        raise GenkitError(
+            message=f'bedrock: {label} requires a ref to send as toolUseId',
+            status='INVALID_ARGUMENT',
+        )
+    return ref
+
+
+def _part_to_blocks(part: Part | Any) -> list[dict[str, Any]]:  # noqa: ANN401
+    """Converts one Genkit part to Converse content blocks.
+
+    Unknown part kinds are silently dropped, matching Go's request-side
+    posture (the response side fails loud instead).
+    """
+    root = part.root if isinstance(part, Part) else part
+    if getattr(root, 'media', None) is not None:
+        return [media_to_block(root)]
+    tool_request = getattr(root, 'tool_request', None)
+    if tool_request is not None:
+        return [
+            {
+                'toolUse': {
+                    'toolUseId': _tool_use_id(tool_request.ref, 'tool request'),
+                    'name': tool_request.name,
+                    'input': tool_request.input,
+                }
+            }
+        ]
+    tool_response = getattr(root, 'tool_response', None)
+    if tool_response is not None:
+        return [
+            {
+                'toolResult': {
+                    'toolUseId': _tool_use_id(tool_response.ref, 'tool response'),
+                    'content': [{'text': _tool_response_text(tool_response.output)}],
+                    'status': 'success',
+                }
+            }
+        ]
+    cache_type = _cache_point_type(root)
+    if cache_type is not None:
+        return [{'cachePoint': {'type': cache_type}}]
+    # `is not None`: a redacted-only reasoning part has reasoning == ''.
+    if getattr(root, 'reasoning', None) is not None:
+        return _reasoning_part_to_blocks(root)
+    if getattr(root, 'text', None) is not None:
+        return [{'text': root.text}]
+    return []
+
+
+def _system_blocks(message: Message | Any) -> list[dict[str, Any]]:  # noqa: ANN401
+    """System messages keep only text and cache points; the rest is dropped."""
+    blocks: list[dict[str, Any]] = []
+    for part in message.content or []:
+        root = part.root if isinstance(part, Part) else part
+        cache_type = _cache_point_type(root)
+        if cache_type is not None:
+            blocks.append({'cachePoint': {'type': cache_type}})
+        # Truthiness, not `is not None`: Bedrock rejects empty system text.
+        elif getattr(root, 'text', None):
+            blocks.append({'text': root.text})
+    return blocks
+
+
+def convert_messages(
+    messages: list[Message] | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Splits Genkit messages into Converse messages and top-level system blocks.
+
+    Genkit's SYSTEM role becomes the separate top-level ``system`` array, not
+    a conversation message. Messages that convert to zero blocks are dropped
+    entirely — Bedrock rejects empty content arrays.
+
+    Returns:
+        A ``(messages, system)`` tuple of Converse-shaped dicts.
+    """
+    converse_messages: list[dict[str, Any]] = []
+    system: list[dict[str, Any]] = []
+    for message in messages or []:
+        if message is None:
+            continue
+        if message.role == Role.SYSTEM:
+            system.extend(_system_blocks(message))
+            continue
+        # Validate the role before converting parts, like Go, so an
+        # unsupported role errors even when its message converts to nothing.
+        role = to_bedrock_role(message.role)
+        blocks: list[dict[str, Any]] = []
+        for part in message.content or []:
+            if part is None:
+                continue
+            blocks.extend(_part_to_blocks(part))
+        if not blocks:
+            continue
+        converse_messages.append({'role': role, 'content': blocks})
+    return converse_messages, system
+
+
+def _normalize_tool_schema(schema: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Normalizes a tool input schema for ``toolSpec.inputSchema.json``.
+
+    Bedrock requires an input schema; a missing one becomes the empty object
+    schema. Injects ``type``/``properties``/``$schema`` defaults like Go.
+    """
+    if schema is None:
+        normalized: dict[str, Any] = {'type': 'object', 'properties': {}}
+    elif isinstance(schema, dict):
+        normalized = dict(schema)
+    elif isinstance(schema, (str, bytes)):
+        try:
+            parsed = json.loads(schema)
+        except (ValueError, TypeError):
+            return {'type': 'object', 'properties': {}}
+        normalized = parsed if isinstance(parsed, dict) else {'type': 'object', 'properties': {}}
+    else:
+        return {'type': 'object', 'properties': {}}
+    normalized.setdefault('type', 'object')
+    if normalized.get('type') == 'object':
+        normalized.setdefault('properties', {})
+    normalized.setdefault('$schema', 'http://json-schema.org/draft-07/schema#')
+    return normalized
+
+
+def to_bedrock_tool(tool: ToolDefinition | None) -> dict[str, Any]:  # noqa: ANN401
+    """Converts a Genkit tool definition to a Converse toolSpec."""
+    if tool is None:
+        raise GenkitError(message='bedrock: tool definition required', status='INVALID_ARGUMENT')
+    if not tool.name:
+        raise GenkitError(message='bedrock: tool name required', status='INVALID_ARGUMENT')
+    tool_spec: dict[str, Any] = {
+        'name': tool.name,
+        'inputSchema': {'json': _normalize_tool_schema(tool.input_schema)},
+    }
+    if tool.description:
+        # Omitted when empty: description is optional, but Bedrock rejects ''.
+        tool_spec['description'] = tool.description
+    return {'toolSpec': tool_spec}
+
+
+def _to_bedrock_tool_choice(tool_choice: str, tools: list[ToolDefinition]) -> dict[str, Any]:  # noqa: ANN401
+    if tool_choice in ('', 'auto'):
+        return {'auto': {}}
+    if tool_choice in ('required', 'any'):
+        return {'any': {}}
+    for tool in tools:
+        if tool is not None and tool.name == tool_choice:
+            return {'tool': {'name': tool_choice}}
+    raise GenkitError(
+        message=f'bedrock: tool_choice {tool_choice!r} does not match any declared tool',
+        status='INVALID_ARGUMENT',
+    )
+
+
+def build_converse_request(model_id: str, request: ModelRequest[Any]) -> dict[str, Any]:  # noqa: ANN401
+    """Builds the keyword arguments for ``client.converse(...)``.
+
+    The model ID is sent verbatim — inference-profile prefixes and ARNs are
+    preserved; only capability lookup ever strips them.
+
+    Args:
+        model_id: Bedrock model ID, inference-profile ID, or ARN.
+        request: The Genkit model request.
+
+    Returns:
+        Keyword arguments for the Converse call.
+    """
+    if request is None:
+        raise GenkitError(message='bedrock: model request is nil', status='INVALID_ARGUMENT')
+    config = normalize_config(request.config)
+    messages, system = convert_messages(request.messages)
+
+    tools = [tool for tool in (request.tools or []) if tool is not None] if request.tools else []
+    # When using tools, AWS Bedrock requires that the conversation doesn't
+    # end with an assistant message.
+    if request.tools and messages and messages[-1]['role'] == 'assistant':
+        messages = messages[:-1]
+
+    kwargs: dict[str, Any] = {'modelId': model_id, 'messages': messages}
+    if system:
+        kwargs['system'] = system
+
+    inference_config = build_inference_config(config)
+    max_tokens_set = bool(inference_config and 'maxTokens' in inference_config)
+    if not max_tokens_set:
+        # Bedrock requires maxTokens for Claude models; inject a default only
+        # when the caller didn't set one.
+        default_max_tokens = default_max_tokens_for_model(model_id)
+        if default_max_tokens is not None:
+            inference_config = dict(inference_config or {})
+            inference_config['maxTokens'] = default_max_tokens
+    if inference_config:
+        kwargs['inferenceConfig'] = inference_config
+
+    if config is not None and config.additional_model_request_fields:
+        # Forwarded verbatim (e.g. Claude extended thinking budgets).
+        kwargs['additionalModelRequestFields'] = config.additional_model_request_fields
+
+    if request.tools:
+        tool_choice = _requested_tool_choice(request, config)
+        # "none" means omit toolConfig entirely — Bedrock has no none mode.
+        if tool_choice == 'none':
+            return kwargs
+        tool_config: dict[str, Any] = {'tools': [to_bedrock_tool(tool) for tool in request.tools]}
+        if tool_choice:
+            tool_config['toolChoice'] = _to_bedrock_tool_choice(tool_choice, tools)
+        kwargs['toolConfig'] = tool_config
+    return kwargs
+
+
+def _requested_tool_choice(request: ModelRequest[Any], config: BedrockConfig | None) -> str:
+    # The Bedrock-specific config wins over the core request field so callers
+    # can name a specific tool, which the core enum cannot express.
+    if config is not None and config.tool_choice:
+        return config.tool_choice
+    if request.tool_choice:
+        return str(request.tool_choice)
+    return ''
+
+
+def _coerce_value(value: Any, schema: Any) -> Any:  # noqa: ANN401
+    """Coerces a tool-input value toward its declared schema type.
+
+    Models occasionally return numbers or booleans as strings and floats for
+    integers; coerce like Go instead of failing tool dispatch.
+    """
+    if not isinstance(schema, dict):
+        return value
+    schema_type = schema.get('type')
+    if schema_type in ('number', 'integer') and isinstance(value, str):
+        try:
+            number = float(value)
+        except ValueError:
+            return value
+        return int(number) if schema_type == 'integer' else number
+    if schema_type == 'integer' and isinstance(value, float):
+        return int(value)
+    if schema_type == 'number' and isinstance(value, int) and not isinstance(value, bool):
+        return float(value)
+    if schema_type == 'string' and isinstance(value, (int, float)) and not isinstance(value, bool):
+        # Go coerces wire numbers to their string form; a raw int fails dispatch.
+        return str(value)
+    if schema_type == 'boolean' and isinstance(value, str):
+        # Matches Go's strconv.ParseBool vocabulary.
+        lowered = value.strip().lower()
+        if lowered in ('true', 't', '1'):
+            return True
+        if lowered in ('false', 'f', '0'):
+            return False
+        return value
+    if schema_type == 'array' and isinstance(value, list):
+        return [_coerce_value(item, schema.get('items')) for item in value]
+    if schema_type == 'object' and isinstance(value, dict):
+        return _coerce_map(value, schema)
+    return value
+
+
+def _coerce_map(value: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
+    # Only object schemas coerce, matching Go; non-object schemas pass through.
+    if schema.get('type') != 'object':
+        return value
+    properties = schema.get('properties')
+    if not isinstance(properties, dict):
+        return value
+    # Keys without a schema are kept as-is.
+    return {key: _coerce_value(item, properties.get(key)) for key, item in value.items()}
+
+
+def _coerce_tool_input(name: str, value: Any, tools: list[ToolDefinition] | None) -> Any:  # noqa: ANN401
+    if not isinstance(value, dict):
+        return value
+    for tool in tools or []:
+        if tool is not None and tool.name == name and isinstance(tool.input_schema, dict):
+            return _coerce_map(value, tool.input_schema)
+    return value
+
+
+def _reasoning_block_to_part(block: dict[str, Any]) -> Part | None:  # noqa: ANN401
+    reasoning_text = block.get('reasoningText')
+    if reasoning_text is not None:
+        # Both wire shapes occur: {'text': ...} and a bare string.
+        if isinstance(reasoning_text, str):
+            text, signature = reasoning_text, None
+        else:
+            text = reasoning_text.get('text') or ''
+            signature = reasoning_text.get('signature')
+        if not text and not signature:
+            return None
+        return _bedrock_reasoning_part(text, signature, None)
+    redacted = block.get('redactedContent')
+    if redacted is not None:
+        if not redacted:
+            return None
+        return _bedrock_reasoning_part('', None, redacted)
+    raise GenkitError(
+        message=f'bedrock: unhandled reasoning content variant {sorted(block.keys())!r}',
+        status='INTERNAL',
+    )
+
+
+def _bedrock_reasoning_part(text: str, signature: str | None, redacted: bytes | None) -> Part:
+    metadata: dict[str, Any] = {}
+    if signature:
+        # Also stored under the generic key so framework-level consumers see it.
+        metadata['signature'] = signature
+        metadata[REASONING_SIGNATURE_METADATA_KEY] = signature
+    if redacted:
+        # Base64 string, not raw bytes: part metadata must stay JSON-serializable.
+        metadata[REDACTED_CONTENT_METADATA_KEY] = base64.b64encode(redacted).decode('ascii')
+    return Part(root=ReasoningPart(reasoning=text, metadata=metadata or None))
+
+
+def content_blocks_to_parts(
+    blocks: list[dict[str, Any]],
+    tools: list[ToolDefinition] | None = None,
+) -> list[Part]:
+    """Converts Converse response content blocks to Genkit parts.
+
+    Unlike the request side, unknown response blocks fail loud: silently
+    dropping model output would corrupt conversations.
+    """
+    parts: list[Part] = []
+    for block in blocks:
+        if 'text' in block:
+            parts.append(Part(root=TextPart(text=block['text'])))
+        elif 'toolUse' in block:
+            tool_use = block['toolUse']
+            tool_input = tool_use.get('input')
+            if tool_input is None:
+                tool_input = {}
+            parts.append(
+                Part(
+                    root=ToolRequestPart(
+                        tool_request=ToolRequest(
+                            ref=tool_use.get('toolUseId'),
+                            name=tool_use.get('name') or '',
+                            input=_coerce_tool_input(tool_use.get('name') or '', tool_input, tools),
+                        )
+                    )
+                )
+            )
+        elif 'reasoningContent' in block:
+            part = _reasoning_block_to_part(block['reasoningContent'])
+            if part is not None:
+                parts.append(part)
+        else:
+            raise GenkitError(
+                message=f'bedrock: unhandled response content variant {sorted(block.keys())!r}',
+                status='INTERNAL',
+            )
+    return parts
+
+
+def map_finish_reason(stop_reason: str | None) -> FinishReason:
+    """Maps a Bedrock stopReason to a Genkit finish reason (unknown → OTHER)."""
+    return STOP_REASON_MAP.get(stop_reason or '', FinishReason.OTHER)
+
+
+def usage_from_response(usage: dict[str, Any] | None) -> ModelUsage | None:  # noqa: ANN401
+    """Maps Converse token usage; totals are trusted verbatim from AWS.
+
+    Only ``cacheReadInputTokens`` surfaces (as ``cached_content_tokens``),
+    matching the Go plugin; cache-write tokens are unreported.
+    """
+    if usage is None:
+        return None
+    return ModelUsage(
+        input_tokens=usage.get('inputTokens'),
+        output_tokens=usage.get('outputTokens'),
+        total_tokens=usage.get('totalTokens'),
+        cached_content_tokens=usage.get('cacheReadInputTokens'),
+    )
+
+
+def to_model_response(response: dict[str, Any] | None, request: ModelRequest[Any]) -> ModelResponse:  # noqa: ANN401
+    """Converts a raw Converse response to a Genkit ModelResponse."""
+    if response is None:
+        raise GenkitError(message='bedrock: converse response is nil', status='INTERNAL')
+    output = response.get('output') or {}
+    message = output.get('message')
+    if output and message is None:
+        raise GenkitError(
+            message=f'bedrock: unexpected output variant {sorted(output.keys())!r}',
+            status='INTERNAL',
+        )
+    parts = content_blocks_to_parts((message or {}).get('content') or [], request.tools)
+    if not parts:
+        # Guardrail-blocked responses have no content; return a well-formed
+        # empty message rather than erroring.
+        parts = [Part(root=TextPart(text=''))]
+    return ModelResponse(
+        message=Message(role=Role.MODEL, content=parts),
+        finish_reason=map_finish_reason(response.get('stopReason')),
+        usage=usage_from_response(response.get('usage')),
+        request=request,
+    )

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -476,7 +476,7 @@ def _to_bedrock_tool_choice(tool_choice: str, tools: list[ToolDefinition]) -> di
     if tool_choice in ('required', 'any'):
         return {'any': {}}
     for tool in tools:
-        if tool is not None and tool.name == tool_choice:
+        if tool.name == tool_choice:
             return {'tool': {'name': tool_choice}}
     raise GenkitError(
         message=f'bedrock: tool_choice {tool_choice!r} does not match any declared tool',
@@ -502,10 +502,12 @@ def build_converse_request(model_id: str, request: ModelRequest[Any]) -> dict[st
     config = normalize_config(request.config)
     messages, system = convert_messages(request.messages)
 
-    tools = [tool for tool in (request.tools or []) if tool is not None] if request.tools else []
-    # When using tools, AWS Bedrock requires that the conversation doesn't
-    # end with an assistant message.
-    if request.tools and messages and messages[-1]['role'] == 'assistant':
+    tools = request.tools or []
+    tool_choice = _requested_tool_choice(request, config) if tools else ''
+    # "none" means omit toolConfig entirely — Bedrock has no none mode.
+    send_tool_config = bool(tools) and tool_choice != 'none'
+    # Bedrock rejects a trailing assistant message only when a toolConfig is sent.
+    if send_tool_config and messages and messages[-1]['role'] == 'assistant':
         messages = messages[:-1]
 
     kwargs: dict[str, Any] = {'modelId': model_id, 'messages': messages}
@@ -520,12 +522,8 @@ def build_converse_request(model_id: str, request: ModelRequest[Any]) -> dict[st
         # Forwarded verbatim (e.g. Claude extended thinking budgets).
         kwargs['additionalModelRequestFields'] = config.additional_model_request_fields
 
-    if request.tools:
-        tool_choice = _requested_tool_choice(request, config)
-        # "none" means omit toolConfig entirely — Bedrock has no none mode.
-        if tool_choice == 'none':
-            return kwargs
-        tool_config: dict[str, Any] = {'tools': [to_bedrock_tool(tool) for tool in request.tools]}
+    if send_tool_config:
+        tool_config: dict[str, Any] = {'tools': [to_bedrock_tool(tool) for tool in tools]}
         if tool_choice:
             tool_config['toolChoice'] = _to_bedrock_tool_choice(tool_choice, tools)
         kwargs['toolConfig'] = tool_config

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -190,14 +190,9 @@ def normalize_config(config: Any) -> BedrockConfig | None:  # noqa: ANN401
 
 
 def _effective_max_tokens(config: BedrockConfig | None) -> int | None:
-    if config is None:
+    if config is None or config.max_output_tokens is None or config.max_output_tokens <= 0:
         return None
-    if config.max_tokens is not None and config.max_tokens > 0:
-        return config.max_tokens
-    # Legacy/common key from the core ModelConfig surface.
-    if config.max_output_tokens is not None and config.max_output_tokens > 0:
-        return int(config.max_output_tokens)
-    return None
+    return int(config.max_output_tokens)
 
 
 def build_inference_config(config: BedrockConfig | None) -> dict[str, Any] | None:  # noqa: ANN401

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -16,9 +16,9 @@
 
 """Pure conversion functions between Genkit types and the Bedrock Converse API.
 
-Ported from the Go plugin's ``generate.go``. Everything here is side-effect
-free and testable without AWS: request builders return the keyword arguments
-for ``client.converse(...)``, response parsers take the raw response dict.
+Everything here is side-effect free and testable without AWS: request builders
+return the keyword arguments for ``client.converse(...)``, response parsers take
+the raw response dict.
 """
 
 import base64
@@ -53,7 +53,7 @@ from genkit_amazon_bedrock.config import BedrockConfig
 REASONING_SIGNATURE_METADATA_KEY = 'bedrockReasoningSignature'
 REDACTED_CONTENT_METADATA_KEY = 'bedrockRedactedContent'
 
-# Custom-part key marking a prompt cache point, mirroring the Go plugin.
+# Custom-part key marking a prompt cache point.
 CACHE_POINT_CUSTOM_KEY = 'bedrockCachePointType'
 DEFAULT_CACHE_POINT_TYPE = 'default'
 
@@ -277,7 +277,8 @@ def media_to_block(root: Any) -> dict[str, Any]:  # noqa: ANN401
     media = root.media
     mime = _media_mime(media)
     payload = _decode_media_payload(media.url)
-    # Document formats are checked before image formats, matching Go.
+    # Document formats are checked first: text/plain and text/html are
+    # documents to Converse, and no MIME type belongs to both tables.
     document_format = DOCUMENT_FORMATS.get(mime)
     if document_format is not None:
         return {
@@ -342,8 +343,8 @@ def _tool_use_id(ref: str | None, label: str) -> str:
 def _part_to_blocks(part: Part | Any) -> list[dict[str, Any]]:  # noqa: ANN401
     """Converts one Genkit part to Converse content blocks.
 
-    Unknown part kinds are silently dropped, matching Go's request-side
-    posture (the response side fails loud instead).
+    Unknown part kinds are silently dropped so a foreign part cannot fail a
+    request; the response side fails loud instead.
     """
     root = part.root if isinstance(part, Part) else part
     if getattr(root, 'media', None) is not None:
@@ -415,8 +416,8 @@ def convert_messages(
         if message.role == Role.SYSTEM:
             system.extend(_system_blocks(message))
             continue
-        # Validate the role before converting parts, like Go, so an
-        # unsupported role errors even when its message converts to nothing.
+        # Validate the role before converting parts, so an unsupported role
+        # errors even when its message converts to nothing.
         role = to_bedrock_role(message.role)
         blocks: list[dict[str, Any]] = []
         for part in message.content or []:
@@ -433,7 +434,7 @@ def _normalize_tool_schema(schema: Any) -> dict[str, Any]:  # noqa: ANN401
     """Normalizes a tool input schema for ``toolSpec.inputSchema.json``.
 
     Bedrock requires an input schema; a missing one becomes the empty object
-    schema. Injects ``type``/``properties``/``$schema`` defaults like Go.
+    schema, and ``type``/``properties``/``$schema`` are filled in when absent.
     """
     if schema is None:
         normalized: dict[str, Any] = {'type': 'object', 'properties': {}}
@@ -498,7 +499,7 @@ def build_converse_request(model_id: str, request: ModelRequest[Any]) -> dict[st
         Keyword arguments for the Converse call.
     """
     if request is None:
-        raise GenkitError(message='bedrock: model request is nil', status='INVALID_ARGUMENT')
+        raise GenkitError(message='bedrock: model request is missing', status='INVALID_ARGUMENT')
     config = normalize_config(request.config)
     messages, system = convert_messages(request.messages)
 
@@ -544,7 +545,7 @@ def _coerce_value(value: Any, schema: Any) -> Any:  # noqa: ANN401
     """Coerces a tool-input value toward its declared schema type.
 
     Models occasionally return numbers or booleans as strings and floats for
-    integers; coerce like Go instead of failing tool dispatch.
+    integers; coercing them keeps tool dispatch alive.
     """
     if not isinstance(schema, dict):
         return value
@@ -560,10 +561,10 @@ def _coerce_value(value: Any, schema: Any) -> Any:  # noqa: ANN401
     if schema_type == 'number' and isinstance(value, int) and not isinstance(value, bool):
         return float(value)
     if schema_type == 'string' and isinstance(value, (int, float)) and not isinstance(value, bool):
-        # Go coerces wire numbers to their string form; a raw int fails dispatch.
+        # A raw int against a string field fails pydantic validation.
         return str(value)
     if schema_type == 'boolean' and isinstance(value, str):
-        # Matches Go's strconv.ParseBool vocabulary.
+        # Anything outside this vocabulary is left alone for the tool to reject.
         lowered = value.strip().lower()
         if lowered in ('true', 't', '1'):
             return True
@@ -578,7 +579,7 @@ def _coerce_value(value: Any, schema: Any) -> Any:  # noqa: ANN401
 
 
 def _coerce_map(value: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
-    # Only object schemas coerce, matching Go; non-object schemas pass through.
+    # Only object schemas coerce; non-object schemas pass through.
     if schema.get('type') != 'object':
         return value
     properties = schema.get('properties')
@@ -678,8 +679,8 @@ def map_finish_reason(stop_reason: str | None) -> FinishReason:
 def usage_from_response(usage: dict[str, Any] | None) -> ModelUsage | None:  # noqa: ANN401
     """Maps Converse token usage; totals are trusted verbatim from AWS.
 
-    Only ``cacheReadInputTokens`` surfaces (as ``cached_content_tokens``),
-    matching the Go plugin; cache-write tokens are unreported.
+    Only ``cacheReadInputTokens`` surfaces (as ``cached_content_tokens``);
+    Genkit has no field for cache-write tokens.
     """
     if usage is None:
         return None
@@ -694,7 +695,7 @@ def usage_from_response(usage: dict[str, Any] | None) -> ModelUsage | None:  # n
 def to_model_response(response: dict[str, Any] | None, request: ModelRequest[Any]) -> ModelResponse:  # noqa: ANN401
     """Converts a raw Converse response to a Genkit ModelResponse."""
     if response is None:
-        raise GenkitError(message='bedrock: converse response is nil', status='INTERNAL')
+        raise GenkitError(message='bedrock: converse response is missing', status='INTERNAL')
     output = response.get('output') or {}
     message = output.get('message')
     if output and message is None:

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -132,7 +132,7 @@ def strip_inference_profile_prefix(model_id: str) -> str:
 
 def get_model_info(
     model_name: str,
-    model_type: Literal['chat', 'image', 'embedding'] = 'chat',
+    model_type: Literal['chat', 'text', 'image', 'embedding'] = 'chat',
 ) -> ModelInfo:
     """Infers Genkit model info for a Bedrock model.
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -16,9 +16,9 @@
 
 """Model capability registry for the Amazon Bedrock plugin.
 
-Ported from the Go plugin's ``models.go``. Capabilities are keyed by base
-Bedrock model ID; cross-region inference-profile prefixes are stripped for
-lookup only - the full original model ID is always sent to Bedrock untouched.
+Capabilities are keyed by base Bedrock model ID; cross-region inference-profile
+prefixes are stripped for lookup only - the full original model ID is always
+sent to Bedrock untouched.
 Unknown chat/text models fall back to modern Converse defaults (multimodal +
 tools) at the unstable stage, so newer or inference-profile-only models remain
 callable without a plugin release.

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bedrock model action implementation (Converse API)."""
+
+from typing import Any, Protocol
+
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    ConnectTimeoutError,
+    EndpointConnectionError,
+    NoCredentialsError,
+    NoRegionError,
+    ParamValidationError,
+    PartialCredentialsError,
+    ReadTimeoutError,
+)
+
+from genkit import ModelRequest, ModelResponse, ModelResponseChunk, Role
+from genkit.plugin_api import ActionRunContext, GenkitError, StatusName
+from genkit_amazon_bedrock.converters import build_converse_request, to_model_response
+
+
+class ConverseTransport(Protocol):
+    """Structural contract for the transport seam (see ``transport.py``)."""
+
+    async def converse(self, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
+        """Calls the Converse API and returns the raw response dict."""
+        ...
+
+
+# AWS error codes → Genkit statuses; anything unlisted maps to UNKNOWN.
+_ERROR_CODE_STATUS: dict[str, StatusName] = {
+    'ThrottlingException': 'RESOURCE_EXHAUSTED',
+    'TooManyRequestsException': 'RESOURCE_EXHAUSTED',
+    'ServiceQuotaExceededException': 'RESOURCE_EXHAUSTED',
+    'ValidationException': 'INVALID_ARGUMENT',
+    'AccessDeniedException': 'PERMISSION_DENIED',
+    'UnrecognizedClientException': 'UNAUTHENTICATED',
+    'ExpiredTokenException': 'UNAUTHENTICATED',
+    'ResourceNotFoundException': 'NOT_FOUND',
+    'ModelTimeoutException': 'DEADLINE_EXCEEDED',
+    'ModelNotReadyException': 'UNAVAILABLE',
+    'ServiceUnavailableException': 'UNAVAILABLE',
+    'ModelErrorException': 'INTERNAL',
+}
+
+
+# Client-side botocore failures never reach the service, so they carry no error
+# code; map the exception type instead. Anything unlisted stays UNKNOWN.
+_BOTOCORE_ERROR_STATUS: tuple[tuple[type[BotoCoreError], StatusName], ...] = (
+    (ParamValidationError, 'INVALID_ARGUMENT'),
+    (NoCredentialsError, 'UNAUTHENTICATED'),
+    (PartialCredentialsError, 'UNAUTHENTICATED'),
+    (NoRegionError, 'FAILED_PRECONDITION'),
+    (ReadTimeoutError, 'DEADLINE_EXCEEDED'),
+    (ConnectTimeoutError, 'DEADLINE_EXCEEDED'),
+    (EndpointConnectionError, 'UNAVAILABLE'),
+)
+
+
+def _from_client_error(error: ClientError) -> GenkitError:
+    error_info: dict[str, Any] = error.response.get('Error') or {}
+    code = error_info.get('Code') or ''
+    message = error_info.get('Message') or str(error)
+    return GenkitError(
+        message=f'bedrock converse failed: {code}: {message}' if code else f'bedrock converse failed: {message}',
+        status=_ERROR_CODE_STATUS.get(code, 'UNKNOWN'),
+    )
+
+
+def _from_botocore_error(error: BotoCoreError) -> GenkitError:
+    status: StatusName = 'UNKNOWN'
+    for error_type, mapped in _BOTOCORE_ERROR_STATUS:
+        if isinstance(error, error_type):
+            status = mapped
+            break
+    return GenkitError(message=f'bedrock converse failed: {error}', status=status)
+
+
+class BedrockModel:
+    """Handles a generate call for one Bedrock chat/text model."""
+
+    def __init__(self, model_id: str, transport: ConverseTransport) -> None:
+        """Initializes the model handler.
+
+        Args:
+            model_id: Bedrock model ID, inference-profile ID, or ARN, sent to
+                the Converse API verbatim.
+            transport: The shared transport seam owning the boto3 client.
+        """
+        self._model_id = model_id
+        self._transport = transport
+
+    async def generate(self, request: ModelRequest[Any], ctx: ActionRunContext | None = None) -> ModelResponse:
+        """Runs a non-streaming Converse call.
+
+        Args:
+            request: The Genkit model request.
+            ctx: Action run context; when a streaming callback is attached the
+                full response is emitted as a single chunk until
+                ConverseStream lands in a later slice.
+
+        Returns:
+            The converted model response.
+        """
+        converse_kwargs = build_converse_request(self._model_id, request)
+        try:
+            response = await self._transport.converse(**converse_kwargs)
+        except ClientError as e:
+            raise _from_client_error(e) from e
+        except BotoCoreError as e:
+            raise _from_botocore_error(e) from e
+        model_response = to_model_response(response, request)
+        if ctx is not None and ctx.is_streaming and model_response.message is not None:
+            ctx.send_chunk(ModelResponseChunk(role=Role.MODEL, index=0, content=model_response.message.content))
+        return model_response

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
@@ -16,6 +16,9 @@
 
 """Bedrock model action implementation (Converse API)."""
 
+import math
+import time
+from email.utils import parsedate_to_datetime
 from typing import Any, Protocol
 
 from botocore.exceptions import (
@@ -30,7 +33,7 @@ from botocore.exceptions import (
     ReadTimeoutError,
 )
 
-from genkit import ModelRequest, ModelResponse, ModelResponseChunk, Role
+from genkit import ErrorResponseMetadata, ModelRequest, ModelResponse, ModelResponseChunk, Role
 from genkit.plugin_api import ActionRunContext, GenkitError, StatusName
 from genkit_amazon_bedrock.converters import build_converse_request, to_model_response
 
@@ -73,13 +76,55 @@ _BOTOCORE_ERROR_STATUS: tuple[tuple[type[BotoCoreError], StatusName], ...] = (
 )
 
 
+def _parse_retry_after_ms(value: str) -> float | None:
+    """Parses an HTTP Retry-After value into milliseconds.
+
+    Accepts both forms the header allows, delay-seconds and an HTTP-date.
+    """
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        pass
+    else:
+        # Check the scaled value: a large finite input can overflow to inf.
+        retry_after_ms = seconds * 1000
+        if seconds >= 0 and math.isfinite(retry_after_ms):
+            return retry_after_ms
+    try:
+        retry_at_ms = parsedate_to_datetime(value).timestamp() * 1000
+    except (OSError, OverflowError, TypeError, ValueError):
+        return None
+    return max(0.0, retry_at_ms - time.time() * 1000)
+
+
+def _retry_after_ms(error: ClientError) -> float | None:
+    """Pulls Retry-After out of the response headers Bedrock throttling sends."""
+    metadata = error.response.get('ResponseMetadata') or {}
+    headers = metadata.get('HTTPHeaders') or {}
+    if not isinstance(headers, dict):
+        return None
+    # Header names are case-insensitive; botocore's lowercasing is not promised.
+    for name, value in headers.items():
+        if isinstance(name, str) and name.lower() == 'retry-after' and isinstance(value, str):
+            return _parse_retry_after_ms(value)
+    return None
+
+
 def _from_client_error(error: ClientError) -> GenkitError:
     error_info: dict[str, Any] = error.response.get('Error') or {}
     code = error_info.get('Code') or ''
     message = error_info.get('Message') or str(error)
+    retry_after_ms = _retry_after_ms(error)
+    response_metadata: ErrorResponseMetadata | None = None
+    if retry_after_ms is not None:
+        response_metadata = {'retry_after_ms': retry_after_ms}
     return GenkitError(
         message=f'bedrock converse failed: {code}: {message}' if code else f'bedrock converse failed: {message}',
         status=_ERROR_CODE_STATUS.get(code, 'UNKNOWN'),
+        response_metadata=response_metadata,
     )
 
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -145,7 +145,11 @@ class Bedrock(Plugin):
         """
         if action_type != ActionKind.MODEL:
             return None
-        model_id = name.removeprefix(f'{BEDROCK_PLUGIN_NAME}/')
+        prefix = f'{BEDROCK_PLUGIN_NAME}/'
+        # Direct plugin.model() calls can pass any namespace; only ours resolves.
+        if not name.startswith(prefix):
+            return None
+        model_id = name.removeprefix(prefix)
         model_type = self._configured_model_type(model_id)
         if model_type not in ('chat', 'text'):
             # Image generation lands in a later slice.

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -17,10 +17,9 @@
 """Amazon Bedrock plugin for Genkit.
 
 Registers Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama,
-Mistral, Cohere, and others), embedders (Titan, Cohere, Nova), image
-generators, and the Cohere reranker as Genkit actions. Text generation uses
-the Bedrock Converse and ConverseStream APIs; embeddings, image generation,
-and reranking use InvokeModel.
+Mistral, Cohere, and others) as Genkit model actions. Text generation uses the
+Bedrock Converse API, non-streaming; streaming, embedders, image generation,
+and reranking are not ported yet.
 
 Ported from the Go plugin (genkit-ai/aws-bedrock-go-plugin).
 """
@@ -81,7 +80,6 @@ class Bedrock(Plugin):
         max_pool_connections: int = DEFAULT_MAX_POOL_CONNECTIONS,
         session: 'boto3.session.Session | None' = None,
         models: list[ModelDefinition] | None = None,
-        embedders: list[str] | None = None,
     ) -> None:
         """Initializes the Bedrock plugin.
 
@@ -99,7 +97,6 @@ class Bedrock(Plugin):
                 credentials or advanced SDK wiring.
             models: Bedrock models to register. Models not listed can still be
                 resolved dynamically by namespaced name.
-            embedders: Embedding model IDs to register (Titan, Cohere, Nova).
         """
         self.region = region
         self.max_retries = max_retries
@@ -108,7 +105,6 @@ class Bedrock(Plugin):
         self.max_pool_connections = max_pool_connections
         self._session = session
         self.models = models or []
-        self.embedders = embedders or []
         self._transport = BedrockTransport(
             region=region,
             max_retries=max_retries,
@@ -154,7 +150,7 @@ class Bedrock(Plugin):
         if model_type not in ('chat', 'text'):
             # Image generation lands in a later slice.
             return None
-        return self._create_model_action(name, model_id)
+        return self._create_model_action(model_id)
 
     def _configured_model_type(self, model_id: str) -> str:
         for definition in self.models:
@@ -162,7 +158,7 @@ class Bedrock(Plugin):
                 return definition.type
         return 'chat'
 
-    def _create_model_action(self, name: str, model_id: str) -> Action:
+    def _create_model_action(self, model_id: str) -> Action:
         model_info = get_model_info(model_id)
 
         async def _generate(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -19,9 +19,7 @@
 Registers Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama,
 Mistral, Cohere, and others) as Genkit model actions. Text generation uses the
 Bedrock Converse API, non-streaming; streaming, embedders, image generation,
-and reranking are not ported yet.
-
-Ported from the Go plugin (genkit-ai/aws-bedrock-go-plugin).
+and reranking are not supported yet.
 """
 
 from typing import TYPE_CHECKING

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -27,17 +27,27 @@ Ported from the Go plugin (genkit-ai/aws-bedrock-go-plugin).
 
 from typing import TYPE_CHECKING
 
+from genkit import ModelRequest, ModelResponse
+from genkit.model import model_action_metadata
 from genkit.plugin_api import (
     Action,
     ActionKind,
     ActionMetadata,
+    ActionRunContext,
     Plugin,
+    to_json_schema,
 )
 from genkit_amazon_bedrock.config import (
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_MAX_POOL_CONNECTIONS,
     DEFAULT_MAX_RETRIES,
-    DEFAULT_REQUEST_TIMEOUT,
+    DEFAULT_READ_TIMEOUT,
+    BedrockConfig,
     ModelDefinition,
 )
+from genkit_amazon_bedrock.model_info import get_model_info
+from genkit_amazon_bedrock.models import BedrockModel
+from genkit_amazon_bedrock.transport import BedrockTransport
 
 if TYPE_CHECKING:
     import boto3.session
@@ -66,7 +76,9 @@ class Bedrock(Plugin):
         self,
         region: str | None = None,
         max_retries: int = DEFAULT_MAX_RETRIES,
-        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        max_pool_connections: int = DEFAULT_MAX_POOL_CONNECTIONS,
         session: 'boto3.session.Session | None' = None,
         models: list[ModelDefinition] | None = None,
         embedders: list[str] | None = None,
@@ -75,9 +87,14 @@ class Bedrock(Plugin):
 
         Args:
             region: AWS region. Defaults to the SDK resolution chain
-                (``AWS_REGION``, ``AWS_DEFAULT_REGION``, ``~/.aws/config``).
+                (``AWS_REGION``, ``AWS_DEFAULT_REGION``, ``~/.aws/config``);
+                initialization fails loudly when no region resolves rather
+                than silently picking one.
             max_retries: Retry limit for Bedrock API calls.
-            request_timeout: Per-call timeout in seconds.
+            read_timeout: Socket read timeout in seconds (not a whole-call
+                deadline; long generations must not be killed mid-flight).
+            connect_timeout: Socket connect timeout in seconds.
+            max_pool_connections: HTTP connection pool size.
             session: Optional pre-configured ``boto3.session.Session`` for custom
                 credentials or advanced SDK wiring.
             models: Bedrock models to register. Models not listed can still be
@@ -86,21 +103,38 @@ class Bedrock(Plugin):
         """
         self.region = region
         self.max_retries = max_retries
-        self.request_timeout = request_timeout
+        self.read_timeout = read_timeout
+        self.connect_timeout = connect_timeout
+        self.max_pool_connections = max_pool_connections
         self._session = session
         self.models = models or []
         self.embedders = embedders or []
+        self._transport = BedrockTransport(
+            region=region,
+            max_retries=max_retries,
+            read_timeout=read_timeout,
+            connect_timeout=connect_timeout,
+            max_pool_connections=max_pool_connections,
+            session=session,
+        )
 
     async def init(self) -> list[Action]:
         """Initialize plugin.
 
+        Builds the shared client so misconfiguration (e.g. no resolvable AWS
+        region) fails at startup instead of on the first model call.
+
         Returns:
             Empty list (actions are lazily created via ``resolve``).
         """
+        await self._transport.ensure_client()
         return []
 
     async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
         """Resolve an action by namespaced name.
+
+        Any model ID resolves — the Bedrock catalogue includes arbitrary
+        inference profiles and ARNs and can never be fully enumerated.
 
         Args:
             action_type: The kind of action to resolve.
@@ -109,12 +143,59 @@ class Bedrock(Plugin):
         Returns:
             Action object if resolvable, None otherwise.
         """
-        return None
+        if action_type != ActionKind.MODEL:
+            return None
+        model_id = name.removeprefix(f'{BEDROCK_PLUGIN_NAME}/')
+        model_type = self._configured_model_type(model_id)
+        if model_type not in ('chat', 'text'):
+            # Image generation lands in a later slice.
+            return None
+        return self._create_model_action(name, model_id)
+
+    def _configured_model_type(self, model_id: str) -> str:
+        for definition in self.models:
+            if definition.name == model_id:
+                return definition.type
+        return 'chat'
+
+    def _create_model_action(self, name: str, model_id: str) -> Action:
+        model_info = get_model_info(model_id)
+
+        async def _generate(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+            model = BedrockModel(model_id=model_id, transport=self._transport)
+            return await model.generate(request, ctx)
+
+        return Action(
+            kind=ActionKind.MODEL,
+            name=bedrock_name(model_id),
+            fn=_generate,
+            metadata={
+                'model': {
+                    'label': model_info.label,
+                    'stage': model_info.stage.value if model_info.stage else None,
+                    'supports': (
+                        model_info.supports.model_dump(by_alias=True, exclude_none=True) if model_info.supports else {}
+                    ),
+                    'customOptions': to_json_schema(BedrockConfig),
+                },
+            },
+        )
 
     async def list_actions(self) -> list[ActionMetadata]:
-        """List available Bedrock models and embedders.
+        """List configured Bedrock models.
+
+        Only explicitly configured models are listed; the catalogue itself is
+        open-ended, and any model ID still resolves on demand.
 
         Returns:
-            ActionMetadata for each configured model and embedder.
+            ActionMetadata for each configured chat model.
         """
-        return []
+        return [
+            model_action_metadata(
+                name=bedrock_name(definition.name),
+                info=get_model_info(definition.name, definition.type).model_dump(by_alias=True, exclude_none=True),
+                config_schema=BedrockConfig,
+            )
+            for definition in self.models
+            if definition.type in ('chat', 'text')
+        ]

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -35,10 +35,7 @@ from genkit.plugin_api import (
     to_json_schema,
 )
 from genkit_amazon_bedrock.config import (
-    DEFAULT_CONNECT_TIMEOUT,
-    DEFAULT_MAX_POOL_CONNECTIONS,
-    DEFAULT_MAX_RETRIES,
-    DEFAULT_READ_TIMEOUT,
+    DEFAULT_TOTAL_TIMEOUT,
     BedrockConfig,
     ModelDefinition,
 )
@@ -72,14 +69,20 @@ class Bedrock(Plugin):
     def __init__(
         self,
         region: str | None = None,
-        max_retries: int = DEFAULT_MAX_RETRIES,
-        read_timeout: float = DEFAULT_READ_TIMEOUT,
-        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
-        max_pool_connections: int = DEFAULT_MAX_POOL_CONNECTIONS,
+        max_retries: int | None = None,
+        read_timeout: float | None = None,
+        connect_timeout: float | None = None,
+        max_pool_connections: int | None = None,
+        total_timeout: float | None = DEFAULT_TOTAL_TIMEOUT,
         session: 'boto3.session.Session | None' = None,
         models: list[ModelDefinition] | None = None,
     ) -> None:
         """Initializes the Bedrock plugin.
+
+        The AWS client knobs all default to None, meaning "use the ambient AWS
+        configuration" (``AWS_MAX_ATTEMPTS``, ``AWS_RETRY_MODE``,
+        ``~/.aws/config``, a session's default client config), and fall back to
+        the package defaults only when that configuration says nothing.
 
         Args:
             region: AWS region. Defaults to the SDK resolution chain
@@ -87,10 +90,13 @@ class Bedrock(Plugin):
                 initialization fails loudly when no region resolves rather
                 than silently picking one.
             max_retries: Retry limit for Bedrock API calls.
-            read_timeout: Socket read timeout in seconds (not a whole-call
-                deadline; long generations must not be killed mid-flight).
+            read_timeout: Socket read timeout in seconds. Resets on every byte
+                received, so it caps silence, not the call.
             connect_timeout: Socket connect timeout in seconds.
             max_pool_connections: HTTP connection pool size.
+            total_timeout: Whole-call deadline in seconds, covering retries and
+                the slow-dribble case the read timeout cannot see. None removes
+                the deadline, leaving only the socket timeouts.
             session: Optional pre-configured ``boto3.session.Session`` for custom
                 credentials or advanced SDK wiring.
             models: Bedrock models to register. Models not listed can still be
@@ -101,6 +107,7 @@ class Bedrock(Plugin):
         self.read_timeout = read_timeout
         self.connect_timeout = connect_timeout
         self.max_pool_connections = max_pool_connections
+        self.total_timeout = total_timeout
         self._session = session
         self.models = models or []
         self._transport = BedrockTransport(
@@ -109,6 +116,7 @@ class Bedrock(Plugin):
             read_timeout=read_timeout,
             connect_timeout=connect_timeout,
             max_pool_connections=max_pool_connections,
+            total_timeout=total_timeout,
             session=session,
         )
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transport seam for the Amazon Bedrock plugin.
+
+Every boto3 call goes through this module. boto3 is synchronous, so calls are
+bridged onto worker threads with ``asyncio.to_thread`` to keep the event loop
+unblocked for the seconds-to-minutes an LLM call takes. Keeping the whole SDK
+surface behind one seam lets us swap in AWS's official async SDK once it
+matures without touching converters or models.
+"""
+
+import asyncio
+import os
+import threading
+from typing import TYPE_CHECKING, Any
+
+from genkit.plugin_api import GenkitError
+
+if TYPE_CHECKING:
+    import boto3.session
+
+NO_REGION_MESSAGE = (
+    'bedrock: no AWS region resolved; set Bedrock(region=...), AWS_REGION, '
+    'AWS_DEFAULT_REGION, or a region in ~/.aws/config'
+)
+
+
+class BedrockTransport:
+    """Owns the shared bedrock-runtime client and the sync-to-async bridge.
+
+    The sync boto3 client is not bound to an event loop (unlike async SDK
+    clients), so one client instance safely serves both the application loop
+    and the Dev UI reflection loop; boto3 clients are thread-safe for calls,
+    only creation needs the lock.
+    """
+
+    def __init__(
+        self,
+        *,
+        region: str | None = None,
+        max_retries: int,
+        read_timeout: float,
+        connect_timeout: float,
+        max_pool_connections: int,
+        session: 'boto3.session.Session | None' = None,
+    ) -> None:
+        """Initializes the transport.
+
+        Args:
+            region: AWS region; falls back to the SDK resolution chain.
+            max_retries: Retry limit for Bedrock API calls.
+            read_timeout: Socket read timeout in seconds. Deliberately not a
+                whole-call deadline: long generations stream for minutes and
+                must not be killed mid-flight.
+            connect_timeout: Socket connect timeout in seconds.
+            max_pool_connections: HTTP connection pool size, raised off the
+                botocore default of 10 so the pool is never the bottleneck.
+                Concurrency is bounded first by the event loop's default
+                thread-pool executor, which ``asyncio.to_thread`` dispatches to.
+            session: Optional pre-configured ``boto3.session.Session`` for
+                custom credentials or advanced SDK wiring.
+        """
+        self._region = region
+        self._max_retries = max_retries
+        self._read_timeout = read_timeout
+        self._connect_timeout = connect_timeout
+        self._max_pool_connections = max_pool_connections
+        self._session = session
+        self._client: Any = None
+        self._lock = threading.Lock()
+
+    def client(self) -> Any:  # noqa: ANN401
+        """Returns the shared bedrock-runtime client, building it on first use.
+
+        Raises:
+            GenkitError: FAILED_PRECONDITION when no region resolves. Matching
+                the Go plugin, there is deliberately no default region: a
+                silent ``us-east-1`` fallback sends traffic (and data) to a
+                region the user never chose.
+        """
+        with self._lock:
+            if self._client is None:
+                self._client = self._build_client()
+            return self._client
+
+    async def ensure_client(self) -> None:
+        """Builds the client off-loop so init fails fast on config errors."""
+        await asyncio.to_thread(self.client)
+
+    async def converse(self, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
+        """Calls the Converse API on a worker thread.
+
+        Args:
+            kwargs: Keyword arguments passed verbatim to ``converse``.
+
+        Returns:
+            The raw Converse response dict.
+        """
+        return await asyncio.to_thread(self._converse_sync, kwargs)
+
+    def _converse_sync(self, kwargs: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
+        return self.client().converse(**kwargs)
+
+    def _build_client(self) -> Any:  # noqa: ANN401
+        import boto3.session
+        from botocore.config import Config
+
+        session = self._session or boto3.session.Session()
+        # botocore only began reading AWS_REGION in 1.41, below this package's
+        # floor, so resolve it here. A caller-supplied session states its own
+        # region first; otherwise env wins over ~/.aws/config, as in the SDKs.
+        env_region = os.environ.get('AWS_REGION')
+        if self._session is not None:
+            region = self._region or session.region_name or env_region
+        else:
+            region = self._region or env_region or session.region_name
+        if not region:
+            raise GenkitError(message=NO_REGION_MESSAGE, status='FAILED_PRECONDITION')
+
+        return session.client(
+            'bedrock-runtime',
+            region_name=region,
+            config=Config(
+                retries={'max_attempts': self._max_retries, 'mode': 'standard'},
+                read_timeout=self._read_timeout,
+                connect_timeout=self._connect_timeout,
+                max_pool_connections=self._max_pool_connections,
+            ),
+        )

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
@@ -29,6 +29,13 @@ import threading
 from typing import TYPE_CHECKING, Any
 
 from genkit.plugin_api import GenkitError
+from genkit_amazon_bedrock.config import (
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_MAX_POOL_CONNECTIONS,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_READ_TIMEOUT,
+    DEFAULT_TOTAL_TIMEOUT,
+)
 
 if TYPE_CHECKING:
     import boto3.session
@@ -37,6 +44,40 @@ NO_REGION_MESSAGE = (
     'bedrock: no AWS region resolved; set Bedrock(region=...), AWS_REGION, '
     'AWS_DEFAULT_REGION, or a region in ~/.aws/config'
 )
+
+
+def _botocore_session(session: Any) -> Any:  # noqa: ANN401
+    """Returns the botocore session underneath a boto3 session, if reachable."""
+    return getattr(session, '_session', None)
+
+
+def _has_ambient_setting(session: Any, name: str) -> bool:  # noqa: ANN401
+    """True when ``AWS_<NAME>`` or the active ~/.aws/config profile sets ``name``.
+
+    Both sources are read directly rather than through
+    ``get_config_variable``, which folds in botocore's own default and so
+    reports ``retry_mode`` as configured even when nobody configured it.
+    """
+    from botocore.exceptions import ProfileNotFound
+
+    if os.environ.get(f'AWS_{name.upper()}'):
+        return True
+    botocore_session = _botocore_session(session)
+    if botocore_session is None:
+        return False
+    try:
+        scoped_config = botocore_session.get_scoped_config()
+    except ProfileNotFound:
+        return False
+    return bool(scoped_config.get(name))
+
+
+def _ambient_client_config(session: Any) -> Any:  # noqa: ANN401
+    """Returns the session's default client config, if one was installed."""
+    botocore_session = _botocore_session(session)
+    if botocore_session is None:
+        return None
+    return botocore_session.get_default_client_config()
 
 
 class BedrockTransport:
@@ -52,25 +93,30 @@ class BedrockTransport:
         self,
         *,
         region: str | None = None,
-        max_retries: int,
-        read_timeout: float,
-        connect_timeout: float,
-        max_pool_connections: int,
+        max_retries: int | None = None,
+        read_timeout: float | None = None,
+        connect_timeout: float | None = None,
+        max_pool_connections: int | None = None,
+        total_timeout: float | None = DEFAULT_TOTAL_TIMEOUT,
         session: 'boto3.session.Session | None' = None,
     ) -> None:
         """Initializes the transport.
 
+        Every botocore knob below takes None to mean "whatever the ambient AWS
+        configuration says", falling back to the package default only when that
+        configuration is silent too.
+
         Args:
             region: AWS region; falls back to the SDK resolution chain.
             max_retries: Retry limit for Bedrock API calls.
-            read_timeout: Socket read timeout in seconds. Deliberately not a
-                whole-call deadline: long generations stream for minutes and
-                must not be killed mid-flight.
+            read_timeout: Socket read timeout in seconds, reset on every byte
+                received, so it bounds silence rather than the whole call.
             connect_timeout: Socket connect timeout in seconds.
             max_pool_connections: HTTP connection pool size, raised off the
                 botocore default of 10 so the pool is never the bottleneck.
                 Concurrency is bounded first by the event loop's default
                 thread-pool executor, which ``asyncio.to_thread`` dispatches to.
+            total_timeout: Whole-call deadline in seconds; None removes it.
             session: Optional pre-configured ``boto3.session.Session`` for
                 custom credentials or advanced SDK wiring.
         """
@@ -79,6 +125,7 @@ class BedrockTransport:
         self._read_timeout = read_timeout
         self._connect_timeout = connect_timeout
         self._max_pool_connections = max_pool_connections
+        self._total_timeout = total_timeout
         self._session = session
         self._client: Any = None
         self._lock = threading.Lock()
@@ -108,18 +155,29 @@ class BedrockTransport:
 
         Returns:
             The raw Converse response dict.
+
+        Raises:
+            GenkitError: DEADLINE_EXCEEDED when the call outruns the total
+                timeout. The caller is freed at that point, but boto3 offers no
+                way to abort an in-flight call, so the worker thread stays busy
+                until the socket timeouts below it fire.
         """
-        return await asyncio.to_thread(self._converse_sync, kwargs)
+        call = asyncio.to_thread(self._converse_sync, kwargs)
+        if self._total_timeout is None:
+            return await call
+        try:
+            return await asyncio.wait_for(call, self._total_timeout)
+        except asyncio.TimeoutError as e:
+            raise GenkitError(
+                message=f'bedrock converse failed: call exceeded the {self._total_timeout}s total timeout',
+                status='DEADLINE_EXCEEDED',
+            ) from e
 
     def _converse_sync(self, kwargs: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
         return self.client().converse(**kwargs)
 
-    def _build_client(self) -> Any:  # noqa: ANN401
-        import boto3.session
-        from botocore.config import Config
-
-        session = self._session or boto3.session.Session()
-        # botocore only began reading AWS_REGION in 1.41, below this package's
+    def _resolve_region(self, session: Any) -> str:  # noqa: ANN401
+        # botocore only began reading AWS_REGION in 1.41, above this package's
         # floor, so resolve it here. A caller-supplied session states its own
         # region first; otherwise env wins over ~/.aws/config, as in the SDKs.
         env_region = os.environ.get('AWS_REGION')
@@ -129,14 +187,70 @@ class BedrockTransport:
             region = self._region or env_region or session.region_name
         if not region:
             raise GenkitError(message=NO_REGION_MESSAGE, status='FAILED_PRECONDITION')
+        return region
 
-        return session.client(
-            'bedrock-runtime',
-            region_name=region,
-            config=Config(
-                retries={'max_attempts': self._max_retries, 'mode': 'standard'},
-                read_timeout=self._read_timeout,
-                connect_timeout=self._connect_timeout,
-                max_pool_connections=self._max_pool_connections,
-            ),
-        )
+    def _client_config(self, session: Any) -> Any:  # noqa: ANN401
+        """Builds the botocore config, leaving anything the caller stated alone.
+
+        botocore reads AWS_MAX_ATTEMPTS, AWS_RETRY_MODE, ~/.aws/config and a
+        session's default client config only where the config passed to
+        ``client()`` leaves that key unset; whatever is passed wins outright.
+        So the package defaults go on underneath as a floor, the ambient
+        configuration on top of them, and the explicit arguments last.
+        """
+        from botocore.config import Config
+
+        defaults: dict[str, Any] = {
+            'read_timeout': DEFAULT_READ_TIMEOUT,
+            'connect_timeout': DEFAULT_CONNECT_TIMEOUT,
+            'max_pool_connections': DEFAULT_MAX_POOL_CONNECTIONS,
+        }
+        explicit: dict[str, Any] = {}
+        for key, value in (
+            ('read_timeout', self._read_timeout),
+            ('connect_timeout', self._connect_timeout),
+            ('max_pool_connections', self._max_pool_connections),
+        ):
+            if value is not None:
+                explicit[key] = value
+
+        ambient = _ambient_client_config(session)
+        retries = self._retry_config(session, ambient)
+        if retries:
+            explicit['retries'] = retries
+
+        config = Config(**defaults)
+        if ambient is not None:
+            config = config.merge(ambient)
+        return config.merge(Config(**explicit))
+
+    def _retry_config(self, session: Any, ambient: Any) -> dict[str, Any]:  # noqa: ANN401
+        """Resolves the retry keys one at a time.
+
+        botocore resolves ``max_attempts`` and ``retry_mode`` independently
+        from the env and config file, but a retries block sent to ``client()``
+        outranks both for every key it carries, and merging replaces the block
+        wholesale rather than key by key. So each key is filled in here only
+        when nothing else supplies it: sending ``{'mode': ...}`` alone still
+        lets AWS_MAX_ATTEMPTS through, and vice versa.
+        """
+        retries: dict[str, Any] = {}
+        if not _has_ambient_setting(session, 'max_attempts'):
+            retries['max_attempts'] = DEFAULT_MAX_RETRIES
+        if not _has_ambient_setting(session, 'retry_mode'):
+            retries['mode'] = 'standard'
+        # Re-apply the session's own block by hand, since the merge below would
+        # otherwise drop whichever keys it does not carry.
+        ambient_retries = getattr(ambient, 'retries', None)
+        if ambient_retries:
+            retries.update(ambient_retries)
+        if self._max_retries is not None:
+            retries['max_attempts'] = self._max_retries
+        return retries
+
+    def _build_client(self) -> Any:  # noqa: ANN401
+        import boto3.session
+
+        session = self._session or boto3.session.Session()
+        region = self._resolve_region(session)
+        return session.client('bedrock-runtime', region_name=region, config=self._client_config(session))

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
@@ -87,10 +87,9 @@ class BedrockTransport:
         """Returns the shared bedrock-runtime client, building it on first use.
 
         Raises:
-            GenkitError: FAILED_PRECONDITION when no region resolves. Matching
-                the Go plugin, there is deliberately no default region: a
-                silent ``us-east-1`` fallback sends traffic (and data) to a
-                region the user never chose.
+            GenkitError: FAILED_PRECONDITION when no region resolves. There is
+                deliberately no default region: a silent ``us-east-1`` fallback
+                sends traffic (and data) to a region the user never chose.
         """
         with self._lock:
             if self._client is None:

--- a/py/packages/genkit-amazon-bedrock/tests/converters_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/converters_test.py
@@ -752,11 +752,6 @@ def test_reasoning_text_block_becomes_reasoning_part_with_both_keys() -> None:
     assert root.metadata[REASONING_SIGNATURE_METADATA_KEY] == 'sig'
 
 
-def test_reasoning_text_bare_string_shape_is_handled() -> None:
-    parts = content_blocks_to_parts([{'reasoningContent': {'reasoningText': 'raw thought'}}])
-    assert parts[0].root.reasoning == 'raw thought'
-
-
 def test_redacted_content_block_becomes_reasoning_part() -> None:
     parts = content_blocks_to_parts([{'reasoningContent': {'redactedContent': b'blob'}}])
     root = parts[0].root

--- a/py/packages/genkit-amazon-bedrock/tests/converters_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/converters_test.py
@@ -31,7 +31,6 @@ from genkit_amazon_bedrock.converters import (
     build_inference_config,
     cache_point_part,
     content_blocks_to_parts,
-    default_max_tokens_for_model,
     map_finish_reason,
     normalize_config,
     to_bedrock_role,
@@ -181,37 +180,20 @@ def test_top_k_and_version_are_accepted_but_ignored() -> None:
     assert 'additionalModelRequestFields' not in kwargs
 
 
-# --- Claude maxTokens injection --------------------------------------------
+# --- maxTokens --------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    'model_id,expected',
-    [
-        ('anthropic.claude-3-haiku-20240307-v1:0', 4096),
-        ('anthropic.claude-3-5-sonnet-20241022-v2:0', 8192),
-        ('anthropic.claude-3-7-sonnet-20250219-v1:0', 8192),
-        ('us.anthropic.claude-sonnet-4-5-20250929-v1:0', 8192),
-        ('anthropic.claude-opus-4-6-v1', 8192),
-        ('amazon.nova-lite-v1:0', None),
-    ],
-)
-def test_default_max_tokens_for_model(model_id, expected) -> None:
-    assert default_max_tokens_for_model(model_id) == expected
-
-
-def test_claude_gets_default_max_tokens_injected() -> None:
-    kwargs = build_converse_request('anthropic.claude-3-haiku-20240307-v1:0', user_text_request())
-    assert kwargs['inferenceConfig'] == {'maxTokens': 4096}
-
-
-def test_claude_keeps_user_configured_max_tokens() -> None:
+def test_configured_max_tokens_is_sent() -> None:
     request = user_text_request(config=BedrockConfig(max_tokens=32))
     kwargs = build_converse_request('anthropic.claude-3-haiku-20240307-v1:0', request)
     assert kwargs['inferenceConfig'] == {'maxTokens': 32}
 
 
-def test_non_claude_without_config_has_no_inference_config() -> None:
-    kwargs = build_converse_request('amazon.nova-lite-v1:0', user_text_request())
+@pytest.mark.parametrize('model_id', ['us.anthropic.claude-sonnet-4-5-20250929-v1:0', 'amazon.nova-lite-v1:0'])
+def test_no_max_tokens_is_injected_for_any_model(model_id) -> None:
+    # Verified live: Converse accepts Claude requests without maxTokens and
+    # applies a service default, so nothing is guessed on the caller's behalf.
+    kwargs = build_converse_request(model_id, user_text_request())
     assert 'inferenceConfig' not in kwargs
 
 

--- a/py/packages/genkit-amazon-bedrock/tests/converters_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/converters_test.py
@@ -1,0 +1,863 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Converse request/response converters.
+
+The expectations mirror the Go plugin's ``generate_test.go`` matrix — they
+encode Bedrock wire-format truths, not incidental structure.
+"""
+
+import base64
+
+import pytest
+from genkit_amazon_bedrock.config import BedrockConfig
+from genkit_amazon_bedrock.converters import (
+    REASONING_SIGNATURE_METADATA_KEY,
+    REDACTED_CONTENT_METADATA_KEY,
+    build_converse_request,
+    build_inference_config,
+    cache_point_part,
+    content_blocks_to_parts,
+    default_max_tokens_for_model,
+    map_finish_reason,
+    normalize_config,
+    to_bedrock_role,
+    to_bedrock_tool,
+    to_model_response,
+    usage_from_response,
+)
+
+from genkit import (
+    FinishReason,
+    Message,
+    ModelConfig,
+    ModelRequest,
+    Part,
+    ReasoningPart,
+    Role,
+    TextPart,
+    ToolDefinition,
+)
+from genkit.plugin_api import GenkitError
+
+PNG_BYTES = b'\x89PNG\r\n\x1a\nfakeimagedata'
+PNG_B64 = base64.b64encode(PNG_BYTES).decode()
+
+
+def user_text_request(text: str = 'hello', **kwargs) -> ModelRequest:
+    return ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=text))])],
+        **kwargs,
+    )
+
+
+# --- Stop reasons ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'stop_reason,expected',
+    [
+        ('end_turn', FinishReason.STOP),
+        ('stop_sequence', FinishReason.STOP),
+        ('tool_use', FinishReason.STOP),
+        ('max_tokens', FinishReason.LENGTH),
+        ('model_context_window_exceeded', FinishReason.LENGTH),
+        ('content_filtered', FinishReason.BLOCKED),
+        ('guardrail_intervened', FinishReason.BLOCKED),
+        ('malformed_model_output', FinishReason.OTHER),
+        ('malformed_tool_use', FinishReason.OTHER),
+        ('some_future_reason', FinishReason.OTHER),
+        ('', FinishReason.OTHER),
+        (None, FinishReason.OTHER),
+    ],
+)
+def test_map_finish_reason(stop_reason, expected) -> None:
+    assert map_finish_reason(stop_reason) == expected
+
+
+# --- Roles ----------------------------------------------------------------
+
+
+def test_roles_map_to_converse_vocabulary() -> None:
+    assert to_bedrock_role(Role.USER) == 'user'
+    assert to_bedrock_role(Role.TOOL) == 'user'
+    assert to_bedrock_role(Role.MODEL) == 'assistant'
+
+
+def test_unsupported_role_raises() -> None:
+    with pytest.raises(GenkitError):
+        to_bedrock_role('reviewer')
+
+
+def test_unsupported_role_errors_even_for_empty_message() -> None:
+    # The role is validated before parts are converted, like Go.
+    request = ModelRequest(messages=[Message(role='reviewer', content=[])])
+    with pytest.raises(GenkitError, match='unsupported role'):
+        build_converse_request('amazon.nova-lite-v1:0', request)
+
+
+# --- Config normalization -------------------------------------------------
+
+
+def test_normalize_config_none_and_passthrough() -> None:
+    assert normalize_config(None) is None
+    config = BedrockConfig(tool_choice='auto')
+    assert normalize_config(config) is config
+
+
+def test_normalize_config_from_model_config() -> None:
+    config = normalize_config(ModelConfig(temperature=0.5, max_output_tokens=100, top_p=0.9))
+    assert config is not None
+    assert config.temperature == 0.5
+    assert config.max_output_tokens == 100
+    assert config.top_p == 0.9
+
+
+@pytest.mark.parametrize(
+    'raw,field,expected',
+    [
+        ({'maxOutputTokens': 50}, 'max_output_tokens', 50),
+        ({'max_tokens': 60}, 'max_tokens', 60),
+        ({'maxTokens': 70}, 'max_tokens', 70),
+    ],
+)
+def test_normalize_config_from_dict_with_legacy_keys(raw, field, expected) -> None:
+    config = normalize_config(raw)
+    assert config is not None
+    assert getattr(config, field) == expected
+
+
+def test_normalize_config_rejects_unsupported_type() -> None:
+    with pytest.raises(GenkitError):
+        normalize_config(42)
+
+
+def test_build_inference_config_empty_is_none() -> None:
+    assert build_inference_config(None) is None
+    assert build_inference_config(BedrockConfig()) is None
+    assert build_inference_config(BedrockConfig(tool_choice='auto')) is None
+
+
+def test_build_inference_config_fields() -> None:
+    config = BedrockConfig(max_tokens=256, temperature=0.7, top_p=0.9, stop_sequences=['END'])
+    assert build_inference_config(config) == {
+        'maxTokens': 256,
+        'temperature': 0.7,
+        'topP': 0.9,
+        'stopSequences': ['END'],
+    }
+
+
+def test_bedrock_max_tokens_wins_over_common_field() -> None:
+    inference_config = build_inference_config(BedrockConfig(max_tokens=100, max_output_tokens=999))
+    assert inference_config is not None
+    assert inference_config['maxTokens'] == 100
+
+
+def test_explicit_zero_temperature_is_sent() -> None:
+    # None means unset; an explicit 0.0 is a real setting and must be sent.
+    inference_config = build_inference_config(BedrockConfig(temperature=0.0))
+    assert inference_config == {'temperature': 0.0}
+
+
+def test_top_k_and_version_are_accepted_but_ignored() -> None:
+    # Converse has no first-class topK or version; Go drops them silently.
+    request = user_text_request(config=BedrockConfig(top_k=40, version='v9'))
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert 'inferenceConfig' not in kwargs
+    assert 'additionalModelRequestFields' not in kwargs
+
+
+# --- Claude maxTokens injection --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'model_id,expected',
+    [
+        ('anthropic.claude-3-haiku-20240307-v1:0', 4096),
+        ('anthropic.claude-3-5-sonnet-20241022-v2:0', 8192),
+        ('anthropic.claude-3-7-sonnet-20250219-v1:0', 8192),
+        ('us.anthropic.claude-sonnet-4-5-20250929-v1:0', 8192),
+        ('anthropic.claude-opus-4-6-v1', 8192),
+        ('amazon.nova-lite-v1:0', None),
+    ],
+)
+def test_default_max_tokens_for_model(model_id, expected) -> None:
+    assert default_max_tokens_for_model(model_id) == expected
+
+
+def test_claude_gets_default_max_tokens_injected() -> None:
+    kwargs = build_converse_request('anthropic.claude-3-haiku-20240307-v1:0', user_text_request())
+    assert kwargs['inferenceConfig'] == {'maxTokens': 4096}
+
+
+def test_claude_keeps_user_configured_max_tokens() -> None:
+    request = user_text_request(config=BedrockConfig(max_tokens=32))
+    kwargs = build_converse_request('anthropic.claude-3-haiku-20240307-v1:0', request)
+    assert kwargs['inferenceConfig'] == {'maxTokens': 32}
+
+
+def test_non_claude_without_config_has_no_inference_config() -> None:
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', user_text_request())
+    assert 'inferenceConfig' not in kwargs
+
+
+# --- Request assembly -------------------------------------------------------
+
+
+def test_model_id_sent_verbatim_with_inference_profile_prefix() -> None:
+    kwargs = build_converse_request('us.amazon.nova-lite-v1:0', user_text_request())
+    assert kwargs['modelId'] == 'us.amazon.nova-lite-v1:0'
+
+
+def test_simple_text_round_trip_shape() -> None:
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', user_text_request('hi'))
+    assert kwargs['messages'] == [{'role': 'user', 'content': [{'text': 'hi'}]}]
+    assert 'system' not in kwargs
+    assert 'toolConfig' not in kwargs
+
+
+def test_system_message_becomes_top_level_system() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(root=TextPart(text='be terse'))]),
+            Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['system'] == [{'text': 'be terse'}]
+    assert kwargs['messages'] == [{'role': 'user', 'content': [{'text': 'hi'}]}]
+
+
+def test_empty_system_text_is_dropped() -> None:
+    # Bedrock rejects empty system text, so a blank rendered prompt is dropped
+    # rather than sent; regular message text has no such floor.
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(root=TextPart(text=''))]),
+            Message(role=Role.USER, content=[Part(root=TextPart(text=''))]),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert 'system' not in kwargs
+    assert kwargs['messages'] == [{'role': 'user', 'content': [{'text': ''}]}]
+
+
+def test_cache_point_in_system_and_messages() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(root=TextPart(text='rules')), cache_point_part()]),
+            Message(role=Role.USER, content=[Part(root=TextPart(text='hi')), cache_point_part()]),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['system'] == [{'text': 'rules'}, {'cachePoint': {'type': 'default'}}]
+    assert kwargs['messages'][0]['content'] == [{'text': 'hi'}, {'cachePoint': {'type': 'default'}}]
+
+
+def test_multi_turn_roles() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='q'))]),
+            Message(role=Role.MODEL, content=[Part(root=TextPart(text='a'))]),
+            Message(role=Role.USER, content=[Part(root=TextPart(text='q2'))]),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert [m['role'] for m in kwargs['messages']] == ['user', 'assistant', 'user']
+
+
+def test_empty_messages_are_dropped() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
+            Message(role=Role.MODEL, content=[]),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert len(kwargs['messages']) == 1
+
+
+def test_tool_role_message_becomes_user_tool_result() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.TOOL,
+                content=[
+                    Part.model_validate({'toolResponse': {'ref': 'call-1', 'name': 'weather', 'output': {'temp': 21}}})
+                ],
+            ),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    message = kwargs['messages'][0]
+    assert message['role'] == 'user'
+    tool_result = message['content'][0]['toolResult']
+    assert tool_result['toolUseId'] == 'call-1'
+    assert tool_result['status'] == 'success'
+    # Non-string outputs ride as a JSON string in a text content block.
+    assert tool_result['content'] == [{'text': '{"temp": 21}'}]
+
+
+def test_string_tool_output_is_verbatim() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.TOOL,
+                content=[
+                    Part.model_validate({'toolResponse': {'ref': 'call-2', 'name': 'weather', 'output': 'sunny'}})
+                ],
+            ),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    tool_result = kwargs['messages'][0]['content'][0]['toolResult']
+    assert tool_result['content'] == [{'text': 'sunny'}]
+    assert tool_result['toolUseId'] == 'call-2'
+
+
+@pytest.mark.parametrize(
+    'part',
+    [
+        {'toolRequest': {'name': 'weather', 'input': {}}},
+        {'toolResponse': {'name': 'weather', 'output': 'sunny'}},
+    ],
+    ids=['tool_request', 'tool_response'],
+)
+def test_tool_part_without_ref_errors(part: dict[str, object]) -> None:
+    # Bedrock's toolUseId has a one-character floor, so '' cannot be sent.
+    request = ModelRequest(messages=[Message(role=Role.TOOL, content=[Part.model_validate(part)])])
+    with pytest.raises(GenkitError, match='requires a ref to send as toolUseId') as excinfo:
+        build_converse_request('amazon.nova-lite-v1:0', request)
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+def test_tool_request_part_becomes_tool_use_block() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.MODEL,
+                content=[
+                    Part.model_validate({
+                        'toolRequest': {'ref': 'call-9', 'name': 'weather', 'input': {'city': 'Lagos'}}
+                    })
+                ],
+            ),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['messages'][0]['content'][0]['toolUse'] == {
+        'toolUseId': 'call-9',
+        'name': 'weather',
+        'input': {'city': 'Lagos'},
+    }
+
+
+# --- Media ------------------------------------------------------------------
+
+
+def test_image_data_url_decodes_to_raw_bytes() -> None:
+    part = Part.model_validate({'media': {'url': f'data:image/png;base64,{PNG_B64}'}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    image = kwargs['messages'][0]['content'][0]['image']
+    assert image['format'] == 'png'
+    assert image['source']['bytes'] == PNG_BYTES
+
+
+def test_explicit_content_type_beats_data_url_header() -> None:
+    part = Part.model_validate({'media': {'url': f'data:image/png;base64,{PNG_B64}', 'contentType': 'image/jpeg'}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['messages'][0]['content'][0]['image']['format'] == 'jpeg'
+
+
+def test_jpg_alias_normalizes_to_jpeg() -> None:
+    part = Part.model_validate({'media': {'url': PNG_B64, 'contentType': 'image/jpg'}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['messages'][0]['content'][0]['image']['format'] == 'jpeg'
+
+
+def test_document_mime_maps_to_document_block() -> None:
+    part = Part.model_validate({'media': {'url': PNG_B64, 'contentType': 'application/pdf'}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    document = kwargs['messages'][0]['content'][0]['document']
+    assert document['format'] == 'pdf'
+    assert document['name'] == 'document'
+    assert document['source']['bytes'] == PNG_BYTES
+
+
+def test_html_is_document_not_image() -> None:
+    part = Part.model_validate({'media': {'url': PNG_B64, 'contentType': 'text/html'}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert 'document' in kwargs['messages'][0]['content'][0]
+
+
+@pytest.mark.parametrize(
+    'mime,block_kind,expected_format',
+    [
+        ('image/gif', 'image', 'gif'),
+        ('image/webp', 'image', 'webp'),
+        ('text/csv', 'document', 'csv'),
+        ('text/markdown', 'document', 'md'),
+        ('text/plain', 'document', 'txt'),
+        ('application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'document', 'docx'),
+        ('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'document', 'xlsx'),
+    ],
+)
+def test_media_mime_format_matrix(mime, block_kind, expected_format) -> None:
+    part = Part.model_validate({'media': {'url': PNG_B64, 'contentType': mime}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    block = kwargs['messages'][0]['content'][0]
+    assert block[block_kind]['format'] == expected_format
+
+
+@pytest.mark.parametrize(
+    'url,match',
+    [
+        ('https://example.com/cat.png', 'remote URLs are not supported'),
+        ('data:image/png,rawdata', 'must be base64-encoded'),
+        ('   ', 'empty data'),
+        ('!!!not-base64!!!', 'decode base64 media'),
+    ],
+)
+def test_media_payload_validation_errors(url, match) -> None:
+    part = Part.model_validate({'media': {'url': url, 'contentType': 'image/png'}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    with pytest.raises(GenkitError, match=match):
+        build_converse_request('amazon.nova-lite-v1:0', request)
+
+
+def test_unsupported_mime_type_errors() -> None:
+    part = Part.model_validate({'media': {'url': PNG_B64, 'contentType': 'video/mp4'}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    with pytest.raises(GenkitError, match='unsupported media MIME type'):
+        build_converse_request('amazon.nova-lite-v1:0', request)
+
+
+def test_media_without_content_type_errors() -> None:
+    part = Part.model_validate({'media': {'url': PNG_B64}})
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[part])])
+    with pytest.raises(GenkitError, match='no content type'):
+        build_converse_request('amazon.nova-lite-v1:0', request)
+
+
+# --- Tools and tool choice ---------------------------------------------------
+
+
+WEATHER_TOOL = ToolDefinition(
+    name='weather',
+    description='Get the weather',
+    input_schema={'type': 'object', 'properties': {'city': {'type': 'string'}}},
+)
+
+
+def test_tools_become_tool_specs() -> None:
+    request = user_text_request(tools=[WEATHER_TOOL])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    tool_spec = kwargs['toolConfig']['tools'][0]['toolSpec']
+    assert tool_spec['name'] == 'weather'
+    assert tool_spec['description'] == 'Get the weather'
+    assert tool_spec['inputSchema']['json']['properties'] == {'city': {'type': 'string'}}
+    # No toolChoice unless requested; Bedrock defaults to auto.
+    assert 'toolChoice' not in kwargs['toolConfig']
+
+
+def test_tool_schema_defaults_injected() -> None:
+    tool = ToolDefinition(name='noop', description='')
+    schema = to_bedrock_tool(tool)['toolSpec']['inputSchema']['json']
+    assert schema['type'] == 'object'
+    assert schema['properties'] == {}
+    assert schema['$schema'] == 'http://json-schema.org/draft-07/schema#'
+
+
+def test_empty_tool_description_is_omitted() -> None:
+    # Bedrock rejects an empty description, and a tool declared without a
+    # docstring reaches the plugin with description ''.
+    tool_spec = to_bedrock_tool(ToolDefinition(name='noop', description=''))['toolSpec']
+    assert 'description' not in tool_spec
+    assert tool_spec['name'] == 'noop'
+
+
+def test_tool_without_name_errors() -> None:
+    with pytest.raises(GenkitError, match='tool name required'):
+        to_bedrock_tool(ToolDefinition(name='', description=''))
+
+
+@pytest.mark.parametrize(
+    'tool_choice,expected',
+    [
+        ('auto', {'auto': {}}),
+        ('required', {'any': {}}),
+        ('any', {'any': {}}),
+        ('weather', {'tool': {'name': 'weather'}}),
+    ],
+)
+def test_tool_choice_mapping(tool_choice, expected) -> None:
+    request = user_text_request(tools=[WEATHER_TOOL], config=BedrockConfig(tool_choice=tool_choice))
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['toolConfig']['toolChoice'] == expected
+
+
+def test_tool_choice_none_omits_tool_config_entirely() -> None:
+    request = user_text_request(tools=[WEATHER_TOOL], config=BedrockConfig(tool_choice='none'))
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert 'toolConfig' not in kwargs
+
+
+def test_request_tool_choice_used_when_config_silent() -> None:
+    request = user_text_request(tools=[WEATHER_TOOL], tool_choice='required')
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['toolConfig']['toolChoice'] == {'any': {}}
+
+
+def test_unknown_named_tool_choice_errors() -> None:
+    request = user_text_request(tools=[WEATHER_TOOL], config=BedrockConfig(tool_choice='no-such-tool'))
+    with pytest.raises(GenkitError, match='does not match any declared tool'):
+        build_converse_request('amazon.nova-lite-v1:0', request)
+
+
+def test_tool_choice_without_tools_is_ignored() -> None:
+    request = user_text_request(config=BedrockConfig(tool_choice='weather'))
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert 'toolConfig' not in kwargs
+
+
+def test_trailing_assistant_message_dropped_when_tools_present() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='q'))]),
+            Message(role=Role.MODEL, content=[Part(root=TextPart(text='thinking...'))]),
+        ],
+        tools=[WEATHER_TOOL],
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert [m['role'] for m in kwargs['messages']] == ['user']
+
+
+def test_trailing_assistant_message_kept_without_tools() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='q'))]),
+            Message(role=Role.MODEL, content=[Part(root=TextPart(text='a'))]),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert [m['role'] for m in kwargs['messages']] == ['user', 'assistant']
+
+
+def test_trailing_assistant_dropped_even_under_tool_choice_none() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='q'))]),
+            Message(role=Role.MODEL, content=[Part(root=TextPart(text='a'))]),
+        ],
+        tools=[WEATHER_TOOL],
+        config=BedrockConfig(tool_choice='none'),
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert [m['role'] for m in kwargs['messages']] == ['user']
+
+
+def test_additional_model_request_fields_forwarded_verbatim() -> None:
+    thinking = {'thinking': {'type': 'enabled', 'budget_tokens': 2048}}
+    request = user_text_request(config=BedrockConfig(additional_model_request_fields=thinking))
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['additionalModelRequestFields'] == thinking
+
+
+# --- Reasoning round-trip (request side) -------------------------------------
+
+
+def test_bedrock_reasoning_part_round_trips() -> None:
+    # The signature is a string on the Converse wire; it must replay verbatim.
+    part = Part(
+        root=ReasoningPart(
+            reasoning='step by step',
+            metadata={REASONING_SIGNATURE_METADATA_KEY: 'sig-abc123=='},
+        )
+    )
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.MODEL, content=[part]),
+            Message(role=Role.USER, content=[Part(root=TextPart(text='go on'))]),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['messages'][0]['content'] == [
+        {'reasoningContent': {'reasoningText': {'text': 'step by step', 'signature': 'sig-abc123=='}}}
+    ]
+
+
+def test_bytes_signature_form_is_tolerated() -> None:
+    part = Part(
+        root=ReasoningPart(
+            reasoning='step by step',
+            metadata={REASONING_SIGNATURE_METADATA_KEY: b'sig-abc123=='},
+        )
+    )
+    request = ModelRequest(messages=[Message(role=Role.MODEL, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    block = kwargs['messages'][0]['content'][0]['reasoningContent']['reasoningText']
+    assert block['signature'] == 'sig-abc123=='
+
+
+def test_redacted_content_emitted_before_signed_text() -> None:
+    part = Part(
+        root=ReasoningPart(
+            reasoning='visible part',
+            metadata={
+                REASONING_SIGNATURE_METADATA_KEY: 'sig',
+                REDACTED_CONTENT_METADATA_KEY: base64.b64encode(b'redacted-blob').decode(),
+            },
+        )
+    )
+    request = ModelRequest(messages=[Message(role=Role.MODEL, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    blocks = kwargs['messages'][0]['content']
+    assert blocks[0] == {'reasoningContent': {'redactedContent': b'redacted-blob'}}
+    assert blocks[1]['reasoningContent']['reasoningText']['text'] == 'visible part'
+
+
+def test_redacted_only_reasoning_part_still_replays() -> None:
+    # Redacted-only parts have reasoning == '' and must not be dropped.
+    part = Part(
+        root=ReasoningPart(
+            reasoning='',
+            metadata={REDACTED_CONTENT_METADATA_KEY: base64.b64encode(b'blob').decode()},
+        )
+    )
+    request = ModelRequest(messages=[Message(role=Role.MODEL, content=[part])])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    assert kwargs['messages'][0]['content'] == [{'reasoningContent': {'redactedContent': b'blob'}}]
+
+
+def test_generic_reasoning_part_is_not_replayed() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='q'))]),
+            Message(role=Role.MODEL, content=[Part(root=ReasoningPart(reasoning='foreign thoughts'))]),
+        ]
+    )
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    # The reasoning-only assistant message converts to zero blocks and drops.
+    assert [m['role'] for m in kwargs['messages']] == ['user']
+
+
+# --- Response conversion ------------------------------------------------------
+
+
+def converse_response(**overrides) -> dict:
+    response = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 10, 'outputTokens': 5, 'totalTokens': 15},
+    }
+    response.update(overrides)
+    return response
+
+
+def test_text_response_round_trip() -> None:
+    request = user_text_request()
+    response = to_model_response(converse_response(), request)
+    assert response.message is not None
+    assert response.message.role == Role.MODEL
+    assert response.message.content[0].root.text == 'hello'
+    assert response.finish_reason == FinishReason.STOP
+    assert response.usage is not None
+    assert response.usage.input_tokens == 10
+    assert response.usage.output_tokens == 5
+    assert response.usage.total_tokens == 15
+    assert response.request is request
+
+
+def test_tool_use_block_becomes_tool_request_part() -> None:
+    blocks = [{'toolUse': {'toolUseId': 'call-1', 'name': 'weather', 'input': {'city': 'Lagos'}}}]
+    parts = content_blocks_to_parts(blocks)
+    tool_request = parts[0].root.tool_request
+    assert tool_request is not None
+    assert tool_request.ref == 'call-1'
+    assert tool_request.name == 'weather'
+    assert tool_request.input == {'city': 'Lagos'}
+
+
+def test_tool_use_with_missing_input_gets_empty_object() -> None:
+    parts = content_blocks_to_parts([{'toolUse': {'toolUseId': 'x', 'name': 'noop'}}])
+    tool_request = parts[0].root.tool_request
+    assert tool_request is not None
+    assert tool_request.input == {}
+
+
+def test_tool_input_coerced_toward_schema() -> None:
+    tool = ToolDefinition(
+        name='calc',
+        description='',
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'count': {'type': 'integer'},
+                'ratio': {'type': 'number'},
+                'enabled': {'type': 'boolean'},
+                'note': {'type': 'string'},
+            },
+        },
+    )
+    blocks = [
+        {
+            'toolUse': {
+                'toolUseId': 'c1',
+                'name': 'calc',
+                'input': {'count': '7', 'ratio': '0.5', 'enabled': 'true', 'note': 'hi', 'extra': '1'},
+            }
+        }
+    ]
+    parts = content_blocks_to_parts(blocks, [tool])
+    tool_request = parts[0].root.tool_request
+    assert tool_request is not None
+    assert tool_request.input == {'count': 7, 'ratio': 0.5, 'enabled': True, 'note': 'hi', 'extra': '1'}
+
+
+@pytest.mark.parametrize('value,expected', [(7, '7'), (7.5, '7.5'), (True, True)], ids=['int', 'float', 'bool'])
+def test_number_coerced_to_string_schema(value: object, expected: object) -> None:
+    # Go coerces a wire number to its string form; without it, tool dispatch
+    # fails pydantic validation. Booleans are left alone, as in Go.
+    tool = ToolDefinition(
+        name='calc',
+        description='',
+        input_schema={'type': 'object', 'properties': {'note': {'type': 'string'}}},
+    )
+    blocks = [{'toolUse': {'toolUseId': 'c1', 'name': 'calc', 'input': {'note': value}}}]
+    parts = content_blocks_to_parts(blocks, [tool])
+    tool_request = parts[0].root.tool_request
+    assert tool_request is not None
+    assert tool_request.input == {'note': expected}
+
+
+def test_tool_input_float_truncates_for_integer_schema() -> None:
+    tool = ToolDefinition(
+        name='calc', description='', input_schema={'type': 'object', 'properties': {'n': {'type': 'integer'}}}
+    )
+    parts = content_blocks_to_parts([{'toolUse': {'toolUseId': 'c', 'name': 'calc', 'input': {'n': 7.9}}}], [tool])
+    tool_request = parts[0].root.tool_request
+    assert tool_request is not None
+    assert tool_request.input == {'n': 7}
+
+
+def test_reasoning_text_block_becomes_reasoning_part_with_both_keys() -> None:
+    blocks = [{'reasoningContent': {'reasoningText': {'text': 'because', 'signature': 'sig'}}}]
+    parts = content_blocks_to_parts(blocks)
+    root = parts[0].root
+    assert root.reasoning == 'because'
+    assert root.metadata is not None
+    assert root.metadata['signature'] == 'sig'
+    assert root.metadata[REASONING_SIGNATURE_METADATA_KEY] == 'sig'
+
+
+def test_reasoning_text_bare_string_shape_is_handled() -> None:
+    parts = content_blocks_to_parts([{'reasoningContent': {'reasoningText': 'raw thought'}}])
+    assert parts[0].root.reasoning == 'raw thought'
+
+
+def test_redacted_content_block_becomes_reasoning_part() -> None:
+    parts = content_blocks_to_parts([{'reasoningContent': {'redactedContent': b'blob'}}])
+    root = parts[0].root
+    assert root.reasoning == ''
+    assert root.metadata is not None
+    # Stored as a base64 string so the part survives JSON serialization.
+    assert root.metadata[REDACTED_CONTENT_METADATA_KEY] == base64.b64encode(b'blob').decode()
+
+
+def test_reasoning_survives_response_to_request_round_trip() -> None:
+    # The full circle: wire response blocks -> Genkit parts -> wire request
+    # blocks, byte-identical, including non-UTF8 redacted content.
+    redacted_blob = b'\x89\xff\x00binary'
+    response_blocks = [
+        {'reasoningContent': {'reasoningText': {'text': 'because', 'signature': 'sig-abc123=='}}},
+        {'reasoningContent': {'redactedContent': redacted_blob}},
+    ]
+    parts = content_blocks_to_parts(response_blocks)
+    request = ModelRequest(messages=[Message(role=Role.MODEL, content=parts)])
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    replayed = kwargs['messages'][0]['content']
+    assert replayed[0] == {'reasoningContent': {'reasoningText': {'text': 'because', 'signature': 'sig-abc123=='}}}
+    assert replayed[1] == {'reasoningContent': {'redactedContent': redacted_blob}}
+
+
+def test_reasoning_parts_serialize_to_json() -> None:
+    # Tracing serializes action output with model_dump_json; raw bytes in
+    # metadata would crash it for non-UTF8 redacted blobs.
+    parts = content_blocks_to_parts([
+        {'reasoningContent': {'reasoningText': {'text': 'because', 'signature': 'sig'}}},
+        {'reasoningContent': {'redactedContent': b'\x89\xff\x00binary'}},
+    ])
+    message = Message(role=Role.MODEL, content=parts)
+    assert message.model_dump_json()
+
+
+def test_empty_reasoning_block_is_skipped() -> None:
+    assert content_blocks_to_parts([{'reasoningContent': {'reasoningText': {}}}]) == []
+
+
+def test_unknown_reasoning_variant_errors() -> None:
+    with pytest.raises(GenkitError, match='unhandled reasoning content variant'):
+        content_blocks_to_parts([{'reasoningContent': {'futureThing': 1}}])
+
+
+def test_unknown_response_block_errors() -> None:
+    with pytest.raises(GenkitError, match='unhandled response content variant'):
+        content_blocks_to_parts([{'video': {'format': 'mp4'}}])
+
+
+def test_empty_response_content_yields_placeholder_text_part() -> None:
+    response = converse_response(
+        output={'message': {'role': 'assistant', 'content': []}},
+        stopReason='guardrail_intervened',
+    )
+    model_response = to_model_response(response, user_text_request())
+    assert model_response.message is not None
+    assert model_response.message.content[0].root.text == ''
+    assert model_response.finish_reason == FinishReason.BLOCKED
+
+
+def test_missing_output_tolerated() -> None:
+    response = converse_response(output={})
+    model_response = to_model_response(response, user_text_request())
+    assert model_response.message is not None
+    assert model_response.message.content[0].root.text == ''
+
+
+def test_usage_maps_cache_read_tokens_only() -> None:
+    usage = usage_from_response({
+        'inputTokens': 4,
+        'outputTokens': 6,
+        'totalTokens': 110,
+        'cacheReadInputTokens': 100,
+        'cacheWriteInputTokens': 50,
+    })
+    assert usage is not None
+    assert usage.input_tokens == 4
+    assert usage.output_tokens == 6
+    # Totals are trusted verbatim from AWS, never recomputed.
+    assert usage.total_tokens == 110
+    assert usage.cached_content_tokens == 100
+
+
+def test_usage_none_when_absent() -> None:
+    assert usage_from_response(None) is None

--- a/py/packages/genkit-amazon-bedrock/tests/converters_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/converters_test.py
@@ -545,7 +545,8 @@ def test_trailing_assistant_message_kept_without_tools() -> None:
     assert [m['role'] for m in kwargs['messages']] == ['user', 'assistant']
 
 
-def test_trailing_assistant_dropped_even_under_tool_choice_none() -> None:
+def test_trailing_assistant_kept_under_tool_choice_none() -> None:
+    # No toolConfig is sent under "none", so the prefill has nothing to violate.
     request = ModelRequest(
         messages=[
             Message(role=Role.USER, content=[Part(root=TextPart(text='q'))]),
@@ -555,7 +556,8 @@ def test_trailing_assistant_dropped_even_under_tool_choice_none() -> None:
         config=BedrockConfig(tool_choice='none'),
     )
     kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
-    assert [m['role'] for m in kwargs['messages']] == ['user']
+    assert [m['role'] for m in kwargs['messages']] == ['user', 'assistant']
+    assert 'toolConfig' not in kwargs
 
 
 def test_additional_model_request_fields_forwarded_verbatim() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/converters_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/converters_test.py
@@ -125,17 +125,16 @@ def test_normalize_config_from_model_config() -> None:
 
 
 @pytest.mark.parametrize(
-    'raw,field,expected',
+    'raw,expected',
     [
-        ({'maxOutputTokens': 50}, 'max_output_tokens', 50),
-        ({'max_tokens': 60}, 'max_tokens', 60),
-        ({'maxTokens': 70}, 'max_tokens', 70),
+        ({'maxOutputTokens': 50}, 50),
+        ({'max_output_tokens': 60}, 60),
     ],
 )
-def test_normalize_config_from_dict_with_legacy_keys(raw, field, expected) -> None:
+def test_normalize_config_from_dict_accepts_both_spellings(raw, expected) -> None:
     config = normalize_config(raw)
     assert config is not None
-    assert getattr(config, field) == expected
+    assert config.max_output_tokens == expected
 
 
 def test_normalize_config_rejects_unsupported_type() -> None:
@@ -150,7 +149,7 @@ def test_build_inference_config_empty_is_none() -> None:
 
 
 def test_build_inference_config_fields() -> None:
-    config = BedrockConfig(max_tokens=256, temperature=0.7, top_p=0.9, stop_sequences=['END'])
+    config = BedrockConfig(max_output_tokens=256, temperature=0.7, top_p=0.9, stop_sequences=['END'])
     assert build_inference_config(config) == {
         'maxTokens': 256,
         'temperature': 0.7,
@@ -159,10 +158,9 @@ def test_build_inference_config_fields() -> None:
     }
 
 
-def test_bedrock_max_tokens_wins_over_common_field() -> None:
-    inference_config = build_inference_config(BedrockConfig(max_tokens=100, max_output_tokens=999))
-    assert inference_config is not None
-    assert inference_config['maxTokens'] == 100
+def test_non_positive_max_output_tokens_is_dropped() -> None:
+    # Bedrock rejects maxTokens below 1; treat it as unset rather than fail.
+    assert build_inference_config(BedrockConfig(max_output_tokens=0)) is None
 
 
 def test_explicit_zero_temperature_is_sent() -> None:
@@ -183,15 +181,13 @@ def test_top_k_and_version_are_accepted_but_ignored() -> None:
 
 
 def test_configured_max_tokens_is_sent() -> None:
-    request = user_text_request(config=BedrockConfig(max_tokens=32))
+    request = user_text_request(config=BedrockConfig(max_output_tokens=32))
     kwargs = build_converse_request('anthropic.claude-3-haiku-20240307-v1:0', request)
     assert kwargs['inferenceConfig'] == {'maxTokens': 32}
 
 
 @pytest.mark.parametrize('model_id', ['us.anthropic.claude-sonnet-4-5-20250929-v1:0', 'amazon.nova-lite-v1:0'])
 def test_no_max_tokens_is_injected_for_any_model(model_id) -> None:
-    # Verified live: Converse accepts Claude requests without maxTokens and
-    # applies a service default, so nothing is guessed on the caller's behalf.
     kwargs = build_converse_request(model_id, user_text_request())
     assert 'inferenceConfig' not in kwargs
 

--- a/py/packages/genkit-amazon-bedrock/tests/converters_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/converters_test.py
@@ -16,8 +16,7 @@
 
 """Tests for the Converse request/response converters.
 
-The expectations mirror the Go plugin's ``generate_test.go`` matrix — they
-encode Bedrock wire-format truths, not incidental structure.
+The expectations encode Bedrock wire-format truths, not incidental structure.
 """
 
 import base64
@@ -102,7 +101,7 @@ def test_unsupported_role_raises() -> None:
 
 
 def test_unsupported_role_errors_even_for_empty_message() -> None:
-    # The role is validated before parts are converted, like Go.
+    # The role is validated before parts are converted.
     request = ModelRequest(messages=[Message(role='reviewer', content=[])])
     with pytest.raises(GenkitError, match='unsupported role'):
         build_converse_request('amazon.nova-lite-v1:0', request)
@@ -173,7 +172,7 @@ def test_explicit_zero_temperature_is_sent() -> None:
 
 
 def test_top_k_and_version_are_accepted_but_ignored() -> None:
-    # Converse has no first-class topK or version; Go drops them silently.
+    # Converse has no first-class topK or version, so both are dropped.
     request = user_text_request(config=BedrockConfig(top_k=40, version='v9'))
     kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
     assert 'inferenceConfig' not in kwargs
@@ -720,8 +719,8 @@ def test_tool_input_coerced_toward_schema() -> None:
 
 @pytest.mark.parametrize('value,expected', [(7, '7'), (7.5, '7.5'), (True, True)], ids=['int', 'float', 'bool'])
 def test_number_coerced_to_string_schema(value: object, expected: object) -> None:
-    # Go coerces a wire number to its string form; without it, tool dispatch
-    # fails pydantic validation. Booleans are left alone, as in Go.
+    # A wire number against a string field fails pydantic validation unless
+    # it is coerced. Booleans are left alone.
     tool = ToolDefinition(
         name='calc',
         description='',

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -18,7 +18,8 @@
 
 Opt-in: set ``BEDROCK_LIVE_TESTS=1`` plus working AWS credentials and a
 region (``AWS_REGION`` or ``~/.aws/config``). These call real models and
-incur cost. The models used need only default model access.
+incur cost. The Anthropic models additionally need the account's one-time
+use-case agreement (Bedrock console -> Model access).
 """
 
 import os
@@ -41,6 +42,7 @@ pytestmark = [
     ),
 ]
 
+CLAUDE = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
 NOVA = 'us.amazon.nova-lite-v1:0'
 DEEPSEEK = 'us.deepseek.r1-v1:0'
 
@@ -122,6 +124,48 @@ async def test_undocumented_tool_round_trip() -> None:
         tools=[weather],
     )
     assert (await make_model(NOVA).generate(follow_up)).message is not None
+
+
+async def test_claude_sync_without_config() -> None:
+    # No config on purpose: Converse accepts Claude requests without maxTokens
+    # and applies a service default, so the plugin injects nothing.
+    response = await make_model(CLAUDE).generate(text_request("Reply with the single word 'pong'."))
+    assert response.finish_reason == FinishReason.STOP
+    assert response.message is not None
+    text = response.message.content[0].root.text
+    assert text is not None and 'pong' in text.lower()
+
+
+async def test_claude_reasoning_signature_round_trip() -> None:
+    model = make_model(CLAUDE)
+    # Bedrock requires budget_tokens >= 1024 and maxTokens above it; thinking
+    # requests reject custom temperature, so none is set.
+    config = BedrockConfig(
+        max_tokens=4096,
+        additional_model_request_fields={'thinking': {'type': 'enabled', 'budget_tokens': 1024}},
+    )
+    request = text_request('What is 17 * 23? Think it through.', config=config)
+    response = await model.generate(request)
+
+    assert response.message is not None
+    reasoning_parts = [
+        part.root for part in response.message.content if getattr(part.root, 'reasoning', None) is not None
+    ]
+    assert reasoning_parts, 'expected a reasoning part on a thinking-enabled sync call'
+    assert reasoning_parts[0].metadata is not None
+    assert reasoning_parts[0].metadata.get(REASONING_SIGNATURE_METADATA_KEY)
+
+    # Replaying the signed reasoning verbatim must be accepted by Bedrock.
+    follow_up = ModelRequest(
+        messages=[
+            *request.messages,
+            response.message,
+            Message(role=Role.USER, content=[Part(root=TextPart(text='Now add 100 to that.'))]),
+        ],
+        config=config,
+    )
+    follow_up_response = await model.generate(follow_up)
+    assert follow_up_response.finish_reason == FinishReason.STOP
 
 
 async def test_deepseek_reasoning_sync_and_round_trip() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live Bedrock tests, mirroring the Go plugin's live matrix.
+
+Opt-in: set ``BEDROCK_LIVE_TESTS=1`` plus working AWS credentials and a
+region (``AWS_REGION`` or ``~/.aws/config``). These call real models and
+incur cost. The models used need only default model access.
+"""
+
+import os
+
+import pytest
+from genkit_amazon_bedrock.config import BedrockConfig
+from genkit_amazon_bedrock.converters import (
+    REASONING_SIGNATURE_METADATA_KEY,
+)
+from genkit_amazon_bedrock.models import BedrockModel
+from genkit_amazon_bedrock.transport import BedrockTransport
+
+from genkit import FinishReason, Message, ModelRequest, Part, Role, TextPart, ToolDefinition
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not os.environ.get('BEDROCK_LIVE_TESTS'),
+        reason='BEDROCK_LIVE_TESTS not set; live Bedrock tests are opt-in',
+    ),
+]
+
+NOVA = 'us.amazon.nova-lite-v1:0'
+DEEPSEEK = 'us.deepseek.r1-v1:0'
+
+
+def make_model(model_id: str) -> BedrockModel:
+    transport = BedrockTransport(
+        region=os.environ.get('AWS_REGION'),
+        max_retries=3,
+        read_timeout=300.0,
+        connect_timeout=60.0,
+        max_pool_connections=10,
+    )
+    return BedrockModel(model_id=model_id, transport=transport)
+
+
+def text_request(text: str, **kwargs) -> ModelRequest:
+    return ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=text))])],
+        **kwargs,
+    )
+
+
+def undocumented_weather_tool() -> ToolDefinition:
+    # No description on purpose: Bedrock rejects an empty one, and a Genkit
+    # tool declared without a docstring arrives that way.
+    return ToolDefinition(
+        name='get_weather',
+        description='',
+        input_schema={
+            'type': 'object',
+            'properties': {'city': {'type': 'string'}},
+            'required': ['city'],
+        },
+    )
+
+
+async def test_nova_sync() -> None:
+    response = await make_model(NOVA).generate(text_request("Reply with the single word 'pong'."))
+    assert response.finish_reason == FinishReason.STOP
+    assert response.message is not None
+    assert response.message.content[0].root.text
+    assert response.usage is not None
+    assert response.usage.input_tokens is not None and response.usage.input_tokens > 0
+
+
+async def test_undocumented_tool_round_trip() -> None:
+    weather = undocumented_weather_tool()
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='What is the weather in Lagos?'))])],
+        tools=[weather],
+        config=BedrockConfig(tool_choice='get_weather'),
+    )
+    response = await make_model(NOVA).generate(request)
+
+    assert response.message is not None
+    tool_requests = [part.root.tool_request for part in response.message.content if part.root.tool_request is not None]
+    assert tool_requests, 'expected the model to call the tool'
+    assert tool_requests[0].name == 'get_weather'
+    assert tool_requests[0].ref
+
+    # Feeding the result back must also be accepted.
+    follow_up = ModelRequest(
+        messages=[
+            *request.messages,
+            response.message,
+            Message(
+                role=Role.TOOL,
+                content=[
+                    Part.model_validate({
+                        'toolResponse': {
+                            'ref': tool_requests[0].ref,
+                            'name': 'get_weather',
+                            'output': {'celsius': 31},
+                        }
+                    })
+                ],
+            ),
+        ],
+        tools=[weather],
+    )
+    assert (await make_model(NOVA).generate(follow_up)).message is not None
+
+
+async def test_deepseek_reasoning_sync_and_round_trip() -> None:
+    model = make_model(DEEPSEEK)
+    config = BedrockConfig(max_tokens=2048)
+    request = text_request('What is 17 * 23? Think it through.', config=config)
+    response = await model.generate(request)
+
+    assert response.message is not None
+    reasoning_parts = [
+        part.root for part in response.message.content if getattr(part.root, 'reasoning', None) is not None
+    ]
+    assert reasoning_parts, 'expected a reasoning part from a reasoning model'
+    # Signatures are Anthropic-specific, so replay stays gated off here.
+    metadata = reasoning_parts[0].metadata
+    assert metadata is None or not metadata.get(REASONING_SIGNATURE_METADATA_KEY)
+
+    follow_up = ModelRequest(
+        messages=[
+            *request.messages,
+            response.message,
+            Message(role=Role.USER, content=[Part(root=TextPart(text='Now add 100 to that.'))]),
+        ],
+        config=config,
+    )
+    assert (await model.generate(follow_up)).finish_reason == FinishReason.STOP

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Live Bedrock tests, mirroring the Go plugin's live matrix.
+"""Live Bedrock tests.
 
 Opt-in: set ``BEDROCK_LIVE_TESTS=1`` plus working AWS credentials and a
 region (``AWS_REGION`` or ``~/.aws/config``). These call real models and

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -141,7 +141,7 @@ async def test_claude_reasoning_signature_round_trip() -> None:
     # Bedrock requires budget_tokens >= 1024 and maxTokens above it; thinking
     # requests reject custom temperature, so none is set.
     config = BedrockConfig(
-        max_tokens=4096,
+        max_output_tokens=4096,
         additional_model_request_fields={'thinking': {'type': 'enabled', 'budget_tokens': 1024}},
     )
     request = text_request('What is 17 * 23? Think it through.', config=config)
@@ -170,7 +170,7 @@ async def test_claude_reasoning_signature_round_trip() -> None:
 
 async def test_deepseek_reasoning_sync_and_round_trip() -> None:
     model = make_model(DEEPSEEK)
-    config = BedrockConfig(max_tokens=2048)
+    config = BedrockConfig(max_output_tokens=2048)
     request = text_request('What is 17 * 23? Think it through.', config=config)
     response = await model.generate(request)
 

--- a/py/packages/genkit-amazon-bedrock/tests/models_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/models_test.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the BedrockModel generate orchestration (no AWS involved)."""
+
+from typing import Any
+
+import pytest
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    EndpointConnectionError,
+    NoCredentialsError,
+    ParamValidationError,
+    ReadTimeoutError,
+)
+from genkit_amazon_bedrock.models import BedrockModel
+
+from genkit import FinishReason, Message, ModelRequest, Part, Role, TextPart
+from genkit.plugin_api import ActionRunContext, GenkitError
+
+
+class FakeTransport:
+    """Stands in for BedrockTransport; records the Converse kwargs."""
+
+    def __init__(self, response: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+        self.response = response
+        self.error = error
+        self.kwargs: dict[str, Any] | None = None
+
+    async def converse(self, **kwargs: Any) -> dict[str, Any]:
+        self.kwargs = kwargs
+        if self.error is not None:
+            raise self.error
+        return self.response or {}
+
+
+def text_request(text: str = 'hello') -> ModelRequest:
+    return ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=text))])])
+
+
+def text_response(text: str = 'world') -> dict[str, Any]:
+    return {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': text}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 2, 'totalTokens': 3},
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_round_trip() -> None:
+    transport = FakeTransport(response=text_response('hi there'))
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
+
+    response = await model.generate(text_request())
+
+    assert transport.kwargs is not None
+    assert transport.kwargs['modelId'] == 'amazon.nova-lite-v1:0'
+    assert transport.kwargs['messages'] == [{'role': 'user', 'content': [{'text': 'hello'}]}]
+    assert response.message is not None
+    assert response.message.content[0].root.text == 'hi there'
+    assert response.finish_reason == FinishReason.STOP
+    assert response.usage is not None
+    assert response.usage.total_tokens == 3
+
+
+@pytest.mark.asyncio
+async def test_streaming_context_receives_single_bridge_chunk() -> None:
+    transport = FakeTransport(response=text_response('streamed'))
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
+    chunks = []
+    ctx = ActionRunContext(streaming_callback=chunks.append)
+
+    response = await model.generate(text_request(), ctx)
+
+    assert len(chunks) == 1
+    assert chunks[0].content[0].root.text == 'streamed'
+    assert response.message is not None
+    assert response.message.content[0].root.text == 'streamed'
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_context_sends_no_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = FakeTransport(response=text_response())
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
+    ctx = ActionRunContext()
+    # Recorded directly: a context with no callback reports is_streaming False,
+    # so only spying on send_chunk proves the guard is what suppresses chunks.
+    sent: list[Any] = []
+    monkeypatch.setattr(ctx, 'send_chunk', sent.append)
+
+    await model.generate(text_request(), ctx)
+
+    assert sent == []
+
+
+@pytest.mark.parametrize(
+    'error,expected_status',
+    [
+        (ParamValidationError(report='bad param'), 'INVALID_ARGUMENT'),
+        (NoCredentialsError(), 'UNAUTHENTICATED'),
+        (ReadTimeoutError(endpoint_url='https://bedrock-runtime.us-east-1.amazonaws.com'), 'DEADLINE_EXCEEDED'),
+        (EndpointConnectionError(endpoint_url='https://bedrock-runtime.us-east-1.amazonaws.com'), 'UNAVAILABLE'),
+        (BotoCoreError(), 'UNKNOWN'),
+    ],
+    ids=['param_validation', 'no_credentials', 'read_timeout', 'endpoint_connection', 'unlisted'],
+)
+@pytest.mark.asyncio
+async def test_botocore_errors_map_to_genkit_statuses(error: BotoCoreError, expected_status: str) -> None:
+    transport = FakeTransport(error=error)
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
+
+    with pytest.raises(GenkitError) as excinfo:
+        await model.generate(text_request())
+
+    assert excinfo.value.status == expected_status
+    assert 'bedrock converse failed' in excinfo.value.original_message
+    assert excinfo.value.__cause__ is error
+
+
+@pytest.mark.parametrize(
+    'code,expected_status',
+    [
+        ('ThrottlingException', 'RESOURCE_EXHAUSTED'),
+        ('ValidationException', 'INVALID_ARGUMENT'),
+        ('AccessDeniedException', 'PERMISSION_DENIED'),
+        ('ResourceNotFoundException', 'NOT_FOUND'),
+        ('ModelTimeoutException', 'DEADLINE_EXCEEDED'),
+        ('ServiceUnavailableException', 'UNAVAILABLE'),
+        ('SomeFutureException', 'UNKNOWN'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_client_errors_map_to_genkit_statuses(code, expected_status) -> None:
+    error = ClientError({'Error': {'Code': code, 'Message': 'nope'}}, 'Converse')
+    transport = FakeTransport(error=error)
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
+
+    with pytest.raises(GenkitError) as excinfo:
+        await model.generate(text_request())
+
+    assert excinfo.value.status == expected_status
+    assert 'bedrock converse failed' in excinfo.value.original_message
+    assert excinfo.value.__cause__ is error

--- a/py/packages/genkit-amazon-bedrock/tests/models_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/models_test.py
@@ -22,9 +22,12 @@ import pytest
 from botocore.exceptions import (
     BotoCoreError,
     ClientError,
+    ConnectTimeoutError,
     EndpointConnectionError,
     NoCredentialsError,
+    NoRegionError,
     ParamValidationError,
+    PartialCredentialsError,
     ReadTimeoutError,
 )
 from genkit_amazon_bedrock.models import BedrockModel
@@ -107,16 +110,31 @@ async def test_non_streaming_context_sends_no_chunks(monkeypatch: pytest.MonkeyP
     assert sent == []
 
 
+ENDPOINT = 'https://bedrock-runtime.us-east-1.amazonaws.com'
+
+
 @pytest.mark.parametrize(
     'error,expected_status',
     [
         (ParamValidationError(report='bad param'), 'INVALID_ARGUMENT'),
         (NoCredentialsError(), 'UNAUTHENTICATED'),
-        (ReadTimeoutError(endpoint_url='https://bedrock-runtime.us-east-1.amazonaws.com'), 'DEADLINE_EXCEEDED'),
-        (EndpointConnectionError(endpoint_url='https://bedrock-runtime.us-east-1.amazonaws.com'), 'UNAVAILABLE'),
+        (PartialCredentialsError(provider='env', cred_var='aws_secret_access_key'), 'UNAUTHENTICATED'),
+        (NoRegionError(), 'FAILED_PRECONDITION'),
+        (ReadTimeoutError(endpoint_url=ENDPOINT), 'DEADLINE_EXCEEDED'),
+        (ConnectTimeoutError(endpoint_url=ENDPOINT), 'DEADLINE_EXCEEDED'),
+        (EndpointConnectionError(endpoint_url=ENDPOINT), 'UNAVAILABLE'),
         (BotoCoreError(), 'UNKNOWN'),
     ],
-    ids=['param_validation', 'no_credentials', 'read_timeout', 'endpoint_connection', 'unlisted'],
+    ids=[
+        'param_validation',
+        'no_credentials',
+        'partial_credentials',
+        'no_region',
+        'read_timeout',
+        'connect_timeout',
+        'endpoint_connection',
+        'unlisted',
+    ],
 )
 @pytest.mark.asyncio
 async def test_botocore_errors_map_to_genkit_statuses(error: BotoCoreError, expected_status: str) -> None:
@@ -135,12 +153,19 @@ async def test_botocore_errors_map_to_genkit_statuses(error: BotoCoreError, expe
     'code,expected_status',
     [
         ('ThrottlingException', 'RESOURCE_EXHAUSTED'),
+        ('TooManyRequestsException', 'RESOURCE_EXHAUSTED'),
+        ('ServiceQuotaExceededException', 'RESOURCE_EXHAUSTED'),
         ('ValidationException', 'INVALID_ARGUMENT'),
         ('AccessDeniedException', 'PERMISSION_DENIED'),
+        ('UnrecognizedClientException', 'UNAUTHENTICATED'),
+        ('ExpiredTokenException', 'UNAUTHENTICATED'),
         ('ResourceNotFoundException', 'NOT_FOUND'),
         ('ModelTimeoutException', 'DEADLINE_EXCEEDED'),
+        ('ModelNotReadyException', 'UNAVAILABLE'),
         ('ServiceUnavailableException', 'UNAVAILABLE'),
+        ('ModelErrorException', 'INTERNAL'),
         ('SomeFutureException', 'UNKNOWN'),
+        ('', 'UNKNOWN'),
     ],
 )
 @pytest.mark.asyncio
@@ -155,3 +180,47 @@ async def test_client_errors_map_to_genkit_statuses(code: str, expected_status: 
     assert excinfo.value.status == expected_status
     assert 'bedrock converse failed' in excinfo.value.original_message
     assert excinfo.value.__cause__ is error
+
+
+def throttling_error(headers: dict[str, str] | None = None) -> ClientError:
+    response: dict[str, Any] = {'Error': {'Code': 'ThrottlingException', 'Message': 'slow down'}}
+    if headers is not None:
+        response['ResponseMetadata'] = {'HTTPHeaders': headers}
+    return ClientError(response, 'Converse')
+
+
+async def generate_error(error: Exception) -> GenkitError:
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=FakeTransport(error=error))
+    with pytest.raises(GenkitError) as excinfo:
+        await model.generate(text_request())
+    return excinfo.value
+
+
+@pytest.mark.asyncio
+async def test_throttling_surfaces_retry_after_seconds() -> None:
+    genkit_error = await generate_error(throttling_error({'retry-after': '2'}))
+
+    assert genkit_error.status == 'RESOURCE_EXHAUSTED'
+    assert genkit_error.response_metadata == {'retry_after_ms': 2000.0}
+
+
+@pytest.mark.asyncio
+async def test_retry_after_accepts_an_http_date() -> None:
+    genkit_error = await generate_error(throttling_error({'Retry-After': 'Wed, 21 Oct 2015 07:28:00 GMT'}))
+
+    assert genkit_error.response_metadata is not None
+    # The date is long past, so the wait clamps to zero rather than going negative.
+    assert genkit_error.response_metadata['retry_after_ms'] == 0.0
+
+
+@pytest.mark.parametrize(
+    'headers',
+    [None, {}, {'retry-after': ''}, {'retry-after': 'soon'}, {'content-type': 'application/json'}],
+    ids=['no_metadata', 'no_headers', 'empty', 'unparseable', 'absent'],
+)
+@pytest.mark.asyncio
+async def test_missing_or_unparseable_retry_after_is_omitted(headers: dict[str, str] | None) -> None:
+    genkit_error = await generate_error(throttling_error(headers))
+
+    assert genkit_error.status == 'RESOURCE_EXHAUSTED'
+    assert genkit_error.response_metadata is None

--- a/py/packages/genkit-amazon-bedrock/tests/models_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/models_test.py
@@ -144,7 +144,7 @@ async def test_botocore_errors_map_to_genkit_statuses(error: BotoCoreError, expe
     ],
 )
 @pytest.mark.asyncio
-async def test_client_errors_map_to_genkit_statuses(code, expected_status) -> None:
+async def test_client_errors_map_to_genkit_statuses(code: str, expected_status: str) -> None:
     error = ClientError({'Error': {'Code': code, 'Message': 'nope'}}, 'Converse')
     transport = FakeTransport(error=error)
     model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -101,6 +101,12 @@ async def test_resolve_ignores_non_model_kinds() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_ignores_other_plugin_namespaces() -> None:
+    plugin = Bedrock(region='us-east-1')
+    assert await plugin.resolve(ActionKind.MODEL, 'openai/gpt-4') is None
+
+
+@pytest.mark.asyncio
 async def test_resolve_skips_non_chat_model_definitions() -> None:
     plugin = Bedrock(
         region='us-east-1',

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -41,10 +41,13 @@ def test_constructor_defaults() -> None:
     plugin = Bedrock()
     # No default region: resolution falls to the SDK chain and fails loudly.
     assert plugin.region is None
-    assert plugin.max_retries == 3
-    assert plugin.read_timeout == 3600.0
-    assert plugin.connect_timeout == 60.0
-    assert plugin.max_pool_connections == 50
+    # The AWS client knobs stay unset so the caller's own AWS configuration is
+    # what the transport defers to; package defaults apply below that.
+    assert plugin.max_retries is None
+    assert plugin.read_timeout is None
+    assert plugin.connect_timeout is None
+    assert plugin.max_pool_connections is None
+    assert plugin.total_timeout == 3600.0
     assert plugin.models == []
 
 

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -46,7 +46,6 @@ def test_constructor_defaults() -> None:
     assert plugin.connect_timeout == 60.0
     assert plugin.max_pool_connections == 50
     assert plugin.models == []
-    assert plugin.embedders == []
 
 
 def test_model_definition_defaults_to_chat() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -14,10 +14,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the Amazon Bedrock plugin scaffold."""
+"""Tests for the Amazon Bedrock plugin wiring."""
 
+from types import SimpleNamespace
+from typing import Any, cast
+
+import boto3.session
 import pytest
 from genkit_amazon_bedrock import Bedrock, BedrockConfig, ModelDefinition, bedrock_name
+
+from genkit.plugin_api import ActionKind, GenkitError
 
 
 def test_plugin_name() -> None:
@@ -33,9 +39,12 @@ def test_bedrock_name_prefixes_model_id() -> None:
 
 def test_constructor_defaults() -> None:
     plugin = Bedrock()
+    # No default region: resolution falls to the SDK chain and fails loudly.
     assert plugin.region is None
     assert plugin.max_retries == 3
-    assert plugin.request_timeout == 30.0
+    assert plugin.read_timeout == 3600.0
+    assert plugin.connect_timeout == 60.0
+    assert plugin.max_pool_connections == 50
     assert plugin.models == []
     assert plugin.embedders == []
 
@@ -48,23 +57,79 @@ def test_model_definition_defaults_to_chat() -> None:
 def test_config_accepts_camel_case_and_extra_fields() -> None:
     config = BedrockConfig.model_validate({
         'toolChoice': 'auto',
+        'maxTokens': 128,
         'additionalModelRequestFields': {'thinking': {'type': 'enabled'}},
         'someFutureKnob': True,
     })
     assert config.tool_choice == 'auto'
+    assert config.max_tokens == 128
     assert config.additional_model_request_fields == {'thinking': {'type': 'enabled'}}
 
 
 @pytest.mark.asyncio
 async def test_init_returns_no_eager_actions() -> None:
-    plugin = Bedrock()
+    plugin = Bedrock(region='us-east-1')
     assert await plugin.init() == []
 
 
 @pytest.mark.asyncio
-async def test_resolve_returns_none_until_actions_land() -> None:
-    from genkit.plugin_api import ActionKind
+async def test_init_fails_loudly_without_region() -> None:
+    # A stub session isolates the test from ambient AWS env/config.
+    stub_session = cast(boto3.session.Session, SimpleNamespace(region_name=None))
+    plugin = Bedrock(session=stub_session)
+    with pytest.raises(GenkitError, match='no AWS region resolved') as excinfo:
+        await plugin.init()
+    assert excinfo.value.status == 'FAILED_PRECONDITION'
 
-    plugin = Bedrock()
-    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.nova-lite-v1:0')) is None
+
+@pytest.mark.asyncio
+async def test_resolve_returns_model_action_for_any_model_id() -> None:
+    plugin = Bedrock(region='us-east-1')
+    action = await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.nova-lite-v1:0'))
+    assert action is not None
+    assert action.name == 'bedrock/amazon.nova-lite-v1:0'
+    assert action.metadata is not None
+    model_metadata = cast(dict[str, Any], action.metadata['model'])
+    assert model_metadata['supports']['tools'] is True
+    assert model_metadata['customOptions']['properties'].get('toolChoice') is not None
+
+
+@pytest.mark.asyncio
+async def test_resolve_ignores_non_model_kinds() -> None:
+    plugin = Bedrock(region='us-east-1')
     assert await plugin.resolve(ActionKind.FLOW, 'bedrock/whatever') is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_skips_non_chat_model_definitions() -> None:
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[ModelDefinition(name='amazon.titan-image-generator-v1', type='image')],
+    )
+    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.titan-image-generator-v1')) is None
+
+
+@pytest.mark.asyncio
+async def test_text_type_routes_like_chat() -> None:
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[ModelDefinition(name='meta.llama3-8b-instruct-v1:0', type='text')],
+    )
+    action = await plugin.resolve(ActionKind.MODEL, bedrock_name('meta.llama3-8b-instruct-v1:0'))
+    assert action is not None
+    actions = await plugin.list_actions()
+    assert [a.name for a in actions] == ['bedrock/meta.llama3-8b-instruct-v1:0']
+
+
+@pytest.mark.asyncio
+async def test_list_actions_lists_configured_chat_models() -> None:
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[
+            ModelDefinition(name='amazon.nova-lite-v1:0'),
+            ModelDefinition(name='amazon.titan-image-generator-v1', type='image'),
+        ],
+    )
+    actions = await plugin.list_actions()
+    assert [a.name for a in actions] == ['bedrock/amazon.nova-lite-v1:0']
+    assert actions[0].action_type == ActionKind.MODEL

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -56,12 +56,12 @@ def test_model_definition_defaults_to_chat() -> None:
 def test_config_accepts_camel_case_and_extra_fields() -> None:
     config = BedrockConfig.model_validate({
         'toolChoice': 'auto',
-        'maxTokens': 128,
+        'maxOutputTokens': 128,
         'additionalModelRequestFields': {'thinking': {'type': 'enabled'}},
         'someFutureKnob': True,
     })
     assert config.tool_choice == 'auto'
-    assert config.max_tokens == 128
+    assert config.max_output_tokens == 128
     assert config.additional_model_request_fields == {'thinking': {'type': 'enabled'}}
 
 

--- a/py/packages/genkit-amazon-bedrock/tests/request_validation_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/request_validation_test.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validates built requests against the bedrock-runtime service model.
+
+Several Converse fields are ``NonEmptyString`` (``min: 1``) and botocore
+enforces that client-side, so an empty value fails the call before it reaches
+AWS. These tests run the real validator over the request builder's output, which
+catches that whole class of defect without credentials or network access.
+"""
+
+import base64
+
+import botocore.session
+import pytest
+from botocore.validate import ParamValidator
+from genkit_amazon_bedrock.config import BedrockConfig
+from genkit_amazon_bedrock.converters import build_converse_request, cache_point_part
+
+from genkit import (
+    Message,
+    ModelRequest,
+    Part,
+    ReasoningPart,
+    Role,
+    TextPart,
+    ToolDefinition,
+)
+
+CONVERSE_INPUT_SHAPE = (
+    botocore.session.get_session().get_service_model('bedrock-runtime').operation_model('Converse').input_shape
+)
+
+PNG_B64 = base64.b64encode(b'\x89PNG\r\n\x1a\nfakeimagedata').decode()
+
+
+def assert_valid_converse_request(request: ModelRequest) -> dict:
+    """Builds the request and asserts botocore accepts every parameter."""
+    kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
+    report = ParamValidator().validate(kwargs, CONVERSE_INPUT_SHAPE)
+    assert not report.has_errors(), report.generate_report()
+    return kwargs
+
+
+def test_undocumented_tool_passes_validation() -> None:
+    # A tool declared without a docstring reaches the plugin with description
+    # '', which the NonEmptyString floor on toolSpec.description rejects.
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        tools=[ToolDefinition(name='noop', description='', input_schema={'type': 'object', 'properties': {}})],
+    )
+    kwargs = assert_valid_converse_request(request)
+    assert 'description' not in kwargs['toolConfig']['tools'][0]['toolSpec']
+
+
+def test_blank_system_prompt_passes_validation() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(root=TextPart(text=''))]),
+            Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
+        ]
+    )
+    assert_valid_converse_request(request)
+
+
+def test_empty_assistant_text_passes_validation() -> None:
+    # to_model_response emits a '' text part for guardrail-blocked responses;
+    # replaying it must stay valid (ContentBlock.text has no floor).
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
+            Message(role=Role.MODEL, content=[Part(root=TextPart(text=''))]),
+            Message(role=Role.USER, content=[Part(root=TextPart(text='again'))]),
+        ]
+    )
+    assert_valid_converse_request(request)
+
+
+def test_tool_round_trip_passes_validation() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='weather?'))]),
+            Message(
+                role=Role.MODEL,
+                content=[
+                    Part.model_validate({
+                        'toolRequest': {'ref': 'call-1', 'name': 'weather', 'input': {'city': 'Lagos'}}
+                    })
+                ],
+            ),
+            Message(
+                role=Role.TOOL,
+                content=[
+                    Part.model_validate({'toolResponse': {'ref': 'call-1', 'name': 'weather', 'output': {'c': 21}}})
+                ],
+            ),
+        ],
+        tools=[
+            ToolDefinition(
+                name='weather',
+                description='Get the weather',
+                input_schema={'type': 'object', 'properties': {'city': {'type': 'string'}}},
+            )
+        ],
+    )
+    assert_valid_converse_request(request)
+
+
+def test_media_and_cache_points_pass_validation() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(root=TextPart(text='rules')), cache_point_part()]),
+            Message(
+                role=Role.USER,
+                content=[
+                    Part.model_validate({'media': {'url': f'data:image/png;base64,{PNG_B64}'}}),
+                    Part.model_validate({'media': {'url': f'data:application/pdf;base64,{PNG_B64}'}}),
+                    Part(root=TextPart(text='what is this?')),
+                    cache_point_part(),
+                ],
+            ),
+        ]
+    )
+    assert_valid_converse_request(request)
+
+
+def test_reasoning_replay_passes_validation() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='think'))]),
+            Message(
+                role=Role.MODEL,
+                content=[
+                    Part(
+                        root=ReasoningPart(
+                            reasoning='step one',
+                            metadata={'bedrockReasoningSignature': 'sig-abc', 'signature': 'sig-abc'},
+                        )
+                    ),
+                    Part(root=TextPart(text='done')),
+                ],
+            ),
+            Message(role=Role.USER, content=[Part(root=TextPart(text='continue'))]),
+        ]
+    )
+    assert_valid_converse_request(request)
+
+
+@pytest.mark.parametrize('model_id', ['anthropic.claude-sonnet-4-5-20250929-v1:0', 'amazon.nova-lite-v1:0'])
+def test_inference_config_passes_validation(model_id: str) -> None:
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=BedrockConfig(temperature=0.0, top_p=0.9, max_tokens=256, stop_sequences=['STOP']),
+    )
+    kwargs = build_converse_request(model_id, request)
+    report = ParamValidator().validate(kwargs, CONVERSE_INPUT_SHAPE)
+    assert not report.has_errors(), report.generate_report()

--- a/py/packages/genkit-amazon-bedrock/tests/request_validation_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/request_validation_test.py
@@ -163,7 +163,7 @@ def test_reasoning_replay_passes_validation() -> None:
 def test_inference_config_passes_validation(model_id: str) -> None:
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
-        config=BedrockConfig(temperature=0.0, top_p=0.9, max_tokens=256, stop_sequences=['STOP']),
+        config=BedrockConfig(temperature=0.0, top_p=0.9, max_output_tokens=256, stop_sequences=['STOP']),
     )
     kwargs = build_converse_request(model_id, request)
     report = ParamValidator().validate(kwargs, CONVERSE_INPUT_SHAPE)

--- a/py/packages/genkit-amazon-bedrock/tests/transport_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/transport_test.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Region resolution tests. Client construction needs no credentials."""
+
+import boto3.session
+import pytest
+from genkit_amazon_bedrock.transport import BedrockTransport
+
+from genkit.plugin_api import GenkitError
+
+REGION_ENV_VARS = ('AWS_REGION', 'AWS_DEFAULT_REGION', 'AWS_PROFILE', 'AWS_CONFIG_FILE')
+
+
+@pytest.fixture(autouse=True)
+def _isolate_aws_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Drops ambient AWS config so the tests see only what they set."""
+    for name in REGION_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    # Points botocore at an empty config file rather than the developer's own.
+    empty_config = tmp_path / 'aws-config'
+    empty_config.write_text('')
+    monkeypatch.setenv('AWS_CONFIG_FILE', str(empty_config))
+
+
+def make_transport(**kwargs) -> BedrockTransport:
+    defaults = {
+        'max_retries': 3,
+        'read_timeout': 3600.0,
+        'connect_timeout': 60.0,
+        'max_pool_connections': 50,
+    }
+    return BedrockTransport(**{**defaults, **kwargs})
+
+
+def test_explicit_region_wins() -> None:
+    client = make_transport(region='eu-west-1').client()
+    assert client.meta.region_name == 'eu-west-1'
+
+
+def test_aws_region_env_var_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    # botocore below 1.41 reads only AWS_DEFAULT_REGION, so the plugin resolves
+    # AWS_REGION itself; without that this raises FAILED_PRECONDITION.
+    monkeypatch.setenv('AWS_REGION', 'us-east-2')
+    assert make_transport().client().meta.region_name == 'us-east-2'
+
+
+def test_aws_default_region_env_var_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('AWS_DEFAULT_REGION', 'ap-south-1')
+    assert make_transport().client().meta.region_name == 'ap-south-1'
+
+
+def test_aws_region_beats_aws_default_region(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('AWS_REGION', 'us-east-2')
+    monkeypatch.setenv('AWS_DEFAULT_REGION', 'ap-south-1')
+    assert make_transport().client().meta.region_name == 'us-east-2'
+
+
+def test_supplied_session_region_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A caller who configured a session chose that region deliberately.
+    monkeypatch.setenv('AWS_REGION', 'us-east-2')
+    session = boto3.session.Session(region_name='sa-east-1')
+    assert make_transport(session=session).client().meta.region_name == 'sa-east-1'
+
+
+def test_missing_region_fails_loudly() -> None:
+    with pytest.raises(GenkitError, match='no AWS region resolved') as excinfo:
+        make_transport().client()
+    assert excinfo.value.status == 'FAILED_PRECONDITION'
+
+
+def test_client_is_built_once() -> None:
+    transport = make_transport(region='eu-west-1')
+    assert transport.client() is transport.client()
+
+
+def test_botocore_config_carries_the_timeouts() -> None:
+    config = make_transport(region='eu-west-1', read_timeout=1800.0).client().meta.config
+    assert config.read_timeout == 1800.0
+    assert config.connect_timeout == 60.0
+    assert config.max_pool_connections == 50
+    # botocore normalizes max_attempts to total attempts: 3 retries plus the first call.
+    assert config.retries['total_max_attempts'] == 4
+    assert config.retries['mode'] == 'standard'

--- a/py/packages/genkit-amazon-bedrock/tests/transport_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/transport_test.py
@@ -14,21 +14,38 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Region resolution tests. Client construction needs no credentials."""
+"""Transport tests: region resolution, client config, and the boto3 bridge.
+
+Client construction needs no credentials, and the bridge tests stand a fake
+client in for boto3 so the real ``converse`` path runs without AWS.
+"""
+
+import asyncio
+import threading
+from typing import Any
 
 import boto3.session
 import pytest
+from botocore.config import Config
+from botocore.exceptions import ClientError
 from genkit_amazon_bedrock.transport import BedrockTransport
 
 from genkit.plugin_api import GenkitError
 
-REGION_ENV_VARS = ('AWS_REGION', 'AWS_DEFAULT_REGION', 'AWS_PROFILE', 'AWS_CONFIG_FILE')
+AWS_ENV_VARS = (
+    'AWS_REGION',
+    'AWS_DEFAULT_REGION',
+    'AWS_PROFILE',
+    'AWS_CONFIG_FILE',
+    'AWS_MAX_ATTEMPTS',
+    'AWS_RETRY_MODE',
+)
 
 
 @pytest.fixture(autouse=True)
 def _isolate_aws_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """Drops ambient AWS config so the tests see only what they set."""
-    for name in REGION_ENV_VARS:
+    for name in AWS_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
     # Points botocore at an empty config file rather than the developer's own.
     empty_config = tmp_path / 'aws-config'
@@ -37,13 +54,39 @@ def _isolate_aws_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
 
 
 def make_transport(**kwargs) -> BedrockTransport:
-    defaults = {
-        'max_retries': 3,
-        'read_timeout': 3600.0,
-        'connect_timeout': 60.0,
-        'max_pool_connections': 50,
-    }
-    return BedrockTransport(**{**defaults, **kwargs})
+    return BedrockTransport(**kwargs)
+
+
+class FakeClient:
+    """Stands in for the boto3 bedrock-runtime client."""
+
+    def __init__(
+        self,
+        response: dict[str, Any] | None = None,
+        error: Exception | None = None,
+        before_return: Any = None,  # noqa: ANN401
+    ) -> None:
+        self.response = response if response is not None else {'stopReason': 'end_turn'}
+        self.error = error
+        self.before_return = before_return
+        self.calls: list[dict[str, Any]] = []
+        self.thread_idents: list[int] = []
+
+    def converse(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        self.thread_idents.append(threading.get_ident())
+        if self.before_return is not None:
+            self.before_return()
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def stub_transport(monkeypatch: pytest.MonkeyPatch, client: FakeClient, **kwargs) -> BedrockTransport:
+    """Builds a transport whose client() hands back ``client``."""
+    transport = make_transport(region='eu-west-1', **kwargs)
+    monkeypatch.setattr(transport, '_build_client', lambda: client)
+    return transport
 
 
 def test_explicit_region_wins() -> None:
@@ -95,3 +138,159 @@ def test_botocore_config_carries_the_timeouts() -> None:
     # botocore normalizes max_attempts to total attempts: 3 retries plus the first call.
     assert config.retries['total_max_attempts'] == 4
     assert config.retries['mode'] == 'standard'
+
+
+# --- Deferring to the caller's AWS configuration ----------------------------
+
+
+def test_retry_env_vars_are_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Sending our own retries block would win outright and silently drop these.
+    monkeypatch.setenv('AWS_MAX_ATTEMPTS', '10')
+    monkeypatch.setenv('AWS_RETRY_MODE', 'adaptive')
+    config = make_transport(region='eu-west-1').client().meta.config
+    assert config.retries == {'total_max_attempts': 10, 'mode': 'adaptive'}
+
+
+def test_max_attempts_env_alone_keeps_the_default_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Deferring on the whole block would hand back botocore's legacy mode, a
+    # downgrade nobody asked for; only the key the env sets is left alone.
+    monkeypatch.setenv('AWS_MAX_ATTEMPTS', '10')
+    config = make_transport(region='eu-west-1').client().meta.config
+    assert config.retries == {'total_max_attempts': 10, 'mode': 'standard'}
+
+
+def test_retry_mode_env_alone_keeps_the_default_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('AWS_RETRY_MODE', 'adaptive')
+    config = make_transport(region='eu-west-1').client().meta.config
+    assert config.retries == {'total_max_attempts': 4, 'mode': 'adaptive'}
+
+
+def test_config_file_retry_settings_are_honored(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    config_file = tmp_path / 'aws-config-retries'
+    config_file.write_text('[default]\nmax_attempts = 7\n')
+    monkeypatch.setenv('AWS_CONFIG_FILE', str(config_file))
+    config = make_transport(region='eu-west-1').client().meta.config
+    assert config.retries == {'total_max_attempts': 7, 'mode': 'standard'}
+
+
+def test_explicit_max_retries_beats_the_env_without_forcing_the_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Tuning the retry count must not drag the caller off adaptive, which is
+    # the mode that matters under Bedrock throttling.
+    monkeypatch.setenv('AWS_MAX_ATTEMPTS', '10')
+    monkeypatch.setenv('AWS_RETRY_MODE', 'adaptive')
+    config = make_transport(region='eu-west-1', max_retries=1).client().meta.config
+    assert config.retries == {'total_max_attempts': 2, 'mode': 'adaptive'}
+
+
+def test_session_retry_block_survives_and_explicit_attempts_still_win() -> None:
+    session = boto3.session.Session(region_name='eu-west-1')
+    session._session.set_default_client_config(Config(retries={'mode': 'adaptive', 'max_attempts': 9}))
+    assert make_transport(session=session).client().meta.config.retries['mode'] == 'adaptive'
+    config = make_transport(session=session, max_retries=1).client().meta.config
+    assert config.retries == {'total_max_attempts': 2, 'mode': 'adaptive'}
+
+
+def test_session_client_config_is_honored() -> None:
+    session = boto3.session.Session(region_name='eu-west-1')
+    session._session.set_default_client_config(Config(read_timeout=11.0, max_pool_connections=7))
+    config = make_transport(session=session).client().meta.config
+    assert config.read_timeout == 11.0
+    assert config.max_pool_connections == 7
+    # Keys the caller left alone still get the package default.
+    assert config.connect_timeout == 60.0
+
+
+def test_explicit_timeout_beats_the_session_client_config() -> None:
+    session = boto3.session.Session(region_name='eu-west-1')
+    session._session.set_default_client_config(Config(read_timeout=11.0))
+    config = make_transport(session=session, read_timeout=22.0).client().meta.config
+    assert config.read_timeout == 22.0
+
+
+# --- The boto3 bridge -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_converse_forwards_kwargs_and_returns_the_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient(response={'output': {'message': {'role': 'assistant', 'content': [{'text': 'hi'}]}}})
+    transport = stub_transport(monkeypatch, client)
+
+    response = await transport.converse(modelId='amazon.nova-lite-v1:0', messages=[{'role': 'user'}])
+
+    assert response == client.response
+    assert client.calls == [{'modelId': 'amazon.nova-lite-v1:0', 'messages': [{'role': 'user'}]}]
+
+
+@pytest.mark.asyncio
+async def test_converse_runs_off_the_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+    transport = stub_transport(monkeypatch, client)
+
+    await transport.converse(modelId='amazon.nova-lite-v1:0')
+
+    assert client.thread_idents[0] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_converse_reuses_the_one_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+    transport = stub_transport(monkeypatch, client)
+    builds = 0
+
+    def build() -> FakeClient:
+        nonlocal builds
+        builds += 1
+        return client
+
+    monkeypatch.setattr(transport, '_build_client', build)
+
+    await asyncio.gather(*(transport.converse(modelId='amazon.nova-lite-v1:0') for _ in range(4)))
+
+    assert builds == 1
+    assert len(client.calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_converse_propagates_boto3_errors_unwrapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Mapping AWS failures to Genkit statuses belongs to models.py, not here.
+    error = ClientError({'Error': {'Code': 'ValidationException', 'Message': 'nope'}}, 'Converse')
+    transport = stub_transport(monkeypatch, FakeClient(error=error))
+
+    with pytest.raises(ClientError) as excinfo:
+        await transport.converse(modelId='amazon.nova-lite-v1:0')
+
+    assert excinfo.value is error
+
+
+@pytest.mark.asyncio
+async def test_converse_gives_up_at_the_total_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    release = threading.Event()
+    transport = stub_transport(monkeypatch, FakeClient(before_return=lambda: release.wait(30)), total_timeout=0.05)
+
+    try:
+        with pytest.raises(GenkitError, match='total timeout') as excinfo:
+            await transport.converse(modelId='amazon.nova-lite-v1:0')
+        assert excinfo.value.status == 'DEADLINE_EXCEEDED'
+    finally:
+        # The worker thread outlives the deadline; let it finish before teardown.
+        release.set()
+
+
+@pytest.mark.asyncio
+async def test_no_total_timeout_waits_for_the_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Blocks on the worker thread, long enough that a deadline would have bitten.
+    client = FakeClient(before_return=lambda: threading.Event().wait(0.05))
+    transport = stub_transport(monkeypatch, client, total_timeout=None)
+
+    assert await transport.converse(modelId='amazon.nova-lite-v1:0') == client.response
+
+
+@pytest.mark.asyncio
+async def test_ensure_client_builds_off_the_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    idents: list[int] = []
+    transport = make_transport(region='eu-west-1')
+    monkeypatch.setattr(transport, '_build_client', lambda: idents.append(threading.get_ident()) or FakeClient())
+
+    await transport.ensure_client()
+
+    assert idents and idents[0] != threading.get_ident()

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -137,6 +137,7 @@ default = true
 [tool.uv.sources]
 # Samples (alphabetical by package name from pyproject.toml)
 agents               = { workspace = true }
+amazon-bedrock-sample = { workspace = true }
 anthropic-sample     = { workspace = true }
 basic-flows          = { workspace = true }
 context              = { workspace = true }

--- a/py/samples/amazon-bedrock-sample/README.md
+++ b/py/samples/amazon-bedrock-sample/README.md
@@ -3,12 +3,17 @@
 Run text generation, structured output, tool calling, and reasoning through
 Genkit with Amazon Bedrock's Converse API.
 
-You need an AWS account with Amazon Bedrock model access granted for the three
+You need an AWS account with Amazon Bedrock model access granted for the four
 models the sample uses:
 
 - `us.amazon.nova-lite-v1:0`
 - `us.meta.llama3-3-70b-instruct-v1:0`
 - `us.deepseek.r1-v1:0`
+- `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+
+The Anthropic model additionally needs the account's one-time use-case
+agreement (Bedrock console, Model access, Anthropic use case details); the
+`thinking` flow fails with `ResourceNotFoundException` until it is granted.
 
 Credentials come from the standard AWS chain; environment variables, an
 `AWS_PROFILE` (including SSO profiles after `aws sso login`), or instance
@@ -39,12 +44,11 @@ Then open [http://localhost:4000](http://localhost:4000) and try:
 - `cat_profile`
 - `weather_report`
 - `reasoning`
+- `thinking`
 
 The plugin resolves any Bedrock model ID, inference profile, or ARN on demand,
-so the Dev UI model runner also works with models beyond the three declared
-ones. Anthropic models are a common addition, but they need a one-time
-account-level agreement (Bedrock console → Model access → Anthropic use case
-details) before any request succeeds.
+so the Dev UI model runner also works with models beyond the four declared
+ones.
 
 Bedrock has no constrained-decoding mode, so structured output is carried by
 prompt instructions: pass `output_instructions=True` alongside `output_format`

--- a/py/samples/amazon-bedrock-sample/README.md
+++ b/py/samples/amazon-bedrock-sample/README.md
@@ -1,0 +1,52 @@
+# Amazon Bedrock
+
+Run text generation, structured output, tool calling, and reasoning through
+Genkit with Amazon Bedrock's Converse API.
+
+You need an AWS account with Amazon Bedrock model access granted for the three
+models the sample uses:
+
+- `us.amazon.nova-lite-v1:0`
+- `us.meta.llama3-3-70b-instruct-v1:0`
+- `us.deepseek.r1-v1:0`
+
+Credentials come from the standard AWS chain; environment variables, an
+`AWS_PROFILE` (including SSO profiles after `aws sso login`), or instance
+credentials. A region is required, from `AWS_REGION`, `AWS_DEFAULT_REGION`, or
+the active profile:
+
+```bash
+export AWS_PROFILE=my-profile
+export AWS_REGION=us-east-1
+```
+
+Run the quick smoke test:
+
+```bash
+uv sync
+uv run src/main.py
+```
+
+To explore all flows in Dev UI instead:
+
+```bash
+genkit start -- uv run src/main.py
+```
+
+Then open [http://localhost:4000](http://localhost:4000) and try:
+
+- `haiku`
+- `cat_profile`
+- `weather_report`
+- `reasoning`
+
+The plugin resolves any Bedrock model ID, inference profile, or ARN on demand,
+so the Dev UI model runner also works with models beyond the three declared
+ones. Anthropic models are a common addition, but they need a one-time
+account-level agreement (Bedrock console → Model access → Anthropic use case
+details) before any request succeeds.
+
+Bedrock has no constrained-decoding mode, so structured output is carried by
+prompt instructions: pass `output_instructions=True` alongside `output_format`
+and `output_schema`, as `cat_profile` does. Without it the schema never reaches
+the model and it answers in prose.

--- a/py/samples/amazon-bedrock-sample/pyproject.toml
+++ b/py/samples/amazon-bedrock-sample/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "amazon-bedrock-sample"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "genkit",
+  "genkit-amazon-bedrock",
+  "pydantic>=2.10.5",
+  "structlog>=25.2.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -29,6 +29,7 @@ from genkit import Genkit, ModelResponse, ReasoningPart
 NOVA = 'bedrock/us.amazon.nova-lite-v1:0'
 LLAMA = 'bedrock/us.meta.llama3-3-70b-instruct-v1:0'
 DEEPSEEK = 'bedrock/us.deepseek.r1-v1:0'
+CLAUDE = 'bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0'
 
 # Declaring models is optional — resolve() serves any Bedrock model ID or ARN
 # on demand — but declared ones show up in the Dev UI model list.
@@ -39,6 +40,7 @@ ai = Genkit(
                 ModelDefinition(name='us.amazon.nova-lite-v1:0'),
                 ModelDefinition(name='us.meta.llama3-3-70b-instruct-v1:0'),
                 ModelDefinition(name='us.deepseek.r1-v1:0'),
+                ModelDefinition(name='us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
             ]
         )
     ],
@@ -128,6 +130,25 @@ async def reasoning(data: TopicInput) -> dict[str, object]:
         model=DEEPSEEK,
         prompt=f'What is 17 * 23? Think it through, then state the answer. Mention {data.topic} once.',
         config={'maxTokens': 2048},
+    )
+    return _reasoning_summary(response)
+
+
+@ai.flow()
+async def thinking(data: TopicInput) -> dict[str, object]:
+    """Claude extended thinking: signed reasoning that survives replay.
+
+    Unlike DeepSeek, Claude signs its reasoning, so ``signatures_present`` is
+    true here and the parts are replayed verbatim on multi-turn follow-ups.
+    """
+    response = await ai.generate(
+        model=CLAUDE,
+        prompt=f'What is 17 * 23? Think it through, then state the answer. Mention {data.topic} once.',
+        config={
+            'maxTokens': 4096,
+            # Bedrock requires budget_tokens >= 1024, below maxTokens.
+            'additionalModelRequestFields': {'thinking': {'type': 'enabled', 'budget_tokens': 1024}},
+        },
     )
     return _reasoning_summary(response)
 

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Amazon Bedrock samples for the non-streaming Converse path.
+
+Needs AWS credentials and a region (``AWS_REGION`` or ``~/.aws/config``) with
+model access granted for the three models below. Streaming is not wired up yet,
+so every flow here is a single Converse call.
+"""
+
+from genkit_amazon_bedrock import Bedrock, ModelDefinition
+from pydantic import BaseModel, Field
+
+from genkit import Genkit, ModelResponse, ReasoningPart
+
+NOVA = 'bedrock/us.amazon.nova-lite-v1:0'
+LLAMA = 'bedrock/us.meta.llama3-3-70b-instruct-v1:0'
+DEEPSEEK = 'bedrock/us.deepseek.r1-v1:0'
+
+# Declaring models is optional — resolve() serves any Bedrock model ID or ARN
+# on demand — but declared ones show up in the Dev UI model list.
+ai = Genkit(
+    plugins=[
+        Bedrock(
+            models=[
+                ModelDefinition(name='us.amazon.nova-lite-v1:0'),
+                ModelDefinition(name='us.meta.llama3-3-70b-instruct-v1:0'),
+                ModelDefinition(name='us.deepseek.r1-v1:0'),
+            ]
+        )
+    ],
+    model=NOVA,
+)
+
+
+class TopicInput(BaseModel):
+    """Input for a plain-text generation."""
+
+    topic: str = Field(default='coding', description='Topic for the haiku')
+
+
+class CatInput(BaseModel):
+    """Input for a structured generation."""
+
+    name: str = Field(default='Mittens', description='Name of the cat to invent')
+
+
+class Cat(BaseModel):
+    """Structured cat profile."""
+
+    name: str
+    breed: str
+    age: int
+    personality: str
+
+
+class CityInput(BaseModel):
+    """Input for the weather tool."""
+
+    city: str = Field(default='Lagos', description='City to look up')
+
+
+@ai.tool()
+async def current_weather(city_input: CityInput) -> str:
+    """Return mocked weather data for tool-calling demos."""
+    return f'The weather in {city_input.city} is 31C and humid.'
+
+
+@ai.flow()
+async def haiku(data: TopicInput) -> str:
+    """Plain-text generate through Converse."""
+    response = await ai.generate(prompt=f'Write a haiku about {data.topic}.')
+    return response.text
+
+
+@ai.flow()
+async def cat_profile(data: CatInput) -> Cat:
+    """Structured output, carried by prompt instructions.
+
+    Bedrock has no constrained-decoding mode, and the core's json format only
+    injects the schema when ``output_instructions`` is set, so it is required
+    here. Model choice matters too: the Nova models answer in prose often
+    enough to fail extraction, so this uses Llama 3.3.
+    """
+    response = await ai.generate(
+        model=LLAMA,
+        prompt=f'Invent a cat named {data.name}.',
+        output_format='json',
+        output_schema=Cat,
+        output_instructions=True,
+        config={'maxTokens': 1024},
+    )
+    return response.output
+
+
+@ai.flow()
+async def weather_report(data: CityInput) -> str:
+    """Tool calling: the model calls the tool, then answers from its output."""
+    response = await ai.generate(
+        prompt=f'What is the weather in {data.city}? Use the tool, then answer in one sentence.',
+        tools=['current_weather'],
+    )
+    return response.text
+
+
+@ai.flow()
+async def reasoning(data: TopicInput) -> dict[str, object]:
+    """Reasoning parts parsed off a Converse response.
+
+    DeepSeek R1 reasons on every turn, so no thinking config is needed. Its
+    reasoning carries no signature, which is why ``signatures_present`` is
+    false here: signatures are Anthropic-specific and gate replay.
+    """
+    response = await ai.generate(
+        model=DEEPSEEK,
+        prompt=f'What is 17 * 23? Think it through, then state the answer. Mention {data.topic} once.',
+        config={'maxTokens': 2048},
+    )
+    return _reasoning_summary(response)
+
+
+def _reasoning_summary(response: ModelResponse) -> dict[str, object]:
+    """Summarize the reasoning parts on a response."""
+    reasoning_text: list[str] = []
+    signed: list[bool] = []
+    for message in response.messages:
+        for part in message.content:
+            root = part.root
+            if isinstance(root, ReasoningPart):
+                reasoning_text.append(root.reasoning)
+                signed.append(bool(root.metadata and root.metadata.get('bedrockReasoningSignature')))
+    return {
+        'answer': response.text,
+        'reasoning_parts': len(reasoning_text),
+        'reasoning_preview': ''.join(reasoning_text)[:500],
+        'signatures_present': signed,
+    }
+
+
+async def main() -> None:
+    """Run the lightweight flows once from the CLI."""
+    try:
+        print(await haiku(TopicInput()))  # noqa: T201
+        print(await weather_report(CityInput()))  # noqa: T201
+    except Exception as error:
+        # Printed, not raised: in dev mode the Dev UI stays up either way.
+        print(  # noqa: T201
+            f'Set AWS credentials and a region, and grant model access for {NOVA}, {LLAMA}, and {DEEPSEEK}, '
+            f'before running this sample.\n{error}'
+        )
+
+
+if __name__ == '__main__':
+    ai.run_main(main())

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -103,7 +103,7 @@ async def cat_profile(data: CatInput) -> Cat:
         output_format='json',
         output_schema=Cat,
         output_instructions=True,
-        config={'maxTokens': 1024},
+        config={'maxOutputTokens': 1024},
     )
     return response.output
 
@@ -129,7 +129,7 @@ async def reasoning(data: TopicInput) -> dict[str, object]:
     response = await ai.generate(
         model=DEEPSEEK,
         prompt=f'What is 17 * 23? Think it through, then state the answer. Mention {data.topic} once.',
-        config={'maxTokens': 2048},
+        config={'maxOutputTokens': 2048},
     )
     return _reasoning_summary(response)
 
@@ -145,8 +145,8 @@ async def thinking(data: TopicInput) -> dict[str, object]:
         model=CLAUDE,
         prompt=f'What is 17 * 23? Think it through, then state the answer. Mention {data.topic} once.',
         config={
-            'maxTokens': 4096,
-            # Bedrock requires budget_tokens >= 1024, below maxTokens.
+            'maxOutputTokens': 4096,
+            # Bedrock requires budget_tokens >= 1024, below maxOutputTokens.
             'additionalModelRequestFields': {'thinking': {'type': 'enabled', 'budget_tokens': 1024}},
         },
     )

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -17,7 +17,7 @@
 """Amazon Bedrock samples for the non-streaming Converse path.
 
 Needs AWS credentials and a region (``AWS_REGION`` or ``~/.aws/config``) with
-model access granted for the three models below. Streaming is not wired up yet,
+model access granted for the four models below. Streaming is not wired up yet,
 so every flow here is a single Converse call.
 """
 

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.36" },
+    { name = "boto3", specifier = ">=1.37.24" },
     { name = "genkit", editable = "packages/genkit" },
 ]
 

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -9,13 +9,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "2026-07-23T09:19:13.945347Z"
-exclude-newer-span = "P7D"
-
 [manifest]
 members = [
     "agents",
+    "amazon-bedrock-sample",
     "anthropic-sample",
     "basic-flows",
     "context",
@@ -101,6 +98,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/c0/184a89bd5feba14ff3c41cfaf1dd8a82c05f5ceedbc92145e17042eb08a4/altair-6.0.0.tar.gz", hash = "sha256:614bf5ecbe2337347b590afb111929aa9c16c9527c4887d96c9bc7f6640756b4", size = 763834, upload-time = "2025-11-12T08:59:11.519Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/33/ef2f2409450ef6daa61459d5de5c08128e7d3edb773fefd0a324d1310238/altair-6.0.0-py3-none-any.whl", hash = "sha256:09ae95b53d5fe5b16987dccc785a7af8588f2dca50de1e7a156efa8a461515f8", size = 795410, upload-time = "2025-11-12T08:59:09.804Z" },
+]
+
+[[package]]
+name = "amazon-bedrock-sample"
+version = "0.1.0"
+source = { editable = "samples/amazon-bedrock-sample" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-amazon-bedrock" },
+    { name = "pydantic" },
+    { name = "structlog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-amazon-bedrock", editable = "packages/genkit-amazon-bedrock" },
+    { name = "pydantic", specifier = ">=2.10.5" },
+    { name = "structlog", specifier = ">=25.2.0" },
 ]
 
 [[package]]

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1690,12 +1690,14 @@ version = "0.9.0"
 source = { editable = "packages/genkit-amazon-bedrock" }
 dependencies = [
     { name = "boto3" },
+    { name = "botocore" },
     { name = "genkit" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.37.24" },
+    { name = "botocore", specifier = ">=1.37.24" },
     { name = "genkit", editable = "packages/genkit" },
 ]
 


### PR DESCRIPTION
Slice 3 of #5820. Non-streaming Converse generate path for the Amazon Bedrock Python plugin, ported from `genkit-ai/aws-bedrock-go-plugin` (`generate.go`, `types.go`). Stacked on #5699.

## What lands

- `transport.py`: every boto3 call goes through here. One shared client built lazily under a lock, each call pushed onto a worker thread with `asyncio.to_thread` so the loop stays free for the seconds-to-minutes a generate takes. Keeping boto3 behind one module means we can swap in AWS's async SDK later without touching converters or models.
- `converters.py`: pure request/response conversion. Roles, system extraction, media, tools and tool choice, cache points, stop reasons, token usage, tool-input coercion, reasoning parts.
- `models.py`: `BedrockModel.generate` plus AWS error to `GenkitError` status mapping.
- `plugin.py`: `resolve()` and `list_actions()` wired to real model actions.
- `samples/amazon-bedrock-sample`: Dev UI sample with text, structured output, tool calling, and reasoning flows, over Nova Lite, Llama 3.3, and DeepSeek R1.

Region resolution now fails loudly instead of defaulting to `us-east-1`, same as the Go plugin. A silent default sends traffic, and data, to a region nobody picked.

## Reasoning round-trips

Converse `reasoningContent` blocks become Genkit `ReasoningPart`s, and Bedrock-originated signed reasoning is replayed verbatim on follow-up turns. Verified live both ways: DeepSeek R1 (unsigned reasoning, not replayed) and Claude Sonnet 4.5 extended thinking (signed reasoning, replayed and accepted by the service, follow-up computes correctly).

Two wire facts reviewers should know:

- The Converse `signature` is a string on the wire. Go stores `[]byte` only because Go marshals bytes to base64 in JSON; base64-decoding it in Python corrupts the replay, and botocore rejects bytes for that field anyway.
- `redactedContent` is bytes, stored base64-encoded in part metadata because raw bytes crash `model_dump_json` during tracing on non-UTF-8 blobs. Wire-shape handling is unit-tested; Anthropic's documented magic-string trigger returns ordinary `reasoningText` through Bedrock, so no live trigger for a redacted block is known.

Both metadata keys are Bedrock-specific (`bedrockReasoningSignature`, `bedrockRedactedContent`) so reasoning from another provider never gets replayed into a Bedrock request.

## Divergences from Go

1. Timeouts are botocore `read_timeout`/`connect_timeout`/`max_pool_connections` (3600/60/50) rather than Go's whole-call deadline, which kills long generations mid-flight.
2. `resolve()` is lazy and serves any model ID, inference profile or ARN. `init()` returns `[]`, the Bedrock catalogue can't be enumerated.
3. AWS error codes map to `GenkitError` statuses. Go has no mapping.
4. `request.tool_choice` is a fallback; the Bedrock config wins because it can name a specific tool the core enum can't express.
5. Explicit `temperature=0.0` is sent, not dropped as unset.
6. `AWS_REGION` is read directly. botocore only started honoring it in 1.41, above our floor, so leaving it to the SDK chain would silently ignore the var our own error message tells you to set.
7. Go injects a default `maxTokens` for Claude models. We don't: the requirement and the per-family values couldn't be verified here, and guessing one silently caps output. Callers set `maxTokens` themselves.
8. Streaming requests work but arrive as one chunk until ConverseStream lands next slice.
9. boto3 floor is `>=1.37.24`, first release with cache points and `reasoningContent`.

Structured output needs `output_instructions=True` passed alongside `output_format` and `output_schema`. `supports.constrained` is `NONE` because Converse has no constrained-decoding mode, and core's json format injects no instructions on its own, so without the flag the schema never reaches the model. The sample and its README both show the working call.

## Lockfile

`uv.lock` refreshed with uv 0.12.0, what CI's unpinned `setup-uv` installs today. That drops the `exclude-newer`/`exclude-newer-span` options block this branch inherited (no released uv accepts `exclude-newer-span`, main's lock doesn't carry the block, and `uv lock --check` fails while it's there) and records the plugin's real version. Rest of the churn is 0.12.0 marker normalization, no dependency versions changed.

## Tests

159 unit tests, no AWS, plus 3 opt-in live tests (`BEDROCK_LIVE_TESTS=1`). 

Ran Nova Lite for text and the undocumented-tool round trip, DeepSeek R1 for reasoning, Llama 3.3 for structured output.

`tests/request_validation_test.py` runs botocore's own `ParamValidator` over built requests against the bedrock-runtime service model. Several Converse fields are `NonEmptyString` (`min: 1`) and botocore enforces that client-side, so an empty tool description, system text or `toolUseId` fails before it reaches AWS, as `ParamValidationError` (a `BotoCoreError`, not a `ClientError`). Go never hits this, its SDK does no client-side length check. The corpus covers every request-shaping branch the builder has: undocumented tool, blank system prompt, empty assistant text, tool round trip, media and cache points, dropped reasoning, and inference config on two model families.

## Dev UI

<img width="1013" height="525" alt="Screenshot 2026-07-31 at 14 08 19" src="https://github.com/user-attachments/assets/eb5bf85b-f775-438a-91dc-624870fa44f4" />
<img width="1014" height="409" alt="Screenshot 2026-07-31 at 14 09 07" src="https://github.com/user-attachments/assets/626b9716-c81d-4be5-966a-c2846f502e93" />
<img width="1013" height="695" alt="Screenshot 2026-07-31 at 14 10 36" src="https://github.com/user-attachments/assets/213174d2-28d6-44e8-a536-5411f49d6fb2" />
<img width="1010" height="766" alt="Screenshot 2026-08-03 at 17 22 20" src="https://github.com/user-attachments/assets/b271bb61-78f4-4506-b2a2-49de0305a425" />


Declared models resolve, the plugin's `customOptions` schema (Max tokens, Tool choice) renders in the model runner, and the sample registers five flows and one tool.