### PR TITLE
fix(go/ai/exp): suppress agent stream the moment a detach directive lands

### DIFF
--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -442,7 +442,7 @@ func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason
 // ([SessionRunner.Result], [Session.Artifacts]) or turn-end snapshot taken
 // afterward observes them. Only the forward to the client is asynchronous, and
 // it is dropped once the work context is cancelled (client disconnect, abort,
-// or agent completion); the side effects still apply.
+// or agent completion) or the run has detached; the side effects still apply.
 type Responder struct {
 	in  chan<- *AgentStreamChunk
 	ctx context.Context
@@ -451,6 +451,10 @@ type Responder struct {
 	// the sender's goroutine, so reads and snapshots that follow a Send
 	// cannot miss the chunk.
 	effects func(*AgentStreamChunk)
+	// detached mirrors the router's ingress latch: once the run detaches,
+	// send skips the wire forward (a detached run streams nothing) while
+	// still applying side effects.
+	detached *atomic.Bool
 }
 
 // SendModelChunk sends a generation chunk (token-level streaming).
@@ -478,6 +482,9 @@ func (r Responder) SendArtifact(artifact *Artifact) {
 func (r Responder) send(chunk *AgentStreamChunk) {
 	if r.effects != nil {
 		r.effects(chunk)
+	}
+	if r.detached != nil && r.detached.Load() {
+		return
 	}
 	select {
 	case r.in <- chunk:
@@ -1089,13 +1096,16 @@ func newAgentRuntime[State any](
 		name:     name,
 		cfg:      cfg,
 		session:  session,
-		intake:   startDetachIntake(inCh),
 		fnDone:   make(chan fnDoneResult[State], 1),
 		fatalErr: make(chan error, 1),
 	}
 	// Started after rt exists so the router can signal a fail-closed stream
 	// transform error back through rt.failTransform.
 	rt.router = startChunkRouter(ctx, session, outCh, cfg.streamTransform, rt.failTransform)
+	// Started after the router so the intake's reader can latch the router's
+	// ingress filter the moment a detach directive lands, before the inputs
+	// riding it reach the runner (see detachIntake.handleDetach).
+	rt.intake = startDetachIntake(inCh, rt.router.markDetached)
 
 	rt.sess = &SessionRunner[State]{
 		Session: session,
@@ -1226,14 +1236,26 @@ func (rt *agentRuntime[State]) run(
 
 	select {
 	case <-rt.intake.detachSignal():
-		if err := rt.checkDetachCapabilities(); err != nil {
-			rt.drainAndWait(cancelWork)
-			return rt.failedOutput(clientCtx, err), nil
-		}
 		return rt.handleDetach(clientCtx, workCtx, cancelWork, markDetached)
 
 	case res := <-rt.fnDone:
-		return rt.handleFnDone(clientCtx, cancelWork, res)
+		// A detach that raced fn's completion still wins: the intake
+		// suppressed the wire the moment it read the directive, so
+		// resolving this as a synchronous completion would hand back a
+		// completed output whose stream was silently truncated. Both arms
+		// being ready is a coin flip (select picks among ready cases at
+		// random); checking the signal explicitly settles the race at
+		// directive-read time, like the JS runtime's input pump.
+		select {
+		case <-rt.intake.detachSignal():
+			// Hand the settled result back to handleDetach's finalizer
+			// (or drainAndWait, on the capability-rejection path). fnDone
+			// is buffered and fn sends exactly once, so this cannot block.
+			rt.fnDone <- res
+			return rt.handleDetach(clientCtx, workCtx, cancelWork, markDetached)
+		default:
+			return rt.handleFnDone(clientCtx, cancelWork, res)
+		}
 
 	case cause := <-rt.fatalErr:
 		return rt.handleTransformFailure(clientCtx, cancelWork, cause)
@@ -1451,18 +1473,28 @@ func (rt *agentRuntime[State]) failedOutput(ctx context.Context, cause error) *A
 	return out
 }
 
-// handleDetach commits the pending snapshot, returns its ID, and spawns the
-// status-subscriber and finalizer goroutines that own the rest of the
-// invocation. Per-turn snapshots are suspended for the remainder so the
-// queued inputs roll into a single finalize rewrite; the chunk router
-// stops writing to outCh and discards further chunks, whose in-process
-// side effects (e.g. artifacts added via Responder.SendArtifact) still
-// apply at Send time, so user code does not have to branch on detach.
+// handleDetach resolves an observed detach signal: it rejects the detach
+// when the store cannot support it, and otherwise commits the pending
+// snapshot, returns its ID, and spawns the status-subscriber and finalizer
+// goroutines that own the rest of the invocation. Per-turn snapshots are
+// suspended for the remainder so the queued inputs roll into a single
+// finalize rewrite.
+//
+// The router's ingress filter has been latched since the intake read the
+// detach directive, so nothing the detached turn produces enters the pipe.
+// Filtered chunks keep their in-process side effects (e.g. artifacts added
+// via Responder.SendArtifact), which apply at Send time, so user code does
+// not have to branch on detach.
 func (rt *agentRuntime[State]) handleDetach(
 	clientCtx, workCtx context.Context,
 	cancelWork context.CancelFunc,
 	markDetached func(),
 ) (*AgentOutput[State], error) {
+	if err := rt.checkDetachCapabilities(); err != nil {
+		rt.drainAndWait(cancelWork)
+		return rt.failedOutput(clientCtx, err), nil
+	}
+
 	// Stop mirroring clientCtx. From here, only the abort subscription or
 	// fn completion can cancel workCtx.
 	markDetached()
@@ -1478,8 +1510,8 @@ func (rt *agentRuntime[State]) handleDetach(
 	// already cancelled (or cancels mid-write), we still want the pending
 	// row durable so observers can find it later. Decouple this write.
 	//
-	// checkDetachCapabilities (run before detach is honored) guarantees the
-	// store is a SnapshotSubscriber, so the runtime can observe the abort flip.
+	// The capability check above guarantees the store is a
+	// SnapshotSubscriber, so the runtime can observe the abort flip.
 	subscriber := rt.cfg.store.(SnapshotSubscriber)
 
 	// Stamp the pending row's timestamps and an initial heartbeat (refreshed on
@@ -1504,8 +1536,9 @@ func (rt *agentRuntime[State]) handleDetach(
 			"agent %q: detach: save pending snapshot: %v", rt.name, err)), nil
 	}
 	// The router can no longer write to outCh once we return; the bidi
-	// framework closes it shortly after. The router stops writing and
-	// trashes any further chunks.
+	// framework closes it shortly after. Post-detach chunks never entered
+	// the pipe (ingress filter), so this only flushes or drops a pre-detach
+	// turn's in-flight tail.
 	rt.router.stopAndWait()
 
 	// Refresh the heartbeat on an interval, decoupled from clientCtx (the work
@@ -1835,10 +1868,10 @@ func resumeSessionFrom[State any](s *Session[State], snap *SessionSnapshot[State
 // an artifact chunk's artifact to the session) is applied synchronously by
 // Responder.send before the chunk enters the router, so every chunk gets it
 // in its sender's goroutine regardless of whether detach has landed; the
-// router owns only the wire forward to outCh, which is the one thing detach
-// suppresses, since the bidi framework closes outCh shortly after bidiFn
-// returns. The router
-// commits to not writing before we return so that close is safe, and
+// wire forward is the one thing detach suppresses, by latching the
+// detached ingress filter so a detached run's chunks never enter the pipe.
+// The router commits to not writing before we return so that close is safe
+// (the bidi framework closes outCh shortly after bidiFn returns), and
 // keeps draining its input so the user fn never blocks on a responder
 // send.
 
@@ -1854,6 +1887,14 @@ type chunkRouter[State any] struct {
 	// the invocation resolves as a failed output. Nil only when no transform is
 	// configured, since that is the only thing that can fail here.
 	fail func(error)
+
+	// detached latches when the intake reader observes a detach directive:
+	// from then on chunks are filtered at ingress (Responder.send and
+	// sendChunk skip the r.in send), so nothing a detached run produces
+	// enters the pipe. The latch store happens-before the detach's inputs
+	// are released to the runner, so every chunk of the detached turn
+	// observes it; in-process side effects still apply at Send time.
+	detached atomic.Bool
 
 	done          chan struct{}
 	stopWriting   chan struct{}
@@ -1884,15 +1925,14 @@ func startChunkRouter[State any](
 
 func (r *chunkRouter[State]) run() {
 	defer close(r.done)
-	if !r.forward() {
-		// r.in closed while writes were still allowed; nothing left to do.
-		return
-	}
+	r.forward()
+	// forward has committed to not writing. Signal before draining so a
+	// stopAndWait waiter is released whichever way forward exited.
 	close(r.writerStopped)
-	// Writes stopped (detach, shutdown, or client disconnect): keep
-	// draining so a producer mid-send never blocks. The chunks' side
+	// Keep draining so a producer mid-send never blocks. The chunks' side
 	// effects already happened at Send time; only the wire forward to
-	// outCh is suppressed, so the chunks are simply discarded.
+	// outCh is suppressed, so the chunks are simply discarded. (When
+	// forward exited because r.in closed, this exits immediately.)
 	for range r.in {
 	}
 }
@@ -1912,14 +1952,14 @@ func (r *chunkRouter[State]) applySideEffects(chunk *AgentStreamChunk) {
 }
 
 // forward delivers chunks to outCh until told to stop writing, the
-// action context ends, or r.in closes. Returns true if the router must
-// keep draining (writes stopped), false if r.in closed.
-func (r *chunkRouter[State]) forward() bool {
+// action context ends, or r.in closes. On every return it has committed
+// to never writing to out again.
+func (r *chunkRouter[State]) forward() {
 	for {
 		select {
 		case chunk, ok := <-r.in:
 			if !ok {
-				return false
+				return
 			}
 			shaped, err := r.shape(chunk)
 			if err != nil {
@@ -1928,7 +1968,7 @@ func (r *chunkRouter[State]) forward() bool {
 				// output, and switch to discard mode so no further chunk
 				// reaches the wire: fail-closed means stop forwarding entirely.
 				r.fail(err)
-				return true
+				return
 			}
 			if shaped == nil {
 				// The stream transform dropped the chunk from the wire. Its
@@ -1940,16 +1980,16 @@ func (r *chunkRouter[State]) forward() bool {
 			select {
 			case r.out <- chunk:
 			case <-r.stopWriting:
-				return true
+				return
 			case <-r.ctx.Done():
 				// The client is gone (disconnect cancels the action
 				// context), so nothing will drain out again and a blocked
 				// forward would wedge close. Drop the chunk and switch to
 				// side-effects-only mode.
-				return true
+				return
 			}
 		case <-r.stopWriting:
-			return true
+			return
 		}
 	}
 }
@@ -1985,21 +2025,31 @@ func (r *chunkRouter[State]) shape(chunk *AgentStreamChunk) (out *AgentStreamChu
 // responder returns a [Responder] that applies chunk side effects
 // synchronously and sends chunks into the router for the wire forward.
 // The returned Responder's Send methods drop the forward (returning
-// promptly) when ctx is cancelled.
+// promptly) when ctx is cancelled or the run has detached.
 func (r *chunkRouter[State]) responder(ctx context.Context) Responder {
-	return Responder{in: r.in, ctx: ctx, effects: r.applySideEffects}
+	return Responder{in: r.in, ctx: ctx, effects: r.applySideEffects, detached: &r.detached}
 }
 
 // sendChunk delivers chunk to the router for producers other than the
 // user agent function (e.g. the runtime's emitTurnEnd). It skips the
 // in-process side effects (the only runtime-produced chunk is TurnEnd,
-// which has none: no artifact) and returns promptly if ctx is cancelled,
-// dropping the chunk.
+// which has none: no artifact) and returns promptly if ctx is cancelled
+// or the run has detached, dropping the chunk.
 func (r *chunkRouter[State]) sendChunk(ctx context.Context, chunk *AgentStreamChunk) {
+	if r.detached.Load() {
+		return
+	}
 	select {
 	case r.in <- chunk:
 	case <-ctx.Done():
 	}
+}
+
+// markDetached latches the router into detached mode, filtering chunks at
+// ingress from here on (see the detached field). Called by the intake
+// reader the instant it observes a detach directive.
+func (r *chunkRouter[State]) markDetached() {
+	r.detached.Store(true)
 }
 
 // stopAndWait tells the router to stop writing to out and blocks until it
@@ -2128,13 +2178,25 @@ func (p *customPatcher[State]) onChange() {
 //
 // Snapshot suspension after detach is not the intake's concern: the
 // runner gates writes itself (see SessionRunner.suspendSnapshots), so a
-// detach can atomically wait out an in-flight turn-end write. The intake
-// only owns input pacing.
+// detach can atomically wait out an in-flight turn-end write.
+//
+// Wire suppression is the intake's concern, though, because it is an
+// ordering constraint on input release that only the reader can enforce:
+// a detached run streams nothing to the client, so the router's ingress
+// filter must be latched before the inputs riding the detach directive
+// reach the runner. The runtime's detach handler cannot guarantee that
+// itself - it runs in another goroutine, behind a store write, by which
+// time the background turn may already have emitted.
 
 type detachIntake struct {
 	src    <-chan *AgentInput
 	dst    chan *AgentInput
 	notify chan struct{} // buffered size 1; wakes forwarder when queue grows
+
+	// onDetach suppresses the client stream, called by the reader the
+	// instant a detach directive is observed. Never nil: the runtime wires
+	// it to the router's markDetached; standalone intake tests pass a no-op.
+	onDetach func()
 
 	// turnDone is signaled at each turn end to release the forwarder so
 	// it may pop the next input. Initialized with one token so the very
@@ -2145,20 +2207,21 @@ type detachIntake struct {
 	queue []*AgentInput
 
 	readDone atomic.Bool
-	detachCh chan struct{} // signaled by reader when detach observed
+	detachCh chan struct{} // closed by reader when detach observed
 
 	stop     chan struct{}
 	stopOnce sync.Once
 	done     chan struct{}
 }
 
-func startDetachIntake(src <-chan *AgentInput) *detachIntake {
+func startDetachIntake(src <-chan *AgentInput, onDetach func()) *detachIntake {
 	i := &detachIntake{
 		src:      src,
 		dst:      make(chan *AgentInput),
 		notify:   make(chan struct{}, 1),
+		onDetach: onDetach,
 		turnDone: make(chan struct{}, 1),
-		detachCh: make(chan struct{}, 1),
+		detachCh: make(chan struct{}),
 		stop:     make(chan struct{}),
 		done:     make(chan struct{}),
 	}
@@ -2231,9 +2294,14 @@ func (i *detachIntake) enqueue(input *AgentInput) {
 	i.signal()
 }
 
-// handleDetach drains any buffered src inputs into the queue and signals
-// the detach handler. The detach handler then suspends turn-end snapshots
-// (via the runner) while the queued inputs finish processing.
+// handleDetach suppresses the client stream, drains any buffered src
+// inputs into the queue, and signals the detach handler. The detach
+// handler then suspends turn-end snapshots (via the runner) while the
+// queued inputs finish processing.
+//
+// onDetach comes first: the inputs released below are the ones whose turn
+// produces the chunks a detached run must not stream (see the type
+// comment above for why only the reader can enforce that ordering).
 //
 // A pure detach signal (no Messages, no Resume payload) is dropped
 // rather than enqueued: it carries no payload to process, so it would
@@ -2241,6 +2309,8 @@ func (i *detachIntake) enqueue(input *AgentInput) {
 // on the detach signal can do so by calling
 // Send(&AgentInput{Detach: true, Message: ...}) explicitly.
 func (i *detachIntake) handleDetach(first *AgentInput) {
+	i.onDetach()
+
 	var drained []*AgentInput
 	if hasInputPayload(first) {
 		drained = append(drained, first)
@@ -2267,10 +2337,11 @@ drainLoop:
 		i.signal()
 	}
 
-	select {
-	case i.detachCh <- struct{}{}:
-	case <-i.stop:
-	}
+	// A latch rather than a token: closing lets any number of observers
+	// (the run select's detach arm and its fnDone-arm re-check) see the
+	// signal without consuming it. handleDetach runs at most once (read
+	// returns right after it), so the close cannot double-fire.
+	close(i.detachCh)
 }
 
 // hasInputPayload reports whether the input carries data the runner would

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -3530,6 +3530,106 @@ func TestAgent_Detach_SendArtifactPostDetachLandsInSnapshot(t *testing.T) {
 	}
 }
 
+func TestAgent_Detach_SuppressesChunksFromTheDetachedTurn(t *testing.T) {
+	// A detached run streams nothing to the client: it hands back a pending
+	// snapshot and the rest is observed through the store (see
+	// tests/specs/agent.yaml, "detached run emits no customPatch chunks").
+	//
+	// The suppression has to be in force before the input riding the detach
+	// directive reaches the runner, not merely by the time the runtime
+	// finishes handling the detach. This turn emits the instant it starts,
+	// and the store gate parks the detach path at its first write (the
+	// pending row, or a turn-end write racing snapshot suspension, which
+	// blocks the detach handler just the same), so the detach handler
+	// cannot finish before the turn has emitted. That is the ordering that
+	// used to leak chunks onto the wire.
+	reg := newTestRegistry(t)
+	store := &blockingSaveStore[testState]{
+		testInMemStore: newTestInMemStore[testState](),
+		entered:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+
+	emitted := make(chan struct{})
+	af := DefineCustomAgent(reg, "detachSuppressesChunks",
+		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				// Every way a turn produces a chunk: the custom-state
+				// patcher, an explicit responder send, and the turn end.
+				sess.UpdateCustom(func(s testState) testState {
+					s.Counter++
+					return s
+				})
+				resp.SendArtifact(&Artifact{
+					Name:  "background.txt",
+					Parts: []*ai.Part{ai.NewTextPart("written in the background")},
+				})
+				close(emitted)
+				return nil, nil
+			})
+		},
+		WithSessionStore[testState](store),
+	)
+
+	conn, err := af.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// chunks is only read after <-drained, i.e. after the collector
+	// goroutine has exited, so no synchronization is needed beyond the
+	// channel close.
+	var chunks []*AgentStreamChunk
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for chunk, rerr := range conn.Receive() {
+			if rerr != nil {
+				return
+			}
+			chunks = append(chunks, chunk)
+		}
+	}()
+
+	if err := conn.Send(&AgentInput{
+		Detach:  true,
+		Message: ai.NewUserTextMessage("go"),
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	// The detach path is parked at its first store write and the
+	// background turn has emitted everything it is going to; whatever the
+	// client sees now, it would still see if the store were slower.
+	<-store.entered
+	<-emitted
+	close(store.release)
+
+	conn.Close()
+	<-drained
+	out, err := outputWithin(t, conn, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if out.FinishReason != AgentFinishReasonDetached {
+		t.Fatalf("FinishReason = %q, want %q", out.FinishReason, AgentFinishReasonDetached)
+	}
+	if len(chunks) != 0 {
+		b, _ := json.Marshal(chunks)
+		t.Errorf("detached run streamed %d chunk(s), want none: %s", len(chunks), b)
+	}
+
+	// The turn's work still lands: only the wire forward is suppressed.
+	final := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusCompleted
+	})
+	if final.State.Custom.Counter != 1 {
+		t.Errorf("final custom counter = %d, want 1", final.State.Custom.Counter)
+	}
+	if len(final.State.Artifacts) != 1 || final.State.Artifacts[0].Name != "background.txt" {
+		t.Errorf("final artifacts = %v, want [background.txt]", final.State.Artifacts)
+	}
+}
+
 func TestAgent_Detach_FlowErrorsBecomesError(t *testing.T) {
 	reg := newTestRegistry(t)
 	store := newTestInMemStore[testState]()
@@ -6975,7 +7075,7 @@ func TestDetachIntake_SkipsNilInputs(t *testing.T) {
 		src <- nil
 		close(src)
 
-		intake := startDetachIntake(src)
+		intake := startDetachIntake(src, func() {})
 		defer intake.stopAndWait()
 
 		var got []string
@@ -6995,7 +7095,7 @@ func TestDetachIntake_SkipsNilInputs(t *testing.T) {
 		src <- &AgentInput{Message: ai.NewUserTextMessage("two")}
 		close(src)
 
-		intake := startDetachIntake(src)
+		intake := startDetachIntake(src, func() {})
 		defer intake.stopAndWait()
 		go func() { <-intake.detachSignal() }()
 


### PR DESCRIPTION
Fixes the flaky conformance case `detached run emits no customPatch chunks` ([failing run](https://github.com/genkit-ai/genkit/actions/runs/30670042183/job/91285635466)). Wire suppression for a detached run lived in the runtime's detach handler, one goroutine hop and one store write after the intake had already released the detach's inputs to the runner, so a fast background turn could put its `customPatch`, artifact, and `turnEnd` chunks on the wire before suppression engaged. Loaded CI runners hit that window. JS does not have this hole: its input pump flips `isDetached` before forwarding the input, and every emit site checks it.

Ports that shape to Go. The router gains a `detached` ingress latch (an `atomic.Bool`): the intake reader sets it the instant it reads the directive, before releasing the inputs riding it, and `Responder.send`/`sendChunk` skip the wire forward once it is set, so a detached run's chunks never enter the pipe. In-process side effects (artifacts, custom-state mutations) still apply at Send time. The latch store happens-before the input handoff to the runner, which is what makes every chunk of the detached turn observe it; only the reader sits ahead of that handoff, which is why the latch cannot live in the detach handler. The router's stop/drain machinery is untouched and keeps owning shutdown safety.

Moving suppression earlier exposed a second race: the run select's `fnDone` and detach arms can both be ready (select picks among ready arms at random), and an `fnDone` win would now resolve a detached invocation as a completed output whose stream had been silently muted. The `fnDone` arm re-checks the detach signal (`detachCh` became a closed latch, so observers do not consume it) and re-buffers the settled result for the finalizer, settling the race at directive-read time the way JS's `Promise.race` does.

Two deliberate edges: a rejected detach (store without detach support) now also mutes the stream from directive read, since the invocation resolves as failed either way (JS leaves the stream running there), and the symmetric disconnect-vs-detach coin flip on the `clientCtx.Done()` arm predates this change and is left alone, since a disconnect has no wire to protect.

## Verification

`TestAgent_Detach_SuppressesChunksFromTheDetachedTurn` pins the leak deterministically: a gated store parks the detach path at its first write while the turn emits, exactly the interleaving that leaked; it fails 10/10 with the reader-side latch removed. The previously flaky conformance case reproduced at ~2/150 under `-race` on main and is 150/150 clean here. Go 1.26.3 in `go/`: the conformance, detach, intake, and stream-transform suites pass `-race -count=10` and `GOMAXPROCS=1 -count=5`, and the full `go test ./...` passes all 40 packages.
