### PR TITLE
fix(py): correct PyPI package READMEs and metadata for renamed plugins

### DIFF
--- a/py/packages/genkit-anthropic/README.md
+++ b/py/packages/genkit-anthropic/README.md
@@ -5,7 +5,30 @@
 >
 > **Preview** — This plugin is in preview and may have API changes in future releases.
 
-This Genkit plugin provides a set of tools and utilities for working with Anthropic.
+Anthropic Claude model provider for Genkit.
+
+## Installation
+
+```bash
+pip install genkit-anthropic
+```
+
+## Usage
+
+```python
+from genkit import Genkit
+from genkit_anthropic import Anthropic
+
+ai = Genkit(plugins=[Anthropic()])
+
+res = await ai.generate(
+    model='anthropic/claude-sonnet-4-5',
+    prompt='Explain recursion in 10 words.',
+)
+print(res.text)
+```
+
+Set `ANTHROPIC_API_KEY` in the environment, or pass `api_key=` to `Anthropic()`.
 
 ## Disclaimer
 

--- a/py/packages/genkit-anthropic/pyproject.toml
+++ b/py/packages/genkit-anthropic/pyproject.toml
@@ -62,7 +62,6 @@ version = "0.9.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-Changelog       = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit-anthropic/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"

--- a/py/packages/genkit-django/README.md
+++ b/py/packages/genkit-django/README.md
@@ -1,11 +1,11 @@
 # Genkit Django Plugin
 
-`genkit-plugin-django` exposes Genkit flows as HTTP endpoints in a Django application. It mirrors `genkit-plugin-flask` and `genkit-plugin-fastapi`: one decorator turns a `@ai.flow()` into a Django view that speaks the Genkit HTTP protocol (JSON envelope, optional SSE streaming, structured error responses).
+`genkit-django` exposes Genkit flows as HTTP endpoints in a Django application. It mirrors `genkit-flask` and `genkit-fastapi`: one decorator turns a `@ai.flow()` into a Django view that speaks the Genkit HTTP protocol (JSON envelope, optional SSE streaming, structured error responses).
 
 ## Install
 
 ```bash
-pip install genkit-plugin-django
+pip install genkit-django
 ```
 
 ## Usage

--- a/py/packages/genkit-django/pyproject.toml
+++ b/py/packages/genkit-django/pyproject.toml
@@ -67,7 +67,6 @@ version = "0.9.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-Changelog       = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit-django/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"

--- a/py/packages/genkit-evaluators/README.md
+++ b/py/packages/genkit-evaluators/README.md
@@ -11,7 +11,7 @@ No LLM or API keys required.
 ## Installation
 
 ```bash
-pip install genkit-plugin-evaluators
+pip install genkit-evaluators
 ```
 
 ## Usage

--- a/py/packages/genkit-evaluators/pyproject.toml
+++ b/py/packages/genkit-evaluators/pyproject.toml
@@ -41,8 +41,10 @@ requires-python = ">=3.10"
 version = "0.9.0"
 
 [project.urls]
-"Homepage" = "https://github.com/genkit-ai/genkit"
-"Repository" = "https://github.com/genkit-ai/genkit/tree/main/py"
+"Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
+"Documentation" = "https://firebase.google.com/docs/genkit"
+"Homepage"      = "https://github.com/genkit-ai/genkit"
+"Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"
 
 [build-system]
 build-backend = "hatchling.build"

--- a/py/packages/genkit-fastapi/README.md
+++ b/py/packages/genkit-fastapi/README.md
@@ -5,11 +5,12 @@ Serve Genkit flows as FastAPI endpoints.
 ## Installation
 
 ```bash
-pip install genkit-plugin-fastapi
+pip install genkit-fastapi
 ```
 
 ## Usage
 
+```python
 from fastapi import FastAPI
 from genkit import Genkit
 from genkit_fastapi import genkit_fastapi_handler
@@ -29,6 +30,7 @@ async def chat_flow(prompt: str) -> str:
 @genkit_fastapi_handler(ai)
 async def chat():
     return chat_flow
+```
 
 ## Running
 

--- a/py/packages/genkit-fastapi/pyproject.toml
+++ b/py/packages/genkit-fastapi/pyproject.toml
@@ -56,7 +56,6 @@ version = "0.9.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-"Changelog"     = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit-fastapi/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"

--- a/py/packages/genkit-flask/README.md
+++ b/py/packages/genkit-flask/README.md
@@ -1,3 +1,31 @@
-# Genkit Flask plugin
+# Genkit Flask Plugin
 
-This Genkit plugin provides a set of tools and utilities for working with Flask.
+Expose Genkit flows as HTTP endpoints in a Flask application.
+
+## Installation
+
+```bash
+pip install genkit-flask
+```
+
+## Usage
+
+```python
+from flask import Flask
+from genkit import Genkit
+from genkit_flask import genkit_flask_handler
+from genkit_google_genai import GoogleAI
+
+app = Flask(__name__)
+ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
+
+
+@app.post('/api/greet')
+@genkit_flask_handler(ai)
+@ai.flow()
+async def greet_user(name: str) -> str:
+    res = await ai.generate(prompt=f'Say hello to {name} in one sentence.')
+    return res.text
+```
+
+Requires Flask 3.0+.

--- a/py/packages/genkit-flask/pyproject.toml
+++ b/py/packages/genkit-flask/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "pydantic>=2.10.5",
   "flask>=3.1.3",
 ]
-description = "Genkit Firebase Plugin"
+description = "Genkit Flask Plugin"
 keywords = [
   "genkit",
   "ai",
@@ -68,7 +68,6 @@ version = "0.9.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-Changelog       = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit-flask/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"

--- a/py/packages/genkit-google-cloud/README.md
+++ b/py/packages/genkit-google-cloud/README.md
@@ -1,4 +1,23 @@
-# Google Cloud Plugin
+# Genkit Google Cloud Plugin
 
-This Genkit plugin provides a set of tools and utilities for working with Google
-Cloud.
+Export Genkit telemetry to Google Cloud Trace, Cloud Monitoring, and Cloud Logging.
+
+## Installation
+
+```bash
+pip install genkit-google-cloud
+```
+
+## Usage
+
+```python
+from genkit import Genkit
+from genkit_google_cloud import enable_google_cloud_telemetry
+from genkit_google_genai import GoogleAI
+
+enable_google_cloud_telemetry(project_id='my-project')
+
+ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
+```
+
+Requires Google Cloud Application Default Credentials (ADC) or explicit credentials.

--- a/py/packages/genkit-google-cloud/pyproject.toml
+++ b/py/packages/genkit-google-cloud/pyproject.toml
@@ -70,7 +70,6 @@ version = "0.9.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-Changelog       = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit-google-cloud/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"

--- a/py/packages/genkit-google-genai/README.md
+++ b/py/packages/genkit-google-genai/README.md
@@ -7,7 +7,7 @@ This Genkit plugin provides a unified interface for Google AI (Gemini) and Verte
 ```bash
 uv venv
 source .venv/bin/activate
-pip install genkit-plugins-google-genai
+pip install genkit genkit-google-genai
 ```
 
 ## Configuration
@@ -80,7 +80,7 @@ Built-in evaluators for assessing model output quality. Evaluators are automatic
 
 ```python
 from genkit import Genkit
-from genkit._core.typing import BaseDataPoint
+from genkit.evaluator import BaseDataPoint
 from genkit_google_genai import VertexAI
 
 ai = Genkit(plugins=[VertexAI(project='my-project')])
@@ -119,7 +119,7 @@ for result in results.root:
 
 For comprehensive usage examples, see:
 
-- [`py/samples/google-genai-media/README.md`](../../samples/google-genai-media/README.md) - Speech, image, and video generation
-- [`py/samples/gemini-code-execution/README.md`](../../samples/gemini-code-execution/README.md) - Gemini code execution
-- [`py/samples/gemini-context-caching/README.md`](../../samples/gemini-context-caching/README.md) - Context caching for large prompts
-- [`py/samples/vertexai-imagen/README.md`](../../samples/vertexai-imagen/README.md) - Vertex AI Imagen generation
+- [google-genai-media](https://github.com/genkit-ai/genkit/tree/main/py/samples/google-genai-media) - Speech, image, and video generation
+- [gemini-code-execution](https://github.com/genkit-ai/genkit/tree/main/py/samples/gemini-code-execution) - Gemini code execution
+- [gemini-context-caching](https://github.com/genkit-ai/genkit/tree/main/py/samples/gemini-context-caching) - Context caching for large prompts
+- [vertexai-imagen](https://github.com/genkit-ai/genkit/tree/main/py/samples/vertexai-imagen) - Vertex AI Imagen generation

--- a/py/packages/genkit-google-genai/pyproject.toml
+++ b/py/packages/genkit-google-genai/pyproject.toml
@@ -70,7 +70,6 @@ version = "0.9.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-Changelog       = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit-google-genai/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"

--- a/py/packages/genkit-middleware/README.md
+++ b/py/packages/genkit-middleware/README.md
@@ -38,7 +38,7 @@ These pre-packaged middlewares will be available to play with in the Dev UI by d
 ## Installation
 
 ```bash
-pip install genkit-plugin-middleware
+pip install genkit-middleware
 ```
 
 ## Usage

--- a/py/packages/genkit-ollama/README.md
+++ b/py/packages/genkit-ollama/README.md
@@ -49,8 +49,8 @@ print(len(embeddings[0].embedding))
 
 These snippets assume an async context (`await` inside an `async def`); pasting
 them at module top level raises `SyntaxError: 'await' outside function`. See the
-[runnable sample](../../samples/ollama-sample) for a complete `async def main()`
-plus `ai.run_main(...)` entry point.
+[runnable sample](https://github.com/genkit-ai/genkit/tree/main/py/samples/ollama-sample)
+for a complete `async def main()` plus `ai.run_main(...)` entry point.
 
 ### Streaming
 
@@ -168,7 +168,7 @@ with the URL it tried. Start the daemon (`ollama serve`) or set
 
 ## Sample
 
-See [`py/samples/ollama-sample`](../../samples/ollama-sample) for a runnable sample covering
+See [py/samples/ollama-sample](https://github.com/genkit-ai/genkit/tree/main/py/samples/ollama-sample) for a runnable sample covering
 chat, streaming, tool calling, and embeddings with a local Ollama server.
 
 ## Notes

--- a/py/packages/genkit-openai/README.md
+++ b/py/packages/genkit-openai/README.md
@@ -1,8 +1,32 @@
-# OpenAI API Compatible model provider Plugin
+# Genkit OpenAI Plugin (Community)
 
 > **Community Plugin** — This plugin is community-maintained and is not an
 > official Google or OpenAI product. It is provided on an "as-is" basis.
 >
 > **Preview** — This plugin is in preview and may have API changes in future releases.
 
-This Genkit plugin provides a set of tools and utilities for working with OpenAI.
+OpenAI-compatible model provider for Genkit (OpenAI, Azure OpenAI, and other
+compatible endpoints).
+
+## Installation
+
+```bash
+pip install genkit-openai
+```
+
+## Usage
+
+```python
+from genkit import Genkit
+from genkit_openai import OpenAI
+
+ai = Genkit(plugins=[OpenAI()])
+
+res = await ai.generate(
+    model='openai/gpt-4o',
+    prompt='Suggest 2 catchy names for an AI newsletter.',
+)
+print(res.text)
+```
+
+Set `OPENAI_API_KEY` in the environment, or pass `api_key=` to `OpenAI()`.

--- a/py/packages/genkit-openai/pyproject.toml
+++ b/py/packages/genkit-openai/pyproject.toml
@@ -62,7 +62,6 @@ version = "0.9.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-Changelog       = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit-openai/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"

--- a/py/packages/genkit-vertexai/README.md
+++ b/py/packages/genkit-vertexai/README.md
@@ -1,4 +1,28 @@
-# Google Cloud Vertex AI Plugin
+# Genkit Vertex AI Plugin
 
-This Genkit plugin provides a set of tools and utilities for working with Google
-Cloud Vertex AI.
+Integrate Genkit with Google Cloud Vertex AI, including Model Garden and Vector Search.
+
+## Installation
+
+```bash
+pip install genkit-vertexai
+```
+
+## Usage
+
+```python
+from genkit import Genkit
+from genkit_vertexai.model_garden import ModelGarden
+
+ai = Genkit(
+    plugins=[ModelGarden(project_id='my-project', location='us-central1')],
+)
+
+res = await ai.generate(
+    model='modelgarden/anthropic/claude-3-5-sonnet-v2@20241022',
+    prompt='Explain recursion in 10 words.',
+)
+print(res.text)
+```
+
+Requires Google Cloud Application Default Credentials (ADC) or explicit credentials.

--- a/py/packages/genkit-vertexai/pyproject.toml
+++ b/py/packages/genkit-vertexai/pyproject.toml
@@ -74,7 +74,6 @@ version = "0.9.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-Changelog       = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit-vertexai/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"

--- a/py/packages/genkit/README.md
+++ b/py/packages/genkit/README.md
@@ -12,7 +12,7 @@ you can use Genkit independently of any Google services.
 
 ```bash
 pip install genkit
-pip install genkit-plugin-google-genai
+pip install genkit-google-genai
 ```
 
 

--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -89,7 +89,6 @@ vertex-ai             = ["genkit-vertexai"]
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"
-"Changelog"     = "https://github.com/genkit-ai/genkit/blob/main/py/packages/genkit/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/genkit-ai/genkit"
 "Repository"    = "https://github.com/genkit-ai/genkit/tree/main/py"


### PR DESCRIPTION
## Summary
- Fix install commands and prose still pointing at `genkit-plugin-*` (and the misspelled `genkit-plugins-google-genai`) so PyPI project pages install the new package names
- Correct `genkit-flask` summary from "Firebase" to "Flask"
- Add install/usage sections to stub READMEs (`flask`, `google-cloud`, `vertexai`, `openai`, `anthropic`)
- Drop broken Changelog URLs (only `genkit-ollama` has a CHANGELOG file) and use absolute GitHub sample links that work on PyPI

## Test plan
- [ ] Spot-check PyPI long descriptions after next publish / TestPyPI dry-run build
- [ ] Confirm `pip install` commands in each package README match `project.name` in `pyproject.toml`
- [ ] Confirm no relative `../../samples/...` links remain in package READMEs