### PR TITLE
feat(go/ai): type prompt content functions and fix the message slots

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -160,6 +160,11 @@ input:
 ---
 {{role "system"}}
 You are {{personality}}. Keep responses concise.
+
+{{history}}
+
+{{role "user"}}
+If the question is ambiguous, ask one clarifying question instead of guessing.
 ```
 
 ```go
@@ -868,6 +873,42 @@ for result, err := range jokePrompt.ExecuteStream(ctx, JokeRequest{Topic: "cats"
 
 [See full example](samples/basic-prompts)
 
+### Build Prompts from Your Data
+
+Fill any part of a prompt with a Go function instead of a template. The function receives your input type, and what it returns is sent as written, so text from a user or a database never has to be escaped:
+
+```go
+type Ticket struct {
+    Question   string `json:"question"`
+    Screenshot string `json:"screenshot,omitempty"` // data URI, optional
+}
+
+supportPrompt := genkit.DefinePrompt(g, "support",
+    ai.WithModelName("googleai/gemini-flash-latest"),
+    ai.WithInputType(Ticket{}),
+    ai.WithSystem("You are a support agent. Answer in two sentences."),
+
+    // Text plus an image, assembled per request.
+    ai.WithPromptPartsFn(func(ctx context.Context, t Ticket) ([]*ai.Part, error) {
+        parts := []*ai.Part{ai.NewTextPart(t.Question)}
+        if t.Screenshot != "" {
+            parts = append(parts, ai.NewMediaPart("image/png", t.Screenshot))
+        }
+        return parts, nil
+    }),
+)
+
+// The braces below reach the model as typed, not as a template.
+resp, _ := supportPrompt.Execute(ctx, ai.WithInput(Ticket{
+    Question:   "Why does my {{template}} not render?",
+    Screenshot: screenshotDataURI,
+}))
+```
+
+Every slot has a function form: `WithSystemFn` and `WithPromptFn` for the single-message slots (with `WithSystemPartsFn` and `WithPromptPartsFn` for multi-part content), `WithMessagesFn` for the conversation, and `WithDocsFn` to attach retrieved documents.
+
+[See full example](samples/basic-prompt-content)
+
 ### Load Prompts from Files
 
 Keep prompts separate from code using `.prompt` files with YAML frontmatter:
@@ -1157,6 +1198,7 @@ Explore working examples to see Genkit in action:
 | [basic](samples/basic) | Simple text generation with streaming |
 | [basic-structured](samples/basic-structured) | Typed JSON output with `GenerateData` and `GenerateDataStream` |
 | [basic-prompts](samples/basic-prompts) | Prompt templates with Handlebars and `.prompt` files |
+| [basic-prompt-content](samples/basic-prompt-content) | Prompt content computed from your data, with media and retrieved docs |
 | [basic-agents](samples/basic-agents) | Multi-turn agents (inline, prompt-file, and custom-loop) with snapshots and background detach |
 | [basic-agents-server](samples/basic-agents-server) | Serving store-backed and stateless agents over HTTP |
 | [intermediate-interrupts](samples/intermediate-interrupts) | Human-in-the-loop with tool interrupts |
@@ -1164,6 +1206,7 @@ Explore working examples to see Genkit in action:
 | [basic-middleware/filesystem](samples/basic-middleware/filesystem) | Scoped filesystem tools for the model |
 | [basic-middleware/skills](samples/basic-middleware/skills) | On-demand loadable `SKILL.md` personas |
 | [prompts-embed](samples/prompts-embed) | Embed prompts in your binary |
+| [basic-errors](samples/basic-errors) | Classifying failures with sentinels and recovering with `errors.Is` |
 | [durable-streaming](samples/durable-streaming) | Reconnectable streams with replay |
 
 ---

--- a/go/README.md
+++ b/go/README.md
@@ -907,6 +907,8 @@ resp, _ := supportPrompt.Execute(ctx, ai.WithInput(Ticket{
 
 Every slot has a function form: `WithSystemFn` and `WithPromptFn` for the single-message slots (with `WithSystemPartsFn` and `WithPromptPartsFn` for multi-part content), `WithMessagesFn` for the conversation, and `WithDocsFn` to attach retrieved documents.
 
+Each of the two single-message slots holds one message, so its text, parts, and function forms are four ways to write the same thing and the last one set wins. Documents and conversation messages accumulate instead.
+
 [See full example](samples/basic-prompt-content)
 
 ### Load Prompts from Files

--- a/go/README.md
+++ b/go/README.md
@@ -400,7 +400,8 @@ Options compose, so you can build a request up from several helpers. Options
 carrying multiple items (`ai.WithMessages`, `ai.WithTools`, `ai.WithDocs`,
 `ai.WithUse`) accumulate across repeats, while single-value options
 (`ai.WithConfig`, `ai.WithModelName`, `ai.WithSystem`) take the last one set.
-Repeating an option is never an error, so a request can be assembled in pieces:
+Repeating an option is how a request gets assembled in pieces, not a mistake to
+be reported:
 
 ```go
 opts := []ai.GenerateOption{
@@ -421,10 +422,13 @@ if terse {
 response, _ := genkit.Generate(ctx, g, append(opts, ai.WithPrompt("What should I pack for Tokyo?"))...)
 ```
 
-Tool names must be unique across the merged list: repeating the same tool in
-two helpers is rejected when the request runs. These rules cover a single
-options list; APIs that layer two lists, like a prompt's define-time options
-against `Execute`-time options, document their own precedence.
+What still fails is a combination no merge could make sense of, rather than a
+repeat. Tool names must be unique across the merged list, so the same tool from
+two helpers is rejected when the request runs, and `genkit.DefinePrompt` panics
+if given a conversation template alongside separately supplied messages, since
+the template already is the conversation. These rules cover a single options
+list; APIs that layer two lists, like a prompt's define-time options against
+`Execute`-time options, document their own precedence.
 
 ### Generate Structured Data
 

--- a/go/ai/errors.go
+++ b/go/ai/errors.go
@@ -56,9 +56,8 @@ var (
 
 	// ErrInputTypeMismatch means a prompt's input could not be interpreted as
 	// the type a content function declared, so the function was never called.
-	// Reaching it means the input a prompt was invoked with disagrees with the
-	// function that consumes it, whether that input came from [WithInput], the
-	// default recorded by [WithInputType], or the wire.
+	// The input may have come from [WithInput], the default recorded by
+	// [WithInputType], or the wire.
 	ErrInputTypeMismatch = status.ErrInvalidArgument.Subtype("input type mismatch")
 
 	// ErrUnresolvedToolRequest means a resumed generation left an interrupted

--- a/go/ai/errors.go
+++ b/go/ai/errors.go
@@ -54,6 +54,13 @@ var (
 	// not allow.
 	ErrInvalidPart = status.ErrInvalidArgument.Subtype("invalid part")
 
+	// ErrInputTypeMismatch means a prompt's input could not be interpreted as
+	// the type a content function declared, so the function was never called.
+	// Reaching it means the input a prompt was invoked with disagrees with the
+	// function that consumes it, whether that input came from [WithInput], the
+	// default recorded by [WithInputType], or the wire.
+	ErrInputTypeMismatch = status.ErrInvalidArgument.Subtype("input type mismatch")
+
 	// ErrUnresolvedToolRequest means a resumed generation left an interrupted
 	// tool request without a Respond or Restart directive.
 	ErrUnresolvedToolRequest = status.ErrInvalidArgument.Subtype("unresolved tool request")

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -259,9 +259,10 @@ func (s *SessionRunner[State]) Run(ctx context.Context, fn func(ctx context.Cont
 			TurnIndex:        s.turnIndex,
 		}
 		spanMeta := &tracing.SpanMetadata{
-			// Match the JS agent's turn span so cross-language traces line up:
-			// name "runTurn-N" (1-indexed) and type flowStep with no subtype
-			// (JS's run() sets only genkit:type, no genkit:metadata:subtype).
+			// The turn span's shape is fixed so traces from every SDK
+			// line up: name "runTurn-N" (1-indexed) and type flowStep
+			// with no subtype (genkit:type only, no
+			// genkit:metadata:subtype).
 			Name: fmt.Sprintf("runTurn-%d", s.turnIndex+1),
 			Type: "flowStep",
 		}
@@ -1030,9 +1031,9 @@ type fnDoneResult[State any] struct {
 // keys under which an agent records its identifiers: the session ID on the
 // root action span, and the turn-end snapshot ID on each server-managed turn
 // span. They are the "genkit:metadata:"-prefixed forms of the
-// "agent:sessionId" / "agent:snapshotId" custom-metadata keys the JS agent
-// sets via setCustomMetadataAttributes; the prefix is inlined here because
-// Go's tracing package exposes no setCustomMetadataAttributes helper.
+// "agent:sessionId" / "agent:snapshotId" custom-metadata keys every agent
+// records; the prefix is inlined here because Go's tracing package exposes no
+// custom-metadata helper.
 const (
 	sessionIDSpanAttrKey  = "genkit:metadata:agent:sessionId"
 	snapshotIDSpanAttrKey = "genkit:metadata:agent:snapshotId"
@@ -1087,10 +1088,9 @@ func newAgentRuntime[State any](
 
 	// Tag the agent's root action span (the current span here, before any turn
 	// span is opened) with the session ID so traces from the same conversation
-	// can be correlated. Mirrors the JS agent, which calls
-	// setCustomMetadataAttributes({'agent:sessionId': ...}) once at the start of
-	// the action body. trace.SpanFromContext never returns nil (it yields a
-	// no-op span when none is active), so the SetAttributes is always safe.
+	// can be correlated. It is written once at the start of the action body.
+	// trace.SpanFromContext never returns nil (it yields a no-op span when none
+	// is active), so the SetAttributes is always safe.
 	trace.SpanFromContext(ctx).SetAttributes(
 		attribute.String(sessionIDSpanAttrKey, session.state.SessionID))
 
@@ -2473,6 +2473,94 @@ func (i *detachIntake) stopAndWait() {
 // excluded from session history after generation.
 const promptMessageKey = "_genkit_prompt"
 
+// sessionMessageKey marks the session's own messages on their way into the
+// prompt render. The prompt decides where they land, so afterwards this is the
+// only thing that separates them from the prompt's scaffolding. It never
+// reaches the model: [tagRenderedMessages] strips it in the same pass that
+// tags the scaffolding.
+const sessionMessageKey = "_genkit_history"
+
+// taggedMessage returns a copy of m carrying key in its metadata.
+//
+// The copy matters: Render may alias message metadata from shared prompt
+// config (e.g. messages registered via [ai.WithMessages]), so writing in place
+// would leak the tag into the registered prompt and race with concurrent
+// invocations.
+func taggedMessage(m *ai.Message, key string) *ai.Message {
+	tagged := *m
+	tagged.Metadata = maps.Clone(tagged.Metadata)
+	if tagged.Metadata == nil {
+		tagged.Metadata = make(map[string]any, 1)
+	}
+	tagged.Metadata[key] = true
+	return &tagged
+}
+
+// hasTag reports whether m carries key.
+func hasTag(m *ai.Message, key string) bool {
+	return m.Metadata != nil && m.Metadata[key] == true
+}
+
+// untaggedMessage returns m without key, copying only when it is present.
+func untaggedMessage(m *ai.Message, key string) *ai.Message {
+	if !hasTag(m, key) {
+		return m
+	}
+	stripped := *m
+	stripped.Metadata = maps.Clone(stripped.Metadata)
+	delete(stripped.Metadata, key)
+	if len(stripped.Metadata) == 0 {
+		stripped.Metadata = nil
+	}
+	return &stripped
+}
+
+// markSessionMessages copies the session's messages with [sessionMessageKey]
+// so the render can be handed them without the tag reaching session state.
+func markSessionMessages(history []*ai.Message) []*ai.Message {
+	marked := make([]*ai.Message, 0, len(history))
+	for _, m := range history {
+		if m == nil {
+			continue
+		}
+		marked = append(marked, taggedMessage(m, sessionMessageKey))
+	}
+	return marked
+}
+
+// tagRenderedMessages splits the render output in one pass: what came from the
+// session loses its marker, since that is an implementation detail the model
+// should not see, and everything else is tagged as the prompt's scaffolding so
+// it can be dropped from session history after generation.
+func tagRenderedMessages(messages []*ai.Message) []*ai.Message {
+	tagged := make([]*ai.Message, 0, len(messages))
+	for _, m := range messages {
+		if m == nil {
+			continue
+		}
+		if hasTag(m, sessionMessageKey) {
+			tagged = append(tagged, untaggedMessage(m, sessionMessageKey))
+			continue
+		}
+		tagged = append(tagged, taggedMessage(m, promptMessageKey))
+	}
+	return tagged
+}
+
+// turnSessionMessages reduces the generate response's full message list to what
+// the session should hold: everything except the prompt's scaffolding, which
+// leaves the placed conversation, the tool loop's messages, and the reply.
+func turnSessionMessages(full []*ai.Message) []*ai.Message {
+	msgs := make([]*ai.Message, 0, len(full))
+	for _, m := range full {
+		if m == nil || hasTag(m, promptMessageKey) {
+			continue
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs
+}
+
 // validateUserMessage rejects inputs the prompt-backed agent loop can't
 // safely consume: a non-user role would be appended to history under the
 // wrong speaker, and tool request / response parts belong on the
@@ -2639,35 +2727,34 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 				return nil, err
 			}
 
-			actionOpts, err := prompt.Render(ctx, defaultInput)
+			// Hand the conversation to the render instead of splicing it
+			// in afterwards: a prompt-backed agent is a prompt, so where
+			// the conversation goes is the prompt's decision, the same as
+			// it is for [ai.Prompt.Execute]. A prompt that declares no
+			// messages of its own gets it in the middle, between the
+			// system message and the user prompt. One that declares its
+			// own places it with {{history}} or [ai.HistoryFromContext],
+			// which is what makes trimming or summarizing possible.
+			//
+			// The conversation handed over is the whole session, this
+			// turn's message included, since sess.Run has already stored
+			// it. A prompt therefore sees every message the session holds,
+			// not a truncated view of it.
+			//
+			// Only the render sees this context. Generation below runs on
+			// the original, so the conversation does not ride along into
+			// tools and prompts invoked inside the generate loop.
+			history := sess.Messages()
+			actionOpts, err := prompt.Render(ai.NewHistoryContext(ctx, markSessionMessages(history)), defaultInput)
 			if err != nil {
 				return nil, fmt.Errorf("prompt render: %w", err)
 			}
 
-			// Tag base messages so they can be filtered out of session
-			// history after generation. Tag copies rather than the
-			// rendered messages themselves: Render can alias message
-			// metadata from shared prompt config (e.g. messages
-			// registered via [ai.WithMessages]), so tagging in place
-			// would leak the tag into the registered prompt and race
-			// with concurrent invocations.
-			base := make([]*ai.Message, 0, len(actionOpts.Messages))
-			for _, m := range actionOpts.Messages {
-				if m == nil {
-					continue
-				}
-				tagged := *m
-				tagged.Metadata = maps.Clone(tagged.Metadata)
-				if tagged.Metadata == nil {
-					tagged.Metadata = make(map[string]any, 1)
-				}
-				tagged.Metadata[promptMessageKey] = true
-				base = append(base, &tagged)
-			}
-
-			// Append conversation history after the base messages.
-			history := sess.Messages()
-			actionOpts.Messages = append(base, history...)
+			// Whatever the render produced that did not come from the
+			// session is the prompt's own scaffolding (system message,
+			// template output, few-shot examples). Tag it so it can be
+			// filtered out of session history after generation.
+			actionOpts.Messages = tagRenderedMessages(actionOpts.Messages)
 
 			// If a resume payload was provided, validate that every
 			// restart / respond entry references a tool request the model
@@ -2694,19 +2781,19 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 				return nil, fmt.Errorf("generate: %w", err)
 			}
 
-			// Replace session messages with the full history minus base
-			// messages. This captures intermediate tool call/response
-			// messages from the tool loop, not just the final response.
+			// Replace session messages with the full history minus the
+			// prompt's scaffolding. This captures intermediate tool
+			// call/response messages from the tool loop, not just the
+			// final response, and it is what carries a resumed tool
+			// request's resolved content back into the session.
+			//
+			// Because the result is the conversation the prompt actually
+			// placed, a prompt that trims or summarizes its history trims
+			// the session too: the compacted conversation is the agent's
+			// conversation from that turn on, rather than being recomputed
+			// from an ever-growing transcript every turn.
 			if modelResp.Request != nil {
-				history := modelResp.History()
-				msgs := make([]*ai.Message, 0, len(history))
-				for _, m := range history {
-					if m.Metadata != nil && m.Metadata[promptMessageKey] == true {
-						continue
-					}
-					msgs = append(msgs, m)
-				}
-				sess.SetMessages(msgs)
+				sess.SetMessages(turnSessionMessages(modelResp.History()))
 			} else if modelResp.Message != nil {
 				sess.AddMessages(modelResp.Message)
 			}

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2475,16 +2475,13 @@ const promptMessageKey = "_genkit_prompt"
 
 // sessionMessageKey marks the session's own messages on their way into the
 // prompt render. The prompt decides where they land, so afterwards this is the
-// only thing that separates them from the prompt's scaffolding. It never
-// reaches the model: [tagRenderedMessages] strips it in the same pass that
-// tags the scaffolding.
+// only thing separating them from its scaffolding. [tagRenderedMessages] strips
+// it before the model sees anything.
 const sessionMessageKey = "_genkit_history"
 
-// taggedMessage returns a copy of m carrying key in its metadata.
-//
-// The copy matters: Render may alias message metadata from shared prompt
-// config (e.g. messages registered via [ai.WithMessages]), so writing in place
-// would leak the tag into the registered prompt and race with concurrent
+// taggedMessage returns a copy of m carrying key in its metadata. Copying
+// matters: Render may alias metadata from shared prompt config, so writing in
+// place would leak the tag into the registered prompt and race with concurrent
 // invocations.
 func taggedMessage(m *ai.Message, key string) *ai.Message {
 	tagged := *m
@@ -2529,9 +2526,8 @@ func markSessionMessages(history []*ai.Message) []*ai.Message {
 }
 
 // tagRenderedMessages splits the render output in one pass: what came from the
-// session loses its marker, since that is an implementation detail the model
-// should not see, and everything else is tagged as the prompt's scaffolding so
-// it can be dropped from session history after generation.
+// session loses its marker, and everything else is tagged as the prompt's
+// scaffolding so it can be dropped from session history after generation.
 func tagRenderedMessages(messages []*ai.Message) []*ai.Message {
 	tagged := make([]*ai.Message, 0, len(messages))
 	for _, m := range messages {
@@ -2729,21 +2725,14 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 
 			// Hand the conversation to the render instead of splicing it
 			// in afterwards: a prompt-backed agent is a prompt, so where
-			// the conversation goes is the prompt's decision, the same as
-			// it is for [ai.Prompt.Execute]. A prompt that declares no
-			// messages of its own gets it in the middle, between the
-			// system message and the user prompt. One that declares its
-			// own places it with {{history}} or [ai.HistoryFromContext],
-			// which is what makes trimming or summarizing possible.
+			// the conversation goes is the prompt's decision, which is
+			// what makes trimming or summarizing possible.
 			//
-			// The conversation handed over is the whole session, this
-			// turn's message included, since sess.Run has already stored
-			// it. A prompt therefore sees every message the session holds,
-			// not a truncated view of it.
-			//
-			// Only the render sees this context. Generation below runs on
-			// the original, so the conversation does not ride along into
-			// tools and prompts invoked inside the generate loop.
+			// This is the whole session, including this turn's message,
+			// since sess.Run has already stored it. Only the render sees
+			// the context: generation below runs on the original, so the
+			// conversation does not ride along into tools and prompts
+			// invoked inside the generate loop.
 			history := sess.Messages()
 			actionOpts, err := prompt.Render(ai.NewHistoryContext(ctx, markSessionMessages(history)), defaultInput)
 			if err != nil {
@@ -2787,11 +2776,10 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 			// final response, and it is what carries a resumed tool
 			// request's resolved content back into the session.
 			//
-			// Because the result is the conversation the prompt actually
-			// placed, a prompt that trims or summarizes its history trims
-			// the session too: the compacted conversation is the agent's
-			// conversation from that turn on, rather than being recomputed
-			// from an ever-growing transcript every turn.
+			// It is the conversation the prompt actually placed, so a
+			// prompt that trims or summarizes its history trims the
+			// session too, rather than recompacting an ever-growing
+			// transcript every turn.
 			if modelResp.Request != nil {
 				sess.SetMessages(turnSessionMessages(modelResp.History()))
 			} else if modelResp.Message != nil {

--- a/go/ai/exp/agent_history_test.go
+++ b/go/ai/exp/agent_history_test.go
@@ -1,0 +1,372 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+)
+
+// A prompt-backed agent hands its conversation to the prompt's render rather
+// than splicing it in afterwards, so where the history lands is the prompt's
+// decision. These tests pin each placement rule against the model requests the
+// turns actually produce, and against what the session is left holding.
+
+// recordingModel defines a model that records every request it receives and
+// replies with scripted text, falling back to "reply" once the script is
+// exhausted.
+func recordingModel(t *testing.T, r api.Registry, name string, replies ...string) *[]*ai.ModelRequest {
+	t.Helper()
+	ai.ConfigureFormats(r)
+	ai.DefineGenerateAction(context.Background(), r)
+	var requests []*ai.ModelRequest
+	turn := 0
+	ai.DefineModel(r, name, &ai.ModelOptions{
+		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
+	}, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		requests = append(requests, req)
+		text := "reply"
+		if turn < len(replies) {
+			text = replies[turn]
+		}
+		turn++
+		resp := &ai.ModelResponse{Request: req, Message: ai.NewModelTextMessage(text)}
+		if cb != nil {
+			if err := cb(ctx, &ai.ModelResponseChunk{Content: resp.Message.Content}); err != nil {
+				return nil, err
+			}
+		}
+		return resp, nil
+	})
+	return &requests
+}
+
+// summarize renders messages as "role:text" for whole-conversation assertions.
+func summarize(messages []*ai.Message) []string {
+	out := make([]string, 0, len(messages))
+	for _, m := range messages {
+		out = append(out, string(m.Role)+":"+strings.TrimSpace(m.Text()))
+	}
+	return out
+}
+
+func assertConversation(t *testing.T, got []*ai.Message, want []string) {
+	t.Helper()
+	if summary := summarize(got); !slices.Equal(summary, want) {
+		t.Errorf("conversation =\n  %q\nwant\n  %q", summary, want)
+	}
+}
+
+// runTurns drives an agent through the given user messages on one connection
+// and returns the final session messages.
+func runTurns(t *testing.T, af *Agent[testState], texts ...string) []*ai.Message {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := af.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	for _, text := range texts {
+		sendTurn(t, conn, text)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	return out.State.Messages
+}
+
+// TestPromptAgent_HistoryPlacement covers each way a prompt can place the
+// conversation it is handed, across two turns so accumulation is visible.
+func TestPromptAgent_HistoryPlacement(t *testing.T) {
+	// The prompt declares nothing, so the conversation is the whole middle:
+	// [system, ...history].
+	t.Run("system only", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		reqs := recordingModel(t, reg, "test/order1", "a1", "a2")
+		af := DefineAgent[testState](reg, "orderSystemOnly", InlinePrompt{
+			ai.WithModelName("test/order1"),
+			ai.WithSystem("Be helpful."),
+		})
+
+		session := runTurns(t, af, "q1", "q2")
+
+		assertConversation(t, (*reqs)[1].Messages, []string{
+			"system:Be helpful.", "user:q1", "model:a1", "user:q2",
+		})
+		// The system message is the prompt's, so it is re-rendered every
+		// turn and never accumulates in the session.
+		assertConversation(t, session, []string{
+			"user:q1", "model:a1", "user:q2", "model:a2",
+		})
+	})
+
+	// With a user prompt the conversation goes between it and the system
+	// message, so the template's turn stays last. The agent loop used to
+	// append history after the whole render, which put the template's user
+	// turn ahead of the conversation.
+	t.Run("system and user prompt", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		reqs := recordingModel(t, reg, "test/order2", "a1", "a2")
+		af := DefineAgent[testState](reg, "orderSystemPrompt", InlinePrompt{
+			ai.WithModelName("test/order2"),
+			ai.WithSystem("Be helpful."),
+			ai.WithPrompt("Be concise."),
+		})
+
+		session := runTurns(t, af, "q1", "q2")
+
+		assertConversation(t, (*reqs)[1].Messages, []string{
+			"system:Be helpful.", "user:q1", "model:a1", "user:q2", "user:Be concise.",
+		})
+		assertConversation(t, session, []string{
+			"user:q1", "model:a1", "user:q2", "model:a2",
+		})
+	})
+
+	// {{history}} puts the conversation exactly where the template says.
+	t.Run("messages template with history marker", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		reqs := recordingModel(t, reg, "test/order3", "a1", "a2")
+		af := DefineAgent[testState](reg, "orderMarker", InlinePrompt{
+			ai.WithModelName("test/order3"),
+			ai.WithSystem("Be helpful."),
+			ai.WithMessagesTemplate(`{{role "user"}}Here is the conversation so far:
+{{history}}
+{{role "model"}}Now respond to the latest message.`),
+		})
+
+		session := runTurns(t, af, "q1", "q2")
+
+		assertConversation(t, (*reqs)[1].Messages, []string{
+			"system:Be helpful.",
+			"user:Here is the conversation so far:",
+			"user:q1", "model:a1", "user:q2",
+			"model:Now respond to the latest message.",
+		})
+		assertConversation(t, session, []string{
+			"user:q1", "model:a1", "user:q2", "model:a2",
+		})
+	})
+
+	// Without the marker, dotprompt inserts the conversation before the
+	// template's final user message.
+	t.Run("messages template without marker", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		reqs := recordingModel(t, reg, "test/order4", "a1", "a2")
+		af := DefineAgent[testState](reg, "orderNoMarker", InlinePrompt{
+			ai.WithModelName("test/order4"),
+			ai.WithMessagesTemplate(`{{role "model"}}I am ready.
+{{role "user"}}Answer carefully.`),
+		})
+
+		session := runTurns(t, af, "q1", "q2")
+
+		assertConversation(t, (*reqs)[1].Messages, []string{
+			"model:I am ready.",
+			"user:q1", "model:a1", "user:q2",
+			"user:Answer carefully.",
+		})
+		assertConversation(t, session, []string{
+			"user:q1", "model:a1", "user:q2", "model:a2",
+		})
+	})
+
+	// A function owns the conversation outright: it reads what it was handed
+	// and decides what survives. Trimming is the context-window case, and it
+	// is what the loop could not express while history was appended after
+	// the render.
+	t.Run("messages function trims history", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		reqs := recordingModel(t, reg, "test/order5", "a1", "a2", "a3")
+		af := DefineAgent[testState](reg, "orderTrim", InlinePrompt{
+			ai.WithModelName("test/order5"),
+			ai.WithSystem("Be helpful."),
+			ai.WithMessagesFn(func(ctx context.Context, _ any) ([]*ai.Message, error) {
+				history := ai.HistoryFromContext(ctx)
+				if len(history) <= 2 {
+					return history, nil
+				}
+				dropped := len(history) - 2
+				note := ai.NewUserTextMessage(fmt.Sprintf("(%d earlier messages omitted)", dropped))
+				return append([]*ai.Message{note}, history[dropped:]...), nil
+			}),
+		})
+
+		session := runTurns(t, af, "q1", "q2", "q3")
+
+		// Turn 3 sees the note plus the last two messages, not the whole
+		// transcript.
+		assertConversation(t, (*reqs)[2].Messages, []string{
+			"system:Be helpful.",
+			"user:(2 earlier messages omitted)",
+			"model:a2", "user:q3",
+		})
+		// The session holds the conversation the prompt placed, so the
+		// compaction persists rather than being recomputed from an
+		// ever-growing transcript every turn. The note is the prompt's, so
+		// it is dropped as scaffolding.
+		assertConversation(t, session, []string{
+			"model:a2", "user:q3", "model:a3",
+		})
+	})
+
+	// Static messages are content the prompt already produced, so the
+	// conversation is not spliced in on top of them. The caller's messages
+	// are placed only by a prompt that asks for them, or by one that
+	// declares no conversation at all.
+	t.Run("static messages own the conversation", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		reqs := recordingModel(t, reg, "test/order6", "a1", "a2")
+		af := DefineAgent[testState](reg, "orderStatic", InlinePrompt{
+			ai.WithModelName("test/order6"),
+			ai.WithSystem("Be helpful."),
+			ai.WithMessages(ai.NewUserTextMessage("example in"), ai.NewModelTextMessage("example out")),
+		})
+
+		session := runTurns(t, af, "q1", "q2")
+
+		assertConversation(t, (*reqs)[1].Messages, []string{
+			"system:Be helpful.", "user:example in", "model:example out",
+		})
+		// Nothing from the session reached the request, so the turn's own
+		// reply is all that comes back into it and the conversation never
+		// accumulates. This is the sharp end of the ownership rule: a
+		// prompt that declares static messages and never places the
+		// conversation has no conversation.
+		assertConversation(t, session, []string{"model:a2"})
+	})
+}
+
+// TestPromptAgent_HistoryTagStrippedBeforeModel pins that the marker used to
+// tell the session's messages from the prompt's scaffolding never reaches the
+// model, and that neither marker survives into the session.
+func TestPromptAgent_HistoryTagStrippedBeforeModel(t *testing.T) {
+	reg := newTestRegistry(t)
+	reqs := recordingModel(t, reg, "test/tagcheck", "a1", "a2")
+	af := DefineAgent[testState](reg, "tagCheck", InlinePrompt{
+		ai.WithModelName("test/tagcheck"),
+		ai.WithSystem("Be helpful."),
+	})
+
+	session := runTurns(t, af, "q1", "q2")
+
+	for i, m := range (*reqs)[1].Messages {
+		if _, ok := m.Metadata[sessionMessageKey]; ok {
+			t.Errorf("request message %d (%s) carries %s: %v", i, m.Role, sessionMessageKey, m.Metadata)
+		}
+	}
+	// The scaffolding tag is what the loop filters on, so it must be present
+	// on the system message and absent from the conversation.
+	if !hasTag((*reqs)[1].Messages[0], promptMessageKey) {
+		t.Errorf("system message is not tagged %s", promptMessageKey)
+	}
+	for i, m := range (*reqs)[1].Messages[1:] {
+		if hasTag(m, promptMessageKey) {
+			t.Errorf("history message %d (%s) is tagged %s", i, m.Role, promptMessageKey)
+		}
+	}
+	for i, m := range session {
+		if _, ok := m.Metadata[sessionMessageKey]; ok {
+			t.Errorf("session message %d carries %s: %v", i, sessionMessageKey, m.Metadata)
+		}
+		if _, ok := m.Metadata[promptMessageKey]; ok {
+			t.Errorf("session message %d carries %s: %v", i, promptMessageKey, m.Metadata)
+		}
+	}
+}
+
+// TestPromptAgent_StateReachesContentFunction covers the other half of what a
+// content function can read during an agent turn: the live session, and through
+// it the custom state, which is how a prompt adapts to what earlier turns
+// established.
+func TestPromptAgent_StateReachesContentFunction(t *testing.T) {
+	reg := newTestRegistry(t)
+	ai.ConfigureFormats(reg)
+	ai.DefineGenerateAction(context.Background(), reg)
+
+	// A tool is the write side: it reaches the live session from its context
+	// and updates the custom state, which the next turn's render sees.
+	bump := ai.DefineTool(reg, "bump", "increments the counter",
+		func(tc *ai.ToolContext, _ struct{}) (string, error) {
+			sess := SessionFromContext[testState](tc)
+			if sess == nil {
+				return "", fmt.Errorf("no session on the tool context")
+			}
+			sess.UpdateCustom(func(s testState) testState {
+				s.Counter++
+				return s
+			})
+			return "ok", nil
+		})
+
+	// Calls bump once per turn, then answers on the pass that carries the
+	// tool's response.
+	var systemSeen []string
+	ai.DefineModel(reg, "test/statefn", &ai.ModelOptions{
+		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
+	}, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		for _, m := range req.Messages {
+			if m.Role == ai.RoleSystem {
+				systemSeen = append(systemSeen, m.Text())
+			}
+		}
+		for _, p := range req.Messages[len(req.Messages)-1].Content {
+			if p.IsToolResponse() {
+				return &ai.ModelResponse{Request: req, Message: ai.NewModelTextMessage("done")}, nil
+			}
+		}
+		return &ai.ModelResponse{Request: req, Message: ai.NewModelMessage(
+			ai.NewToolRequestPart(&ai.ToolRequest{Name: "bump", Input: map[string]any{}}),
+		)}, nil
+	})
+
+	var renders int
+	af := DefineAgent[testState](reg, "stateFnAgent", InlinePrompt{
+		ai.WithModelName("test/statefn"),
+		ai.WithTools(bump),
+		ai.WithSystemFn(func(ctx context.Context, _ any) (string, error) {
+			renders++
+			sess := SessionFromContext[testState](ctx)
+			if sess == nil {
+				return "", fmt.Errorf("no session on the render context")
+			}
+			return fmt.Sprintf("counter=%d", sess.Custom().Counter), nil
+		}),
+	})
+
+	runTurns(t, af, "q1", "q2")
+
+	if renders != 2 {
+		t.Errorf("system function ran %d times, want one render per turn", renders)
+	}
+	// One render per turn, so turn 2 is told what turn 1's tool wrote. The
+	// system message is rendered once and reused across the tool loop, so it
+	// reaches the model twice per turn with the same text.
+	if want := []string{"counter=0", "counter=0", "counter=1", "counter=1"}; !slices.Equal(systemSeen, want) {
+		t.Errorf("system messages = %q, want %q", systemSeen, want)
+	}
+}

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/registry"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -1009,7 +1010,7 @@ func defineLastGoodTestAgent(reg api.Registry, name string, opts ...AgentOption[
 						s.Counter = 999
 						return s
 					})
-					return nil, core.NewError(core.UNAVAILABLE, "model timeout")
+					return nil, status.Errorf(status.ErrUnavailable, "model timeout")
 				}
 				sess.AddMessages(ai.NewModelTextMessage("echo: " + text))
 				sess.UpdateCustom(func(s testState) testState {
@@ -5048,7 +5049,7 @@ func TestAgent_StateTransform_ErrorFailsClientManagedOutputClosed(t *testing.T) 
 	reg := newTestRegistry(t)
 
 	transform := func(_ context.Context, s *SessionState[testState]) (*SessionState[testState], error) {
-		return nil, core.NewError(core.PERMISSION_DENIED, "cannot shape state")
+		return nil, status.Errorf(status.ErrPermissionDenied, "cannot shape state")
 	}
 
 	af := DefineCustomAgent(reg, "clientXformErr",
@@ -5071,6 +5072,9 @@ func TestAgent_StateTransform_ErrorFailsClientManagedOutputClosed(t *testing.T) 
 	if out.Error == nil || out.Error.Status != core.PERMISSION_DENIED {
 		t.Errorf("Error = %+v, want status %q from the transform", out.Error, core.PERMISSION_DENIED)
 	}
+	if !errors.Is(out.Error, status.ErrPermissionDenied) {
+		t.Errorf("Error = %+v, want it to match status.ErrPermissionDenied", out.Error)
+	}
 	// failedOutput shapes the last-good state through the same transform, which
 	// errors again here; the runtime omits state rather than leaking it.
 	if out.State != nil {
@@ -5088,7 +5092,7 @@ func TestAgent_StateTransform_ErrorFailsSnapshotReadClosed(t *testing.T) {
 	store := newTestInMemStore[testState]()
 
 	transform := func(_ context.Context, s *SessionState[testState]) (*SessionState[testState], error) {
-		return nil, core.NewError(core.PERMISSION_DENIED, "cannot shape state")
+		return nil, status.Errorf(status.ErrPermissionDenied, "cannot shape state")
 	}
 
 	af := DefineCustomAgent(reg, "snapXformErr",
@@ -7100,10 +7104,13 @@ func TestPromptAgent_InlineMessages_DoesNotMutateSharedMetadata(t *testing.T) {
 	if _, ok := shared.Metadata[promptMessageKey]; ok {
 		t.Errorf("prompt message tag leaked into shared config message metadata: %v", shared.Metadata)
 	}
-	// The base message must still be filtered out of session history:
-	// 1 user message + 1 model reply = 2.
-	if got := len(response.State.Messages); got != 2 {
-		t.Errorf("expected 2 messages, got %d", got)
+	// The base message must still be filtered out of session history. This
+	// prompt declares its own conversation, so it owns the placement and
+	// never places the session's messages: what comes back is the reply
+	// alone. See TestPromptAgent_HistoryPlacement for the rule and the forms
+	// that do place it.
+	if got := len(response.State.Messages); got != 1 {
+		t.Errorf("expected 1 message, got %d", got)
 		for i, m := range response.State.Messages {
 			t.Logf("  msg[%d]: role=%s text=%s", i, m.Role, m.Text())
 		}

--- a/go/ai/exp/custompatch_test.go
+++ b/go/ai/exp/custompatch_test.go
@@ -18,12 +18,14 @@ package exp
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
 )
 
 // collectTurnPatches consumes one turn's chunks, returning the customPatch from
@@ -221,7 +223,7 @@ func TestCustomPatch_StateTransformErrorFailsInvocationClosed(t *testing.T) {
 			})
 		},
 		WithStateTransform(func(_ context.Context, st *SessionState[testState]) (*SessionState[testState], error) {
-			return nil, core.NewError(core.PERMISSION_DENIED, "cannot shape custom state")
+			return nil, status.Errorf(status.ErrPermissionDenied, "cannot shape custom state")
 		}),
 	)
 
@@ -246,6 +248,12 @@ func TestCustomPatch_StateTransformErrorFailsInvocationClosed(t *testing.T) {
 	}
 	if out.Error == nil || out.Error.Status != core.PERMISSION_DENIED {
 		t.Errorf("Error = %+v, want status %q from the transform", out.Error, core.PERMISSION_DENIED)
+	}
+	// The sentinel has to survive the failure path too, not just the status
+	// name: the runtime rebuilds the error onto the output, and a caller that
+	// branches with errors.Is would silently stop matching if it didn't.
+	if !errors.Is(out.Error, status.ErrPermissionDenied) {
+		t.Errorf("Error = %+v, want it to match status.ErrPermissionDenied", out.Error)
 	}
 }
 

--- a/go/ai/exp/inline.go
+++ b/go/ai/exp/inline.go
@@ -30,8 +30,17 @@ import "github.com/firebase/genkit/go/ai"
 //		WithSessionStore(store),
 //	)
 //
-// To give the template a default render input, include [ai.WithInputType] among
-// the options. For an agent backed by a prompt already in the registry (e.g.
-// one defined via [ai.DefinePrompt] or loaded from a .prompt file), use
-// [DefinePromptAgent] instead, which takes no InlinePrompt.
+// Any option [genkit.DefinePrompt] accepts is valid here; see its documentation
+// for the full list. To give the template a default render input, include
+// [ai.WithInputType] among the options. For an agent backed by a prompt already
+// in the registry (e.g. one defined via [ai.DefinePrompt] or loaded from a
+// .prompt file), use [DefinePromptAgent] instead, which takes no InlinePrompt.
+//
+// The session's conversation is handed to the prompt on every turn, so the same
+// placement rules apply as anywhere else. A prompt that sets [ai.WithMessages],
+// [ai.WithMessagesTemplate], or [ai.WithMessagesFn] owns the conversation and
+// must place it, with {{history}} in the template or [ai.HistoryFromContext] in
+// the function; that is what lets an agent trim or summarize its own history.
+// A prompt that sets none of them, which is the common case, has the
+// conversation placed for it between the system message and the user prompt.
 type InlinePrompt []ai.PromptOption

--- a/go/ai/exp/inline.go
+++ b/go/ai/exp/inline.go
@@ -36,11 +36,10 @@ import "github.com/firebase/genkit/go/ai"
 // in the registry (e.g. one defined via [ai.DefinePrompt] or loaded from a
 // .prompt file), use [DefinePromptAgent] instead, which takes no InlinePrompt.
 //
-// The session's conversation is handed to the prompt on every turn, so the same
-// placement rules apply as anywhere else. A prompt that sets [ai.WithMessages],
-// [ai.WithMessagesTemplate], or [ai.WithMessagesFn] owns the conversation and
-// must place it, with {{history}} in the template or [ai.HistoryFromContext] in
-// the function; that is what lets an agent trim or summarize its own history.
-// A prompt that sets none of them, which is the common case, has the
-// conversation placed for it between the system message and the user prompt.
+// The session's conversation is handed to the prompt on every turn, under the
+// usual placement rules: a prompt that sets [ai.WithMessages],
+// [ai.WithMessagesTemplate], or [ai.WithMessagesFn] must place it with
+// {{history}} or [ai.HistoryFromContext], which is what lets an agent trim or
+// summarize its own history. One that sets none of them, the common case, has
+// it placed between the system message and the user prompt.
 type InlinePrompt []ai.PromptOption

--- a/go/ai/exp/streamtransform_test.go
+++ b/go/ai/exp/streamtransform_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
 )
 
 // TestStreamTransform_RedactsModelChunksOnWire verifies a stream transform that
@@ -277,7 +278,7 @@ func TestStreamTransform_ReshapesTurnEnd(t *testing.T) {
 func TestStreamTransform_ErrorFailsInvocationClosed(t *testing.T) {
 	transform := func(_ context.Context, c *AgentStreamChunk) (*AgentStreamChunk, error) {
 		if c.ModelChunk != nil {
-			return nil, core.NewError(core.PERMISSION_DENIED, "cannot shape chunk")
+			return nil, status.Errorf(status.ErrPermissionDenied, "cannot shape chunk")
 		}
 		return c, nil
 	}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -671,14 +671,28 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 		}
 	}
 
+	// Generate has no prompt input, so content functions are called with a nil
+	// raw input, which each option turns into the zero value of its own input
+	// type. Nothing here is rendered as a template: there are no input
+	// variables to render against.
 	messages := []*Message{}
-	if genOpts.SystemFn != nil {
-		system, err := genOpts.SystemFn(ctx, nil)
+	if genOpts.SystemText != nil {
+		messages = append(messages, NewSystemTextMessage(*genOpts.SystemText))
+	} else if genOpts.SystemFn != nil {
+		parts, err := genOpts.SystemFn(ctx, nil)
 		if err != nil {
 			return nil, err
 		}
-
-		messages = append(messages, NewSystemTextMessage(system))
+		if len(parts) > 0 {
+			messages = append(messages, &Message{Role: RoleSystem, Content: parts})
+		}
+	}
+	// A conversation template needs a prompt to compile it, and Generate has
+	// none. Rejecting beats rendering nothing, since the caller would otherwise
+	// lose the whole conversation silently.
+	if genOpts.MessagesText != nil {
+		return nil, status.Errorf(status.ErrInvalidArgument,
+			"Generate: WithMessagesTemplate needs a prompt to compile the template. Define one with DefinePrompt, or pass this conversation with WithMessages or WithMessagesFn.")
 	}
 	if genOpts.MessagesFn != nil {
 		msgs, err := genOpts.MessagesFn(ctx, nil)
@@ -688,13 +702,16 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 
 		messages = append(messages, msgs...)
 	}
-	if genOpts.PromptFn != nil {
-		prompt, err := genOpts.PromptFn(ctx, nil)
+	if genOpts.PromptText != nil {
+		messages = append(messages, NewUserTextMessage(*genOpts.PromptText))
+	} else if genOpts.PromptFn != nil {
+		parts, err := genOpts.PromptFn(ctx, nil)
 		if err != nil {
 			return nil, err
 		}
-
-		messages = append(messages, NewUserTextMessage(prompt))
+		if len(parts) > 0 {
+			messages = append(messages, &Message{Role: RoleUser, Content: parts})
+		}
 	}
 
 	if modelRef, ok := genOpts.Model.(ModelRef); ok && genOpts.Config == nil {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -671,10 +671,9 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 		}
 	}
 
-	// Generate has no prompt input, so content functions are called with a nil
-	// raw input, which each option turns into the zero value of its own input
-	// type. Nothing here is rendered as a template: there are no input
-	// variables to render against.
+	// Generate has no prompt input, so content functions get a nil raw input,
+	// which each turns into the zero value of its own type, and no text is
+	// compiled: there would be nothing to render it against.
 	messages := []*Message{}
 	if genOpts.SystemText != nil {
 		messages = append(messages, NewSystemTextMessage(*genOpts.SystemText))

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -687,13 +687,6 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 			messages = append(messages, &Message{Role: RoleSystem, Content: parts})
 		}
 	}
-	// A conversation template needs a prompt to compile it, and Generate has
-	// none. Rejecting beats rendering nothing, since the caller would otherwise
-	// lose the whole conversation silently.
-	if genOpts.MessagesText != nil {
-		return nil, status.Errorf(status.ErrInvalidArgument,
-			"Generate: WithMessagesTemplate needs a prompt to compile the template. Define one with DefinePrompt, or pass this conversation with WithMessages or WithMessagesFn.")
-	}
 	if genOpts.MessagesFn != nil {
 		msgs, err := genOpts.MessagesFn(ctx, nil)
 		if err != nil {

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -56,9 +56,9 @@ import (
 // options) document their own precedence.
 //
 // Applying options therefore never fails on a "set more than once" conflict.
-// The only failures are genuinely invalid arguments (for example a type that
-// WithInputType cannot turn into a schema), which panic at the call site where
-// the mistake is.
+// What does fail is a genuinely invalid argument (a type that WithInputType
+// cannot turn into a schema) or the refused combination above, and both panic
+// at the call site where the mistake is rather than deferring to the request.
 
 // PromptFn is a function that generates a prompt from a prompt's input.
 //

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -349,16 +349,17 @@ func WithMessages(messages ...*Message) CommonGenOption {
 // template where it was first declared.
 //
 // Compiling the template needs a prompt, so this applies to [DefinePrompt]
-// only. Passing it to [Generate] or to [Prompt.Execute] is an error: use
-// [WithMessages] or [WithMessagesFn] there to supply the conversation the
-// prompt's own template will place.
-func WithMessagesTemplate(text string, args ...any) CommonGenOption {
+// only. That is why it returns a [PromptOption] rather than a
+// [CommonGenOption]: passing it to [Generate] or [Prompt.Execute] does not
+// compile. Use [WithMessages] or [WithMessagesFn] there to supply the
+// conversation the prompt's own template will place.
+func WithMessagesTemplate(text string, args ...any) PromptOption {
 	if len(args) > 0 {
 		// Assigning avoids a compile-time warning about non-constant text.
 		t := text
 		text = fmt.Sprintf(t, args...)
 	}
-	return &commonGenOptions{MessagesText: &text}
+	return &promptOptions{commonGenOptions: commonGenOptions{MessagesText: &text}}
 }
 
 // WithMessagesFn adds messages produced by fn at request time, placed between

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -37,17 +37,15 @@ import (
 //   - Single-value options take the last one set. WithConfig, WithModel /
 //     WithModelName, WithSystem, WithPrompt, the output-schema options, and the
 //     like each fill one slot, so the final call wins and earlier ones are
-//     overwritten rather than rejected. A slot is shared by every option that
-//     fills it: WithSystem, WithSystemParts, WithSystemFn, and WithSystemPartsFn
-//     are four ways to write one system message, so the last of them wins and
-//     the others are discarded, not merged into it.
+//     overwritten rather than rejected. Every option that fills a slot shares
+//     it: WithSystem, WithSystemParts, WithSystemFn, and WithSystemPartsFn are
+//     four ways to write one system message, so they do not merge.
 //
 // One combination is refused rather than merged. WithMessagesTemplate lays out
-// the whole conversation, down to where {{history}} puts the caller's, so there
-// is no position relative to it that separately supplied messages could
-// meaningfully take. Giving it in the same DefinePrompt call as WithMessages or
-// WithMessagesFn panics, saying so. Repeating the template alone is fine and
-// takes the last one, as any other slot does.
+// the whole conversation, down to where {{history}} puts the caller's, so
+// separately supplied messages have no position relative to it. Passing it to
+// DefinePrompt alongside WithMessages or WithMessagesFn panics. Repeating the
+// template alone is an ordinary slot.
 //
 // A zero value does not fill a slot: WithMaxTurns(0), WithToolChoice(""), or
 // WithConfig(nil) is a no-op, so an earlier non-zero value cannot be un-set by
@@ -62,16 +60,14 @@ import (
 
 // PromptFn is a function that generates a prompt from a prompt's input.
 //
-// The input argument is untyped. Prefer passing a function with a concrete
-// input type to [WithPromptFn] or [WithSystemFn], which coerces the input for
-// you and works on every invocation path.
+// The input is untyped. [WithPromptFn] and [WithSystemFn] take a function with
+// a concrete input type and convert for you.
 type PromptFn = func(context.Context, any) (string, error)
 
 // MessagesFn is a function that generates messages from a prompt's input.
 //
-// The input argument is untyped. Prefer passing a function with a concrete
-// input type to [WithMessagesFn], which coerces the input for you and works on
-// every invocation path.
+// The input is untyped. [WithMessagesFn] takes a function with a concrete input
+// type and converts for you.
 type MessagesFn = func(context.Context, any) ([]*Message, error)
 
 // appendMessagesFn composes two message-producing functions so their outputs
@@ -103,10 +99,8 @@ func appendMessagesFn(existing, next MessagesFn) MessagesFn {
 	}
 }
 
-// appendDocsFn composes two document-producing functions so their outputs
-// concatenate in call order, backing the accumulate semantics of [WithDocsFn]
-// the same way [appendMessagesFn] does for messages. Either side may be nil,
-// in which case the other is returned unwrapped.
+// appendDocsFn is [appendMessagesFn] for documents, backing the accumulate
+// semantics of [WithDocsFn].
 func appendDocsFn(existing, next DocsFn) DocsFn {
 	if existing == nil {
 		return next
@@ -129,57 +123,49 @@ func appendDocsFn(existing, next DocsFn) DocsFn {
 
 // PartsFn is a function that generates message content from a prompt's input.
 //
-// The input argument is untyped. Prefer passing a function with a concrete
-// input type to [WithPromptPartsFn] or [WithSystemPartsFn], which coerces the
-// input for you and works on every invocation path.
+// The input is untyped. [WithPromptPartsFn] and [WithSystemPartsFn] take a
+// function with a concrete input type and convert for you.
 type PartsFn = func(context.Context, any) ([]*Part, error)
 
 // DocsFn is a function that generates context documents from a prompt's input.
 //
-// The input argument is untyped. Prefer passing a function with a concrete
-// input type to [WithDocsFn], which coerces the input for you and works on
-// every invocation path.
+// The input is untyped. [WithDocsFn] takes a function with a concrete input
+// type and converts for you.
 type DocsFn = func(context.Context, any) ([]*Document, error)
 
 // coerceFn adapts a typed content function to the untyped signature the option
-// structs store, converting the raw input to In on each call. Every
-// content-function option funnels through this so the conversion contract has
-// exactly one implementation.
+// structs store.
 //
 // The raw value's Go type depends on how the prompt was invoked: an in-process
 // call with [WithInput] passes the value through as-is, while the reflection
-// API (Dev UI, flows over HTTP) and the default input recorded by
-// [WithInputType] both arrive as map[string]any. Converting here means content
-// functions see the same type regardless of the caller. A nil raw value yields
-// the zero value of In, which is what [Generate] passes since it has no prompt
-// input at all.
+// API (Dev UI, flows over HTTP) and the default recorded by [WithInputType]
+// both arrive as map[string]any. Converting here means content functions see
+// the same type whichever way they were reached. A nil raw value yields the
+// zero value of In, which is what [Generate] passes.
 func coerceFn[In, Out any](fn func(context.Context, In) (Out, error)) func(context.Context, any) (Out, error) {
 	return func(ctx context.Context, raw any) (Out, error) {
 		in, err := base.ConvertToExact[In](raw)
 		if err != nil {
 			var zero Out
-			// Classified here rather than at the conversion: the mismatch is
-			// only diagnosable as a caller's bad input once it has a content
-			// function to disagree with.
+			// base cannot classify this itself: the same failure is only a
+			// caller's bad input once a content function disagrees with it.
 			return zero, status.Errorf(ErrInputTypeMismatch, "content function input: %w", err)
 		}
 		return fn(ctx, in)
 	}
 }
 
-// staticPartsFn adapts a fixed set of parts to a [PartsFn], handing out a
-// fresh slice per render so that later stages appending to the message's
-// content cannot reach the parts stored on the prompt.
+// staticPartsFn adapts fixed parts to a [PartsFn]. It clones per render, so a
+// later append to the message's content cannot reach the parts stored on the
+// prompt.
 func staticPartsFn(parts []*Part) PartsFn {
 	return func(context.Context, any) ([]*Part, error) {
 		return slices.Clone(parts), nil
 	}
 }
 
-// textPartsFn adapts a string-returning content function to a [PartsFn].
-// An empty string yields no parts, so the renderers emit no message: a
-// function that returns "" means "no content this time", matching how empty
-// template text behaves.
+// textPartsFn adapts a string-returning content function to a [PartsFn]. An
+// empty string yields no parts and so no message, matching empty template text.
 func textPartsFn[In any](fn func(context.Context, In) (string, error)) PartsFn {
 	coerced := coerceFn(fn)
 	return func(ctx context.Context, raw any) ([]*Part, error) {
@@ -237,7 +223,7 @@ func WithConfig(config any) ConfigOption {
 type commonGenOptions struct {
 	configOptions
 	Model              ModelArg          // Model to use.
-	MessagesFn         MessagesFn        // Messages set since the last MessagesText, if any. Used verbatim.
+	MessagesFn         MessagesFn        // Function to generate messages. Used verbatim.
 	MessagesText       *string           // Template text for the conversation, rendered as a dotprompt template.
 	Tools              []ToolRef         // References to tools to use.
 	Resources          []Resource        // Resources to be temporarily available during generation.
@@ -260,15 +246,10 @@ type CommonGenOption interface {
 func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) {
 	o.configOptions.applyConfig(&opts.configOptions)
 
-	// The two standard rules, nothing special: verbatim messages accumulate,
-	// and the conversation template is a slot the last one set wins. Combining
-	// the two is refused by [DefinePrompt] rather than merged here, since no
-	// merge of them means anything.
 	opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
 	if o.MessagesText != nil {
 		opts.MessagesText = o.MessagesText
 	}
-
 	if o.Model != nil {
 		opts.Model = o.Model
 	}
@@ -300,18 +281,16 @@ func (o *commonGenOptions) applyPromptExecute(opts *promptExecutionOptions) {
 // user prompts. Repeating this option, or mixing it with [WithMessagesFn],
 // appends: messages accumulate in the order the options are passed.
 //
-// Message text is used verbatim and is never rendered as a dotprompt template,
-// so history containing literal braces, such as a user asking about {{#if}},
-// passes through untouched. To build message text from a prompt's input, either
-// interpolate it before calling this or use [WithMessagesFn], which receives
-// the typed input, or [WithMessagesTemplate] for a multi-turn dotprompt
-// template.
+// Message text is used verbatim, never compiled as a dotprompt template, so
+// history containing literal braces passes through untouched. To build message
+// text from a prompt's input, use [WithMessagesFn], which receives the typed
+// input, or [WithMessagesTemplate] for a multi-turn template.
 //
 // Declaring the conversation makes the prompt responsible for the messages
 // passed to [Prompt.Execute]: they are not spliced in automatically, because
 // only the prompt knows where its examples end and a real conversation begins.
-// Use [WithMessagesTemplate] with {{history}} or [WithMessagesFn] with
-// [HistoryFromContext] to place them.
+// Place them with {{history}} in a [WithMessagesTemplate] or
+// [HistoryFromContext] in a [WithMessagesFn].
 func WithMessages(messages ...*Message) CommonGenOption {
 	return WithMessagesFn(func(context.Context, any) ([]*Message, error) {
 		return messages, nil
@@ -321,34 +300,24 @@ func WithMessages(messages ...*Message) CommonGenOption {
 // WithMessagesTemplate sets the conversation to a dotprompt template.
 // Optional args are applied to text with [fmt.Sprintf].
 //
-// This is the multi-turn form: each {{role "..."}} block in the text starts a
-// new message, so one template can express a system preamble, few-shot
-// examples, and the user turn. It is what a .prompt file's body compiles to.
+// This is the multi-turn form: each {{role "..."}} block starts a new message,
+// so one template can express a system preamble, few-shot examples, and the
+// user turn. It is what a .prompt file's body compiles to.
 //
-// Messages passed to [Prompt.Execute] are available to the template as
-// {{history}}. Without an explicit {{history}}, they are inserted before the
-// final user message, so a template that ends with the user's turn keeps the
-// conversation in the right order.
+// Messages passed to [Prompt.Execute] reach the template at {{history}}, or,
+// without an explicit {{history}}, are inserted before its final user message.
 //
 // Unlike [WithMessages], the text here is compiled, so literal braces in it are
-// template syntax. Content that came from a user or from a remote source
-// belongs in [WithMessages] or [WithMessagesFn], which never compile it.
+// template syntax. Content from a user or a remote source belongs in
+// [WithMessages] or [WithMessagesFn], which never compile it.
 //
-// A template is the whole conversation, down to where {{history}} puts the
-// caller's, so nothing else can contribute to it: passing this in the same
-// [DefinePrompt] call as [WithMessages] or [WithMessagesFn] panics. Messages
-// that belong to the prompt go in the template as {{role}} blocks; the
-// conversation a caller passes to [Prompt.Execute] is a separate option list
-// and reaches the template at {{history}} as usual.
+// The template is the whole conversation, so nothing else can contribute to it:
+// passing this in the same [DefinePrompt] call as [WithMessages] or
+// [WithMessagesFn] panics. Write those messages as {{role}} blocks instead.
+// Repeating this option alone fills one slot, so the last one set wins.
 //
-// Repeating this option alone is fine: it fills one slot, so the last one set
-// wins.
-//
-// Compiling the template needs a prompt, so this applies to [DefinePrompt]
-// only. That is why it returns a [PromptOption] rather than a
-// [CommonGenOption]: passing it to [Generate] or [Prompt.Execute] does not
-// compile. Use [WithMessages] or [WithMessagesFn] there to supply the
-// conversation the prompt's own template will place.
+// Compiling needs a prompt, so this is a [PromptOption]: passing it to
+// [Generate] or [Prompt.Execute] does not compile. Use [WithMessages] there.
 func WithMessagesTemplate(text string, args ...any) PromptOption {
 	if len(args) > 0 {
 		// Assigning avoids a compile-time warning about non-constant text.
@@ -362,17 +331,14 @@ func WithMessagesTemplate(text string, args ...any) PromptOption {
 // the system and user prompts. Like [WithMessages], repeating this option (or
 // mixing the two) appends the produced messages in call order.
 //
-// The function receives the prompt's input coerced to In, so In may be the
-// struct or map type passed to [WithInputType]. Input arrives as the zero value
-// of In when there is none, which is always the case for [Generate].
+// fn receives the prompt's input converted to In, or the zero value of In when
+// there is none, as at [Generate]. Its messages are used verbatim, as with
+// [WithMessages].
 //
-// The returned messages are used verbatim, as with [WithMessages], so message
-// text may safely contain user content and literal braces.
-//
-// The messages it returns belong to the conversation the prompt declares, so
-// messages supplied at execution time are not appended on top of them. They are
-// available to the function instead via [HistoryFromContext], which lets it
-// summarize, truncate, or reorder them rather than only prepend to them.
+// Those messages are the conversation the prompt declares, so messages supplied
+// at execution time are not appended on top of them. fn reads them from
+// [HistoryFromContext] instead, and can summarize or truncate them rather than
+// only prepend to them.
 func WithMessagesFn[In any](fn func(context.Context, In) ([]*Message, error)) CommonGenOption {
 	return &commonGenOptions{MessagesFn: coerceFn(fn)}
 }
@@ -480,9 +446,8 @@ func (o *inputOptions) applyTool(opts *toolOptions)     { o.applyInput(&opts.inp
 // The inputted value may serve as the default input if no input is given at generation time depending on the action.
 // Only supports structs and map[string]any.
 func WithInputType(input any) InputOption {
-	// Converting rather than marshaling by hand keeps the default input's Go
-	// types aligned with the schema, so a numeric field defaults to the same
-	// type it has when the caller supplies input over the wire.
+	// Converting rather than marshaling by hand gives the default input the
+	// same Go types it would have arriving over the wire.
 	defaultInput, err := base.ConvertToExact[map[string]any](input)
 	if err != nil {
 		panic(fmt.Errorf("type %T is not supported, only structs and map[string]any are supported (WithInputType)", input))
@@ -553,9 +518,8 @@ func WithMetadata(metadata map[string]any) PromptOption {
 // promptingOptions are options for the system and user prompts of a prompt or generate request.
 //
 // Each slot holds either template text or a content function, never both. Text
-// is rendered as a dotprompt template against the prompt's input; a function's
-// result is used verbatim, since only text the prompt author wrote is
-// compiled.
+// is compiled against the prompt's input; a function's result is used verbatim,
+// since only text the prompt author wrote is compiled.
 type promptingOptions struct {
 	SystemText *string // Template text for the system prompt.
 	SystemFn   PartsFn // Function returning system prompt content.
@@ -571,14 +535,12 @@ type PromptingOption interface {
 	applyPrompting(*promptingOptions)
 }
 
-// applyPrompting merges the two single-message slots. Each holds one message,
-// so the four ways of filling one (text, parts, and their function forms) share
-// a slot and the last option to set it wins.
+// applyPrompting merges the two single-message slots, each shared by the four
+// options that fill it, so the last one set wins.
 //
-// The losing field is cleared rather than left behind. Both fields feed the
-// same message and the renderer has to consult them in some fixed order, so a
-// stale one would let that order pick the winner instead of the caller, and no
-// later option could undo an earlier one.
+// Both fields of a slot are assigned together to clear the loser: the renderer
+// consults them in a fixed order, and a leftover value would let that order
+// pick the winner instead of the caller.
 func (o *promptingOptions) applyPrompting(opts *promptingOptions) {
 	if o.SystemText != nil || o.SystemFn != nil {
 		opts.SystemText, opts.SystemFn = o.SystemText, o.SystemFn
@@ -606,14 +568,12 @@ func sprintfText(text string, args []any) string {
 // WithSystem sets the system prompt message.
 // The system prompt is always the first message in the list.
 //
-// When used with [DefinePrompt], the text is rendered as a dotprompt template
-// against the prompt's input, so it may reference input fields such as
-// {{name}}. args, if given, are applied with [fmt.Sprintf] first.
+// With [DefinePrompt], the text is compiled as a dotprompt template against the
+// prompt's input, so it may reference input fields such as {{name}}. args, if
+// given, are applied with [fmt.Sprintf] first.
 //
-// The message is always a system message. A {{role}} marker in the text is an
-// error rather than a silent override, since it would either restate the role
-// or ask for one this slot cannot hold; [WithMessagesTemplate] is where turns
-// with their own roles belong.
+// A {{role}} marker in the text is an error: this slot is one system message.
+// [WithMessagesTemplate] is where turns with their own roles belong.
 func WithSystem(text string, args ...any) PromptingOption {
 	text = sprintfText(text, args)
 	return &promptingOptions{SystemText: &text}
@@ -622,16 +582,13 @@ func WithSystem(text string, args ...any) PromptingOption {
 // WithSystemFn sets the function that generates the system prompt message.
 // The system prompt is always the first message in the list.
 //
-// The function receives the prompt's input coerced to In, so In may be the
-// struct or map type passed to [WithInputType]. Input arrives as the zero value
-// of In when there is none, which is always the case for [Generate].
+// fn receives the prompt's input converted to In, or the zero value of In when
+// there is none, as at [Generate]. Its string is used verbatim, never compiled
+// as a template, so it may safely hold user content and literal braces. Use
+// [WithSystemPartsFn] to return non-text content.
 //
-// The returned string is used verbatim; unlike [WithSystem] it is not rendered
-// as a dotprompt template, so it may safely contain user content and literal
-// braces. Use [WithSystemPartsFn] to return non-text content.
-//
-// This fills the same single message as [WithSystem], [WithSystemParts], and
-// [WithSystemPartsFn], so the last of them set wins and the rest are discarded.
+// It shares one slot with [WithSystem], [WithSystemParts], and
+// [WithSystemPartsFn]: the last one set wins.
 func WithSystemFn[In any](fn func(context.Context, In) (string, error)) PromptingOption {
 	return &promptingOptions{SystemFn: textPartsFn(fn)}
 }
@@ -639,14 +596,13 @@ func WithSystemFn[In any](fn func(context.Context, In) (string, error)) Promptin
 // WithSystemParts sets the content of the system prompt message.
 // The system prompt is always the first message in the list.
 //
-// It is the multi-part form of [WithSystem], for system instructions that mix
-// text with media or other non-text parts. The parts are used verbatim: unlike
-// [WithSystem] text, they are not rendered as a dotprompt template. Use
-// [WithSystemPartsFn] when the content depends on the prompt's input.
+// It is the multi-part form of [WithSystem], for instructions that mix text
+// with media or other non-text parts. The parts are used verbatim, never
+// compiled as a template. Use [WithSystemPartsFn] when the content depends on
+// the prompt's input.
 //
-// This fills the same single message as [WithSystem], [WithSystemFn], and
-// [WithSystemPartsFn], so the last of them set wins and the rest are discarded.
-// Parts are not appended to text from an earlier [WithSystem].
+// It shares one slot with [WithSystem], [WithSystemFn], and
+// [WithSystemPartsFn]: the last one set wins.
 func WithSystemParts(parts ...*Part) PromptingOption {
 	return &promptingOptions{SystemFn: staticPartsFn(parts)}
 }
@@ -654,12 +610,11 @@ func WithSystemParts(parts ...*Part) PromptingOption {
 // WithSystemPartsFn sets the function that generates the content of the system
 // prompt message. The system prompt is always the first message in the list.
 //
-// It is the multi-part form of [WithSystemFn], for system instructions that mix
-// text with media or other non-text parts. The returned parts are used
+// It is the multi-part form of [WithSystemFn]. The returned parts are used
 // verbatim.
 //
-// This fills the same single message as [WithSystem], [WithSystemParts], and
-// [WithSystemFn], so the last of them set wins and the rest are discarded.
+// It shares one slot with [WithSystem], [WithSystemParts], and [WithSystemFn]:
+// the last one set wins.
 func WithSystemPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) PromptingOption {
 	return &promptingOptions{SystemFn: coerceFn(fn)}
 }
@@ -667,14 +622,12 @@ func WithSystemPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) Pr
 // WithPrompt sets the user prompt message.
 // The user prompt is always the last message in the list.
 //
-// When used with [DefinePrompt], the text is rendered as a dotprompt template
-// against the prompt's input, so it may reference input fields such as
-// {{name}}. args, if given, are applied with [fmt.Sprintf] first.
+// With [DefinePrompt], the text is compiled as a dotprompt template against the
+// prompt's input, so it may reference input fields such as {{name}}. args, if
+// given, are applied with [fmt.Sprintf] first.
 //
-// The message is always a user message. A {{role}} marker in the text is an
-// error rather than a silent override, since it would either restate the role
-// or ask for one this slot cannot hold; [WithMessagesTemplate] is where turns
-// with their own roles belong.
+// A {{role}} marker in the text is an error: this slot is one user message.
+// [WithMessagesTemplate] is where turns with their own roles belong.
 func WithPrompt(text string, args ...any) PromptingOption {
 	text = sprintfText(text, args)
 	return &promptingOptions{PromptText: &text}
@@ -683,16 +636,13 @@ func WithPrompt(text string, args ...any) PromptingOption {
 // WithPromptFn sets the function that generates the user prompt message.
 // The user prompt is always the last message in the list.
 //
-// The function receives the prompt's input coerced to In, so In may be the
-// struct or map type passed to [WithInputType]. Input arrives as the zero value
-// of In when there is none, which is always the case for [Generate].
+// fn receives the prompt's input converted to In, or the zero value of In when
+// there is none, as at [Generate]. Its string is used verbatim, never compiled
+// as a template, so it may safely hold user content and literal braces. Use
+// [WithPromptPartsFn] to return non-text content.
 //
-// The returned string is used verbatim; unlike [WithPrompt] it is not rendered
-// as a dotprompt template, so it may safely contain user content and literal
-// braces. Use [WithPromptPartsFn] to return non-text content.
-//
-// This fills the same single message as [WithPrompt], [WithPromptParts], and
-// [WithPromptPartsFn], so the last of them set wins and the rest are discarded.
+// It shares one slot with [WithPrompt], [WithPromptParts], and
+// [WithPromptPartsFn]: the last one set wins.
 func WithPromptFn[In any](fn func(context.Context, In) (string, error)) PromptingOption {
 	return &promptingOptions{PromptFn: textPartsFn(fn)}
 }
@@ -701,9 +651,9 @@ func WithPromptFn[In any](fn func(context.Context, In) (string, error)) Promptin
 // The user prompt is always the last message in the list.
 //
 // It is the multi-part form of [WithPrompt], for prompts that mix text with
-// media or other non-text parts. The parts are used verbatim: unlike
-// [WithPrompt] text, they are not rendered as a dotprompt template. Use
-// [WithPromptPartsFn] when the content depends on the prompt's input.
+// media or other non-text parts. The parts are used verbatim, never compiled as
+// a template. Use [WithPromptPartsFn] when the content depends on the prompt's
+// input.
 //
 //	genkit.Generate(ctx, g,
 //		ai.WithModelName("googleai/gemini-flash-latest"),
@@ -713,9 +663,8 @@ func WithPromptFn[In any](fn func(context.Context, In) (string, error)) Promptin
 //		),
 //	)
 //
-// This fills the same single message as [WithPrompt], [WithPromptFn], and
-// [WithPromptPartsFn], so the last of them set wins and the rest are discarded.
-// Parts are not appended to text from an earlier [WithPrompt].
+// It shares one slot with [WithPrompt], [WithPromptFn], and
+// [WithPromptPartsFn]: the last one set wins.
 func WithPromptParts(parts ...*Part) PromptingOption {
 	return &promptingOptions{PromptFn: staticPartsFn(parts)}
 }
@@ -723,11 +672,11 @@ func WithPromptParts(parts ...*Part) PromptingOption {
 // WithPromptPartsFn sets the function that generates the content of the user
 // prompt message. The user prompt is always the last message in the list.
 //
-// It is the multi-part form of [WithPromptFn], for prompts that mix text with
-// media or other non-text parts. The returned parts are used verbatim.
+// It is the multi-part form of [WithPromptFn]. The returned parts are used
+// verbatim.
 //
-// This fills the same single message as [WithPrompt], [WithPromptParts], and
-// [WithPromptFn], so the last of them set wins and the rest are discarded.
+// It shares one slot with [WithPrompt], [WithPromptParts], and [WithPromptFn]:
+// the last one set wins.
 func WithPromptPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) PromptingOption {
 	return &promptingOptions{PromptFn: coerceFn(fn)}
 }
@@ -915,11 +864,8 @@ type DocumentOption interface {
 	applyDocument(*documentOptions)
 }
 
-// applyDocument applies the option to the context options.
-// applyDocument accumulates documents: fixed ones from [WithDocs] and
-// [WithTextDocs] append in call order, and the functions from [WithDocsFn]
-// compose so their results concatenate the same way. Resolution runs the fixed
-// documents first, then the computed ones.
+// applyDocument accumulates documents: the fixed ones append in call order and
+// the [WithDocsFn] functions compose the same way.
 func (o *documentOptions) applyDocument(docOpts *documentOptions) {
 	docOpts.Documents = append(docOpts.Documents, o.Documents...)
 	docOpts.DocsFn = appendDocsFn(docOpts.DocsFn, o.DocsFn)
@@ -960,18 +906,15 @@ func WithDocs(docs ...*Document) DocumentOption {
 	return &documentOptions{Documents: docs}
 }
 
-// WithDocsFn sets the function that selects the context documents for a prompt.
-// It applies only to [DefinePrompt], since it is the only place where the
-// documents are not yet known when the option is constructed.
+// WithDocsFn sets the function that selects the context documents for a prompt,
+// such as by querying a retriever. It applies only to [DefinePrompt], since
+// only a prompt has input to give it.
 //
-// The function receives the prompt's input coerced to In, so In may be the
-// struct or map type passed to [WithInputType]. This is the hook for retrieval
-// that depends on the input, such as running a query against a retriever
-// derived from the input fields.
+// fn receives the prompt's input converted to In.
 //
 // Documents accumulate: repeating this option, or combining it with [WithDocs]
 // or [WithTextDocs], adds to the set rather than replacing it. The fixed
-// documents are resolved first, then the computed ones, each in call order.
+// documents resolve first, then the computed ones, each in call order.
 func WithDocsFn[In any](fn func(context.Context, In) ([]*Document, error)) PromptOption {
 	return &promptOptions{documentOptions: documentOptions{DocsFn: coerceFn(fn)}}
 }

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -42,12 +42,12 @@ import (
 //     are four ways to write one system message, so the last of them wins and
 //     the others are discarded, not merged into it.
 //
-// The conversation is the one collection with an exception. WithMessages and
-// WithMessagesFn accumulate as above, but WithMessagesTemplate resets: a
-// template lays out the whole conversation, down to where {{history}} puts the
-// caller's, so there is no coherent way to fold separately supplied messages
-// into it. It drops whatever came before it, and messages set after it
-// accumulate onto it.
+// One combination is refused rather than merged. WithMessagesTemplate lays out
+// the whole conversation, down to where {{history}} puts the caller's, so there
+// is no position relative to it that separately supplied messages could
+// meaningfully take. Giving it in the same DefinePrompt call as WithMessages or
+// WithMessagesFn panics, saying so. Repeating the template alone is fine and
+// takes the last one, as any other slot does.
 //
 // A zero value does not fill a slot: WithMaxTurns(0), WithToolChoice(""), or
 // WithConfig(nil) is a no-op, so an earlier non-zero value cannot be un-set by
@@ -260,16 +260,13 @@ type CommonGenOption interface {
 func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) {
 	o.configOptions.applyConfig(&opts.configOptions)
 
-	// Verbatim messages accumulate with each other, but a template resets the
-	// conversation: it lays the whole thing out, down to where {{history}} puts
-	// the caller's, so there is no coherent way to fold separately supplied
-	// messages into it. Whatever was set before it is dropped, and messages set
-	// after it accumulate onto it.
+	// The two standard rules, nothing special: verbatim messages accumulate,
+	// and the conversation template is a slot the last one set wins. Combining
+	// the two is refused by [DefinePrompt] rather than merged here, since no
+	// merge of them means anything.
+	opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
 	if o.MessagesText != nil {
 		opts.MessagesText = o.MessagesText
-		opts.MessagesFn = nil
-	} else {
-		opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
 	}
 
 	if o.Model != nil {
@@ -337,11 +334,15 @@ func WithMessages(messages ...*Message) CommonGenOption {
 // template syntax. Content that came from a user or from a remote source
 // belongs in [WithMessages] or [WithMessagesFn], which never compile it.
 //
-// A template resets the conversation. It lays the whole thing out, down to
-// where {{history}} puts the caller's, so any [WithMessages],
-// [WithMessagesFn], or [WithMessagesTemplate] set before it is dropped rather
-// than folded into it. Messages set after it accumulate onto it, so ordering
-// still reads left to right.
+// A template is the whole conversation, down to where {{history}} puts the
+// caller's, so nothing else can contribute to it: passing this in the same
+// [DefinePrompt] call as [WithMessages] or [WithMessagesFn] panics. Messages
+// that belong to the prompt go in the template as {{role}} blocks; the
+// conversation a caller passes to [Prompt.Execute] is a separate option list
+// and reaches the template at {{history}} as usual.
+//
+// Repeating this option alone is fine: it fills one slot, so the last one set
+// wins.
 //
 // Compiling the template needs a prompt, so this applies to [DefinePrompt]
 // only. That is why it returns a [PromptOption] rather than a

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -43,11 +43,11 @@ import (
 //     the others are discarded, not merged into it.
 //
 // The conversation is the one collection with an exception. WithMessages and
-// WithMessagesFn accumulate as above, but WithMessagesTemplate does not: a
-// template lays out the whole conversation and is where {{history}} places the
-// caller's, so a second template replaces the first rather than leaving two
-// layouts to divide one conversation. Messages given after a template
-// accumulate behind it, which keeps the template where it was first declared.
+// WithMessagesFn accumulate as above, but WithMessagesTemplate resets: a
+// template lays out the whole conversation, down to where {{history}} puts the
+// caller's, so there is no coherent way to fold separately supplied messages
+// into it. It drops whatever came before it, and messages set after it
+// accumulate onto it.
 //
 // A zero value does not fill a slot: WithMaxTurns(0), WithToolChoice(""), or
 // WithConfig(nil) is a no-op, so an earlier non-zero value cannot be un-set by
@@ -237,9 +237,8 @@ func WithConfig(config any) ConfigOption {
 type commonGenOptions struct {
 	configOptions
 	Model              ModelArg          // Model to use.
-	MessagesFn         MessagesFn        // Messages contributed before MessagesText. Used verbatim.
+	MessagesFn         MessagesFn        // Messages set since the last MessagesText, if any. Used verbatim.
 	MessagesText       *string           // Template text for the conversation, rendered as a dotprompt template.
-	MessagesAfterFn    MessagesFn        // Messages contributed after MessagesText. Used verbatim.
 	Tools              []ToolRef         // References to tools to use.
 	Resources          []Resource        // Resources to be temporarily available during generation.
 	ToolChoice         ToolChoice        // Whether tool calls are required, disabled, or optional.
@@ -261,19 +260,16 @@ type CommonGenOption interface {
 func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) {
 	o.configOptions.applyConfig(&opts.configOptions)
 
-	// Verbatim messages accumulate, but a conversation template does not: it
-	// lays out the whole conversation and is where {{history}} places the
-	// caller's, so a second template replaces the first rather than leaving two
-	// layouts to fight over one conversation. Messages that arrive after a
-	// template accumulate behind it, which keeps the template where it was
-	// first declared and lets the rest still read left to right.
-	if opts.MessagesText == nil {
-		opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
-	} else {
-		opts.MessagesAfterFn = appendMessagesFn(opts.MessagesAfterFn, o.MessagesFn)
-	}
+	// Verbatim messages accumulate with each other, but a template resets the
+	// conversation: it lays the whole thing out, down to where {{history}} puts
+	// the caller's, so there is no coherent way to fold separately supplied
+	// messages into it. Whatever was set before it is dropped, and messages set
+	// after it accumulate onto it.
 	if o.MessagesText != nil {
 		opts.MessagesText = o.MessagesText
+		opts.MessagesFn = nil
+	} else {
+		opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
 	}
 
 	if o.Model != nil {
@@ -341,12 +337,11 @@ func WithMessages(messages ...*Message) CommonGenOption {
 // template syntax. Content that came from a user or from a remote source
 // belongs in [WithMessages] or [WithMessagesFn], which never compile it.
 //
-// Repeating this option replaces the template rather than adding a second one:
-// the template lays out the whole conversation and is where {{history}} goes,
-// so two of them would divide one conversation between two layouts. Messages
-// from [WithMessages] and [WithMessagesFn] still accumulate around it, before
-// it or behind it according to where they were passed, which leaves the
-// template where it was first declared.
+// A template resets the conversation. It lays the whole thing out, down to
+// where {{history}} puts the caller's, so any [WithMessages],
+// [WithMessagesFn], or [WithMessagesTemplate] set before it is dropped rather
+// than folded into it. Messages set after it accumulate onto it, so ordering
+// still reads left to right.
 //
 // Compiling the template needs a prompt, so this applies to [DefinePrompt]
 // only. That is why it returns a [PromptOption] rather than a

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -866,14 +866,13 @@ type DocumentOption interface {
 
 // applyDocument accumulates documents: the fixed ones append in call order and
 // the [WithDocsFn] functions compose the same way.
-func (o *documentOptions) applyDocument(docOpts *documentOptions) {
-	docOpts.Documents = append(docOpts.Documents, o.Documents...)
-	docOpts.DocsFn = appendDocsFn(docOpts.DocsFn, o.DocsFn)
+func (o *documentOptions) applyDocument(opts *documentOptions) {
+	opts.Documents = append(opts.Documents, o.Documents...)
+	opts.DocsFn = appendDocsFn(opts.DocsFn, o.DocsFn)
 }
 
-// applyPrompt applies the option to the prompt options.
-func (o *documentOptions) applyPrompt(pOpts *promptOptions) {
-	o.applyDocument(&pOpts.documentOptions)
+func (o *documentOptions) applyPrompt(opts *promptOptions) {
+	o.applyDocument(&opts.documentOptions)
 }
 
 func (o *documentOptions) applyGenerate(opts *generateOptions) {

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -18,11 +18,12 @@ package ai
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/internal/base"
 )
 
 // Options follow the standard Go functional-options pattern: pass as many as
@@ -36,7 +37,17 @@ import (
 //   - Single-value options take the last one set. WithConfig, WithModel /
 //     WithModelName, WithSystem, WithPrompt, the output-schema options, and the
 //     like each fill one slot, so the final call wins and earlier ones are
-//     overwritten rather than rejected.
+//     overwritten rather than rejected. A slot is shared by every option that
+//     fills it: WithSystem, WithSystemParts, WithSystemFn, and WithSystemPartsFn
+//     are four ways to write one system message, so the last of them wins and
+//     the others are discarded, not merged into it.
+//
+// The conversation is the one collection with an exception. WithMessages and
+// WithMessagesFn accumulate as above, but WithMessagesTemplate does not: a
+// template lays out the whole conversation and is where {{history}} places the
+// caller's, so a second template replaces the first rather than leaving two
+// layouts to divide one conversation. Messages given after a template
+// accumulate behind it, which keeps the template where it was first declared.
 //
 // A zero value does not fill a slot: WithMaxTurns(0), WithToolChoice(""), or
 // WithConfig(nil) is a no-op, so an earlier non-zero value cannot be un-set by
@@ -49,10 +60,18 @@ import (
 // WithInputType cannot turn into a schema), which panic at the call site where
 // the mistake is.
 
-// PromptFn is a function that generates a prompt.
+// PromptFn is a function that generates a prompt from a prompt's input.
+//
+// The input argument is untyped. Prefer passing a function with a concrete
+// input type to [WithPromptFn] or [WithSystemFn], which coerces the input for
+// you and works on every invocation path.
 type PromptFn = func(context.Context, any) (string, error)
 
-// MessagesFn is a function that generates messages.
+// MessagesFn is a function that generates messages from a prompt's input.
+//
+// The input argument is untyped. Prefer passing a function with a concrete
+// input type to [WithMessagesFn], which coerces the input for you and works on
+// every invocation path.
 type MessagesFn = func(context.Context, any) ([]*Message, error)
 
 // appendMessagesFn composes two message-producing functions so their outputs
@@ -81,6 +100,97 @@ func appendMessagesFn(existing, next MessagesFn) MessagesFn {
 		// would write into the spare capacity of the array backing their
 		// history. Concat always allocates a fresh slice.
 		return slices.Concat(before, after), nil
+	}
+}
+
+// appendDocsFn composes two document-producing functions so their outputs
+// concatenate in call order, backing the accumulate semantics of [WithDocsFn]
+// the same way [appendMessagesFn] does for messages. Either side may be nil,
+// in which case the other is returned unwrapped.
+func appendDocsFn(existing, next DocsFn) DocsFn {
+	if existing == nil {
+		return next
+	}
+	if next == nil {
+		return existing
+	}
+	return func(ctx context.Context, input any) ([]*Document, error) {
+		before, err := existing(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		after, err := next(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		return slices.Concat(before, after), nil
+	}
+}
+
+// PartsFn is a function that generates message content from a prompt's input.
+//
+// The input argument is untyped. Prefer passing a function with a concrete
+// input type to [WithPromptPartsFn] or [WithSystemPartsFn], which coerces the
+// input for you and works on every invocation path.
+type PartsFn = func(context.Context, any) ([]*Part, error)
+
+// DocsFn is a function that generates context documents from a prompt's input.
+//
+// The input argument is untyped. Prefer passing a function with a concrete
+// input type to [WithDocsFn], which coerces the input for you and works on
+// every invocation path.
+type DocsFn = func(context.Context, any) ([]*Document, error)
+
+// coerceFn adapts a typed content function to the untyped signature the option
+// structs store, converting the raw input to In on each call. Every
+// content-function option funnels through this so the conversion contract has
+// exactly one implementation.
+//
+// The raw value's Go type depends on how the prompt was invoked: an in-process
+// call with [WithInput] passes the value through as-is, while the reflection
+// API (Dev UI, flows over HTTP) and the default input recorded by
+// [WithInputType] both arrive as map[string]any. Converting here means content
+// functions see the same type regardless of the caller. A nil raw value yields
+// the zero value of In, which is what [Generate] passes since it has no prompt
+// input at all.
+func coerceFn[In, Out any](fn func(context.Context, In) (Out, error)) func(context.Context, any) (Out, error) {
+	return func(ctx context.Context, raw any) (Out, error) {
+		in, err := base.ConvertToExact[In](raw)
+		if err != nil {
+			var zero Out
+			// Classified here rather than at the conversion: the mismatch is
+			// only diagnosable as a caller's bad input once it has a content
+			// function to disagree with.
+			return zero, status.Errorf(ErrInputTypeMismatch, "content function input: %w", err)
+		}
+		return fn(ctx, in)
+	}
+}
+
+// staticPartsFn adapts a fixed set of parts to a [PartsFn], handing out a
+// fresh slice per render so that later stages appending to the message's
+// content cannot reach the parts stored on the prompt.
+func staticPartsFn(parts []*Part) PartsFn {
+	return func(context.Context, any) ([]*Part, error) {
+		return slices.Clone(parts), nil
+	}
+}
+
+// textPartsFn adapts a string-returning content function to a [PartsFn].
+// An empty string yields no parts, so the renderers emit no message: a
+// function that returns "" means "no content this time", matching how empty
+// template text behaves.
+func textPartsFn[In any](fn func(context.Context, In) (string, error)) PartsFn {
+	coerced := coerceFn(fn)
+	return func(ctx context.Context, raw any) ([]*Part, error) {
+		text, err := coerced(ctx, raw)
+		if err != nil {
+			return nil, err
+		}
+		if text == "" {
+			return nil, nil
+		}
+		return []*Part{NewTextPart(text)}, nil
 	}
 }
 
@@ -127,7 +237,9 @@ func WithConfig(config any) ConfigOption {
 type commonGenOptions struct {
 	configOptions
 	Model              ModelArg          // Model to use.
-	MessagesFn         MessagesFn        // Function to generate messages.
+	MessagesFn         MessagesFn        // Messages contributed before MessagesText. Used verbatim.
+	MessagesText       *string           // Template text for the conversation, rendered as a dotprompt template.
+	MessagesAfterFn    MessagesFn        // Messages contributed after MessagesText. Used verbatim.
 	Tools              []ToolRef         // References to tools to use.
 	Resources          []Resource        // Resources to be temporarily available during generation.
 	ToolChoice         ToolChoice        // Whether tool calls are required, disabled, or optional.
@@ -149,7 +261,21 @@ type CommonGenOption interface {
 func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) {
 	o.configOptions.applyConfig(&opts.configOptions)
 
-	opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
+	// Verbatim messages accumulate, but a conversation template does not: it
+	// lays out the whole conversation and is where {{history}} places the
+	// caller's, so a second template replaces the first rather than leaving two
+	// layouts to fight over one conversation. Messages that arrive after a
+	// template accumulate behind it, which keeps the template where it was
+	// first declared and lets the rest still read left to right.
+	if opts.MessagesText == nil {
+		opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
+	} else {
+		opts.MessagesAfterFn = appendMessagesFn(opts.MessagesAfterFn, o.MessagesFn)
+	}
+	if o.MessagesText != nil {
+		opts.MessagesText = o.MessagesText
+	}
+
 	if o.Model != nil {
 		opts.Model = o.Model
 	}
@@ -180,17 +306,78 @@ func (o *commonGenOptions) applyPromptExecute(opts *promptExecutionOptions) {
 // WithMessages adds messages to the request, placed between the system and
 // user prompts. Repeating this option, or mixing it with [WithMessagesFn],
 // appends: messages accumulate in the order the options are passed.
+//
+// Message text is used verbatim and is never rendered as a dotprompt template,
+// so history containing literal braces, such as a user asking about {{#if}},
+// passes through untouched. To build message text from a prompt's input, either
+// interpolate it before calling this or use [WithMessagesFn], which receives
+// the typed input, or [WithMessagesTemplate] for a multi-turn dotprompt
+// template.
+//
+// Declaring the conversation makes the prompt responsible for the messages
+// passed to [Prompt.Execute]: they are not spliced in automatically, because
+// only the prompt knows where its examples end and a real conversation begins.
+// Use [WithMessagesTemplate] with {{history}} or [WithMessagesFn] with
+// [HistoryFromContext] to place them.
 func WithMessages(messages ...*Message) CommonGenOption {
 	return WithMessagesFn(func(context.Context, any) ([]*Message, error) {
 		return messages, nil
 	})
 }
 
+// WithMessagesTemplate sets the conversation to a dotprompt template.
+// Optional args are applied to text with [fmt.Sprintf].
+//
+// This is the multi-turn form: each {{role "..."}} block in the text starts a
+// new message, so one template can express a system preamble, few-shot
+// examples, and the user turn. It is what a .prompt file's body compiles to.
+//
+// Messages passed to [Prompt.Execute] are available to the template as
+// {{history}}. Without an explicit {{history}}, they are inserted before the
+// final user message, so a template that ends with the user's turn keeps the
+// conversation in the right order.
+//
+// Unlike [WithMessages], the text here is compiled, so literal braces in it are
+// template syntax. Content that came from a user or from a remote source
+// belongs in [WithMessages] or [WithMessagesFn], which never compile it.
+//
+// Repeating this option replaces the template rather than adding a second one:
+// the template lays out the whole conversation and is where {{history}} goes,
+// so two of them would divide one conversation between two layouts. Messages
+// from [WithMessages] and [WithMessagesFn] still accumulate around it, before
+// it or behind it according to where they were passed, which leaves the
+// template where it was first declared.
+//
+// Compiling the template needs a prompt, so this applies to [DefinePrompt]
+// only. Passing it to [Generate] or to [Prompt.Execute] is an error: use
+// [WithMessages] or [WithMessagesFn] there to supply the conversation the
+// prompt's own template will place.
+func WithMessagesTemplate(text string, args ...any) CommonGenOption {
+	if len(args) > 0 {
+		// Assigning avoids a compile-time warning about non-constant text.
+		t := text
+		text = fmt.Sprintf(t, args...)
+	}
+	return &commonGenOptions{MessagesText: &text}
+}
+
 // WithMessagesFn adds messages produced by fn at request time, placed between
 // the system and user prompts. Like [WithMessages], repeating this option (or
 // mixing the two) appends the produced messages in call order.
-func WithMessagesFn(fn MessagesFn) CommonGenOption {
-	return &commonGenOptions{MessagesFn: fn}
+//
+// The function receives the prompt's input coerced to In, so In may be the
+// struct or map type passed to [WithInputType]. Input arrives as the zero value
+// of In when there is none, which is always the case for [Generate].
+//
+// The returned messages are used verbatim, as with [WithMessages], so message
+// text may safely contain user content and literal braces.
+//
+// The messages it returns belong to the conversation the prompt declares, so
+// messages supplied at execution time are not appended on top of them. They are
+// available to the function instead via [HistoryFromContext], which lets it
+// summarize, truncate, or reorder them rather than only prepend to them.
+func WithMessagesFn[In any](fn func(context.Context, In) ([]*Message, error)) CommonGenOption {
+	return &commonGenOptions{MessagesFn: coerceFn(fn)}
 }
 
 // WithTools adds tools to use for the generate request. Repeating this option
@@ -296,21 +483,12 @@ func (o *inputOptions) applyTool(opts *toolOptions)     { o.applyInput(&opts.inp
 // The inputted value may serve as the default input if no input is given at generation time depending on the action.
 // Only supports structs and map[string]any.
 func WithInputType(input any) InputOption {
-	var defaultInput map[string]any
-
-	switch v := input.(type) {
-	case map[string]any:
-		defaultInput = v
-	default:
-		data, err := json.Marshal(input)
-		if err != nil {
-			panic(fmt.Errorf("failed to marshal default input (WithInputType): %w", err))
-		}
-
-		err = json.Unmarshal(data, &defaultInput)
-		if err != nil {
-			panic(fmt.Errorf("type %T is not supported, only structs and map[string]any are supported (WithInputType)", input))
-		}
+	// Converting rather than marshaling by hand keeps the default input's Go
+	// types aligned with the schema, so a numeric field defaults to the same
+	// type it has when the caller supplies input over the wire.
+	defaultInput, err := base.ConvertToExact[map[string]any](input)
+	if err != nil {
+		panic(fmt.Errorf("type %T is not supported, only structs and map[string]any are supported (WithInputType)", input))
 	}
 
 	return &inputOptions{
@@ -336,6 +514,7 @@ type promptOptions struct {
 	promptingOptions
 	inputOptions
 	outputOptions
+	documentOptions
 	Description string         // Description of the prompt.
 	Metadata    map[string]any // Arbitrary metadata.
 }
@@ -351,6 +530,8 @@ func (o *promptOptions) applyPrompt(opts *promptOptions) {
 	o.promptingOptions.applyPrompt(opts)
 	o.inputOptions.applyPrompt(opts)
 	o.outputOptions.applyPrompt(opts)
+
+	o.documentOptions.applyPrompt(opts)
 
 	if o.Description != "" {
 		opts.Description = o.Description
@@ -373,9 +554,16 @@ func WithMetadata(metadata map[string]any) PromptOption {
 }
 
 // promptingOptions are options for the system and user prompts of a prompt or generate request.
+//
+// Each slot holds either template text or a content function, never both. Text
+// is rendered as a dotprompt template against the prompt's input; a function's
+// result is used verbatim, since only text the prompt author wrote is
+// compiled.
 type promptingOptions struct {
-	SystemFn PromptFn // Function to generate the system prompt.
-	PromptFn PromptFn // Function to generate the user prompt.
+	SystemText *string // Template text for the system prompt.
+	SystemFn   PartsFn // Function returning system prompt content.
+	PromptText *string // Template text for the user prompt.
+	PromptFn   PartsFn // Function returning user prompt content.
 }
 
 // PromptingOption is an option for the system and user prompts of a prompt or generate request.
@@ -386,15 +574,20 @@ type PromptingOption interface {
 	applyPrompting(*promptingOptions)
 }
 
-// applyPrompting applies the option to the prompting options. The system and
-// user prompts are independent single-value slots, so the last option to set
-// each one wins.
+// applyPrompting merges the two single-message slots. Each holds one message,
+// so the four ways of filling one (text, parts, and their function forms) share
+// a slot and the last option to set it wins.
+//
+// The losing field is cleared rather than left behind. Both fields feed the
+// same message and the renderer has to consult them in some fixed order, so a
+// stale one would let that order pick the winner instead of the caller, and no
+// later option could undo an earlier one.
 func (o *promptingOptions) applyPrompting(opts *promptingOptions) {
-	if o.SystemFn != nil {
-		opts.SystemFn = o.SystemFn
+	if o.SystemText != nil || o.SystemFn != nil {
+		opts.SystemText, opts.SystemFn = o.SystemText, o.SystemFn
 	}
-	if o.PromptFn != nil {
-		opts.PromptFn = o.PromptFn
+	if o.PromptText != nil || o.PromptFn != nil {
+		opts.PromptText, opts.PromptFn = o.PromptText, o.PromptFn
 	}
 }
 
@@ -403,37 +596,143 @@ func (o *promptingOptions) applyGenerate(opts *generateOptions) {
 	o.applyPrompting(&opts.promptingOptions)
 }
 
-// textPromptFn adapts fmt.Sprintf-style text and args into a [PromptFn].
-func textPromptFn(text string, args []any) PromptFn {
-	return func(context.Context, any) (string, error) {
-		// Avoids a compile-time warning about non-constant text.
-		t := text
-		return fmt.Sprintf(t, args...), nil
+// sprintfText applies args to text, leaving it alone when none were given.
+func sprintfText(text string, args []any) string {
+	if len(args) == 0 {
+		return text
 	}
+	// Assigning avoids a compile-time warning about non-constant text.
+	t := text
+	return fmt.Sprintf(t, args...)
 }
 
 // WithSystem sets the system prompt message.
 // The system prompt is always the first message in the list.
+//
+// When used with [DefinePrompt], the text is rendered as a dotprompt template
+// against the prompt's input, so it may reference input fields such as
+// {{name}}. args, if given, are applied with [fmt.Sprintf] first.
+//
+// The message is always a system message. A {{role}} marker in the text is an
+// error rather than a silent override, since it would either restate the role
+// or ask for one this slot cannot hold; [WithMessagesTemplate] is where turns
+// with their own roles belong.
 func WithSystem(text string, args ...any) PromptingOption {
-	return &promptingOptions{SystemFn: textPromptFn(text, args)}
+	text = sprintfText(text, args)
+	return &promptingOptions{SystemText: &text}
 }
 
 // WithSystemFn sets the function that generates the system prompt message.
 // The system prompt is always the first message in the list.
-func WithSystemFn(fn PromptFn) PromptingOption {
-	return &promptingOptions{SystemFn: fn}
+//
+// The function receives the prompt's input coerced to In, so In may be the
+// struct or map type passed to [WithInputType]. Input arrives as the zero value
+// of In when there is none, which is always the case for [Generate].
+//
+// The returned string is used verbatim; unlike [WithSystem] it is not rendered
+// as a dotprompt template, so it may safely contain user content and literal
+// braces. Use [WithSystemPartsFn] to return non-text content.
+//
+// This fills the same single message as [WithSystem], [WithSystemParts], and
+// [WithSystemPartsFn], so the last of them set wins and the rest are discarded.
+func WithSystemFn[In any](fn func(context.Context, In) (string, error)) PromptingOption {
+	return &promptingOptions{SystemFn: textPartsFn(fn)}
+}
+
+// WithSystemParts sets the content of the system prompt message.
+// The system prompt is always the first message in the list.
+//
+// It is the multi-part form of [WithSystem], for system instructions that mix
+// text with media or other non-text parts. The parts are used verbatim: unlike
+// [WithSystem] text, they are not rendered as a dotprompt template. Use
+// [WithSystemPartsFn] when the content depends on the prompt's input.
+//
+// This fills the same single message as [WithSystem], [WithSystemFn], and
+// [WithSystemPartsFn], so the last of them set wins and the rest are discarded.
+// Parts are not appended to text from an earlier [WithSystem].
+func WithSystemParts(parts ...*Part) PromptingOption {
+	return &promptingOptions{SystemFn: staticPartsFn(parts)}
+}
+
+// WithSystemPartsFn sets the function that generates the content of the system
+// prompt message. The system prompt is always the first message in the list.
+//
+// It is the multi-part form of [WithSystemFn], for system instructions that mix
+// text with media or other non-text parts. The returned parts are used
+// verbatim.
+//
+// This fills the same single message as [WithSystem], [WithSystemParts], and
+// [WithSystemFn], so the last of them set wins and the rest are discarded.
+func WithSystemPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) PromptingOption {
+	return &promptingOptions{SystemFn: coerceFn(fn)}
 }
 
 // WithPrompt sets the user prompt message.
 // The user prompt is always the last message in the list.
+//
+// When used with [DefinePrompt], the text is rendered as a dotprompt template
+// against the prompt's input, so it may reference input fields such as
+// {{name}}. args, if given, are applied with [fmt.Sprintf] first.
+//
+// The message is always a user message. A {{role}} marker in the text is an
+// error rather than a silent override, since it would either restate the role
+// or ask for one this slot cannot hold; [WithMessagesTemplate] is where turns
+// with their own roles belong.
 func WithPrompt(text string, args ...any) PromptingOption {
-	return &promptingOptions{PromptFn: textPromptFn(text, args)}
+	text = sprintfText(text, args)
+	return &promptingOptions{PromptText: &text}
 }
 
 // WithPromptFn sets the function that generates the user prompt message.
 // The user prompt is always the last message in the list.
-func WithPromptFn(fn PromptFn) PromptingOption {
-	return &promptingOptions{PromptFn: fn}
+//
+// The function receives the prompt's input coerced to In, so In may be the
+// struct or map type passed to [WithInputType]. Input arrives as the zero value
+// of In when there is none, which is always the case for [Generate].
+//
+// The returned string is used verbatim; unlike [WithPrompt] it is not rendered
+// as a dotprompt template, so it may safely contain user content and literal
+// braces. Use [WithPromptPartsFn] to return non-text content.
+//
+// This fills the same single message as [WithPrompt], [WithPromptParts], and
+// [WithPromptPartsFn], so the last of them set wins and the rest are discarded.
+func WithPromptFn[In any](fn func(context.Context, In) (string, error)) PromptingOption {
+	return &promptingOptions{PromptFn: textPartsFn(fn)}
+}
+
+// WithPromptParts sets the content of the user prompt message.
+// The user prompt is always the last message in the list.
+//
+// It is the multi-part form of [WithPrompt], for prompts that mix text with
+// media or other non-text parts. The parts are used verbatim: unlike
+// [WithPrompt] text, they are not rendered as a dotprompt template. Use
+// [WithPromptPartsFn] when the content depends on the prompt's input.
+//
+//	genkit.Generate(ctx, g,
+//		ai.WithModelName("googleai/gemini-flash-latest"),
+//		ai.WithPromptParts(
+//			ai.NewTextPart("What is in this image?"),
+//			ai.NewMediaPart("image/png", imageURL),
+//		),
+//	)
+//
+// This fills the same single message as [WithPrompt], [WithPromptFn], and
+// [WithPromptPartsFn], so the last of them set wins and the rest are discarded.
+// Parts are not appended to text from an earlier [WithPrompt].
+func WithPromptParts(parts ...*Part) PromptingOption {
+	return &promptingOptions{PromptFn: staticPartsFn(parts)}
+}
+
+// WithPromptPartsFn sets the function that generates the content of the user
+// prompt message. The user prompt is always the last message in the list.
+//
+// It is the multi-part form of [WithPromptFn], for prompts that mix text with
+// media or other non-text parts. The returned parts are used verbatim.
+//
+// This fills the same single message as [WithPrompt], [WithPromptParts], and
+// [WithPromptFn], so the last of them set wins and the rest are discarded.
+func WithPromptPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) PromptingOption {
+	return &promptingOptions{PromptFn: coerceFn(fn)}
 }
 
 // outputOptions are options for the output of a prompt or generate request.
@@ -604,11 +903,14 @@ func withChainedStreaming(callback ModelStreamCallback) ExecutionOption {
 // documentOptions are options for providing context documents to a prompt or generate request or as input to an embedder.
 type documentOptions struct {
 	Documents []*Document // Docs to pass as context or input.
+	DocsFn    DocsFn      // Function to generate docs from a prompt's input.
 }
 
 // DocumentOption is an option for providing context or input documents.
-// It applies to [Generate], [Prompt.Execute], [Embed], and [Retrieve].
+// It applies to [DefinePrompt], [Generate], [Prompt.Execute], [Embed], and
+// [Retrieve].
 type DocumentOption interface {
+	PromptOption
 	GenerateOption
 	PromptExecuteOption
 	EmbedderOption
@@ -616,8 +918,19 @@ type DocumentOption interface {
 	applyDocument(*documentOptions)
 }
 
-func (o *documentOptions) applyDocument(opts *documentOptions) {
-	opts.Documents = append(opts.Documents, o.Documents...)
+// applyDocument applies the option to the context options.
+// applyDocument accumulates documents: fixed ones from [WithDocs] and
+// [WithTextDocs] append in call order, and the functions from [WithDocsFn]
+// compose so their results concatenate the same way. Resolution runs the fixed
+// documents first, then the computed ones.
+func (o *documentOptions) applyDocument(docOpts *documentOptions) {
+	docOpts.Documents = append(docOpts.Documents, o.Documents...)
+	docOpts.DocsFn = appendDocsFn(docOpts.DocsFn, o.DocsFn)
+}
+
+// applyPrompt applies the option to the prompt options.
+func (o *documentOptions) applyPrompt(pOpts *promptOptions) {
+	o.applyDocument(&pOpts.documentOptions)
 }
 
 func (o *documentOptions) applyGenerate(opts *generateOptions) {
@@ -648,6 +961,22 @@ func WithTextDocs(text ...string) DocumentOption {
 // embedder. Repeating this option (or mixing it with [WithTextDocs]) appends.
 func WithDocs(docs ...*Document) DocumentOption {
 	return &documentOptions{Documents: docs}
+}
+
+// WithDocsFn sets the function that selects the context documents for a prompt.
+// It applies only to [DefinePrompt], since it is the only place where the
+// documents are not yet known when the option is constructed.
+//
+// The function receives the prompt's input coerced to In, so In may be the
+// struct or map type passed to [WithInputType]. This is the hook for retrieval
+// that depends on the input, such as running a query against a retriever
+// derived from the input fields.
+//
+// Documents accumulate: repeating this option, or combining it with [WithDocs]
+// or [WithTextDocs], adds to the set rather than replacing it. The fixed
+// documents are resolved first, then the computed ones, each in call order.
+func WithDocsFn[In any](fn func(context.Context, In) ([]*Document, error)) PromptOption {
+	return &promptOptions{documentOptions: documentOptions{DocsFn: coerceFn(fn)}}
 }
 
 // evaluatorOptions are options for providing a dataset to evaluate.

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -134,7 +134,8 @@ type PartsFn = func(context.Context, any) ([]*Part, error)
 type DocsFn = func(context.Context, any) ([]*Document, error)
 
 // coerceFn adapts a typed content function to the untyped signature the option
-// structs store.
+// structs store. option names the option in the error, since a prompt can fill
+// several slots from functions and only one of them rejected the input.
 //
 // The raw value's Go type depends on how the prompt was invoked: an in-process
 // call with [WithInput] passes the value through as-is, while the reflection
@@ -142,14 +143,14 @@ type DocsFn = func(context.Context, any) ([]*Document, error)
 // both arrive as map[string]any. Converting here means content functions see
 // the same type whichever way they were reached. A nil raw value yields the
 // zero value of In, which is what [Generate] passes.
-func coerceFn[In, Out any](fn func(context.Context, In) (Out, error)) func(context.Context, any) (Out, error) {
+func coerceFn[In, Out any](option string, fn func(context.Context, In) (Out, error)) func(context.Context, any) (Out, error) {
 	return func(ctx context.Context, raw any) (Out, error) {
 		in, err := base.ConvertToExact[In](raw)
 		if err != nil {
 			var zero Out
 			// base cannot classify this itself: the same failure is only a
 			// caller's bad input once a content function disagrees with it.
-			return zero, status.Errorf(ErrInputTypeMismatch, "content function input: %w", err)
+			return zero, status.Errorf(ErrInputTypeMismatch, "%s input: %w", option, err)
 		}
 		return fn(ctx, in)
 	}
@@ -166,8 +167,8 @@ func staticPartsFn(parts []*Part) PartsFn {
 
 // textPartsFn adapts a string-returning content function to a [PartsFn]. An
 // empty string yields no parts and so no message, matching empty template text.
-func textPartsFn[In any](fn func(context.Context, In) (string, error)) PartsFn {
-	coerced := coerceFn(fn)
+func textPartsFn[In any](option string, fn func(context.Context, In) (string, error)) PartsFn {
+	coerced := coerceFn(option, fn)
 	return func(ctx context.Context, raw any) ([]*Part, error) {
 		text, err := coerced(ctx, raw)
 		if err != nil {
@@ -340,7 +341,7 @@ func WithMessagesTemplate(text string, args ...any) PromptOption {
 // [HistoryFromContext] instead, and can summarize or truncate them rather than
 // only prepend to them.
 func WithMessagesFn[In any](fn func(context.Context, In) ([]*Message, error)) CommonGenOption {
-	return &commonGenOptions{MessagesFn: coerceFn(fn)}
+	return &commonGenOptions{MessagesFn: coerceFn("WithMessagesFn", fn)}
 }
 
 // WithTools adds tools to use for the generate request. Repeating this option
@@ -590,7 +591,7 @@ func WithSystem(text string, args ...any) PromptingOption {
 // It shares one slot with [WithSystem], [WithSystemParts], and
 // [WithSystemPartsFn]: the last one set wins.
 func WithSystemFn[In any](fn func(context.Context, In) (string, error)) PromptingOption {
-	return &promptingOptions{SystemFn: textPartsFn(fn)}
+	return &promptingOptions{SystemFn: textPartsFn("WithSystemFn", fn)}
 }
 
 // WithSystemParts sets the content of the system prompt message.
@@ -616,7 +617,7 @@ func WithSystemParts(parts ...*Part) PromptingOption {
 // It shares one slot with [WithSystem], [WithSystemParts], and [WithSystemFn]:
 // the last one set wins.
 func WithSystemPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) PromptingOption {
-	return &promptingOptions{SystemFn: coerceFn(fn)}
+	return &promptingOptions{SystemFn: coerceFn("WithSystemPartsFn", fn)}
 }
 
 // WithPrompt sets the user prompt message.
@@ -644,7 +645,7 @@ func WithPrompt(text string, args ...any) PromptingOption {
 // It shares one slot with [WithPrompt], [WithPromptParts], and
 // [WithPromptPartsFn]: the last one set wins.
 func WithPromptFn[In any](fn func(context.Context, In) (string, error)) PromptingOption {
-	return &promptingOptions{PromptFn: textPartsFn(fn)}
+	return &promptingOptions{PromptFn: textPartsFn("WithPromptFn", fn)}
 }
 
 // WithPromptParts sets the content of the user prompt message.
@@ -678,7 +679,7 @@ func WithPromptParts(parts ...*Part) PromptingOption {
 // It shares one slot with [WithPrompt], [WithPromptParts], and [WithPromptFn]:
 // the last one set wins.
 func WithPromptPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) PromptingOption {
-	return &promptingOptions{PromptFn: coerceFn(fn)}
+	return &promptingOptions{PromptFn: coerceFn("WithPromptPartsFn", fn)}
 }
 
 // outputOptions are options for the output of a prompt or generate request.
@@ -915,7 +916,7 @@ func WithDocs(docs ...*Document) DocumentOption {
 // or [WithTextDocs], adds to the set rather than replacing it. The fixed
 // documents resolve first, then the computed ones, each in call order.
 func WithDocsFn[In any](fn func(context.Context, In) ([]*Document, error)) PromptOption {
-	return &promptOptions{documentOptions: documentOptions{DocsFn: coerceFn(fn)}}
+	return &promptOptions{documentOptions: documentOptions{DocsFn: coerceFn("WithDocsFn", fn)}}
 }
 
 // evaluatorOptions are options for providing a dataset to evaluate.

--- a/go/ai/option_test.go
+++ b/go/ai/option_test.go
@@ -211,11 +211,23 @@ func TestSingleValueOptionsLastWins(t *testing.T) {
 			WithPrompt("usr one"),
 			WithPrompt("usr two"),
 		)
-		if sys, _ := g.SystemFn(context.Background(), nil); sys != "sys two" {
-			t.Errorf("system = %q, want %q", sys, "sys two")
+		parts, err := g.SystemFn(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("SystemFn: %v", err)
 		}
-		if usr, _ := g.PromptFn(context.Background(), nil); usr != "usr two" {
-			t.Errorf("prompt = %q, want %q", usr, "usr two")
+		if len(parts) != 1 || parts[0].Text != "sys two" {
+			t.Errorf("system = %+v, want one part %q", parts, "sys two")
+		}
+		// The later function has to clear the earlier text, or the renderer's
+		// fixed order would decide the winner instead of the call order.
+		if g.SystemText != nil {
+			t.Errorf("SystemText = %q, want it cleared by the later WithSystemFn", *g.SystemText)
+		}
+		if g.PromptFn != nil {
+			t.Error("PromptFn set, want it cleared by the later WithPrompt")
+		}
+		if g.PromptText == nil || *g.PromptText != "usr two" {
+			t.Errorf("prompt = %v, want %q", g.PromptText, "usr two")
 		}
 	})
 
@@ -341,8 +353,8 @@ func TestGenerateOptionsComplete(t *testing.T) {
 			Middleware:         []ModelMiddleware{mw},
 		},
 		promptingOptions: promptingOptions{
-			SystemFn: opts.SystemFn,
-			PromptFn: opts.PromptFn,
+			SystemText: opts.SystemText,
+			PromptText: opts.PromptText,
 		},
 		outputOptions: outputOptions{
 			OutputFormat: OutputFormatJSON,
@@ -377,11 +389,13 @@ func TestGenerateOptionsComplete(t *testing.T) {
 	if len(opts.Middleware) == 0 {
 		t.Errorf("Middleware should not be empty")
 	}
-	if opts.SystemFn == nil {
-		t.Errorf("SystemFn should not be nil")
+	// WithSystem and WithPrompt fill their slot with template text; the
+	// parts and function forms fill the same slot with a function instead.
+	if opts.SystemText == nil && opts.SystemFn == nil {
+		t.Errorf("the system slot should be filled")
 	}
-	if opts.PromptFn == nil {
-		t.Errorf("PromptFn should not be nil")
+	if opts.PromptText == nil && opts.PromptFn == nil {
+		t.Errorf("the prompt slot should be filled")
 	}
 	if opts.Stream == nil {
 		t.Errorf("Stream should not be nil")
@@ -436,8 +450,8 @@ func TestPromptOptionsComplete(t *testing.T) {
 			Middleware:         []ModelMiddleware{mw},
 		},
 		promptingOptions: promptingOptions{
-			SystemFn: opts.SystemFn,
-			PromptFn: opts.PromptFn,
+			SystemText: opts.SystemText,
+			PromptText: opts.PromptText,
 		},
 		inputOptions: inputOptions{
 			InputSchema:  opts.InputSchema,
@@ -473,11 +487,13 @@ func TestPromptOptionsComplete(t *testing.T) {
 	if len(opts.Middleware) == 0 {
 		t.Errorf("Middleware should not be empty")
 	}
-	if opts.SystemFn == nil {
-		t.Errorf("SystemFn should not be nil")
+	// WithSystem and WithPrompt fill their slot with template text; the
+	// parts and function forms fill the same slot with a function instead.
+	if opts.SystemText == nil && opts.SystemFn == nil {
+		t.Errorf("the system slot should be filled")
 	}
-	if opts.PromptFn == nil {
-		t.Errorf("PromptFn should not be nil")
+	if opts.PromptText == nil && opts.PromptFn == nil {
+		t.Errorf("the prompt slot should be filled")
 	}
 	if opts.OutputSchema == nil {
 		t.Errorf("OutputSchema should not be nil")

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -513,16 +513,22 @@ func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOp
 		return nil, fmt.Errorf("prompt %q: %w", p.Name(), err)
 	}
 
+	// Fixed documents first, then computed ones: the two accumulate rather
+	// than one replacing the other, matching how the options merged.
 	docs := p.Documents
 	// Skip the function when the execution supplies its own documents:
 	// Execute overwrites the docs afterwards, and for the retrieval use case
 	// WithDocsFn is meant for, running it would spend a query on a result
 	// that is thrown away.
 	if p.DocsFn != nil && !promptDocsOverridden(ctx) {
-		docs, err = p.DocsFn(ctx, input)
+		computed, err := p.DocsFn(ctx, input)
 		if err != nil {
 			return nil, fmt.Errorf("prompt %q: resolving docs: %w", p.Name(), err)
 		}
+		// Concat rather than append: p.Documents belongs to the prompt and is
+		// reused by every execution, so appending would write into the spare
+		// capacity of the array behind it.
+		docs = slices.Concat(docs, computed)
 	}
 
 	return &GenerateActionOptions{

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -681,21 +681,15 @@ func renderMessages(ctx context.Context, opts promptOptions, messages []*Message
 
 	// A prompt that declares no conversation of its own has the caller's used
 	// directly, between the system message and the user prompt.
-	if opts.MessagesFn == nil && opts.MessagesText == nil && opts.MessagesAfterFn == nil {
+	if opts.MessagesFn == nil && opts.MessagesText == nil {
 		return appendMessageClones(messages, history), nil
 	}
 
-	// Otherwise the prompt owns the conversation and its contributions render
-	// in call order, the template sitting where it was first declared. Only the
-	// template can place the caller's history, with {{history}}; a function
-	// reaches it through HistoryFromContext and decides for itself.
-	if opts.MessagesFn != nil {
-		msgs, err := opts.MessagesFn(ctx, raw)
-		if err != nil {
-			return nil, err
-		}
-		messages = appendMessageClones(messages, msgs)
-	}
+	// Otherwise the prompt owns the conversation. A template resets it, so
+	// anything still in MessagesFn was set after the template and renders
+	// behind it. Only the template can place the caller's history, with
+	// {{history}}; a function reaches it through HistoryFromContext and
+	// decides for itself.
 	if opts.MessagesText != nil {
 		rendered, err := renderPrompt(ctx, opts, *opts.MessagesText, input, history, dp)
 		if err != nil {
@@ -706,8 +700,8 @@ func renderMessages(ctx context.Context, opts promptOptions, messages []*Message
 		// renderPrompt before it goes downstream.
 		messages = append(messages, rendered...)
 	}
-	if opts.MessagesAfterFn != nil {
-		msgs, err := opts.MessagesAfterFn(ctx, raw)
+	if opts.MessagesFn != nil {
+		msgs, err := opts.MessagesFn(ctx, raw)
 		if err != nil {
 			return nil, err
 		}

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -190,13 +190,6 @@ func (p *prompt) Execute(ctx context.Context, opts ...PromptExecuteOption) (*Mod
 	for _, opt := range opts {
 		opt.applyPromptExecute(execOpts)
 	}
-	// A template belongs to the prompt, which is what compiles it; nothing
-	// here would render one, so accepting it silently would drop the
-	// caller's conversation.
-	if execOpts.MessagesText != nil {
-		return nil, status.Errorf(status.ErrInvalidArgument,
-			"Prompt.Execute: WithMessagesTemplate applies only to DefinePrompt, where the template is compiled. Pass this execution's conversation with WithMessages or WithMessagesFn.")
-	}
 	// Messages passed at execution time are resolved here and handed to
 	// Render through a context that exists only for that call. The prompt's
 	// own messages take precedence over them, but its content functions can

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -654,9 +654,31 @@ func renderMessages(ctx context.Context, opts promptOptions, messages []*Message
 	if err != nil {
 		return nil, err
 	}
-	messages = appendMessageClones(messages, msgs)
+	messages = appendMessageClones(messages, compactMessages(msgs))
 
 	return messages, nil
+}
+
+// compactMessages returns src without its nil entries, or src itself when it
+// has none. A conversation arrives from a caller-owned slice or a user-written
+// function, and a nil in one has no representation downstream: the template
+// renderer dereferences it, and every other path carries it as far as the
+// action's output schema, which rejects it as a null message.
+//
+// Drop them where the conversation enters, never later. [renderPrompt] hands
+// dotprompt one placeholder per message and restores the originals by position,
+// so a filter applied to only one of those two lists shifts the rest.
+func compactMessages(src []*Message) []*Message {
+	if !slices.Contains(src, nil) {
+		return src
+	}
+	out := make([]*Message, 0, len(src))
+	for _, m := range src {
+		if m != nil {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // appendMessageClones appends a clone of each message in src to dst.

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -58,9 +58,8 @@ type Prompt interface {
 	//   - [WithMessagesFn]: As above, computed from the input
 	//
 	// A prompt that declares a conversation of its own decides where these go,
-	// with {{history}} in a [WithMessagesTemplate] or [HistoryFromContext] in a
-	// [WithMessagesFn]. A prompt that declares none has them used as the
-	// conversation directly, between the system message and the user prompt.
+	// with {{history}} or [HistoryFromContext]. One that declares none uses
+	// them directly, between the system message and the user prompt.
 	//
 	// Overrides, each replacing what the prompt was defined with:
 	//
@@ -102,10 +101,8 @@ func DefinePrompt(r api.Registry, name string, opts ...PromptOption) Prompt {
 	for _, opt := range opts {
 		opt.applyPrompt(pOpts)
 	}
-	// A template lays out the whole conversation, so separately supplied
-	// messages have no position relative to it that means anything. Refuse
-	// rather than pick one: this is a wiring mistake, and the panic fires at
-	// definition, which is the call that has to change.
+	// Panic at definition rather than at render: this is a wiring mistake, and
+	// this is the call that has to change.
 	if pOpts.MessagesText != nil && pOpts.MessagesFn != nil {
 		panic(fmt.Sprintf("ai.DefinePrompt: %q sets both WithMessagesTemplate and WithMessages/WithMessagesFn, which have no meaningful combination: the template is the whole conversation. Write the messages as {{role}} blocks in the template, or drop the template and build the conversation from WithMessages and WithMessagesFn.", name))
 	}
@@ -197,25 +194,21 @@ func (p *prompt) Execute(ctx context.Context, opts ...PromptExecuteOption) (*Mod
 	for _, opt := range opts {
 		opt.applyPromptExecute(execOpts)
 	}
-	// Messages passed at execution time are resolved here and handed to
-	// Render through a context that exists only for that call. The prompt's
-	// own messages take precedence over them, but its content functions can
-	// still reach them via HistoryFromContext, so a prompt that manages its
-	// own history decides how these are woven in. The original ctx, not
-	// renderCtx, feeds the generation below: otherwise the history would ride
-	// the context into every tool call and nested prompt executed during the
-	// generate loop.
+	// Messages passed at execution time reach Render through a context scoped
+	// to that call, so the prompt decides where they land. Generation below
+	// runs on the original ctx: otherwise they would ride along into every
+	// tool call and nested prompt in the generate loop.
 	renderCtx := ctx
 	if execOpts.MessagesFn != nil {
-		history, err := p.resolveHistory(ctx, execOpts)
+		history, err := execOpts.MessagesFn(ctx, execOpts.Input)
 		if err != nil {
 			return nil, err
 		}
 		renderCtx = withPromptHistory(renderCtx, history)
 	}
 	if len(execOpts.Documents) > 0 {
-		// Documents supplied at execution time replace the prompt's own, so
-		// tell Render not to run a WithDocsFn whose result would be discarded.
+		// Documents supplied here replace the prompt's own, so tell Render not
+		// to run a WithDocsFn whose result would be discarded.
 		renderCtx = withPromptDocsOverride(renderCtx)
 	}
 
@@ -451,25 +444,11 @@ fieldLoop:
 	return m, nil
 }
 
-// resolveHistory resolves the messages supplied to [Prompt.Execute] into the
-// history that rendering sees, applying the same rules as messages declared on
-// the prompt: both static messages and a function's messages are used
-// verbatim. The result may alias caller-owned messages; renderMessages clones
-// everything it splices into the request, so no copy is needed here.
-func (p *prompt) resolveHistory(ctx context.Context, execOpts *promptExecutionOptions) ([]*Message, error) {
-	if execOpts.MessagesFn != nil {
-		return execOpts.MessagesFn(ctx, execOpts.Input)
-	}
-
-	return nil, nil
-}
-
 // buildRequest prepares a [GenerateActionOptions] based on the prompt,
 // using the input variables and other information in the [prompt].
 func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOptions, error) {
-	// Template variables are only needed by the text options; content
-	// functions receive the raw input, so skip the conversion when the prompt
-	// has no template text.
+	// Only the text options need template variables; content functions receive
+	// the raw input.
 	var m map[string]any
 	var err error
 	if p.SystemText != nil || p.PromptText != nil || p.MessagesText != nil {
@@ -520,21 +499,16 @@ func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOp
 		return nil, fmt.Errorf("prompt %q: %w", p.Name(), err)
 	}
 
-	// Fixed documents first, then computed ones: the two accumulate rather
-	// than one replacing the other, matching how the options merged.
 	docs := p.Documents
-	// Skip the function when the execution supplies its own documents:
-	// Execute overwrites the docs afterwards, and for the retrieval use case
-	// WithDocsFn is meant for, running it would spend a query on a result
-	// that is thrown away.
+	// Skipped when the execution supplies its own documents, which replace
+	// these: running a retrieval query for a discarded result is waste.
 	if p.DocsFn != nil && !promptDocsOverridden(ctx) {
 		computed, err := p.DocsFn(ctx, input)
 		if err != nil {
 			return nil, fmt.Errorf("prompt %q: resolving docs: %w", p.Name(), err)
 		}
-		// Concat rather than append: p.Documents belongs to the prompt and is
-		// reused by every execution, so appending would write into the spare
-		// capacity of the array behind it.
+		// Concat rather than append: p.Documents is reused by every execution,
+		// so appending would write into the spare capacity behind it.
 		docs = slices.Concat(docs, computed)
 	}
 
@@ -557,17 +531,9 @@ func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOp
 	}, nil
 }
 
-// renderSystemPrompt renders a system prompt message.
-//
-// Template text from [WithSystem] is compiled as a dotprompt template against
-// the input. Content from [WithSystemFn] or [WithSystemPartsFn] is used
-// verbatim: the function already produced its final content, so compiling it
-// would reinterpret computed text (and any user data in it) as a template.
-//
-// The template fills one message. A {{role}} block that splits it into several
-// is an error rather than a silent reinterpretation of the slot, since this
-// message is the system preamble and has to stay one system message ahead of
-// the conversation. Use [WithMessagesTemplate] to write several turns.
+// renderSystemPrompt renders a system prompt message. Text from [WithSystem]
+// is compiled against the input; content from a function is used verbatim,
+// since compiling it would reinterpret computed text as a template.
 func renderSystemPrompt(ctx context.Context, opts promptOptions, messages []*Message, input map[string]any, raw any, dp *dotprompt.Dotprompt) ([]*Message, error) {
 	if opts.SystemFn != nil {
 		parts, err := opts.SystemFn(ctx, raw)
@@ -600,13 +566,8 @@ var roleMarkerPattern = regexp.MustCompile(`\{\{~?\s*role\s`)
 
 // renderSingleMessage renders template text that fills exactly one message of
 // role want, naming option in the error when the template asks for anything
-// else.
-//
-// The role is the slot's, not the template's: [WithSystem] is the system
-// preamble and [WithPrompt] is the final user turn, and the surrounding
-// conversation is positioned against them. A {{role}} marker is therefore
-// either redundant or a contradiction, and in both cases the author means to
-// write turns, so it is refused rather than silently overridden.
+// else. The role is the slot's, not the template's: the rest of the
+// conversation is positioned against these two messages.
 func renderSingleMessage(ctx context.Context, opts promptOptions, text string, input map[string]any, dp *dotprompt.Dotprompt, option string, want Role) (*Message, error) {
 	if roleMarkerPattern.MatchString(text) {
 		return nil, status.Errorf(status.ErrInvalidArgument,
@@ -635,15 +596,8 @@ func renderSingleMessage(ctx context.Context, opts promptOptions, text string, i
 	return rendered[0], nil
 }
 
-// renderUserPrompt renders a user prompt message.
-//
-// Template text from [WithPrompt] is compiled as a dotprompt template against
-// the input. Content from [WithPromptFn] or [WithPromptPartsFn] is used
-// verbatim, for the same reason as in [renderSystemPrompt].
-//
-// As with [renderSystemPrompt], the template fills exactly one message. This
-// one is the final user turn, so a template that produced several would place
-// content after it.
+// renderUserPrompt renders a user prompt message, following the same rules as
+// [renderSystemPrompt].
 func renderUserPrompt(ctx context.Context, opts promptOptions, messages []*Message, input map[string]any, raw any, dp *dotprompt.Dotprompt) ([]*Message, error) {
 	if opts.PromptFn != nil {
 		parts, err := opts.PromptFn(ctx, raw)
@@ -673,37 +627,27 @@ func renderUserPrompt(ctx context.Context, opts promptOptions, messages []*Messa
 //
 // A prompt that declares its own conversation owns the messages supplied at
 // execution time, because only it knows where its few-shot examples end and a
-// real conversation begins. Each form has a way to place them:
-// [WithMessagesTemplate] renders them at {{history}}, or before its final user
-// message when the template does not say; [WithMessagesFn] reads them from
-// [HistoryFromContext]. A prompt that declares nothing gets them here, in the
-// middle, which is where the caller of a system-and-prompt prompt expects a
-// conversation to go.
+// real conversation begins, so it must place them itself. A prompt that
+// declares none gets them here, in the middle.
 //
-// Values from [WithMessages] and [WithMessagesFn] are used verbatim, so
-// conversation history containing literal braces passes through untouched.
-// Only [WithMessagesTemplate] text is compiled.
+// Only [WithMessagesTemplate] text is compiled. Messages are used verbatim, so
+// history containing literal braces passes through untouched.
 func renderMessages(ctx context.Context, opts promptOptions, messages []*Message, input map[string]any, raw any, dp *dotprompt.Dotprompt) ([]*Message, error) {
 	history := HistoryFromContext(ctx)
 
-	// A prompt that declares no conversation of its own has the caller's used
-	// directly, between the system message and the user prompt.
 	if opts.MessagesFn == nil && opts.MessagesText == nil {
 		return appendMessageClones(messages, history), nil
 	}
 
-	// Otherwise the prompt owns the conversation. The template and the verbatim
-	// messages are mutually exclusive, so at most one of these runs. Only the
-	// template can place the caller's history, with {{history}}; a function
-	// reaches it through HistoryFromContext and decides for itself.
+	// The template and the verbatim messages are mutually exclusive, so at most
+	// one of these runs. Only the template places the caller's history, at
+	// {{history}}; a function reaches it through HistoryFromContext instead.
 	if opts.MessagesText != nil {
 		rendered, err := renderPrompt(ctx, opts, *opts.MessagesText, input, history, dp)
 		if err != nil {
 			return nil, err
 		}
-		// Already fresh messages built by the renderer, so no clone is needed
-		// for them; the history dotprompt spliced in is not, and is cloned by
-		// renderPrompt before it goes downstream.
+		// The renderer built these fresh, and cloned the history it spliced in.
 		return append(messages, rendered...), nil
 	}
 	msgs, err := opts.MessagesFn(ctx, raw)
@@ -717,27 +661,13 @@ func renderMessages(ctx context.Context, opts promptOptions, messages []*Message
 
 // appendMessageClones appends a clone of each message in src to dst.
 //
-// Everything renderMessages splices into a request is cloned, whichever
-// source it came from. Message text is deliberately not rendered as a
-// dotprompt template. These messages are overwhelmingly conversation history
-// holding user-authored text, so compiling them made any literal brace a hard
-// parse error and turned remote content, such as prompt messages fetched from
-// an MCP server, into a template-injection surface. Only the string form of
-// the conversation is compiled; message values pass through untouched.
-// Callers that want variables in message text can
-// interpolate it themselves, use [WithMessagesFn], which receives the typed
-// input, or write the turns with [WithMessagesTemplate], the string form,
-// where each {{role}} block produces a message of its own.
-//
-// The clones matter because later stages may mutate messages in place, as
-// middleware does when it stamps metadata. Messages declared with
-// [WithMessages] are stored on the prompt and reused by every execution, and
-// messages from a content function or execute-time history typically alias a
-// session or the caller's own conversation slice, so handing the originals
-// downstream lets one execution corrupt state it does not own. [Message.Clone]
-// copies the Content slice and Metadata map for the same reason: appending to
-// a shared backing array or writing a shared map races even when the
-// [Message] struct itself is fresh.
+// Everything spliced into a request is cloned, because later stages mutate
+// messages in place, as middleware does when it stamps metadata. The originals
+// belong to someone else: [WithMessages] messages are stored on the prompt and
+// reused by every execution, and history typically aliases a session or the
+// caller's own slice. [Message.Clone] copies the Content slice and Metadata map
+// too, since appending to a shared array or writing a shared map races even
+// when the [Message] itself is fresh.
 func appendMessageClones(dst []*Message, src []*Message) []*Message {
 	for _, msg := range src {
 		dst = append(dst, msg.Clone())
@@ -747,10 +677,9 @@ func appendMessageClones(dst []*Message, src []*Message) []*Message {
 
 // renderPrompt renders a prompt template using dotprompt functionalities.
 //
-// history is the conversation the template may place, which dotprompt renders
-// at {{history}} and otherwise inserts before the template's final user
-// message. Only the conversation slot passes it: the system and user prompt
-// slots each fill a single message, so history has no place inside them.
+// history is the conversation the template may place, at {{history}} or, absent
+// that, before the template's final user message. Only the conversation slot
+// passes it; the single-message slots have nowhere to put it.
 func renderPrompt(ctx context.Context, opts promptOptions, templateText string, input map[string]any, history []*Message, dp *dotprompt.Dotprompt) ([]*Message, error) {
 	renderedFunc, err := dp.Compile(templateText, &dotprompt.PromptMetadata{})
 	if err != nil {
@@ -789,10 +718,9 @@ func renderDotpromptToMessages(ctx context.Context, promptFn dotprompt.PromptFun
 	convertedMessages := []*Message{}
 	historyIdx := 0
 	for _, message := range rendered.Messages {
-		// Dotprompt marks the messages it spliced in for {{history}}. Restore
-		// the originals rather than converting the stand-ins back: a message
-		// carries kinds dotprompt has no representation for, such as tool
-		// requests and resources, so a round trip through it would drop them.
+		// Restore the original rather than converting the stand-in back: a
+		// message carries part kinds dotprompt cannot represent, such as tool
+		// requests and resources, which a round trip would drop.
 		if message.Metadata["purpose"] == "history" && historyIdx < len(history) {
 			convertedMessages = append(convertedMessages, history[historyIdx].Clone())
 			historyIdx++
@@ -815,15 +743,11 @@ func renderDotpromptToMessages(ctx context.Context, promptFn dotprompt.PromptFun
 // toDotpromptMessages converts history into the messages dotprompt places for
 // {{history}}.
 //
-// Only the roles have to be faithful. The content is a stand-in, since
-// renderDotpromptToMessages restores each original message once dotprompt has
-// decided where it goes, which is what keeps part kinds dotprompt cannot
-// represent from being lost.
-//
-// The stand-ins are marked as history on the way in. Dotprompt marks them
-// itself when the template places them at {{history}}, but not when it inserts
-// them before the final user message, and the restore needs to recognize them
-// either way.
+// Only the roles have to be faithful: the content is a stand-in, since
+// renderDotpromptToMessages restores each original once dotprompt has decided
+// where it goes. They are marked as history on the way in because dotprompt
+// marks them itself only at {{history}}, not when it inserts them before the
+// final user message, and the restore has to recognize them either way.
 func toDotpromptMessages(history []*Message) []dotprompt.Message {
 	if len(history) == 0 {
 		return nil

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -102,6 +102,13 @@ func DefinePrompt(r api.Registry, name string, opts ...PromptOption) Prompt {
 	for _, opt := range opts {
 		opt.applyPrompt(pOpts)
 	}
+	// A template lays out the whole conversation, so separately supplied
+	// messages have no position relative to it that means anything. Refuse
+	// rather than pick one: this is a wiring mistake, and the panic fires at
+	// definition, which is the call that has to change.
+	if pOpts.MessagesText != nil && pOpts.MessagesFn != nil {
+		panic(fmt.Sprintf("ai.DefinePrompt: %q sets both WithMessagesTemplate and WithMessages/WithMessagesFn, which have no meaningful combination: the template is the whole conversation. Write the messages as {{role}} blocks in the template, or drop the template and build the conversation from WithMessages and WithMessagesFn.", name))
+	}
 
 	p := &prompt{
 		registry:      r,
@@ -685,11 +692,10 @@ func renderMessages(ctx context.Context, opts promptOptions, messages []*Message
 		return appendMessageClones(messages, history), nil
 	}
 
-	// Otherwise the prompt owns the conversation. A template resets it, so
-	// anything still in MessagesFn was set after the template and renders
-	// behind it. Only the template can place the caller's history, with
-	// {{history}}; a function reaches it through HistoryFromContext and
-	// decides for itself.
+	// Otherwise the prompt owns the conversation. The template and the verbatim
+	// messages are mutually exclusive, so at most one of these runs. Only the
+	// template can place the caller's history, with {{history}}; a function
+	// reaches it through HistoryFromContext and decides for itself.
 	if opts.MessagesText != nil {
 		rendered, err := renderPrompt(ctx, opts, *opts.MessagesText, input, history, dp)
 		if err != nil {
@@ -698,15 +704,13 @@ func renderMessages(ctx context.Context, opts promptOptions, messages []*Message
 		// Already fresh messages built by the renderer, so no clone is needed
 		// for them; the history dotprompt spliced in is not, and is cloned by
 		// renderPrompt before it goes downstream.
-		messages = append(messages, rendered...)
+		return append(messages, rendered...), nil
 	}
-	if opts.MessagesFn != nil {
-		msgs, err := opts.MessagesFn(ctx, raw)
-		if err != nil {
-			return nil, err
-		}
-		messages = appendMessageClones(messages, msgs)
+	msgs, err := opts.MessagesFn(ctx, raw)
+	if err != nil {
+		return nil, err
 	}
+	messages = appendMessageClones(messages, msgs)
 
 	return messages, nil
 }

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -44,8 +45,34 @@ type Prompt interface {
 	// Name returns the name of the prompt.
 	Name() string
 	// Execute executes the prompt with the given options and returns a [ModelResponse].
+	//
+	// # Options
+	//
+	// Input:
+	//
+	//   - [WithInput]: Supply the prompt's input, overriding the default from [WithInputType]
+	//
+	// Conversation:
+	//
+	//   - [WithMessages]: Supply the conversation this execution continues
+	//   - [WithMessagesFn]: As above, computed from the input
+	//
+	// A prompt that declares a conversation of its own decides where these go,
+	// with {{history}} in a [WithMessagesTemplate] or [HistoryFromContext] in a
+	// [WithMessagesFn]. A prompt that declares none has them used as the
+	// conversation directly, between the system message and the user prompt.
+	//
+	// Overrides, each replacing what the prompt was defined with:
+	//
+	//   - [WithModel], [WithModelName]: Call a different model
+	//   - [WithConfig]: Replace the generation config
+	//   - [WithDocs], [WithTextDocs]: Replace the context documents, skipping any [WithDocsFn]
+	//   - [WithTools], [WithToolChoice], [WithMaxTurns], [WithReturnToolRequests]: Change tool behavior
+	//   - [WithMiddleware], [WithUse]: Add middleware for this execution
+	//   - [WithStreaming]: Receive streamed chunks
 	Execute(ctx context.Context, opts ...PromptExecuteOption) (*ModelResponse, error)
 	// ExecuteStream executes the prompt with streaming and returns an iterator.
+	// It accepts the same options as Execute.
 	ExecuteStream(ctx context.Context, opts ...PromptExecuteOption) iter.Seq2[*ModelStreamValue, error]
 	// Render renders the prompt with the given input and returns a [GenerateActionOptions] to be used with [GenerateWithRequest].
 	Render(ctx context.Context, input any) (*GenerateActionOptions, error)
@@ -163,10 +190,39 @@ func (p *prompt) Execute(ctx context.Context, opts ...PromptExecuteOption) (*Mod
 	for _, opt := range opts {
 		opt.applyPromptExecute(execOpts)
 	}
+	// A template belongs to the prompt, which is what compiles it; nothing
+	// here would render one, so accepting it silently would drop the
+	// caller's conversation.
+	if execOpts.MessagesText != nil {
+		return nil, status.Errorf(status.ErrInvalidArgument,
+			"Prompt.Execute: WithMessagesTemplate applies only to DefinePrompt, where the template is compiled. Pass this execution's conversation with WithMessages or WithMessagesFn.")
+	}
+	// Messages passed at execution time are resolved here and handed to
+	// Render through a context that exists only for that call. The prompt's
+	// own messages take precedence over them, but its content functions can
+	// still reach them via HistoryFromContext, so a prompt that manages its
+	// own history decides how these are woven in. The original ctx, not
+	// renderCtx, feeds the generation below: otherwise the history would ride
+	// the context into every tool call and nested prompt executed during the
+	// generate loop.
+	renderCtx := ctx
+	if execOpts.MessagesFn != nil {
+		history, err := p.resolveHistory(ctx, execOpts)
+		if err != nil {
+			return nil, err
+		}
+		renderCtx = withPromptHistory(renderCtx, history)
+	}
+	if len(execOpts.Documents) > 0 {
+		// Documents supplied at execution time replace the prompt's own, so
+		// tell Render not to run a WithDocsFn whose result would be discarded.
+		renderCtx = withPromptDocsOverride(renderCtx)
+	}
+
 	// Render() should populate all data from the prompt. Prompt fields should
 	// *not* be referenced in this function as it may have been loaded from
 	// the registry and is missing the options passed in at definition.
-	actionOpts, err := p.Render(ctx, execOpts.Input)
+	actionOpts, err := p.Render(renderCtx, execOpts.Input)
 	if err != nil {
 		return nil, err
 	}
@@ -199,40 +255,6 @@ func (p *prompt) Execute(ctx context.Context, opts ...PromptExecuteOption) (*Mod
 
 	if execOpts.ReturnToolRequests != nil {
 		actionOpts.ReturnToolRequests = *execOpts.ReturnToolRequests
-	}
-
-	if execOpts.MessagesFn != nil {
-		m, err := buildVariables(execOpts.Input)
-		if err != nil {
-			return nil, err
-		}
-
-		tempOpts := promptOptions{
-			commonGenOptions: commonGenOptions{
-				MessagesFn: execOpts.MessagesFn,
-			},
-		}
-
-		execMsgs, err := renderMessages(ctx, tempOpts, []*Message{}, m, execOpts.Input, p.registry.Dotprompt())
-		if err != nil {
-			return nil, err
-		}
-
-		var systemMsgs []*Message
-		var msgs []*Message
-		foundNonSystem := false
-
-		for _, msg := range actionOpts.Messages {
-			if msg.Role == RoleSystem && !foundNonSystem {
-				systemMsgs = append(systemMsgs, msg)
-			} else {
-				foundNonSystem = true
-				msgs = append(msgs, msg)
-			}
-		}
-
-		actionOpts.Messages = append(systemMsgs, execMsgs...)
-		actionOpts.Messages = append(actionOpts.Messages, msgs...)
 	}
 
 	toolRefs := execOpts.Tools
@@ -429,12 +451,32 @@ fieldLoop:
 	return m, nil
 }
 
+// resolveHistory resolves the messages supplied to [Prompt.Execute] into the
+// history that rendering sees, applying the same rules as messages declared on
+// the prompt: both static messages and a function's messages are used
+// verbatim. The result may alias caller-owned messages; renderMessages clones
+// everything it splices into the request, so no copy is needed here.
+func (p *prompt) resolveHistory(ctx context.Context, execOpts *promptExecutionOptions) ([]*Message, error) {
+	if execOpts.MessagesFn != nil {
+		return execOpts.MessagesFn(ctx, execOpts.Input)
+	}
+
+	return nil, nil
+}
+
 // buildRequest prepares a [GenerateActionOptions] based on the prompt,
 // using the input variables and other information in the [prompt].
 func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOptions, error) {
-	m, err := buildVariables(input)
-	if err != nil {
-		return nil, err
+	// Template variables are only needed by the text options; content
+	// functions receive the raw input, so skip the conversion when the prompt
+	// has no template text.
+	var m map[string]any
+	var err error
+	if p.SystemText != nil || p.PromptText != nil || p.MessagesText != nil {
+		m, err = buildVariables(input)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	dp := p.registry.Dotprompt()
@@ -478,6 +520,18 @@ func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOp
 		return nil, fmt.Errorf("prompt %q: %w", p.Name(), err)
 	}
 
+	docs := p.Documents
+	// Skip the function when the execution supplies its own documents:
+	// Execute overwrites the docs afterwards, and for the retrieval use case
+	// WithDocsFn is meant for, running it would spend a query on a result
+	// that is thrown away.
+	if p.DocsFn != nil && !promptDocsOverridden(ctx) {
+		docs, err = p.DocsFn(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("prompt %q: resolving docs: %w", p.Name(), err)
+		}
+	}
+
 	return &GenerateActionOptions{
 		Model:              modelName,
 		Config:             config,
@@ -485,6 +539,7 @@ func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOp
 		MaxTurns:           p.MaxTurns,
 		ReturnToolRequests: p.ReturnToolRequests != nil && *p.ReturnToolRequests,
 		Messages:           messages,
+		Docs:               docs,
 		Tools:              tools,
 		Use:                useRefs,
 		Output: &GenerateActionOutputConfig{
@@ -497,129 +552,215 @@ func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOp
 }
 
 // renderSystemPrompt renders a system prompt message.
+//
+// Template text from [WithSystem] is compiled as a dotprompt template against
+// the input. Content from [WithSystemFn] or [WithSystemPartsFn] is used
+// verbatim: the function already produced its final content, so compiling it
+// would reinterpret computed text (and any user data in it) as a template.
+//
+// The template fills one message. A {{role}} block that splits it into several
+// is an error rather than a silent reinterpretation of the slot, since this
+// message is the system preamble and has to stay one system message ahead of
+// the conversation. Use [WithMessagesTemplate] to write several turns.
 func renderSystemPrompt(ctx context.Context, opts promptOptions, messages []*Message, input map[string]any, raw any, dp *dotprompt.Dotprompt) ([]*Message, error) {
-	if opts.SystemFn == nil {
+	if opts.SystemFn != nil {
+		parts, err := opts.SystemFn(ctx, raw)
+		if err != nil {
+			return nil, err
+		}
+		if len(parts) == 0 {
+			return messages, nil
+		}
+		return append(messages, &Message{Role: RoleSystem, Content: parts}), nil
+	}
+
+	if opts.SystemText == nil {
 		return messages, nil
 	}
 
-	templateText, err := opts.SystemFn(ctx, raw)
+	rendered, err := renderSingleMessage(ctx, opts, *opts.SystemText, input, dp, "WithSystem", RoleSystem)
 	if err != nil {
 		return nil, err
 	}
 
-	renderedMessages, err := renderPrompt(ctx, opts, templateText, input, dp)
+	return append(messages, rendered), nil
+}
+
+// roleMarkerPattern matches a {{role ...}} helper call in template source.
+// Checking the source rather than the rendered messages is what makes the check
+// exact: dotprompt starts every render as a user message, so a rendered user
+// role is indistinguishable from an explicit {{role "user"}}.
+var roleMarkerPattern = regexp.MustCompile(`\{\{~?\s*role\s`)
+
+// renderSingleMessage renders template text that fills exactly one message of
+// role want, naming option in the error when the template asks for anything
+// else.
+//
+// The role is the slot's, not the template's: [WithSystem] is the system
+// preamble and [WithPrompt] is the final user turn, and the surrounding
+// conversation is positioned against them. A {{role}} marker is therefore
+// either redundant or a contradiction, and in both cases the author means to
+// write turns, so it is refused rather than silently overridden.
+func renderSingleMessage(ctx context.Context, opts promptOptions, text string, input map[string]any, dp *dotprompt.Dotprompt, option string, want Role) (*Message, error) {
+	if roleMarkerPattern.MatchString(text) {
+		return nil, status.Errorf(status.ErrInvalidArgument,
+			"%s contains a {{role}} marker: it fills a single %s message whose role is fixed, so use WithMessagesTemplate to write turns",
+			option, want)
+	}
+
+	rendered, err := renderPrompt(ctx, opts, text, input, nil, dp)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, m := range renderedMessages {
-		if m.Role == "" || (len(renderedMessages) == 1 && m.Role == RoleUser) {
-			m.Role = RoleSystem
-		}
-		messages = append(messages, m)
+	if len(rendered) != 1 {
+		return nil, status.Errorf(status.ErrInvalidArgument,
+			"%s produced %d messages, want 1: its template fills a single message, so use WithMessagesTemplate for a multi-turn template",
+			option, len(rendered))
+	}
+	if got := rendered[0].Role; got != want && got != RoleUser {
+		// Belt and braces for a marker the pattern did not catch: RoleUser is
+		// dotprompt's default and so carries no intent.
+		return nil, status.Errorf(status.ErrInvalidArgument,
+			"%s produced a %s message, want %s: use WithMessagesTemplate to write turns with other roles",
+			option, got, want)
 	}
 
-	return messages, nil
+	rendered[0].Role = want
+	return rendered[0], nil
 }
 
 // renderUserPrompt renders a user prompt message.
+//
+// Template text from [WithPrompt] is compiled as a dotprompt template against
+// the input. Content from [WithPromptFn] or [WithPromptPartsFn] is used
+// verbatim, for the same reason as in [renderSystemPrompt].
+//
+// As with [renderSystemPrompt], the template fills exactly one message. This
+// one is the final user turn, so a template that produced several would place
+// content after it.
 func renderUserPrompt(ctx context.Context, opts promptOptions, messages []*Message, input map[string]any, raw any, dp *dotprompt.Dotprompt) ([]*Message, error) {
-	if opts.PromptFn == nil {
+	if opts.PromptFn != nil {
+		parts, err := opts.PromptFn(ctx, raw)
+		if err != nil {
+			return nil, err
+		}
+		if len(parts) == 0 {
+			return messages, nil
+		}
+		return append(messages, &Message{Role: RoleUser, Content: parts}), nil
+	}
+
+	if opts.PromptText == nil {
 		return messages, nil
 	}
 
-	templateText, err := opts.PromptFn(ctx, raw)
+	rendered, err := renderSingleMessage(ctx, opts, *opts.PromptText, input, dp, "WithPrompt", RoleUser)
 	if err != nil {
 		return nil, err
 	}
 
-	renderedMessages, err := renderPrompt(ctx, opts, templateText, input, dp)
-	if err != nil {
-		return nil, err
+	return append(messages, rendered), nil
+}
+
+// renderMessages appends the messages that sit between the system and user
+// prompts.
+//
+// A prompt that declares its own conversation owns the messages supplied at
+// execution time, because only it knows where its few-shot examples end and a
+// real conversation begins. Each form has a way to place them:
+// [WithMessagesTemplate] renders them at {{history}}, or before its final user
+// message when the template does not say; [WithMessagesFn] reads them from
+// [HistoryFromContext]. A prompt that declares nothing gets them here, in the
+// middle, which is where the caller of a system-and-prompt prompt expects a
+// conversation to go.
+//
+// Values from [WithMessages] and [WithMessagesFn] are used verbatim, so
+// conversation history containing literal braces passes through untouched.
+// Only [WithMessagesTemplate] text is compiled.
+func renderMessages(ctx context.Context, opts promptOptions, messages []*Message, input map[string]any, raw any, dp *dotprompt.Dotprompt) ([]*Message, error) {
+	history := HistoryFromContext(ctx)
+
+	// A prompt that declares no conversation of its own has the caller's used
+	// directly, between the system message and the user prompt.
+	if opts.MessagesFn == nil && opts.MessagesText == nil && opts.MessagesAfterFn == nil {
+		return appendMessageClones(messages, history), nil
 	}
 
-	for _, m := range renderedMessages {
-		if m.Role == "" || (len(renderedMessages) == 1 && m.Role != RoleUser) {
-			m.Role = RoleUser
+	// Otherwise the prompt owns the conversation and its contributions render
+	// in call order, the template sitting where it was first declared. Only the
+	// template can place the caller's history, with {{history}}; a function
+	// reaches it through HistoryFromContext and decides for itself.
+	if opts.MessagesFn != nil {
+		msgs, err := opts.MessagesFn(ctx, raw)
+		if err != nil {
+			return nil, err
 		}
-		messages = append(messages, m)
+		messages = appendMessageClones(messages, msgs)
+	}
+	if opts.MessagesText != nil {
+		rendered, err := renderPrompt(ctx, opts, *opts.MessagesText, input, history, dp)
+		if err != nil {
+			return nil, err
+		}
+		// Already fresh messages built by the renderer, so no clone is needed
+		// for them; the history dotprompt spliced in is not, and is cloned by
+		// renderPrompt before it goes downstream.
+		messages = append(messages, rendered...)
+	}
+	if opts.MessagesAfterFn != nil {
+		msgs, err := opts.MessagesAfterFn(ctx, raw)
+		if err != nil {
+			return nil, err
+		}
+		messages = appendMessageClones(messages, msgs)
 	}
 
 	return messages, nil
 }
 
-// renderMessages renders a slice of messages.
-func renderMessages(ctx context.Context, opts promptOptions, messages []*Message, input map[string]any, raw any, dp *dotprompt.Dotprompt) ([]*Message, error) {
-	if opts.MessagesFn == nil {
-		return messages, nil
+// appendMessageClones appends a clone of each message in src to dst.
+//
+// Everything renderMessages splices into a request is cloned, whichever
+// source it came from. Message text is deliberately not rendered as a
+// dotprompt template. These messages are overwhelmingly conversation history
+// holding user-authored text, so compiling them made any literal brace a hard
+// parse error and turned remote content, such as prompt messages fetched from
+// an MCP server, into a template-injection surface. Only the string form of
+// the conversation is compiled; message values pass through untouched.
+// Callers that want variables in message text can
+// interpolate it themselves, use [WithMessagesFn], which receives the typed
+// input, or write the turns with [WithMessagesTemplate], the string form,
+// where each {{role}} block produces a message of its own.
+//
+// The clones matter because later stages may mutate messages in place, as
+// middleware does when it stamps metadata. Messages declared with
+// [WithMessages] are stored on the prompt and reused by every execution, and
+// messages from a content function or execute-time history typically alias a
+// session or the caller's own conversation slice, so handing the originals
+// downstream lets one execution corrupt state it does not own. [Message.Clone]
+// copies the Content slice and Metadata map for the same reason: appending to
+// a shared backing array or writing a shared map races even when the
+// [Message] struct itself is fresh.
+func appendMessageClones(dst []*Message, src []*Message) []*Message {
+	for _, msg := range src {
+		dst = append(dst, msg.Clone())
 	}
-
-	msgs, err := opts.MessagesFn(ctx, raw)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create new message copies to avoid mutating shared messages during concurrent execution
-	renderedMsgs := make([]*Message, 0, len(msgs))
-	for _, msg := range msgs {
-		hasTextPart := slices.ContainsFunc(msg.Content, (*Part).IsText)
-
-		if !hasTextPart {
-			// Create a new message with non-text content instead of mutating the original
-			renderedMsg := &Message{
-				Role:     msg.Role,
-				Content:  msg.Content,
-				Metadata: msg.Metadata,
-			}
-			renderedMsgs = append(renderedMsgs, renderedMsg)
-			continue
-		}
-
-		for _, part := range msg.Content {
-			if part.IsText() {
-				messagesFromText, err := renderPrompt(ctx, opts, part.Text, input, dp)
-				if err != nil {
-					return nil, err
-				}
-				for _, m := range messagesFromText {
-					// If the rendered message has no role, or it is a single message with default role,
-					// use the original message's role.
-					role := m.Role
-					if role == "" || (len(messagesFromText) == 1 && role == RoleUser) {
-						role = msg.Role
-					}
-					renderedMsgs = append(renderedMsgs, &Message{
-						Role:     role,
-						Content:  m.Content,
-						Metadata: msg.Metadata,
-					})
-				}
-			} else {
-				// Preserve non-text parts as-is in the current last message if possible, or create a new one
-				if len(renderedMsgs) > 0 && renderedMsgs[len(renderedMsgs)-1].Role == msg.Role {
-					renderedMsgs[len(renderedMsgs)-1].Content = append(renderedMsgs[len(renderedMsgs)-1].Content, part)
-				} else {
-					renderedMsgs = append(renderedMsgs, &Message{
-						Role:     msg.Role,
-						Content:  []*Part{part},
-						Metadata: msg.Metadata,
-					})
-				}
-			}
-		}
-	}
-
-	return append(messages, renderedMsgs...), nil
+	return dst
 }
 
-// renderPrompt renders a prompt template using dotprompt functionalities
-func renderPrompt(ctx context.Context, opts promptOptions, templateText string, input map[string]any, dp *dotprompt.Dotprompt) ([]*Message, error) {
+// renderPrompt renders a prompt template using dotprompt functionalities.
+//
+// history is the conversation the template may place, which dotprompt renders
+// at {{history}} and otherwise inserts before the template's final user
+// message. Only the conversation slot passes it: the system and user prompt
+// slots each fill a single message, so history has no place inside them.
+func renderPrompt(ctx context.Context, opts promptOptions, templateText string, input map[string]any, history []*Message, dp *dotprompt.Dotprompt) ([]*Message, error) {
 	renderedFunc, err := dp.Compile(templateText, &dotprompt.PromptMetadata{})
 	if err != nil {
 		return nil, err
 	}
 
-	return renderDotpromptToMessages(ctx, renderedFunc, input, &dotprompt.PromptMetadata{
+	return renderDotpromptToMessages(ctx, renderedFunc, input, history, &dotprompt.PromptMetadata{
 		Input: dotprompt.PromptMetadataInput{
 			Default: opts.DefaultInput,
 		},
@@ -627,7 +768,7 @@ func renderPrompt(ctx context.Context, opts promptOptions, templateText string, 
 }
 
 // renderDotpromptToMessages executes a dotprompt prompt function and converts the result to a slice of messages
-func renderDotpromptToMessages(ctx context.Context, promptFn dotprompt.PromptFunction, input map[string]any, additionalMetadata *dotprompt.PromptMetadata) ([]*Message, error) {
+func renderDotpromptToMessages(ctx context.Context, promptFn dotprompt.PromptFunction, input map[string]any, history []*Message, additionalMetadata *dotprompt.PromptMetadata) ([]*Message, error) {
 	// Prepare the context for rendering
 	templateContext := map[string]any{}
 	actionCtx := core.FromContext(ctx)
@@ -640,15 +781,26 @@ func renderDotpromptToMessages(ctx context.Context, promptFn dotprompt.PromptFun
 
 	// Call the prompt function with the input and context
 	rendered, err := promptFn(&dotprompt.DataArgument{
-		Input:   input,
-		Context: templateContext,
+		Input:    input,
+		Messages: toDotpromptMessages(history),
+		Context:  templateContext,
 	}, additionalMetadata)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render prompt: %w", err)
 	}
 
 	convertedMessages := []*Message{}
+	historyIdx := 0
 	for _, message := range rendered.Messages {
+		// Dotprompt marks the messages it spliced in for {{history}}. Restore
+		// the originals rather than converting the stand-ins back: a message
+		// carries kinds dotprompt has no representation for, such as tool
+		// requests and resources, so a round trip through it would drop them.
+		if message.Metadata["purpose"] == "history" && historyIdx < len(history) {
+			convertedMessages = append(convertedMessages, history[historyIdx].Clone())
+			historyIdx++
+			continue
+		}
 		parts, err := convertToPartPointers(message.Content)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert parts: %w", err)
@@ -661,6 +813,41 @@ func renderDotpromptToMessages(ctx context.Context, promptFn dotprompt.PromptFun
 	}
 
 	return convertedMessages, nil
+}
+
+// toDotpromptMessages converts history into the messages dotprompt places for
+// {{history}}.
+//
+// Only the roles have to be faithful. The content is a stand-in, since
+// renderDotpromptToMessages restores each original message once dotprompt has
+// decided where it goes, which is what keeps part kinds dotprompt cannot
+// represent from being lost.
+//
+// The stand-ins are marked as history on the way in. Dotprompt marks them
+// itself when the template places them at {{history}}, but not when it inserts
+// them before the final user message, and the restore needs to recognize them
+// either way.
+func toDotpromptMessages(history []*Message) []dotprompt.Message {
+	if len(history) == 0 {
+		return nil
+	}
+	msgs := make([]dotprompt.Message, 0, len(history))
+	for _, m := range history {
+		content := make([]dotprompt.Part, 0, len(m.Content))
+		for _, p := range m.Content {
+			text := ""
+			if p.IsText() {
+				text = p.Text
+			}
+			content = append(content, &dotprompt.TextPart{Text: text})
+		}
+		msgs = append(msgs, dotprompt.Message{
+			Role:        dotprompt.Role(m.Role),
+			Content:     content,
+			HasMetadata: dotprompt.HasMetadata{Metadata: map[string]any{"purpose": "history"}},
+		})
+	}
+	return msgs
 }
 
 // convertToPartPointers converts []dotprompt.Part to []*Part
@@ -863,7 +1050,7 @@ func LoadPromptFromSource(r api.Registry, source, name, namespace string) (Promp
 
 	key := promptKey(name, variant, namespace)
 
-	prompt := DefinePrompt(r, key, opts, WithPrompt(parsedPrompt.Template))
+	prompt := DefinePrompt(r, key, opts, WithMessagesTemplate(parsedPrompt.Template))
 
 	return prompt, nil
 }
@@ -871,7 +1058,7 @@ func LoadPromptFromSource(r api.Registry, source, name, namespace string) (Promp
 // parseDotpromptUse converts the value of the dotprompt `use:` frontmatter
 // field into a slice of lazy [Middleware] references. Each entry may be a
 // bare string (interpreted as a registered middleware name) or a map with
-// `name` and optional `config`, mirroring the TypeScript MiddlewareRef shape.
+// `name` and optional `config`, the two shapes the frontmatter accepts.
 // Returns nil if the input is nil or an empty slice.
 func parseDotpromptUse(raw any) ([]Middleware, error) {
 	if raw == nil {
@@ -940,7 +1127,7 @@ func contentType(ct, uri string) (string, []byte, error) {
 		// fills in the content type; for gs:// and other natively-supported
 		// URLs (e.g. YouTube) the model resolves it. Defer content-type
 		// validation to the model/plugin layer instead of failing to render
-		// the prompt, matching the behavior of the JS and Python SDKs.
+		// the prompt.
 		return ct, []byte(uri), nil
 	}
 	if contents, isData := strings.CutPrefix(uri, "data:"); isData {

--- a/go/ai/prompt_fn_test.go
+++ b/go/ai/prompt_fn_test.go
@@ -602,10 +602,10 @@ func TestDocsFnSkippedOnExecuteOverride(t *testing.T) {
 	}
 }
 
-// TestConversationMergeSemantics pins how the three conversation options
-// combine. Verbatim messages accumulate with each other, but a template resets
-// the conversation: it lays the whole thing out, down to where {{history}} puts
-// the caller's, so anything set before it is dropped rather than folded in.
+// TestConversationMergeSemantics pins how the conversation options combine.
+// Verbatim messages accumulate and the template is a last-win slot, the two
+// standard rules. Combining the two kinds is refused: a template lays out the
+// whole conversation, so nothing else has a position relative to it.
 func TestConversationMergeSemantics(t *testing.T) {
 	msg := func(text string) *Message { return NewUserTextMessage(text) }
 	collect := func(fn MessagesFn) []string {
@@ -643,48 +643,43 @@ func TestConversationMergeSemantics(t *testing.T) {
 		if got, want := collect(p.MessagesFn), []string{"one", "two", "three"}; !slices.Equal(got, want) {
 			t.Errorf("messages = %v, want %v", got, want)
 		}
-		if p.MessagesText != nil {
-			t.Errorf("MessagesText = %q, want none", *p.MessagesText)
-		}
 	})
 
-	t.Run("a template drops the messages set before it", func(t *testing.T) {
-		p := apply(
-			WithMessages(msg("dropped")),
-			WithMessagesTemplate("the conversation"),
-		)
-		if got := collect(p.MessagesFn); got != nil {
-			t.Errorf("messages = %v, want none: the template resets the conversation", got)
-		}
-		if p.MessagesText == nil || *p.MessagesText != "the conversation" {
-			t.Errorf("template = %v, want %q", p.MessagesText, "the conversation")
-		}
-	})
-
-	t.Run("messages set after a template accumulate onto it", func(t *testing.T) {
-		p := apply(
-			WithMessagesTemplate("the conversation"),
-			WithMessages(msg("after one")),
-			WithMessages(msg("after two")),
-		)
-		if got, want := collect(p.MessagesFn), []string{"after one", "after two"}; !slices.Equal(got, want) {
-			t.Errorf("messages = %v, want %v", got, want)
-		}
-	})
-
-	t.Run("a later template drops an earlier one and everything between", func(t *testing.T) {
-		p := apply(
-			WithMessagesTemplate("first"),
-			WithMessages(msg("between")),
-			WithMessagesTemplate("second"),
-		)
+	t.Run("repeating the template takes the last one", func(t *testing.T) {
+		p := apply(WithMessagesTemplate("first"), WithMessagesTemplate("second"))
 		if p.MessagesText == nil || *p.MessagesText != "second" {
 			t.Errorf("template = %v, want %q", p.MessagesText, "second")
 		}
-		if got := collect(p.MessagesFn); got != nil {
-			t.Errorf("messages = %v, want none", got)
-		}
 	})
+
+	for _, tt := range []struct {
+		name string
+		opts []PromptOption
+	}{
+		{"template then messages", []PromptOption{
+			WithMessagesTemplate("t"), WithMessages(msg("m"))}},
+		{"messages then template", []PromptOption{
+			WithMessages(msg("m")), WithMessagesTemplate("t")}},
+		{"template then messages fn", []PromptOption{
+			WithMessagesTemplate("t"),
+			WithMessagesFn(func(context.Context, any) ([]*Message, error) { return nil, nil })}},
+	} {
+		t.Run("refused: "+tt.name, func(t *testing.T) {
+			r := newTestRegistry(t)
+			m := defineFakeModel(t, r, fakeModelConfig{name: "test/exclusive"})
+			defer func() {
+				rec := recover()
+				if rec == nil {
+					t.Fatal("expected a panic combining a template with verbatim messages")
+				}
+				text, _ := rec.(string)
+				if !strings.Contains(text, "WithMessagesTemplate") || !strings.Contains(text, "WithMessages") {
+					t.Errorf("panic = %v, want it to name both options", rec)
+				}
+			}()
+			DefinePrompt(r, "exclusive_"+tt.name, append([]PromptOption{WithModel(m)}, tt.opts...)...)
+		})
+	}
 }
 
 // TestLiteralPercentSurvivesWithPrompt guards the Sprintf guard in

--- a/go/ai/prompt_fn_test.go
+++ b/go/ai/prompt_fn_test.go
@@ -609,8 +609,8 @@ func TestDocsFnSkippedOnExecuteOverride(t *testing.T) {
 // it, which is what keeps the template where it was first declared.
 func TestConversationMergeSemantics(t *testing.T) {
 	msg := func(text string) *Message { return NewUserTextMessage(text) }
-	opts := &generateOptions{}
-	for _, o := range []CommonGenOption{
+	opts := &promptOptions{}
+	for _, o := range []PromptOption{
 		WithMessages(msg("before one")),
 		WithMessagesFn(func(context.Context, any) ([]*Message, error) {
 			return []*Message{msg("before two")}, nil
@@ -620,7 +620,7 @@ func TestConversationMergeSemantics(t *testing.T) {
 		WithMessagesTemplate("second template"),
 		WithMessages(msg("after two")),
 	} {
-		o.applyGenerate(opts)
+		o.applyPrompt(opts)
 	}
 
 	collect := func(fn MessagesFn) []string {
@@ -908,22 +908,6 @@ func TestHistoryFromContext(t *testing.T) {
 		}
 		assertMessages(t, (*get)(), "system:sys", "user:example in", "model:example out", "user:now answer")
 	})
-}
-
-// TestExecuteRejectsMessagesTemplate pins that a template passed at execution
-// time is refused rather than silently dropped: nothing on that path compiles
-// one, so accepting it would lose the caller's conversation.
-func TestExecuteRejectsMessagesTemplate(t *testing.T) {
-	_, p, _ := capturePrompt(t, "execTemplate", WithSystem("sys"), WithPrompt("ask"))
-
-	_, err := p.Execute(context.Background(),
-		WithMessagesTemplate(`{{role "user"}}dropped on the floor`))
-	if err == nil {
-		t.Fatal("expected an error, got nil")
-	}
-	if !strings.Contains(err.Error(), "WithMessagesTemplate") || !strings.Contains(err.Error(), "WithMessages") {
-		t.Errorf("err = %v, want it to name the option and the alternative", err)
-	}
 }
 
 // TestContentFnErrorPropagates makes sure a coercion failure surfaces as an

--- a/go/ai/prompt_fn_test.go
+++ b/go/ai/prompt_fn_test.go
@@ -603,26 +603,11 @@ func TestDocsFnSkippedOnExecuteOverride(t *testing.T) {
 }
 
 // TestConversationMergeSemantics pins how the three conversation options
-// combine. Verbatim messages accumulate, but a template does not: it lays out
-// the whole conversation and is where {{history}} goes, so a second one
-// replaces the first. Messages that arrive after a template accumulate behind
-// it, which is what keeps the template where it was first declared.
+// combine. Verbatim messages accumulate with each other, but a template resets
+// the conversation: it lays the whole thing out, down to where {{history}} puts
+// the caller's, so anything set before it is dropped rather than folded in.
 func TestConversationMergeSemantics(t *testing.T) {
 	msg := func(text string) *Message { return NewUserTextMessage(text) }
-	opts := &promptOptions{}
-	for _, o := range []PromptOption{
-		WithMessages(msg("before one")),
-		WithMessagesFn(func(context.Context, any) ([]*Message, error) {
-			return []*Message{msg("before two")}, nil
-		}),
-		WithMessagesTemplate("first template"),
-		WithMessages(msg("after one")),
-		WithMessagesTemplate("second template"),
-		WithMessages(msg("after two")),
-	} {
-		o.applyPrompt(opts)
-	}
-
 	collect := func(fn MessagesFn) []string {
 		t.Helper()
 		if fn == nil {
@@ -638,16 +623,68 @@ func TestConversationMergeSemantics(t *testing.T) {
 		}
 		return got
 	}
+	apply := func(opts ...PromptOption) *promptOptions {
+		t.Helper()
+		p := &promptOptions{}
+		for _, o := range opts {
+			o.applyPrompt(p)
+		}
+		return p
+	}
 
-	if got, want := collect(opts.MessagesFn), []string{"before one", "before two"}; !slices.Equal(got, want) {
-		t.Errorf("before the template = %v, want %v", got, want)
-	}
-	if opts.MessagesText == nil || *opts.MessagesText != "second template" {
-		t.Errorf("template = %v, want the last one set", opts.MessagesText)
-	}
-	if got, want := collect(opts.MessagesAfterFn), []string{"after one", "after two"}; !slices.Equal(got, want) {
-		t.Errorf("after the template = %v, want %v", got, want)
-	}
+	t.Run("verbatim messages accumulate across both variants", func(t *testing.T) {
+		p := apply(
+			WithMessages(msg("one")),
+			WithMessagesFn(func(context.Context, any) ([]*Message, error) {
+				return []*Message{msg("two")}, nil
+			}),
+			WithMessages(msg("three")),
+		)
+		if got, want := collect(p.MessagesFn), []string{"one", "two", "three"}; !slices.Equal(got, want) {
+			t.Errorf("messages = %v, want %v", got, want)
+		}
+		if p.MessagesText != nil {
+			t.Errorf("MessagesText = %q, want none", *p.MessagesText)
+		}
+	})
+
+	t.Run("a template drops the messages set before it", func(t *testing.T) {
+		p := apply(
+			WithMessages(msg("dropped")),
+			WithMessagesTemplate("the conversation"),
+		)
+		if got := collect(p.MessagesFn); got != nil {
+			t.Errorf("messages = %v, want none: the template resets the conversation", got)
+		}
+		if p.MessagesText == nil || *p.MessagesText != "the conversation" {
+			t.Errorf("template = %v, want %q", p.MessagesText, "the conversation")
+		}
+	})
+
+	t.Run("messages set after a template accumulate onto it", func(t *testing.T) {
+		p := apply(
+			WithMessagesTemplate("the conversation"),
+			WithMessages(msg("after one")),
+			WithMessages(msg("after two")),
+		)
+		if got, want := collect(p.MessagesFn), []string{"after one", "after two"}; !slices.Equal(got, want) {
+			t.Errorf("messages = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("a later template drops an earlier one and everything between", func(t *testing.T) {
+		p := apply(
+			WithMessagesTemplate("first"),
+			WithMessages(msg("between")),
+			WithMessagesTemplate("second"),
+		)
+		if p.MessagesText == nil || *p.MessagesText != "second" {
+			t.Errorf("template = %v, want %q", p.MessagesText, "second")
+		}
+		if got := collect(p.MessagesFn); got != nil {
+			t.Errorf("messages = %v, want none", got)
+		}
+	})
 }
 
 // TestLiteralPercentSurvivesWithPrompt guards the Sprintf guard in

--- a/go/ai/prompt_fn_test.go
+++ b/go/ai/prompt_fn_test.go
@@ -910,6 +910,38 @@ func TestHistoryFromContext(t *testing.T) {
 	})
 }
 
+// TestDocsAccumulateAcrossVariants pins that the three document options add to
+// one set rather than replacing each other, and that the fixed documents come
+// before the computed ones. Resolution used to overwrite the fixed documents
+// with the function's result, so declaring both silently lost the fixed ones.
+func TestDocsAccumulateAcrossVariants(t *testing.T) {
+	r := newTestRegistry(t)
+	m := defineFakeModel(t, r, fakeModelConfig{name: "test/docsAccum"})
+
+	p := DefinePrompt(r, "docsAccum",
+		WithModel(m),
+		WithPrompt("hi"),
+		WithTextDocs("fixed one"),
+		WithDocsFn(func(ctx context.Context, _ any) ([]*Document, error) {
+			return []*Document{DocumentFromText("computed", nil)}, nil
+		}),
+		WithTextDocs("fixed two"),
+	)
+
+	opts, err := p.Render(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var got []string
+	for _, d := range opts.Docs {
+		got = append(got, d.Content[0].Text)
+	}
+	want := []string{"fixed one", "fixed two", "computed"}
+	if !slices.Equal(got, want) {
+		t.Errorf("docs = %v, want %v", got, want)
+	}
+}
+
 // TestContentFnErrorPropagates makes sure a coercion failure surfaces as an
 // error rather than a panic, which is what the old type assertions produced.
 func TestContentFnErrorPropagates(t *testing.T) {

--- a/go/ai/prompt_fn_test.go
+++ b/go/ai/prompt_fn_test.go
@@ -1,0 +1,1231 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
+)
+
+type fnTestInput struct {
+	Name  string `json:"name"`
+	Theme string `json:"theme"`
+}
+
+// capturePrompt defines a prompt against a request-capturing model.
+func capturePrompt(t *testing.T, name string, opts ...PromptOption) (api.Registry, Prompt, *func() *ModelRequest) {
+	t.Helper()
+	r := newTestRegistry(t)
+	var captured *ModelRequest
+	m := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/capture_" + name,
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			captured = req
+			return &ModelResponse{Message: NewModelTextMessage("ok")}, nil
+		},
+	})
+	get := func() *ModelRequest { return captured }
+	p := DefinePrompt(r, name, append([]PromptOption{WithModel(m)}, opts...)...)
+	return r, p, &get
+}
+
+// TestContentFnInputTypeAcrossCallPaths covers the defect that made these
+// options unusable: the concrete type of the value handed to a content function
+// used to depend on how the prompt was invoked, so a function written against
+// the prompt's input type panicked from the Dev UI and from the default-input
+// path.
+func TestContentFnInputTypeAcrossCallPaths(t *testing.T) {
+	var seen []fnTestInput
+	r := newTestRegistry(t)
+	m := defineFakeModel(t, r, fakeModelConfig{name: "test/echoTyped"})
+
+	p := DefinePrompt(r, "typedInput",
+		WithModel(m),
+		WithInputType(fnTestInput{Theme: "pirate"}),
+		WithPromptFn(func(ctx context.Context, in fnTestInput) (string, error) {
+			seen = append(seen, in)
+			return "hi " + in.Name, nil
+		}),
+	)
+
+	t.Run("typed Go value", func(t *testing.T) {
+		seen = nil
+		if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Name: "bob", Theme: "ninja"})); err != nil {
+			t.Fatal(err)
+		}
+		if want := (fnTestInput{Name: "bob", Theme: "ninja"}); seen[0] != want {
+			t.Errorf("input = %+v, want %+v", seen[0], want)
+		}
+	})
+
+	t.Run("default input from WithInputType", func(t *testing.T) {
+		seen = nil
+		if _, err := p.Execute(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if want := (fnTestInput{Theme: "pirate"}); seen[0] != want {
+			t.Errorf("input = %+v, want %+v", seen[0], want)
+		}
+	})
+
+	t.Run("map input", func(t *testing.T) {
+		seen = nil
+		if _, err := p.Execute(context.Background(), WithInput(map[string]any{"name": "carol", "theme": "noir"})); err != nil {
+			t.Fatal(err)
+		}
+		if want := (fnTestInput{Name: "carol", Theme: "noir"}); seen[0] != want {
+			t.Errorf("input = %+v, want %+v", seen[0], want)
+		}
+	})
+
+	t.Run("reflection API", func(t *testing.T) {
+		seen = nil
+		act := r.ResolveAction("/executable-prompt/typedInput")
+		if act == nil {
+			t.Fatal("prompt action not registered")
+		}
+		if _, err := act.RunJSON(context.Background(), json.RawMessage(`{"name":"dave","theme":"noir"}`), nil); err != nil {
+			t.Fatal(err)
+		}
+		if want := (fnTestInput{Name: "dave", Theme: "noir"}); seen[0] != want {
+			t.Errorf("input = %+v, want %+v", seen[0], want)
+		}
+	})
+
+	t.Run("Generate has no input and gets the zero value", func(t *testing.T) {
+		seen = nil
+		_, err := Generate(context.Background(), r,
+			WithModel(m),
+			WithPromptFn(func(ctx context.Context, in fnTestInput) (string, error) {
+				seen = append(seen, in)
+				return "hi", nil
+			}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if seen[0] != (fnTestInput{}) {
+			t.Errorf("input = %+v, want zero value", seen[0])
+		}
+	})
+}
+
+// TestContentFnLooseInputKeepsSchemaTypes extends the guarantee above from the
+// declared type to the Go types inside it. A loosely typed input cannot restore
+// integer-ness from JSON on its own, so without normalization the same field
+// arrived as an int64 over the wire and a float64 in process.
+func TestContentFnLooseInputKeepsSchemaTypes(t *testing.T) {
+	type counted struct {
+		Count int64  `json:"count"`
+		Name  string `json:"name"`
+	}
+
+	r := newTestRegistry(t)
+	m := defineFakeModel(t, r, fakeModelConfig{name: "test/looseInput"})
+
+	var seen []any
+	p := DefinePrompt(r, "looseInput",
+		WithModel(m),
+		WithInputType(counted{Count: 7}),
+		WithPromptFn(func(ctx context.Context, in map[string]any) (string, error) {
+			seen = append(seen, in["count"])
+			return "hi", nil
+		}),
+	)
+
+	ctx := context.Background()
+	const want = int64(1230000000)
+
+	t.Run("typed Go value", func(t *testing.T) {
+		seen = nil
+		if _, err := p.Execute(ctx, WithInput(counted{Count: want})); err != nil {
+			t.Fatal(err)
+		}
+		if seen[0] != any(want) {
+			t.Errorf("count = %T(%v), want int64(%d)", seen[0], seen[0], want)
+		}
+	})
+
+	t.Run("reflection API", func(t *testing.T) {
+		seen = nil
+		act := r.ResolveAction("/executable-prompt/looseInput")
+		if act == nil {
+			t.Fatal("prompt action not registered")
+		}
+		if _, err := act.RunJSON(ctx, json.RawMessage(`{"count":1230000000,"name":"a"}`), nil); err != nil {
+			t.Fatal(err)
+		}
+		if seen[0] != any(want) {
+			t.Errorf("count = %T(%v), want int64(%d)", seen[0], seen[0], want)
+		}
+	})
+
+	t.Run("default input from WithInputType", func(t *testing.T) {
+		seen = nil
+		if _, err := p.Execute(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if seen[0] != any(int64(7)) {
+			t.Errorf("count = %T(%v), want int64(7)", seen[0], seen[0])
+		}
+	})
+}
+
+// TestUntypedContentFnStillCompiles pins the source compatibility of the
+// generic retrofit: functions written against the old untyped signature still
+// satisfy the options, with In inferred as any.
+func TestUntypedContentFnStillCompiles(t *testing.T) {
+	r := newTestRegistry(t)
+	m := defineFakeModel(t, r, fakeModelConfig{name: "test/echoUntyped"})
+
+	var systemFn PromptFn = func(ctx context.Context, input any) (string, error) {
+		return "system", nil
+	}
+	var messagesFn MessagesFn = func(ctx context.Context, input any) ([]*Message, error) {
+		return []*Message{NewModelTextMessage("history")}, nil
+	}
+
+	p := DefinePrompt(r, "untypedFns",
+		WithModel(m),
+		WithInputType(fnTestInput{}),
+		WithSystemFn(systemFn),
+		WithMessagesFn(messagesFn),
+		WithPromptFn(func(ctx context.Context, input any) (string, error) {
+			// The untyped path still receives the raw value as before.
+			if _, ok := input.(fnTestInput); !ok {
+				t.Errorf("input type = %T, want ai.fnTestInput", input)
+			}
+			return "prompt", nil
+		}),
+	)
+
+	if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Name: "bob"})); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestContentFnResultIsNotATemplate covers the behavior change: a function has
+// already produced its final content, so the result must not be reinterpreted
+// as a dotprompt template. Previously text with literal braces failed to parse
+// and text resembling a placeholder was silently substituted.
+func TestContentFnResultIsNotATemplate(t *testing.T) {
+	literal := "how do I write {{#if x}} in handlebars? Also {{name}} and a bare {{"
+
+	t.Run("prompt fn", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "verbatimPrompt",
+			WithInputType(fnTestInput{}),
+			WithPromptFn(func(ctx context.Context, in fnTestInput) (string, error) {
+				return literal, nil
+			}),
+		)
+		if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Name: "bob"})); err != nil {
+			t.Fatalf("verbatim text should not be parsed as a template: %v", err)
+		}
+		req := (*get)()
+		if got := req.Messages[len(req.Messages)-1].Text(); got != literal {
+			t.Errorf("user text = %q, want %q", got, literal)
+		}
+	})
+
+	t.Run("system fn", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "verbatimSystem",
+			WithInputType(fnTestInput{}),
+			WithSystemFn(func(ctx context.Context, in fnTestInput) (string, error) {
+				return literal, nil
+			}),
+		)
+		if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Name: "bob"})); err != nil {
+			t.Fatalf("verbatim text should not be parsed as a template: %v", err)
+		}
+		req := (*get)()
+		if req.Messages[0].Role != RoleSystem {
+			t.Errorf("Messages[0].Role = %q, want %q", req.Messages[0].Role, RoleSystem)
+		}
+		if got := req.Messages[0].Text(); got != literal {
+			t.Errorf("system text = %q, want %q", got, literal)
+		}
+	})
+
+	t.Run("static messages", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "verbatimStatic",
+			WithInputType(fnTestInput{}),
+			WithMessages(NewUserTextMessage(literal)),
+			WithPrompt("ok"),
+		)
+		if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Name: "bob"})); err != nil {
+			t.Fatalf("verbatim history should not be parsed as a template: %v", err)
+		}
+		req := (*get)()
+		if got := req.Messages[0].Text(); got != literal {
+			t.Errorf("message text = %q, want %q", got, literal)
+		}
+	})
+
+	t.Run("messages fn", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "verbatimMessages",
+			WithInputType(fnTestInput{}),
+			WithMessagesFn(func(ctx context.Context, in fnTestInput) ([]*Message, error) {
+				return []*Message{NewUserTextMessage(literal)}, nil
+			}),
+		)
+		if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Name: "bob"})); err != nil {
+			t.Fatalf("verbatim history should not be parsed as a template: %v", err)
+		}
+		req := (*get)()
+		if got := req.Messages[0].Text(); got != literal {
+			t.Errorf("message text = %q, want %q", got, literal)
+		}
+	})
+
+	t.Run("WithPrompt template text is still rendered", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "stillTemplated",
+			WithInputType(fnTestInput{}),
+			WithPrompt("talk like a {{theme}}"),
+		)
+		if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Theme: "ninja"})); err != nil {
+			t.Fatal(err)
+		}
+		req := (*get)()
+		if got, want := req.Messages[0].Text(), "talk like a ninja"; got != want {
+			t.Errorf("user text = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestHistoryStaysOutOfGenerationContext guards the scoping of the history
+// context: Execute attaches history to a context used only for Render, so the
+// model, tools, and any prompt nested under the generate loop must never see
+// it. Before the fix, a prompt executed from inside a tool inherited the outer
+// prompt's entire conversation.
+func TestHistoryStaysOutOfGenerationContext(t *testing.T) {
+	r := newTestRegistry(t)
+	var leaked []*Message
+	m := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/leakModel",
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			leaked = HistoryFromContext(ctx)
+			return &ModelResponse{Message: NewModelTextMessage("ok")}, nil
+		},
+	})
+	p := DefinePrompt(r, "leakProbe", WithModel(m), WithPrompt("q"))
+	if _, err := p.Execute(context.Background(), WithMessages(NewUserTextMessage("outer history"))); err != nil {
+		t.Fatal(err)
+	}
+	if leaked != nil {
+		t.Errorf("history leaked into the generation context: %v", leaked)
+	}
+}
+
+// TestFnMessagesNotMutatedByInstructionInjection guards the uniform cloning in
+// renderMessages: messages returned by WithMessagesFn typically alias a
+// session or the caller's own slice, and a later stage that appends to its
+// target message in place would corrupt that caller-owned history.
+func TestFnMessagesNotMutatedByInstructionInjection(t *testing.T) {
+	r := newTestRegistry(t)
+	m := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/fnMutModel",
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			return &ModelResponse{Message: NewModelTextMessage(`{"name":"x","theme":"y"}`)}, nil
+		},
+	})
+
+	t.Run("prompt-level MessagesFn", func(t *testing.T) {
+		shared := NewUserTextMessage("session-owned")
+		p := DefinePrompt(r, "fnMutPrompt",
+			WithModel(m),
+			WithMessagesFn(func(ctx context.Context, _ any) ([]*Message, error) {
+				return []*Message{shared}, nil
+			}),
+			WithOutputType(fnTestInput{}),
+			WithCustomConstrainedOutput(),
+		)
+		if _, err := p.Execute(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if len(shared.Content) != 1 {
+			t.Errorf("caller-owned message mutated: len(Content) = %d, want 1", len(shared.Content))
+		}
+	})
+
+	t.Run("execute-time MessagesFn", func(t *testing.T) {
+		shared := NewUserTextMessage("session-owned")
+		p := DefinePrompt(r, "fnMutExec",
+			WithModel(m),
+			WithOutputType(fnTestInput{}),
+			WithCustomConstrainedOutput(),
+		)
+		if _, err := p.Execute(context.Background(), WithMessagesFn(func(ctx context.Context, _ any) ([]*Message, error) {
+			return []*Message{shared}, nil
+		})); err != nil {
+			t.Fatal(err)
+		}
+		if len(shared.Content) != 1 {
+			t.Errorf("caller-owned message mutated: len(Content) = %d, want 1", len(shared.Content))
+		}
+	})
+}
+
+// TestHistoryPlacementByMessagesForm covers who owns the messages passed to
+// Execute. A prompt that declares its own conversation places them, since only
+// it knows where its few-shot examples end; a prompt that declares none gets
+// them in the middle.
+func TestHistoryPlacementByMessagesForm(t *testing.T) {
+	history := []*Message{NewUserTextMessage("history in"), NewModelTextMessage("history out")}
+
+	t.Run("no declared messages puts history in the middle", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "historyMiddle",
+			WithSystem("persona"),
+			WithPrompt("now answer"),
+		)
+		if _, err := p.Execute(context.Background(), WithMessages(history...)); err != nil {
+			t.Fatal(err)
+		}
+		assertMessages(t, (*get)(), "system:persona", "user:history in", "model:history out", "user:now answer")
+	})
+
+	t.Run("static messages own the conversation", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "staticOwns",
+			WithMessages(NewUserTextMessage("few-shot in"), NewModelTextMessage("few-shot out")),
+			WithPrompt("now answer"),
+		)
+		if _, err := p.Execute(context.Background(), WithMessages(history...)); err != nil {
+			t.Fatal(err)
+		}
+		assertMessages(t, (*get)(), "user:few-shot in", "model:few-shot out", "user:now answer")
+	})
+
+	// Without an explicit {{history}} dotprompt places the conversation before
+	// the template's final user message, which is where a caller expects it.
+	t.Run("template places history implicitly", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "templateImplicit",
+			WithMessagesTemplate(`{{role "system"}}persona
+{{role "user"}}few-shot in
+{{role "model"}}few-shot out
+{{role "user"}}now answer`),
+		)
+		if _, err := p.Execute(context.Background(), WithMessages(history...)); err != nil {
+			t.Fatal(err)
+		}
+		assertMessages(t, (*get)(), "system:persona", "user:few-shot in", "model:few-shot out",
+			"user:history in", "model:history out", "user:now answer")
+	})
+
+	t.Run("template places history explicitly", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "templateExplicit",
+			WithMessagesTemplate(`{{role "system"}}persona
+{{history}}
+{{role "user"}}few-shot in`),
+		)
+		if _, err := p.Execute(context.Background(), WithMessages(history...)); err != nil {
+			t.Fatal(err)
+		}
+		assertMessages(t, (*get)(), "system:persona", "user:history in", "model:history out", "user:few-shot in")
+	})
+}
+
+// TestMessagesTemplateRendersInput covers the case the .prompt loader and the
+// menu sample rely on: a multi-turn template whose turns are built from the
+// prompt's input, which is the whole reason the conversation slot is compiled.
+func TestMessagesTemplateRendersInput(t *testing.T) {
+	type item struct {
+		Title string `json:"title"`
+	}
+	type menuInput struct {
+		MenuData []item `json:"menuData"`
+	}
+
+	_, p, get := capturePrompt(t, "menuPreamble",
+		WithInputType(menuInput{}),
+		WithMessagesTemplate(`{{role "user"}}What's on the menu?
+{{role "model"}}Today:{{#each menuData}} {{this.title}}{{/each}}`),
+	)
+	if _, err := p.Execute(context.Background(), WithInput(menuInput{MenuData: []item{{Title: "Soup"}, {Title: "Pie"}}})); err != nil {
+		t.Fatal(err)
+	}
+	assertMessages(t, (*get)(), "user:What's on the menu?", "model:Today: Soup Pie")
+}
+
+// TestMessagesTemplateKeepsNonTextHistory covers the fidelity of the history
+// round trip: dotprompt decides where the messages go, but the originals are
+// restored, so kinds it cannot represent survive.
+func TestMessagesTemplateKeepsNonTextHistory(t *testing.T) {
+	toolReq := &Message{Role: RoleModel, Content: []*Part{
+		NewToolRequestPart(&ToolRequest{Name: "lookup", Input: map[string]any{"q": "x"}}),
+	}}
+
+	_, p, get := capturePrompt(t, "toolHistory",
+		WithMessagesTemplate(`{{role "system"}}persona
+{{role "user"}}now answer`),
+	)
+	if _, err := p.Execute(context.Background(), WithMessages(toolReq)); err != nil {
+		t.Fatal(err)
+	}
+	req := (*get)()
+	for _, msg := range req.Messages {
+		for _, part := range msg.Content {
+			if part == nil {
+				t.Fatalf("history round trip produced a nil part: %v", req.Messages)
+			}
+			if part.ToolRequest != nil && part.ToolRequest.Name == "lookup" {
+				return
+			}
+		}
+	}
+	t.Errorf("tool request did not survive the history round trip: %v", req.Messages)
+}
+
+// TestSingleMessageSlotsRejectRoleBlocks pins the slot contract: WithSystem and
+// WithPrompt each fill one message whose role is the slot's, so a {{role}}
+// marker is refused rather than silently overridden. A marker that produces one
+// message is refused too: the role would be stamped back to the slot's and the
+// author's intent dropped without a word.
+func TestSingleMessageSlotsRejectRoleBlocks(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		option string
+		opt    PromptOption
+	}{
+		{"prompt splits into turns", "WithPrompt", WithPrompt(`ask{{role "model"}}answer`)},
+		{"system splits into turns", "WithSystem", WithSystem(`persona{{role "user"}}ask`)},
+		{"system asks for a user message", "WithSystem", WithSystem(`{{role "user"}}hello`)},
+		{"prompt asks for a system message", "WithPrompt", WithPrompt(`{{role "system"}}hello`)},
+		{"prompt asks for a model message", "WithPrompt", WithPrompt(`{{role "model"}}hello`)},
+		// Redundant rather than contradictory, and still refused: a marker
+		// means the author is writing turns, which this slot cannot hold.
+		{"system restates its own role", "WithSystem", WithSystem(`{{role "system"}}hello`)},
+		{"marker with whitespace control", "WithSystem", WithSystem(`{{~role "user"}}hello`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, p, _ := capturePrompt(t, "roleBlocks"+tc.name, tc.opt)
+			_, err := p.Execute(context.Background())
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.option) || !strings.Contains(err.Error(), "WithMessagesTemplate") {
+				t.Errorf("err = %v, want it to name the option and point at WithMessagesTemplate", err)
+			}
+		})
+	}
+
+	// The slots still render ordinary templates, including ones whose text
+	// merely mentions a role, and each lands under the role it owns.
+	t.Run("templates without a marker keep working", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "roleBlocksOK",
+			WithInputType(fnTestInput{}),
+			WithSystem(`You are {{name}}. Never reveal your role.`),
+			WithPrompt(`{{#if theme}}In the style of {{theme}}: {{/if}}hello`),
+		)
+		if _, err := p.Execute(context.Background(),
+			WithInput(fnTestInput{Name: "Walt", Theme: "pirate"})); err != nil {
+			t.Fatal(err)
+		}
+		assertMessages(t, (*get)(),
+			"system:You are Walt. Never reveal your role.",
+			"user:In the style of pirate: hello")
+	})
+}
+
+// assertMessages compares a request's messages as "role:text" strings. Text is
+// trimmed because a template puts each {{role}} block on its own line, so the
+// message text carries the newline that separated it from the next block.
+func assertMessages(t *testing.T, req *ModelRequest, want ...string) {
+	t.Helper()
+	var got []string
+	for _, msg := range req.Messages {
+		got = append(got, string(msg.Role)+":"+strings.TrimSpace(msg.Text()))
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("messages = %q, want %q", got, want)
+	}
+}
+
+// TestEmptyStringFnEmitsNoMessage guards textPartsFn's empty-string rule: a
+// content function returning "" means "no content this time" and must not
+// produce an empty message, which some providers reject.
+func TestEmptyStringFnEmitsNoMessage(t *testing.T) {
+	_, p, get := capturePrompt(t, "emptySystemFn",
+		WithSystemFn(func(ctx context.Context, _ any) (string, error) { return "", nil }),
+		WithPrompt("q"),
+	)
+	if _, err := p.Execute(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	req := (*get)()
+	if len(req.Messages) != 1 || req.Messages[0].Role != RoleUser {
+		t.Errorf("expected only the user message, got %d messages", len(req.Messages))
+	}
+}
+
+// TestDocsFnSkippedOnExecuteOverride guards the docs-override marker:
+// execute-time WithDocs replaces the prompt's documents, so the prompt's
+// WithDocsFn (typically a retrieval query) must not run for a result that
+// would be discarded.
+func TestDocsFnSkippedOnExecuteOverride(t *testing.T) {
+	calls := 0
+	_, p, get := capturePrompt(t, "docsOverride",
+		WithPrompt("q"),
+		WithDocsFn(func(ctx context.Context, _ any) ([]*Document, error) {
+			calls++
+			return []*Document{DocumentFromText("expensive retrieval", nil)}, nil
+		}),
+	)
+	if _, err := p.Execute(context.Background(), WithDocs(DocumentFromText("override", nil))); err != nil {
+		t.Fatal(err)
+	}
+	req := (*get)()
+	if calls != 0 {
+		t.Errorf("DocsFn ran %d times despite execute-time docs override", calls)
+	}
+	if len(req.Docs) != 1 || req.Docs[0].Content[0].Text != "override" {
+		t.Errorf("request docs = %+v, want the override doc", req.Docs)
+	}
+}
+
+// TestConversationMergeSemantics pins how the three conversation options
+// combine. Verbatim messages accumulate, but a template does not: it lays out
+// the whole conversation and is where {{history}} goes, so a second one
+// replaces the first. Messages that arrive after a template accumulate behind
+// it, which is what keeps the template where it was first declared.
+func TestConversationMergeSemantics(t *testing.T) {
+	msg := func(text string) *Message { return NewUserTextMessage(text) }
+	opts := &generateOptions{}
+	for _, o := range []CommonGenOption{
+		WithMessages(msg("before one")),
+		WithMessagesFn(func(context.Context, any) ([]*Message, error) {
+			return []*Message{msg("before two")}, nil
+		}),
+		WithMessagesTemplate("first template"),
+		WithMessages(msg("after one")),
+		WithMessagesTemplate("second template"),
+		WithMessages(msg("after two")),
+	} {
+		o.applyGenerate(opts)
+	}
+
+	collect := func(fn MessagesFn) []string {
+		t.Helper()
+		if fn == nil {
+			return nil
+		}
+		msgs, err := fn(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("messages fn: %v", err)
+		}
+		var got []string
+		for _, m := range msgs {
+			got = append(got, m.Content[0].Text)
+		}
+		return got
+	}
+
+	if got, want := collect(opts.MessagesFn), []string{"before one", "before two"}; !slices.Equal(got, want) {
+		t.Errorf("before the template = %v, want %v", got, want)
+	}
+	if opts.MessagesText == nil || *opts.MessagesText != "second template" {
+		t.Errorf("template = %v, want the last one set", opts.MessagesText)
+	}
+	if got, want := collect(opts.MessagesAfterFn), []string{"after one", "after two"}; !slices.Equal(got, want) {
+		t.Errorf("after the template = %v, want %v", got, want)
+	}
+}
+
+// TestLiteralPercentSurvivesWithPrompt guards the Sprintf guard in
+// WithSystem/WithPrompt: with no args the text is used as-is, so a literal %
+// is not corrupted into %!x(MISSING) noise.
+func TestLiteralPercentSurvivesWithPrompt(t *testing.T) {
+	_, p, get := capturePrompt(t, "literalPercent",
+		WithPrompt("Give me 50% off %s copy"),
+	)
+	if _, err := p.Execute(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	req := (*get)()
+	if got, want := req.Messages[0].Text(), "Give me 50% off %s copy"; got != want {
+		t.Errorf("prompt text = %q, want %q", got, want)
+	}
+}
+
+// TestStaticMessagesNotSharedAcrossExecutions guards the defensive cloning of
+// prompt-declared messages. Messages given to WithMessages live on the prompt
+// and are reused by every execution, so handing out the originals to a stage
+// that appends to a message in place would let one execution alter the prompt
+// for the next.
+func TestStaticMessagesNotSharedAcrossExecutions(t *testing.T) {
+	shared := NewUserTextMessage("stored on the prompt")
+	shared.Metadata = map[string]any{"origin": "config"}
+
+	r := newTestRegistry(t)
+	var captured *ModelRequest
+	m := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/sharedMessages",
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			captured = req
+			// Stamp metadata the way middleware or the agent loop does; the
+			// write must land on a clone, never on the prompt's stored map.
+			for _, msg := range req.Messages {
+				if msg.Metadata == nil {
+					msg.Metadata = map[string]any{}
+				}
+				msg.Metadata["stamped"] = true
+			}
+			return &ModelResponse{Message: NewModelTextMessage(`{"name":"x","theme":"y"}`)}, nil
+		},
+	})
+
+	// Custom constrained output makes the formatter inject output instructions
+	// rather than relying on the model's native support, and with no system
+	// message the target is the last user message: the shared one.
+	p := DefinePrompt(r, "sharedMessages",
+		WithModel(m),
+		WithMessages(shared),
+		WithOutputType(fnTestInput{}),
+		WithCustomConstrainedOutput(),
+	)
+
+	for i := range 2 {
+		if _, err := p.Execute(context.Background()); err != nil {
+			t.Fatalf("execution %d: %v", i, err)
+		}
+		if got := len(shared.Content); got != 1 {
+			t.Fatalf("execution %d mutated the prompt's stored message: len(Content) = %d, want 1", i, got)
+		}
+		if _, ok := shared.Metadata["stamped"]; ok {
+			t.Fatalf("execution %d: metadata stamp leaked into the prompt's stored message: %v", i, shared.Metadata)
+		}
+		if got := len(captured.Messages[0].Content); got != 2 {
+			t.Errorf("execution %d: len(request Content) = %d, want 2 (text + injected instructions)", i, got)
+		}
+	}
+}
+
+// TestPartsFnMultimodal covers content functions that return non-text parts,
+// which previously required smuggling a {{media}} helper through the template.
+func TestPartsFnMultimodal(t *testing.T) {
+	r := newTestRegistry(t)
+	var captured *ModelRequest
+	m := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/mediaModel",
+		supports: &ModelSupports{
+			Media:      true,
+			Multiturn:  true,
+			SystemRole: true,
+		},
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			captured = req
+			return &ModelResponse{Message: NewModelTextMessage("ok")}, nil
+		},
+	})
+
+	p := DefinePrompt(r, "partsFn",
+		WithModel(m),
+		WithInputType(fnTestInput{}),
+		WithPromptPartsFn(func(ctx context.Context, in fnTestInput) ([]*Part, error) {
+			return []*Part{
+				NewTextPart("describe this for " + in.Name),
+				NewMediaPart("image/png", "https://example.com/a.png"),
+			}, nil
+		}),
+	)
+
+	if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Name: "bob"})); err != nil {
+		t.Fatal(err)
+	}
+
+	content := captured.Messages[len(captured.Messages)-1].Content
+	if len(content) != 2 {
+		t.Fatalf("len(content) = %d, want 2", len(content))
+	}
+	if got, want := content[0].Text, "describe this for bob"; got != want {
+		t.Errorf("content[0].Text = %q, want %q", got, want)
+	}
+	if !content[1].IsMedia() {
+		t.Errorf("content[1] is not media: %+v", content[1])
+	}
+}
+
+// TestWithDocsFn covers input-dependent document selection at prompt definition
+// time, the hook for retrieval that depends on the input.
+func TestWithDocsFn(t *testing.T) {
+	r := newTestRegistry(t)
+	var captured *ModelRequest
+	m := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/docsFnModel",
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			captured = req
+			return &ModelResponse{Message: NewModelTextMessage("ok")}, nil
+		},
+	})
+
+	t.Run("resolved from input", func(t *testing.T) {
+		p := DefinePrompt(r, "docsFn",
+			WithModel(m),
+			WithInputType(fnTestInput{}),
+			WithPrompt("question"),
+			WithDocsFn(func(ctx context.Context, in fnTestInput) ([]*Document, error) {
+				return []*Document{DocumentFromText("doc for "+in.Name, nil)}, nil
+			}),
+		)
+		if _, err := p.Execute(context.Background(), WithInput(fnTestInput{Name: "bob"})); err != nil {
+			t.Fatal(err)
+		}
+		if len(captured.Docs) != 1 {
+			t.Fatalf("len(Docs) = %d, want 1", len(captured.Docs))
+		}
+		if got, want := captured.Docs[0].Content[0].Text, "doc for bob"; got != want {
+			t.Errorf("doc text = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("static docs at definition time", func(t *testing.T) {
+		p := DefinePrompt(r, "staticDocs",
+			WithModel(m),
+			WithPrompt("question"),
+			WithDocs(DocumentFromText("static doc", nil)),
+		)
+		if _, err := p.Execute(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if len(captured.Docs) != 1 {
+			t.Fatalf("len(Docs) = %d, want 1", len(captured.Docs))
+		}
+		if got, want := captured.Docs[0].Content[0].Text, "static doc"; got != want {
+			t.Errorf("doc text = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("error propagates", func(t *testing.T) {
+		p := DefinePrompt(r, "docsFnErr",
+			WithModel(m),
+			WithPrompt("question"),
+			WithDocsFn(func(ctx context.Context, in fnTestInput) ([]*Document, error) {
+				return nil, errTestDocs
+			}),
+		)
+		_, err := p.Execute(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "resolving docs") {
+			t.Errorf("err = %v, want it to mention resolving docs", err)
+		}
+	})
+}
+
+var errTestDocs = errTest("docs unavailable")
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }
+
+// TestHistoryFromContext covers the history handoff: a prompt that declares its
+// own messages owns the caller's history rather than having it appended behind
+// the function's back.
+func TestHistoryFromContext(t *testing.T) {
+	t.Run("MessagesFn reads and reorders history", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "historyFn",
+			WithSystem("sys"),
+			WithPrompt("now answer"),
+			WithMessagesFn(func(ctx context.Context, _ any) ([]*Message, error) {
+				history := HistoryFromContext(ctx)
+				// Prove the function can do what plain appending cannot:
+				// collapse the history into a single summary message.
+				summary := make([]string, 0, len(history))
+				for _, m := range history {
+					summary = append(summary, m.Text())
+				}
+				return []*Message{NewModelTextMessage("summary: " + strings.Join(summary, "|"))}, nil
+			}),
+		)
+
+		if _, err := p.Execute(context.Background(), WithMessages(
+			NewUserTextMessage("first"),
+			NewModelTextMessage("second"),
+		)); err != nil {
+			t.Fatal(err)
+		}
+
+		req := (*get)()
+		if len(req.Messages) != 3 {
+			t.Fatalf("len(Messages) = %d, want 3 (system, summary, user)", len(req.Messages))
+		}
+		if got, want := req.Messages[1].Text(), "summary: first|second"; got != want {
+			t.Errorf("Messages[1] = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no history attached outside Execute", func(t *testing.T) {
+		if got := HistoryFromContext(context.Background()); got != nil {
+			t.Errorf("HistoryFromContext = %v, want nil", got)
+		}
+	})
+
+	t.Run("execute-time messages used when prompt declares none", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "historyFallback",
+			WithSystem("sys"),
+			WithPrompt("now answer"),
+		)
+		if _, err := p.Execute(context.Background(), WithMessages(NewModelTextMessage("prior"))); err != nil {
+			t.Fatal(err)
+		}
+		req := (*get)()
+		if len(req.Messages) != 3 {
+			t.Fatalf("len(Messages) = %d, want 3", len(req.Messages))
+		}
+		if got, want := req.Messages[1].Text(), "prior"; got != want {
+			t.Errorf("Messages[1] = %q, want %q", got, want)
+		}
+	})
+
+	// A prompt that declares static messages owns the conversation: its
+	// examples are not a place to splice a caller's history into, and the
+	// forms that can place it are the template and the function.
+	t.Run("static prompt messages own the conversation", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "historyPlusStatic",
+			WithSystem("sys"),
+			WithMessages(NewUserTextMessage("example in"), NewModelTextMessage("example out")),
+			WithPrompt("now answer"),
+		)
+		if _, err := p.Execute(context.Background(), WithMessages(NewModelTextMessage("prior"))); err != nil {
+			t.Fatal(err)
+		}
+		assertMessages(t, (*get)(), "system:sys", "user:example in", "model:example out", "user:now answer")
+	})
+}
+
+// TestExecuteRejectsMessagesTemplate pins that a template passed at execution
+// time is refused rather than silently dropped: nothing on that path compiles
+// one, so accepting it would lose the caller's conversation.
+func TestExecuteRejectsMessagesTemplate(t *testing.T) {
+	_, p, _ := capturePrompt(t, "execTemplate", WithSystem("sys"), WithPrompt("ask"))
+
+	_, err := p.Execute(context.Background(),
+		WithMessagesTemplate(`{{role "user"}}dropped on the floor`))
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "WithMessagesTemplate") || !strings.Contains(err.Error(), "WithMessages") {
+		t.Errorf("err = %v, want it to name the option and the alternative", err)
+	}
+}
+
+// TestContentFnErrorPropagates makes sure a coercion failure surfaces as an
+// error rather than a panic, which is what the old type assertions produced.
+func TestContentFnErrorPropagates(t *testing.T) {
+	r := newTestRegistry(t)
+	m := defineFakeModel(t, r, fakeModelConfig{name: "test/coerceErr"})
+
+	type numeric struct {
+		Count int `json:"name"` // deliberately mistyped against the input
+	}
+
+	p := DefinePrompt(r, "coerceErr",
+		WithModel(m),
+		WithInputSchema(map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"name": map[string]any{"type": "string"}},
+		}),
+		WithPromptFn(func(ctx context.Context, in numeric) (string, error) {
+			return "unreachable", nil
+		}),
+	)
+
+	_, err := p.Execute(context.Background(), WithInput(map[string]any{"name": "bob"}))
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	// The classification is the contract: a caller branches on the sentinel,
+	// not on the wording. Matching the base sentinel too pins that the failure
+	// is the caller's input rather than an internal fault.
+	if !errors.Is(err, ErrInputTypeMismatch) {
+		t.Errorf("err = %v, want it to match ErrInputTypeMismatch", err)
+	}
+	if !errors.Is(err, status.ErrInvalidArgument) {
+		t.Errorf("err = %v, want it to match status.ErrInvalidArgument", err)
+	}
+	if got := status.Of(err); got != status.InvalidArgument {
+		t.Errorf("status = %v, want %v", got, status.InvalidArgument)
+	}
+	if !strings.Contains(err.Error(), "content function input") {
+		t.Errorf("err = %v, want it to explain the input conversion failure", err)
+	}
+}
+
+// TestContentFnUnrelatedStructIsClassified covers the other way the conversion
+// fails: a struct that cannot be reinterpreted as the function's struct. A JSON
+// round-trip between the two would succeed while leaving every field zero, so
+// this is refused rather than silently handing the function a blank value. It
+// classifies as the same sentinel as a decode failure, so a caller branching on
+// bad input catches both without knowing which one it hit.
+func TestContentFnUnrelatedStructIsClassified(t *testing.T) {
+	r := newTestRegistry(t)
+	m := defineFakeModel(t, r, fakeModelConfig{name: "test/unrelatedStruct"})
+
+	type declared struct {
+		Theme string `json:"theme"`
+	}
+	type supplied struct {
+		Topic string `json:"topic"`
+	}
+
+	p := DefinePrompt(r, "unrelatedStruct",
+		WithModel(m),
+		WithPromptFn(func(ctx context.Context, in declared) (string, error) {
+			return "unreachable", nil
+		}),
+	)
+
+	_, err := p.Execute(context.Background(), WithInput(supplied{Topic: "pirates"}))
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !errors.Is(err, ErrInputTypeMismatch) {
+		t.Errorf("err = %v, want it to match ErrInputTypeMismatch", err)
+	}
+	if got := status.Of(err); got != status.InvalidArgument {
+		t.Errorf("status = %v, want %v", got, status.InvalidArgument)
+	}
+}
+
+// findMessageText returns the message whose first text part equals want.
+func findMessageText(t *testing.T, msgs []*Message, want string) *Message {
+	t.Helper()
+	for _, m := range msgs {
+		for _, p := range m.Content {
+			if p.IsText() && p.Text == want {
+				return m
+			}
+		}
+	}
+	t.Fatalf("no message with text %q in %v", want, msgs)
+	return nil
+}
+
+// TestStaticMessagesAreVerbatim covers the divergence that made conversation
+// history unusable: text given to [WithMessages] used to be compiled as a
+// dotprompt template, so a user asking about handlebars turned into a parse
+// error rather than a request. Only the string form of the conversation is
+// compiled, and the Generate path never templated messages either, so the
+// prompt path was alone in doing it.
+func TestStaticMessagesAreVerbatim(t *testing.T) {
+	const handlebars = "how do I write {{#if x}} in handlebars?"
+
+	t.Run("declared on the prompt", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "staticVerbatimDef",
+			WithMessages(NewUserTextMessage(handlebars)),
+			WithPrompt("hi"),
+		)
+		if _, err := p.Execute(context.Background()); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		findMessageText(t, (*get)().Messages, handlebars)
+	})
+
+	t.Run("supplied at execution time", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "staticVerbatimExec", WithPrompt("hi"))
+		if _, err := p.Execute(context.Background(),
+			WithMessages(NewUserTextMessage(handlebars)),
+		); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		findMessageText(t, (*get)().Messages, handlebars)
+	})
+
+	// A prompt's own text is still a template, so one request can carry an
+	// expanded prompt alongside an unexpanded message.
+	t.Run("prompt text still renders", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "staticVerbatimMixed",
+			WithInputType(fnTestInput{}),
+			WithMessages(NewUserTextMessage("literal {{name}}")),
+			WithPrompt("rendered {{name}}"),
+		)
+		if _, err := p.Execute(context.Background(),
+			WithInput(fnTestInput{Name: "bob"}),
+		); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		msgs := (*get)().Messages
+		findMessageText(t, msgs, "literal {{name}}")
+		findMessageText(t, msgs, "rendered bob")
+	})
+}
+
+// TestStaticMessagesCopiedPerExecution covers why declared messages are copied
+// rather than forwarded by reference: a prompt's declared messages are shared
+// by every execution of it, so one execution's downstream mutation would
+// otherwise be visible to the next.
+func TestStaticMessagesCopiedPerExecution(t *testing.T) {
+	shared := NewUserTextMessage("history")
+	_, p, get := capturePrompt(t, "staticIsolation",
+		WithMessages(shared),
+		WithPrompt("hi"),
+	)
+
+	for i := 0; i < 2; i++ {
+		if _, err := p.Execute(context.Background()); err != nil {
+			t.Fatalf("Execute() %d error = %v", i, err)
+		}
+
+		got := findMessageText(t, (*get)().Messages, "history")
+		if got == shared {
+			t.Fatal("request reused the declared *Message; later stages mutate messages in place")
+		}
+
+		// Stand in for a downstream stage that appends to its target.
+		got.Content = append(got.Content, NewTextPart("injected"))
+
+		if len(shared.Content) != 1 {
+			t.Fatalf("declared message grew to %d parts after execution %d", len(shared.Content), i)
+		}
+	}
+}
+
+// TestStaticPartsOptions covers the value forms of the multi-part content
+// options, for prompts whose media is fixed rather than input-dependent.
+func TestStaticPartsOptions(t *testing.T) {
+	r := newTestRegistry(t)
+	var captured *ModelRequest
+	m := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/staticParts",
+		supports: &ModelSupports{
+			Media:      true,
+			Multiturn:  true,
+			SystemRole: true,
+		},
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			captured = req
+			return &ModelResponse{Message: NewModelTextMessage("ok")}, nil
+		},
+	})
+
+	p := DefinePrompt(r, "staticParts",
+		WithModel(m),
+		WithSystemParts(NewTextPart("you are a vision assistant")),
+		WithPromptParts(
+			NewTextPart("what is in this image? {{not_a_template}}"),
+			NewMediaPart("image/png", "https://example.com/a.png"),
+		),
+	)
+	if _, err := p.Execute(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(captured.Messages), 2; got != want {
+		t.Fatalf("len(Messages) = %d, want %d", got, want)
+	}
+	if captured.Messages[0].Role != RoleSystem || captured.Messages[0].Text() != "you are a vision assistant" {
+		t.Errorf("system message = %+v", captured.Messages[0])
+	}
+	user := captured.Messages[1]
+	if user.Role != RoleUser || len(user.Content) != 2 {
+		t.Fatalf("user message = %+v", user)
+	}
+	// Parts are verbatim: the braces are not compiled as a template.
+	if got, want := user.Content[0].Text, "what is in this image? {{not_a_template}}"; got != want {
+		t.Errorf("user text = %q, want %q", got, want)
+	}
+	if !user.Content[1].IsMedia() {
+		t.Errorf("Content[1] is not media: %+v", user.Content[1])
+	}
+}
+
+// TestStaticPartsConflictWithText makes sure the value and template forms of
+// the same slot are still mutually exclusive.
+func TestStaticPartsConflictWithText(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		opts []PromptingOption
+	}{
+		{"system", []PromptingOption{WithSystem("text"), WithSystemParts(NewTextPart("parts"))}},
+		{"prompt", []PromptingOption{WithPrompt("text"), WithPromptParts(NewTextPart("parts"))}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &promptOptions{}
+			for _, o := range tt.opts {
+				o.applyPrompt(opts)
+			}
+			// The parts form arrived last, so it holds the slot and the text
+			// form is gone: one message, one winner.
+			gotText, gotFn := opts.SystemText, opts.SystemFn
+			if tt.name == "prompt" {
+				gotText, gotFn = opts.PromptText, opts.PromptFn
+			}
+			if gotText != nil {
+				t.Errorf("text = %q, want it cleared by the later parts option", *gotText)
+			}
+			if gotFn == nil {
+				t.Fatal("parts option did not fill the slot")
+			}
+			parts, err := gotFn(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("parts fn: %v", err)
+			}
+			if len(parts) != 1 || parts[0].Text != "parts" {
+				t.Errorf("parts = %+v, want one part %q", parts, "parts")
+			}
+		})
+	}
+}
+
+// TestInstructionInjectionDoesNotMutateCallerMessages exercises the
+// copy-on-write in injectInstructions end to end. The copy itself is unit
+// tested in format_test.go; this runs it through the public entry point,
+// GenerateWithRequest, which takes the caller's own message slice and is what
+// made an in-place append reach a conversation the caller keeps.
+func TestInstructionInjectionDoesNotMutateCallerMessages(t *testing.T) {
+	r := newTestRegistry(t)
+	var captured *ModelRequest
+	defineFakeModel(t, r, fakeModelConfig{
+		name: "test/injectCOW",
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			captured = req
+			return &ModelResponse{Message: NewModelTextMessage(`{"name":"x","theme":"y"}`)}, nil
+		},
+	})
+
+	mine := NewUserTextMessage("my own message")
+	schema := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"name": map[string]any{"type": "string"}},
+	}
+
+	for i := range 2 {
+		_, err := GenerateWithRequest(context.Background(), r, &GenerateActionOptions{
+			Model:    "test/injectCOW",
+			Messages: []*Message{mine},
+			Output: &GenerateActionOutputConfig{
+				Format:      OutputFormatJSON,
+				JsonSchema:  schema,
+				Constrained: false,
+			},
+		}, nil, nil)
+		if err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		if got := len(mine.Content); got != 1 {
+			t.Fatalf("run %d mutated the caller's message: len(Content) = %d, want 1", i, got)
+		}
+		// Every run must still get its own instructions, which the bail-out
+		// would have skipped had the previous run mutated the original.
+		if got := len(captured.Messages[0].Content); got != 2 {
+			t.Errorf("run %d: request Content = %d parts, want 2 (text + instructions)", i, got)
+		}
+	}
+}

--- a/go/ai/prompt_fn_test.go
+++ b/go/ai/prompt_fn_test.go
@@ -1277,3 +1277,104 @@ func TestInstructionInjectionDoesNotMutateCallerMessages(t *testing.T) {
 		}
 	}
 }
+
+// TestNilMessagesAreDropped covers a nil slipping into a conversation, which
+// reaches the framework from a caller-owned slice or a user-written function
+// and used to have no safe path through it: the template renderer dereferenced
+// it, and every other path carried it as far as the action's output schema,
+// which rejects a null message.
+func TestNilMessagesAreDropped(t *testing.T) {
+	// The conversation is placed by a template, so it round-trips through
+	// dotprompt as a placeholder and back. Dropping nils anywhere but on the
+	// way in would shift that positional restore.
+	t.Run("template", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "nil_tpl",
+			WithMessagesTemplate(`{{role "system"}}sys{{history}}{{role "user"}}end`))
+		ctx := NewHistoryContext(context.Background(), []*Message{
+			NewUserTextMessage("A"), nil, NewUserTextMessage("B"),
+		})
+		if _, err := p.Execute(ctx); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		assertNoNilMessages(t, (*get)().Messages)
+		assertUserTexts(t, (*get)().Messages, "A", "B", "end")
+	})
+
+	// No conversation of its own, so the caller's is used directly.
+	t.Run("placed for the prompt", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "nil_plain", WithPrompt("q"))
+		if _, err := p.Execute(context.Background(), WithMessages(
+			NewUserTextMessage("A"), nil, NewUserTextMessage("B"),
+		)); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		assertNoNilMessages(t, (*get)().Messages)
+		assertUserTexts(t, (*get)().Messages, "A", "B", "q")
+	})
+
+	// The prompt's own conversation, returned by a user's function.
+	t.Run("from a content function", func(t *testing.T) {
+		_, p, get := capturePrompt(t, "nil_fn",
+			WithMessagesFn(func(context.Context, any) ([]*Message, error) {
+				return []*Message{NewUserTextMessage("A"), nil, NewUserTextMessage("B")}, nil
+			}))
+		if _, err := p.Execute(context.Background()); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		assertNoNilMessages(t, (*get)().Messages)
+		assertUserTexts(t, (*get)().Messages, "A", "B")
+	})
+
+	// A prompt's own function reads the conversation back, so it must see the
+	// same filtered slice the renderer does.
+	t.Run("read back by HistoryFromContext", func(t *testing.T) {
+		var seen []*Message
+		_, p, _ := capturePrompt(t, "nil_readback",
+			WithMessagesFn(func(ctx context.Context, _ any) ([]*Message, error) {
+				seen = HistoryFromContext(ctx)
+				return seen, nil
+			}))
+		if _, err := p.Execute(context.Background(), WithMessages(
+			NewUserTextMessage("A"), nil, NewUserTextMessage("B"),
+		)); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		assertNoNilMessages(t, seen)
+	})
+}
+
+// TestCompactMessagesKeepsSliceWhenClean pins the allocation-free path: a
+// conversation without nils is passed through, not copied.
+func TestCompactMessagesKeepsSliceWhenClean(t *testing.T) {
+	src := []*Message{NewUserTextMessage("A"), NewUserTextMessage("B")}
+	if got := compactMessages(src); &got[0] != &src[0] {
+		t.Error("compactMessages copied a slice that had no nils")
+	}
+	if got := compactMessages(nil); got != nil {
+		t.Errorf("compactMessages(nil) = %v, want nil", got)
+	}
+}
+
+func assertNoNilMessages(t *testing.T, msgs []*Message) {
+	t.Helper()
+	for i, m := range msgs {
+		if m == nil {
+			t.Fatalf("messages[%d] is nil", i)
+		}
+	}
+}
+
+// assertUserTexts checks the user turns in order, which is what carries the
+// conversation in these cases.
+func assertUserTexts(t *testing.T, msgs []*Message, want ...string) {
+	t.Helper()
+	var got []string
+	for _, m := range msgs {
+		if m.Role == RoleUser {
+			got = append(got, m.Text())
+		}
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("user turns = %v, want %v", got, want)
+	}
+}

--- a/go/ai/prompt_fn_test.go
+++ b/go/ai/prompt_fn_test.go
@@ -1011,8 +1011,64 @@ func TestContentFnErrorPropagates(t *testing.T) {
 	if got := status.Of(err); got != status.InvalidArgument {
 		t.Errorf("status = %v, want %v", got, status.InvalidArgument)
 	}
-	if !strings.Contains(err.Error(), "content function input") {
-		t.Errorf("err = %v, want it to explain the input conversion failure", err)
+	if !strings.Contains(err.Error(), "WithPromptFn input") {
+		t.Errorf("err = %v, want it to name the option that rejected the input", err)
+	}
+}
+
+// TestContentFnErrorNamesItsOption covers a prompt filling several slots from
+// functions: the input can satisfy one and not another, so the error has to say
+// which one it was rather than reporting an anonymous content function.
+func TestContentFnErrorNamesItsOption(t *testing.T) {
+	type ticket struct {
+		Question string `json:"question"`
+	}
+	type query struct {
+		Terms []string `json:"terms"`
+	}
+
+	tests := []struct {
+		name string
+		opt  PromptOption
+		want string
+	}{
+		{"docs", WithDocsFn(func(ctx context.Context, q query) ([]*Document, error) {
+			return nil, nil
+		}), "WithDocsFn input"},
+		{"system", WithSystemFn(func(ctx context.Context, q query) (string, error) {
+			return "", nil
+		}), "WithSystemFn input"},
+		{"prompt parts", WithPromptPartsFn(func(ctx context.Context, q query) ([]*Part, error) {
+			return nil, nil
+		}), "WithPromptPartsFn input"},
+		{"messages", WithMessagesFn(func(ctx context.Context, q query) ([]*Message, error) {
+			return nil, nil
+		}), "WithMessagesFn input"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry(t)
+			m := defineFakeModel(t, r, fakeModelConfig{name: "test/named_" + tt.name})
+			// The user prompt takes the input the caller actually supplies, so
+			// only the slot under test can be the one that fails.
+			p := DefinePrompt(r, "named_"+tt.name, WithModel(m), WithInputType(ticket{}),
+				WithPromptFn(func(ctx context.Context, tk ticket) (string, error) {
+					return tk.Question, nil
+				}),
+				tt.opt)
+
+			_, err := p.Execute(context.Background(), WithInput(ticket{Question: "why"}))
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !errors.Is(err, ErrInputTypeMismatch) {
+				t.Errorf("err = %v, want it to match ErrInputTypeMismatch", err)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("err = %v, want it to contain %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -231,11 +231,11 @@ func TestValidPrompt(t *testing.T) {
 		name           string
 		model          Model
 		systemText     string
-		systemFn       PromptFn
+		systemFn       func(context.Context, HelloPromptInput) (string, error)
 		promptText     string
-		promptFn       PromptFn
+		promptFn       func(context.Context, HelloPromptInput) (string, error)
 		messages       []*Message
-		messagesFn     MessagesFn
+		messagesFn     func(context.Context, HelloPromptInput) ([]*Message, error)
 		tools          []ToolRef
 		config         *GenerationCommonConfig
 		inputType      any
@@ -283,11 +283,11 @@ func TestValidPrompt(t *testing.T) {
 			model:     model,
 			config:    &GenerationCommonConfig{Temperature: 11},
 			inputType: HelloPromptInput{},
-			systemFn: func(ctx context.Context, input any) (string, error) {
-				return "say hello to {{Name}}", nil
+			systemFn: func(ctx context.Context, input HelloPromptInput) (string, error) {
+				return "say hello to " + input.Name, nil
 			},
-			promptFn: func(ctx context.Context, input any) (string, error) {
-				return "my name is {{Name}}", nil
+			promptFn: func(ctx context.Context, input HelloPromptInput) (string, error) {
+				return "my name is " + input.Name, nil
 			},
 			input: HelloPromptInput{Name: "foo"},
 			executeOptions: []PromptExecuteOption{
@@ -363,11 +363,11 @@ func TestValidPrompt(t *testing.T) {
 			inputType:  HelloPromptInput{},
 			systemText: "say hello",
 			promptText: "my name is foo",
-			messagesFn: func(ctx context.Context, input any) ([]*Message, error) {
+			messagesFn: func(ctx context.Context, input HelloPromptInput) ([]*Message, error) {
 				return []*Message{
 					{
 						Role:    RoleModel,
-						Content: []*Part{NewTextPart("your name is {{Name}}")},
+						Content: []*Part{NewTextPart("your name is " + input.Name)},
 					},
 				}, nil
 			},
@@ -407,16 +407,11 @@ func TestValidPrompt(t *testing.T) {
 			inputType:  HelloPromptInput{},
 			systemText: "say hello",
 			promptText: "my name is foo",
-			messagesFn: func(ctx context.Context, input any) ([]*Message, error) {
-				var p HelloPromptInput
-				switch param := input.(type) {
-				case HelloPromptInput:
-					p = param
-				}
+			messagesFn: func(ctx context.Context, input HelloPromptInput) ([]*Message, error) {
 				return []*Message{
 					{
 						Role:    RoleModel,
-						Content: []*Part{NewTextPart(fmt.Sprintf("your name is %s", p.Name))},
+						Content: []*Part{NewTextPart(fmt.Sprintf("your name is %s", input.Name))},
 					},
 				}, nil
 			},
@@ -507,7 +502,10 @@ func TestValidPrompt(t *testing.T) {
 			},
 		},
 		{
-			name:       "execute with MessagesFn option",
+			// Message text is verbatim while the user prompt is still a
+			// template, so within one request {{Name}} survives in the
+			// message and expands in the prompt.
+			name:       "execute with Messages option",
 			model:      model,
 			config:     &GenerationCommonConfig{Temperature: 11},
 			inputType:  HelloPromptInput{},
@@ -518,7 +516,7 @@ func TestValidPrompt(t *testing.T) {
 				WithInput(HelloPromptInput{Name: "foo"}),
 				WithMessages(NewModelTextMessage("I remember you said your name is {{Name}}")),
 			},
-			wantTextOutput: "Echo: system: say hello; I remember you said your name is foo; my name is foo; config: {\n  \"temperature\": 11\n}; context: null",
+			wantTextOutput: "Echo: system: say hello; I remember you said your name is {{Name}}; my name is foo; config: {\n  \"temperature\": 11\n}; context: null",
 			wantGenerated: &ModelRequest{
 				Config: &GenerationCommonConfig{
 					Temperature: 11,
@@ -534,7 +532,7 @@ func TestValidPrompt(t *testing.T) {
 					},
 					{
 						Role:    RoleModel,
-						Content: []*Part{NewTextPart("I remember you said your name is foo")},
+						Content: []*Part{NewTextPart("I remember you said your name is {{Name}}")},
 					},
 					{
 						Role:    RoleUser,

--- a/go/ai/render_context.go
+++ b/go/ai/render_context.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+
+	"github.com/firebase/genkit/go/internal/base"
+)
+
+// promptHistoryKey carries the messages passed to [Prompt.Execute] so that a
+// prompt's own content functions can read them. The prompt is an action whose
+// only input is the prompt input, so execution options cannot be threaded
+// through the call directly.
+//
+// Prompt.Execute attaches these keys to a context used only for the Render
+// call; the generation itself runs on the caller's original context so the
+// values never reach tool handlers or prompts nested under the generate loop.
+var promptHistoryKey = base.NewContextKey[[]*Message]()
+
+// promptDocsOverrideKey marks that the execution supplies its own documents,
+// telling buildRequest to skip a [WithDocsFn] whose result would be discarded.
+var promptDocsOverrideKey = base.NewContextKey[bool]()
+
+// withPromptDocsOverride returns ctx marked so that rendering skips the
+// prompt's docs function.
+func withPromptDocsOverride(ctx context.Context) context.Context {
+	return promptDocsOverrideKey.NewContext(ctx, true)
+}
+
+// promptDocsOverridden reports whether the execution supplies its own
+// documents.
+func promptDocsOverridden(ctx context.Context) bool {
+	return promptDocsOverrideKey.FromContext(ctx)
+}
+
+// withPromptHistory returns ctx carrying the messages supplied at execution
+// time, for [HistoryFromContext] to return.
+func withPromptHistory(ctx context.Context, messages []*Message) context.Context {
+	return promptHistoryKey.NewContext(ctx, messages)
+}
+
+// NewHistoryContext returns ctx carrying a conversation for the next
+// [Prompt.Render] call to place, and is what [HistoryFromContext] reads back.
+//
+// [Prompt.Execute] does this itself for the messages passed to it, so callers
+// of Execute never need this. It is for a caller that drives a prompt by hand,
+// pairing Render with [GenerateWithRequest] to keep control of the generate
+// call, and that still wants the prompt to decide where the conversation goes.
+// The agent runtime is the main example.
+//
+// Scope the returned context to the Render call. The generation itself should
+// run on the original context, so the conversation does not ride along into
+// tool handlers and prompts executed inside the generate loop.
+//
+// The messages are not copied. Render clones everything it places into the
+// request, so the originals are left untouched.
+func NewHistoryContext(ctx context.Context, messages []*Message) context.Context {
+	return withPromptHistory(ctx, messages)
+}
+
+// HistoryFromContext returns the conversation history passed to
+// [Prompt.Execute] via [WithMessages] or [WithMessagesFn], or nil if there is
+// none.
+//
+// It is meant to be called from a prompt's own content functions, where it is
+// the function-form counterpart of {{history}}. A prompt that declares its own
+// conversation takes responsibility
+// for the history: its messages are the whole middle of the conversation, so
+// the caller's messages are not appended on top and a function that wants them
+// must read them here and return them. This is what makes it possible to
+// summarize, truncate, or reorder history rather than only prepend to it. The
+// other way to place them is [WithMessagesTemplate], whose template renders
+// them at {{history}}. A prompt that declares no messages of its own has the
+// caller's history used as the conversation directly.
+//
+// The returned slice is the caller's; treat it as read-only.
+func HistoryFromContext(ctx context.Context) []*Message {
+	return promptHistoryKey.FromContext(ctx)
+}

--- a/go/ai/render_context.go
+++ b/go/ai/render_context.go
@@ -22,14 +22,10 @@ import (
 	"github.com/firebase/genkit/go/internal/base"
 )
 
-// promptHistoryKey carries the messages passed to [Prompt.Execute] so that a
-// prompt's own content functions can read them. The prompt is an action whose
+// promptHistoryKey carries the messages passed to [Prompt.Execute] so a
+// prompt's own content functions can read them. A prompt is an action whose
 // only input is the prompt input, so execution options cannot be threaded
 // through the call directly.
-//
-// Prompt.Execute attaches these keys to a context used only for the Render
-// call; the generation itself runs on the caller's original context so the
-// values never reach tool handlers or prompts nested under the generate loop.
 var promptHistoryKey = base.NewContextKey[[]*Message]()
 
 // promptDocsOverrideKey marks that the execution supplies its own documents,
@@ -57,18 +53,16 @@ func withPromptHistory(ctx context.Context, messages []*Message) context.Context
 // NewHistoryContext returns ctx carrying a conversation for the next
 // [Prompt.Render] call to place, and is what [HistoryFromContext] reads back.
 //
-// [Prompt.Execute] does this itself for the messages passed to it, so callers
-// of Execute never need this. It is for a caller that drives a prompt by hand,
-// pairing Render with [GenerateWithRequest] to keep control of the generate
-// call, and that still wants the prompt to decide where the conversation goes.
-// The agent runtime is the main example.
+// [Prompt.Execute] does this itself, so its callers never need it. It is for
+// code that drives a prompt by hand, pairing Render with [GenerateWithRequest],
+// and still wants the prompt to decide where the conversation goes. The agent
+// runtime is the main example.
 //
-// Scope the returned context to the Render call. The generation itself should
-// run on the original context, so the conversation does not ride along into
-// tool handlers and prompts executed inside the generate loop.
+// Scope the returned context to the Render call. Generation should run on the
+// original, so the conversation does not ride along into tool handlers and
+// prompts executed inside the generate loop.
 //
-// The messages are not copied. Render clones everything it places into the
-// request, so the originals are left untouched.
+// The messages are not copied; Render clones what it places into the request.
 func NewHistoryContext(ctx context.Context, messages []*Message) context.Context {
 	return withPromptHistory(ctx, messages)
 }
@@ -77,16 +71,12 @@ func NewHistoryContext(ctx context.Context, messages []*Message) context.Context
 // [Prompt.Execute] via [WithMessages] or [WithMessagesFn], or nil if there is
 // none.
 //
-// It is meant to be called from a prompt's own content functions, where it is
-// the function-form counterpart of {{history}}. A prompt that declares its own
-// conversation takes responsibility
-// for the history: its messages are the whole middle of the conversation, so
-// the caller's messages are not appended on top and a function that wants them
-// must read them here and return them. This is what makes it possible to
-// summarize, truncate, or reorder history rather than only prepend to it. The
-// other way to place them is [WithMessagesTemplate], whose template renders
-// them at {{history}}. A prompt that declares no messages of its own has the
-// caller's history used as the conversation directly.
+// Call it from a prompt's own content functions, where it is the function-form
+// counterpart of {{history}}. A prompt that declares a conversation owns the
+// history: the caller's messages are not appended on top, so a function that
+// wants them must read them here and return them, which is what makes
+// summarizing or truncating possible. A prompt that declares no messages of its
+// own has the caller's history used as the conversation directly.
 //
 // The returned slice is the caller's; treat it as read-only.
 func HistoryFromContext(ctx context.Context) []*Message {

--- a/go/ai/render_context.go
+++ b/go/ai/render_context.go
@@ -45,9 +45,11 @@ func promptDocsOverridden(ctx context.Context) bool {
 }
 
 // withPromptHistory returns ctx carrying the messages supplied at execution
-// time, for [HistoryFromContext] to return.
+// time, for [HistoryFromContext] to return. Nil messages are dropped on the way
+// in, so every reader, rendering and a prompt's own content functions alike,
+// sees the same usable conversation.
 func withPromptHistory(ctx context.Context, messages []*Message) context.Context {
-	return promptHistoryKey.NewContext(ctx, messages)
+	return promptHistoryKey.NewContext(ctx, compactMessages(messages))
 }
 
 // NewHistoryContext returns ctx carrying a conversation for the next
@@ -63,6 +65,7 @@ func withPromptHistory(ctx context.Context, messages []*Message) context.Context
 // prompts executed inside the generate loop.
 //
 // The messages are not copied; Render clones what it places into the request.
+// Nil entries are dropped.
 func NewHistoryContext(ctx context.Context, messages []*Message) context.Context {
 	return withPromptHistory(ctx, messages)
 }

--- a/go/genkit/doc.go
+++ b/go/genkit/doc.go
@@ -154,6 +154,32 @@ For type-safe prompts with structured input and output, use [DefineDataPrompt]:
 		// result.Chunk is *Recipe, result.Output is final *Recipe
 	}
 
+When a template is not the right tool, any slot can be filled by a function of
+the prompt's input. The function declares its own input type, and what it
+returns is used as written, so text from a user or a database never has to be
+escaped:
+
+	supportPrompt := genkit.DefinePrompt(g, "support",
+		ai.WithInputType(Ticket{}),
+		ai.WithSystem("You are a support agent."),
+		ai.WithPromptPartsFn(func(ctx context.Context, t Ticket) ([]*ai.Part, error) {
+			parts := []*ai.Part{ai.NewTextPart(t.Question)}
+			if t.Screenshot != "" {
+				parts = append(parts, ai.NewMediaPart("image/png", t.Screenshot))
+			}
+			return parts, nil
+		}),
+	)
+
+[ai.WithSystemFn], [ai.WithPromptFn], [ai.WithMessagesFn], and [ai.WithDocsFn]
+fill the other slots the same way.
+
+A prompt that sets any of [ai.WithMessages], [ai.WithMessagesTemplate], or
+[ai.WithMessagesFn] owns the conversation handed to Execute, placing it with
+{{history}} in the template or [ai.HistoryFromContext] in the function. A prompt
+that sets none of them has that conversation used directly, between the system
+message and the user prompt.
+
 Load prompts from .prompt files by specifying a prompt directory:
 
 	g := genkit.Init(ctx,
@@ -360,8 +386,11 @@ Model and Configuration:
 Prompting:
 
   - [ai.WithPrompt]: Set the user prompt (supports format strings)
+  - [ai.WithPromptParts]: Set multi-part user content, such as text plus media
   - [ai.WithSystem]: Set system instructions
-  - [ai.WithMessages]: Provide conversation history
+  - [ai.WithSystemParts]: Set multi-part system content
+  - [ai.WithMessages]: Provide conversation history, used verbatim
+  - [ai.WithMessagesTemplate]: Provide the conversation as a multi-turn template
 
 Tools and Output:
 

--- a/go/genkit/doc.go
+++ b/go/genkit/doc.go
@@ -390,7 +390,6 @@ Prompting:
   - [ai.WithSystem]: Set system instructions
   - [ai.WithSystemParts]: Set multi-part system content
   - [ai.WithMessages]: Provide conversation history, used verbatim
-  - [ai.WithMessagesTemplate]: Provide the conversation as a multi-turn template
 
 Tools and Output:
 

--- a/go/genkit/exp/agent.go
+++ b/go/genkit/exp/agent.go
@@ -35,8 +35,13 @@ import (
 // persistence automatically.
 //
 // The prompt is defined inline via [aix.InlinePrompt] and registered under the
-// agent's name. To back the agent with a prompt already in the registry (e.g.
-// one from a .prompt file), use [DefinePromptAgent] instead.
+// agent's name; it accepts every option [genkit.DefinePrompt] does. To back the
+// agent with a prompt already in the registry (e.g. one from a .prompt file),
+// use [DefinePromptAgent] instead.
+//
+// Each turn hands the session's conversation to the prompt, so a prompt that
+// declares messages of its own places it (see [aix.InlinePrompt]); one that
+// declares none has it placed between the system message and the user prompt.
 //
 // The State type parameter is inferred from the typed agent options
 // (e.g. [aix.WithSessionStore], [aix.WithStateTransform]); pass an explicit
@@ -90,6 +95,13 @@ func DefineAgent[State any](
 // rather than a positional argument, so it composes with the other agent
 // options in one variadic. For full control over the per-turn loop, use
 // [DefineCustomAgent].
+//
+// Each turn hands the session's conversation to the prompt, so a prompt that
+// declares messages of its own places it with {{history}} or
+// [ai.HistoryFromContext] (see [aix.InlinePrompt] for the rule); one that
+// declares none has it placed between the system message and the user prompt.
+// A .prompt file's body is a multi-turn template, so {{history}} works in it
+// directly.
 //
 // The State type parameter is inferred from the typed agent options; pass an
 // explicit [State] only when no typed option provides it.

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -831,18 +831,18 @@ func LookupMiddleware(g *Genkit, name string) *ai.MiddlewareDesc {
 //
 // Prompt Content:
 //
-// Only [ai.WithSystem] and [ai.WithPrompt] take dotprompt templates, rendered
-// against the prompt's input. Everything else here is content the caller
-// already produced and is used verbatim, so it may hold user data and literal
-// braces without being reinterpreted as a template. Those two each fill a
-// single message whose role is fixed, so a {{role}} marker in either is an
-// error; [ai.WithMessagesTemplate] is where turns with their own roles belong.
+// Only [ai.WithSystem], [ai.WithPrompt], and [ai.WithMessagesTemplate] take
+// dotprompt templates. Everything else is content the caller already produced
+// and is used verbatim, so it may hold user data and literal braces. The first
+// two each fill a single message whose role is fixed, so a {{role}} marker in
+// either is an error; [ai.WithMessagesTemplate] is where turns with their own
+// roles belong.
 //
-// The ...Fn options take a function of the prompt's input that declares its own
-// input type. Genkit converts whatever the caller supplied, so one function
-// serves an in-process call, the default input recorded by [ai.WithInputType],
-// and the reflection API alike; an input that cannot be converted to that type
-// fails with [ai.ErrInputTypeMismatch].
+// The ...Fn options take a function that declares its own input type. Genkit
+// converts whatever the caller supplied, so one function serves an in-process
+// call, the default from [ai.WithInputType], and the reflection API alike. An
+// input that cannot be converted fails with [ai.ErrInputTypeMismatch].
+//
 //   - [ai.WithPrompt]: Set the user prompt template (supports {{variable}} syntax)
 //   - [ai.WithPromptFn]: Set a function that generates the user prompt from the input
 //   - [ai.WithPromptParts]: Set fixed multi-part user content, such as text plus media
@@ -862,13 +862,11 @@ func LookupMiddleware(g *Genkit, name string) *ai.MiddlewareDesc {
 // the caller's conversation used directly, between the system message and the
 // user prompt.
 //
-// Repeats merge rather than conflict, by the rules in the [ai] package doc. The
-// four system options fill one message and the four prompt options fill
-// another, so within each group the last one set wins and the others are
-// discarded. Documents accumulate, and so do messages, with one combination
-// refused rather than merged: [ai.WithMessagesTemplate] lays out the whole
-// conversation, so giving it alongside [ai.WithMessages] or [ai.WithMessagesFn]
-// panics here rather than picking one of them.
+// Repeats merge by the rules in the [ai] package doc: the four system options
+// share one message and the four prompt options share another, so the last one
+// set in each group wins, while documents and messages accumulate. The one
+// refused combination is [ai.WithMessagesTemplate] alongside [ai.WithMessages]
+// or [ai.WithMessagesFn], which panics here.
 //
 // Context Documents:
 //   - [ai.WithDocs]: Attach a fixed set of context documents
@@ -1073,10 +1071,10 @@ func LookupDataPrompt[In, Out any](g *Genkit, name string) *ai.DataPrompt[In, Ou
 // and an optional streaming callback (`cb`) of type [ai.ModelStreamCallback] to receive
 // response chunks as they arrive.
 //
-// [ai.Prompt.Execute] attaches the conversation it was given for the render;
-// pairing Render with this function does not, so a prompt that places the
-// conversation itself sees none unless the render context carries one. Pass it
-// with [ai.NewHistoryContext], which is how the agent runtime drives a prompt.
+// [ai.Prompt.Execute] attaches the conversation for the render; pairing Render
+// with this function does not, so a prompt that places the conversation itself
+// sees none unless the render context carries one. Pass it with
+// [ai.NewHistoryContext], which is how the agent runtime drives a prompt.
 //
 // Example (using options rendered from a prompt):
 //
@@ -1113,6 +1111,7 @@ func GenerateWithRequest(ctx context.Context, g *Genkit, actionOpts *ai.Generate
 // Nothing here is templated: Generate has no prompt input to render against, so
 // content functions receive the zero value of their input type. Use
 // [DefinePrompt] for templates and input-driven content.
+//
 //   - [ai.WithPrompt]: Set the user prompt (supports format strings)
 //   - [ai.WithPromptFn]: Set a function that generates the user prompt dynamically
 //   - [ai.WithPromptParts]: Set fixed multi-part user content, such as text plus media

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -111,7 +111,7 @@ func (o *genkitOptions) apply(gOpts *genkitOptions) error {
 }
 
 // WithPlugins provides a list of plugins to initialize when creating the Genkit instance.
-// Each plugin's [Plugin.Init] method will be called sequentially during [Init].
+// Each plugin's [api.Plugin.Init] method will be called sequentially during [Init].
 // This option can only be applied once.
 func WithPlugins(plugins ...api.Plugin) GenkitOption {
 	return &genkitOptions{Plugins: plugins}
@@ -830,12 +830,48 @@ func LookupMiddleware(g *Genkit, name string) *ai.MiddlewareDesc {
 //   - [ai.WithConfig]: Set generation parameters (temperature, max tokens, etc.)
 //
 // Prompt Content:
+//
+// Only [ai.WithSystem] and [ai.WithPrompt] take dotprompt templates, rendered
+// against the prompt's input. Everything else here is content the caller
+// already produced and is used verbatim, so it may hold user data and literal
+// braces without being reinterpreted as a template. Those two each fill a
+// single message whose role is fixed, so a {{role}} marker in either is an
+// error; [ai.WithMessagesTemplate] is where turns with their own roles belong.
+//
+// The ...Fn options take a function of the prompt's input that declares its own
+// input type. Genkit converts whatever the caller supplied, so one function
+// serves an in-process call, the default input recorded by [ai.WithInputType],
+// and the reflection API alike; an input that cannot be converted to that type
+// fails with [ai.ErrInputTypeMismatch].
 //   - [ai.WithPrompt]: Set the user prompt template (supports {{variable}} syntax)
-//   - [ai.WithPromptFn]: Set a function that generates the user prompt dynamically
+//   - [ai.WithPromptFn]: Set a function that generates the user prompt from the input
+//   - [ai.WithPromptParts]: Set fixed multi-part user content, such as text plus media
+//   - [ai.WithPromptPartsFn]: As above, derived from the input
 //   - [ai.WithSystem]: Set system instructions template
-//   - [ai.WithSystemFn]: Set a function that generates system instructions dynamically
+//   - [ai.WithSystemFn]: Set a function that generates system instructions from the input
+//   - [ai.WithSystemParts]: Set fixed multi-part system content, such as text plus media
+//   - [ai.WithSystemPartsFn]: As above, derived from the input
 //   - [ai.WithMessages]: Provide static conversation history
+//   - [ai.WithMessagesTemplate]: Provide the conversation as a multi-turn template
 //   - [ai.WithMessagesFn]: Provide a function that generates conversation history
+//
+// Setting any of the three makes the prompt responsible for the conversation
+// passed to [ai.Prompt.Execute]: it is no longer spliced in automatically, and
+// the prompt places it with {{history}} in the template or
+// [ai.HistoryFromContext] in the function. A prompt that sets none of them has
+// the caller's conversation used directly, between the system message and the
+// user prompt.
+//
+// Repeats merge rather than conflict, by the rules in the [ai] package doc. The
+// four system options fill one message and the four prompt options fill
+// another, so within each group the last one set wins and the others are
+// discarded. Documents accumulate. So does the conversation, except that
+// [ai.WithMessagesTemplate] replaces a previous template instead of adding a
+// second layout, and the messages around it keep their position.
+//
+// Context Documents:
+//   - [ai.WithDocs]: Attach a fixed set of context documents
+//   - [ai.WithDocsFn]: Select context documents from the input, e.g. via a retriever
 //
 // Input Schema:
 //   - [ai.WithInputType]: Set input schema from a Go type (provides default values)
@@ -1029,12 +1065,17 @@ func LookupDataPrompt[In, Out any](g *Genkit, name string) *ai.DataPrompt[In, Ou
 
 // GenerateWithRequest performs a model generation request using explicitly provided
 // [ai.GenerateActionOptions]. This function is typically used in conjunction with
-// prompts defined via [DefinePrompt], where [ai.prompt.Render] produces the
+// prompts defined via [DefinePrompt], where [ai.Prompt.Render] produces the
 // `actionOpts`. It allows fine-grained control over the request sent to the model.
 //
 // It accepts optional model middleware (`mw`) for intercepting/modifying the request/response,
 // and an optional streaming callback (`cb`) of type [ai.ModelStreamCallback] to receive
 // response chunks as they arrive.
+//
+// [ai.Prompt.Execute] attaches the conversation it was given for the render;
+// pairing Render with this function does not, so a prompt that places the
+// conversation itself sees none unless the render context carries one. Pass it
+// with [ai.NewHistoryContext], which is how the agent runtime drives a prompt.
 //
 // Example (using options rendered from a prompt):
 //
@@ -1067,11 +1108,20 @@ func GenerateWithRequest(ctx context.Context, g *Genkit, actionOpts *ai.Generate
 //   - [ai.WithConfig]: Set generation parameters (temperature, max tokens, etc.)
 //
 // Prompting:
+//
+// Nothing here is templated: Generate has no prompt input to render against, so
+// content functions receive the zero value of their input type. Use
+// [DefinePrompt] for templates and input-driven content.
 //   - [ai.WithPrompt]: Set the user prompt (supports format strings)
 //   - [ai.WithPromptFn]: Set a function that generates the user prompt dynamically
+//   - [ai.WithPromptParts]: Set fixed multi-part user content, such as text plus media
+//   - [ai.WithPromptPartsFn]: As above, from a function
 //   - [ai.WithSystem]: Set system instructions
 //   - [ai.WithSystemFn]: Set a function that generates system instructions dynamically
+//   - [ai.WithSystemParts]: Set fixed multi-part system content, such as text plus media
+//   - [ai.WithSystemPartsFn]: As above, from a function
 //   - [ai.WithMessages]: Provide conversation history
+//   - [ai.WithMessagesTemplate]: Provide the conversation as a multi-turn template
 //   - [ai.WithMessagesFn]: Provide a function that generates conversation history
 //
 // Tools and Resources:
@@ -1541,7 +1591,7 @@ func LoadPromptDirFromFS(g *Genkit, fsys fs.FS, dir, namespace string) {
 }
 
 // LoadPrompt loads a single `.prompt` file specified by `path` into the registry,
-// associating it with the given `namespace`, and returns the resulting [ai.prompt].
+// associating it with the given `namespace`, and returns the resulting [ai.Prompt].
 //
 // The `path` should be the full path to the `.prompt` file.
 // The `namespace` acts as a prefix to the prompt name (e.g., namespace "myApp" and
@@ -1629,8 +1679,8 @@ func DefineHelper(g *Genkit, name string, fn any) {
 	g.reg.RegisterHelper(name, fn)
 }
 
-// DefineFormats defines new [ai.Formatter]s and registers them in the registry,
-// each under the name returned by its Name method.
+// DefineFormats defines new formatters ([ai.Formatter]) and registers them in
+// the registry, each under the name returned by its Name method.
 // Formatters control how model responses are structured and parsed.
 //
 // Formatters can be used with [ai.WithOutputFormat] to inject specific formatting

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -865,9 +865,10 @@ func LookupMiddleware(g *Genkit, name string) *ai.MiddlewareDesc {
 // Repeats merge rather than conflict, by the rules in the [ai] package doc. The
 // four system options fill one message and the four prompt options fill
 // another, so within each group the last one set wins and the others are
-// discarded. Documents accumulate, and so do messages, except that
-// [ai.WithMessagesTemplate] resets the conversation: a template lays the whole
-// thing out, so it drops whatever was set before it.
+// discarded. Documents accumulate, and so do messages, with one combination
+// refused rather than merged: [ai.WithMessagesTemplate] lays out the whole
+// conversation, so giving it alongside [ai.WithMessages] or [ai.WithMessagesFn]
+// panics here rather than picking one of them.
 //
 // Context Documents:
 //   - [ai.WithDocs]: Attach a fixed set of context documents

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1121,8 +1121,10 @@ func GenerateWithRequest(ctx context.Context, g *Genkit, actionOpts *ai.Generate
 //   - [ai.WithSystemParts]: Set fixed multi-part system content, such as text plus media
 //   - [ai.WithSystemPartsFn]: As above, from a function
 //   - [ai.WithMessages]: Provide conversation history
-//   - [ai.WithMessagesTemplate]: Provide the conversation as a multi-turn template
 //   - [ai.WithMessagesFn]: Provide a function that generates conversation history
+//
+// [ai.WithMessagesTemplate] is absent by design: compiling a template needs a
+// prompt, so it is a [ai.PromptOption] and passing it here does not compile.
 //
 // Tools and Resources:
 //   - [ai.WithTools]: Enable tools the model can call

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -865,9 +865,9 @@ func LookupMiddleware(g *Genkit, name string) *ai.MiddlewareDesc {
 // Repeats merge rather than conflict, by the rules in the [ai] package doc. The
 // four system options fill one message and the four prompt options fill
 // another, so within each group the last one set wins and the others are
-// discarded. Documents accumulate. So does the conversation, except that
-// [ai.WithMessagesTemplate] replaces a previous template instead of adding a
-// second layout, and the messages around it keep their position.
+// discarded. Documents accumulate, and so do messages, except that
+// [ai.WithMessagesTemplate] resets the conversation: a template lays the whole
+// thing out, so it drops whatever was set before it.
 //
 // Context Documents:
 //   - [ai.WithDocs]: Attach a fixed set of context documents

--- a/go/internal/base/convert_test.go
+++ b/go/internal/base/convert_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package base
+
+import (
+	"errors"
+	"testing"
+)
+
+type convSrc struct {
+	Count int64  `json:"count"`
+	Name  string `json:"name"`
+}
+
+type convOther struct {
+	Title string `json:"title"`
+}
+
+func TestConvertToExactShapes(t *testing.T) {
+	t.Run("nil yields the zero value", func(t *testing.T) {
+		got, err := ConvertToExact[convSrc](nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != (convSrc{}) {
+			t.Errorf("got %+v, want zero", got)
+		}
+	})
+
+	t.Run("exact type passes through untouched", func(t *testing.T) {
+		src := convSrc{Count: 1, Name: "a"}
+		got, err := ConvertToExact[convSrc](src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != src {
+			t.Errorf("got %+v, want %+v", got, src)
+		}
+	})
+
+	t.Run("pointer is dereferenced", func(t *testing.T) {
+		got, err := ConvertToExact[convSrc](&convSrc{Name: "a"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Name != "a" {
+			t.Errorf("got %+v, want Name=a", got)
+		}
+	})
+
+	t.Run("nil pointer yields the zero value", func(t *testing.T) {
+		got, err := ConvertToExact[convSrc]((*convSrc)(nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != (convSrc{}) {
+			t.Errorf("got %+v, want zero", got)
+		}
+	})
+
+	t.Run("value converts to a pointer target", func(t *testing.T) {
+		got, err := ConvertToExact[*convSrc](convSrc{Name: "a"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got == nil || got.Name != "a" {
+			t.Errorf("got %+v, want Name=a", got)
+		}
+	})
+
+	// The wire forms the reflection API produces. A prompt with no declared
+	// input type passes arrays and scalars through unchanged, so a helper that
+	// only accepted map[string]any would reject them.
+	t.Run("map wire form decodes into a struct", func(t *testing.T) {
+		got, err := ConvertToExact[convSrc](map[string]any{"count": 2, "name": "a"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Count != 2 || got.Name != "a" {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("array wire form decodes into a slice", func(t *testing.T) {
+		got, err := ConvertToExact[[]string]([]any{"a", "b"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 || got[0] != "a" {
+			t.Errorf("got %v", got)
+		}
+	})
+
+	t.Run("scalar wire form decodes", func(t *testing.T) {
+		got, err := ConvertToExact[string]("hello")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "hello" {
+			t.Errorf("got %q", got)
+		}
+	})
+}
+
+// TestConvertToExactRefusesStructReinterpretation pins the one case leniency
+// got wrong: a JSON round-trip between unrelated structs succeeds and leaves
+// every field zero, so the caller silently gets a blank value.
+func TestConvertToExactRefusesStructReinterpretation(t *testing.T) {
+	_, err := ConvertToExact[convOther](convSrc{Count: 1, Name: "a"})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !errors.Is(err, ErrTypeMismatch) {
+		t.Errorf("err = %v, want it to wrap ErrTypeMismatch", err)
+	}
+
+	if _, ok := ConvertTo[convOther](convSrc{Name: "a"}); ok {
+		t.Error("ConvertTo reported success for an unrelated struct")
+	}
+}
+
+// TestConvertToExactKeepsIntegers covers the widening a plain JSON round-trip
+// causes: a loosely typed target cannot restore integer-ness on its own, so the
+// decoded value is normalized against the source's inferred schema.
+func TestConvertToExactKeepsIntegers(t *testing.T) {
+	t.Run("struct to a loose map", func(t *testing.T) {
+		got, err := ConvertToExact[map[string]any](convSrc{Count: 1230000000, Name: "a"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := got["count"].(int64); !ok {
+			t.Errorf("count = %T(%v), want int64", got["count"], got["count"])
+		}
+	})
+
+	t.Run("struct slice to a loose slice", func(t *testing.T) {
+		got, err := ConvertToExact[[]any]([]convSrc{{Count: 7}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		first, ok := got[0].(map[string]any)
+		if !ok {
+			t.Fatalf("got[0] = %T, want map", got[0])
+		}
+		if _, ok := first["count"].(int64); !ok {
+			t.Errorf("count = %T(%v), want int64", first["count"], first["count"])
+		}
+	})
+
+	// A value that is already in wire form was normalized by the transport, so
+	// it is returned untouched rather than re-normalized.
+	t.Run("wire form is passed through", func(t *testing.T) {
+		src := map[string]any{"count": int64(5)}
+		got, err := ConvertToExact[map[string]any](src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := got["count"].(int64); !ok {
+			t.Errorf("count = %T, want int64", got["count"])
+		}
+	})
+
+	// A concrete target restores the types itself, so no normalization runs.
+	t.Run("concrete target is untouched", func(t *testing.T) {
+		got, err := ConvertToExact[convSrc](map[string]any{"count": 1230000000})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Count != 1230000000 {
+			t.Errorf("count = %d", got.Count)
+		}
+	})
+
+	// A pointer restores no more than what it points at, so it normalizes too.
+	// The value has to be built rather than asserted, since an assertion only
+	// matches the value form.
+	t.Run("pointer to a loose map", func(t *testing.T) {
+		got, err := ConvertToExact[*map[string]any](convSrc{Count: 1230000000})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got == nil {
+			t.Fatal("got nil")
+		}
+		if _, ok := (*got)["count"].(int64); !ok {
+			t.Errorf("count = %T(%v), want int64", (*got)["count"], (*got)["count"])
+		}
+	})
+
+	t.Run("pointer to any", func(t *testing.T) {
+		got, err := ConvertToExact[*any](convSrc{Count: 1230000000})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got == nil {
+			t.Fatal("got nil")
+		}
+		m, ok := (*got).(map[string]any)
+		if !ok {
+			t.Fatalf("*got = %T, want map[string]any", *got)
+		}
+		if _, ok := m["count"].(int64); !ok {
+			t.Errorf("count = %T(%v), want int64", m["count"], m["count"])
+		}
+	})
+}

--- a/go/internal/base/json.go
+++ b/go/internal/base/json.go
@@ -149,13 +149,11 @@ func InferJSONSchema(x any) *jsonschema.Schema {
 }
 
 // ErrTypeMismatch reports that a value's Go type cannot be reinterpreted as
-// the requested type in [ConvertToExact]. Callers wrap it with their own
-// domain-specific message.
+// the requested type in [ConvertToExact].
 //
-// This package cannot classify it: core/status depends on this one. A caller
-// that surfaces the failure past the framework boundary is responsible for
-// attaching a sentinel users can match, as ai.ErrInputTypeMismatch does for
-// content-function input.
+// This package cannot classify it, since core/status depends on this one. A
+// caller that surfaces the failure past the framework boundary must attach a
+// sentinel users can match, as ai.ErrInputTypeMismatch does.
 var ErrTypeMismatch = errors.New("type mismatch")
 
 // ConvertToExact converts a dynamically typed value to T.
@@ -173,10 +171,9 @@ var ErrTypeMismatch = errors.New("type mismatch")
 // When T cannot carry JSON's types on its own, meaning T is an interface or a
 // map, slice or array whose elements are, the decoded value is normalized
 // against the schema inferred from v (see [NormalizeInput]) so that an integer
-// stays an int64 instead of widening to float64. This is the same
-// normalization the reflection API applies to action input, so a value reaches
-// T with the same Go types whichever way it arrived. That path also drops
-// null-valued keys, again matching the wire behavior.
+// stays an int64 instead of widening to float64. That is what the reflection
+// API does to action input, so a value reaches T with the same Go types
+// whichever way it arrived. It also drops null-valued keys, as the wire does.
 func ConvertToExact[T any](v any) (T, error) {
 	var zero T
 	if v == nil {

--- a/go/internal/base/json.go
+++ b/go/internal/base/json.go
@@ -148,22 +148,172 @@ func InferJSONSchema(x any) *jsonschema.Schema {
 	return s
 }
 
-// ConvertTo attempts to convert a value to type T. It tries a direct type
-// assertion first, then falls back to a JSON round-trip for values that were
-// deserialized from JSON (e.g., map[string]any instead of a concrete struct).
-func ConvertTo[T any](v any) (T, bool) {
+// ErrTypeMismatch reports that a value's Go type cannot be reinterpreted as
+// the requested type in [ConvertToExact]. Callers wrap it with their own
+// domain-specific message.
+//
+// This package cannot classify it: core/status depends on this one. A caller
+// that surfaces the failure past the framework boundary is responsible for
+// attaching a sentinel users can match, as ai.ErrInputTypeMismatch does for
+// content-function input.
+var ErrTypeMismatch = errors.New("type mismatch")
+
+// ConvertToExact converts a dynamically typed value to T.
+//
+// It accepts a value that is already a T, a *T (a nil pointer yields the zero
+// value), or a value in the JSON wire form the framework's transports produce
+// (map[string]any, []any, a scalar), which it decodes into T. A nil value
+// yields the zero value.
+//
+// Reinterpreting one struct as an unrelated struct is refused with an error
+// wrapping [ErrTypeMismatch]: a JSON round-trip between two unrelated structs
+// succeeds while leaving every field zero, so the caller would otherwise get a
+// blank value instead of a diagnosis.
+//
+// When T cannot carry JSON's types on its own, meaning T is an interface or a
+// map, slice or array whose elements are, the decoded value is normalized
+// against the schema inferred from v (see [NormalizeInput]) so that an integer
+// stays an int64 instead of widening to float64. This is the same
+// normalization the reflection API applies to action input, so a value reaches
+// T with the same Go types whichever way it arrived. That path also drops
+// null-valued keys, again matching the wire behavior.
+func ConvertToExact[T any](v any) (T, error) {
+	var zero T
+	if v == nil {
+		return zero, nil
+	}
+	// Covers an exact match and T being an interface that v satisfies, in
+	// which case the value is handed over untouched.
+	if typed, ok := v.(T); ok {
+		return typed, nil
+	}
+	if p, ok := v.(*T); ok {
+		if p == nil {
+			return zero, nil
+		}
+		return *p, nil
+	}
+
+	dstType := reflect.TypeFor[T]()
+	if src, ok := structType(reflect.TypeOf(v)); ok {
+		if dst, ok := structType(dstType); ok && src != dst {
+			return zero, fmt.Errorf("%w: got %T, want %T", ErrTypeMismatch, v, zero)
+		}
+	}
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return zero, fmt.Errorf("cannot convert %T to %T: %w", v, zero, err)
+	}
+
+	if !dynamicType(dstType) {
+		var result T
+		if err := json.Unmarshal(data, &result); err != nil {
+			return zero, fmt.Errorf("cannot convert %T to %T: %w", v, zero, err)
+		}
+		return result, nil
+	}
+
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return zero, fmt.Errorf("cannot convert %T to %T: %w", v, zero, err)
+	}
+	normalized, err := NormalizeInput(decoded, SchemaAsMap(InferJSONSchema(v)))
+	if err != nil {
+		return zero, fmt.Errorf("cannot convert %T to %T: %w", v, zero, err)
+	}
+	if normalized == nil {
+		return zero, nil
+	}
+	result, ok := asTarget[T](normalized)
+	if !ok {
+		return zero, fmt.Errorf("%w: got %T, want %T", ErrTypeMismatch, v, zero)
+	}
+	return result, nil
+}
+
+// asTarget converts an already-normalized dynamic value into T.
+//
+// A type assertion alone only matches the value form, so a pointer target such
+// as *map[string]any would miss and lose the normalization. The pointer chain
+// is allocated around the value instead.
+func asTarget[T any](v any) (T, bool) {
+	var zero T
 	if typed, ok := v.(T); ok {
 		return typed, true
 	}
-	var result T
-	data, err := json.Marshal(v)
-	if err != nil {
-		return result, false
+
+	dst := reflect.TypeFor[T]()
+	if dst.Kind() != reflect.Pointer {
+		return zero, false
 	}
-	if err := json.Unmarshal(data, &result); err != nil {
-		return result, false
+	val := reflect.ValueOf(v)
+	if !val.IsValid() {
+		return zero, false
 	}
-	return result, true
+
+	depth := 0
+	elem := dst
+	for elem.Kind() == reflect.Pointer {
+		elem = elem.Elem()
+		depth++
+	}
+	if !val.Type().AssignableTo(elem) {
+		return zero, false
+	}
+
+	// Build from the element type rather than the value's own type, so that a
+	// *any target holds an interface rather than the concrete value.
+	cur := reflect.New(elem)
+	cur.Elem().Set(val)
+	for range depth - 1 {
+		p := reflect.New(cur.Type())
+		p.Elem().Set(cur)
+		cur = p
+	}
+
+	typed, ok := cur.Interface().(T)
+	return typed, ok
+}
+
+// structType reports whether t is a struct, or a pointer chain ending in one,
+// and returns the struct type itself so that T and *T compare equal.
+func structType(t reflect.Type) (reflect.Type, bool) {
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t != nil && t.Kind() == reflect.Struct {
+		return t, true
+	}
+	return nil, false
+}
+
+// dynamicType reports whether decoding JSON into t yields dynamically typed
+// values, so that t cannot on its own restore the Go types the source had.
+//
+// Pointers are followed, since a *map[string]any restores no more than the
+// map it points at.
+func dynamicType(t reflect.Type) bool {
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == nil {
+		return false
+	}
+	switch t.Kind() {
+	case reflect.Interface:
+		return true
+	case reflect.Map, reflect.Slice, reflect.Array:
+		return t.Elem().Kind() == reflect.Interface
+	}
+	return false
+}
+
+// ConvertTo is [ConvertToExact] for callers that only need to know whether the
+// conversion was possible.
+func ConvertTo[T any](v any) (T, bool) {
+	result, err := ConvertToExact[T](v)
+	return result, err == nil
 }
 
 // anyStructSchema returns the "any" schema used to break recursion. Types

--- a/go/samples/basic-agents/banker.go
+++ b/go/samples/basic-agents/banker.go
@@ -136,7 +136,7 @@ func defineBankerAgent(g *genkit.Genkit) *aix.Agent[any] {
 		})
 
 	return genkitx.DefinePromptAgent[any](g, name,
-		aix.WithSessionStore(mustStore(name)),
+		aix.WithSessionStore(mustStore[any](name)),
 		aix.WithDescription[any]("Money transfer assistant (interruptible tool + human approval)"),
 	)
 }

--- a/go/samples/basic-agents/barista.go
+++ b/go/samples/basic-agents/barista.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// barista.go is the session-state demo.
+//
+// The other agents carry only their conversation from turn to turn. The
+// barista also carries a running order, and its system instruction is rebuilt
+// from that order every turn, so what the agent is told grows as the
+// conversation does. The two halves are:
+//
+//   - the tool (addToOrder) writes session state through the live session it
+//     finds on its context;
+//   - the prompt (ai.WithSystemFn) reads that state back and turns it into
+//     instructions.
+//
+// The state is a Go struct, not a bag of keys: the agent is an
+// Agent[BaristaOrder], so its store, its snapshots, and every read of
+// aix.SessionFromContext are typed end to end. The other agents in this sample
+// keep no state of their own and are Agent[any].
+//
+// This is what a prompt-backed agent can do that a fixed system string cannot,
+// and it is the reason the agent's replies stay consistent over a long order
+// without the model having to re-read the whole transcript.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+	genkitx "github.com/firebase/genkit/go/genkit/exp"
+)
+
+// BaristaOrder is the agent's session state: what the customer has ordered so
+// far. It is the State type parameter on the agent, so the framework infers its
+// JSON schema, the file store persists it, and reads come back as this struct
+// rather than a map.
+//
+// omitempty is load-bearing on the slice: a nil Go slice marshals to null,
+// which does not satisfy the array schema inferred from this type.
+type BaristaOrder struct {
+	Drinks []string `json:"drinks,omitempty"`
+}
+
+// defineBaristaAgent registers the addToOrder tool and an inline-prompt agent
+// whose system instruction is computed from session state on every turn.
+func defineBaristaAgent(g *genkit.Genkit) *aix.Agent[BaristaOrder] {
+	const name = "barista"
+
+	// The write side, defined with the experimental tool API: the function
+	// takes a plain context.Context, so the session lookup reads the same way
+	// it does anywhere else. Use tool.AttachParts if a tool needs to return
+	// content alongside its output. The banker's interruptible tool is the
+	// other half of this API.
+	//
+	// A tool reaches the live session through its context and mutates the
+	// custom state; what it writes is visible to the next turn's prompt
+	// render. UpdateCustom takes and returns the state as its own type, so
+	// appending a drink is one line and a typo is a compile error.
+	addToOrder := genkitx.DefineTool(g, "addToOrder",
+		"Records one drink the customer ordered. Call it every time they ask for a drink.",
+		func(ctx context.Context, in struct {
+			Drink string `json:"drink" jsonschema:"description=The drink to add e.g. flat white"`
+		}) (string, error) {
+			sess := aix.SessionFromContext[BaristaOrder](ctx)
+			if sess == nil {
+				// Classify rather than returning a bare error: the runtime
+				// wraps a tool failure as ai.ErrToolFailed with the cause
+				// preserved, so this stays matchable with errors.Is.
+				return "", status.Errorf(status.ErrFailedPrecondition,
+					"addToOrder must be called inside a session")
+			}
+			sess.UpdateCustom(func(order BaristaOrder) BaristaOrder {
+				order.Drinks = append(order.Drinks, in.Drink)
+				return order
+			})
+			return "Added " + in.Drink + " to the order.", nil
+		})
+
+	return genkitx.DefineAgent(g, name,
+		aix.InlinePrompt{
+			ai.WithModel(flashModel),
+			ai.WithTools(addToOrder),
+			// The read side. WithSystemFn runs once per turn, so the
+			// instruction is rebuilt from whatever the earlier turns left
+			// behind. Its result is used verbatim, so a drink name with a
+			// brace in it never has to be escaped. A template could reach the
+			// same values as {{@state.drinks}}; a function is what lets the
+			// wording branch on them, at the cost of naming the state type.
+			ai.WithSystemFn(func(ctx context.Context, _ any) (string, error) {
+				sess := aix.SessionFromContext[BaristaOrder](ctx)
+				if sess == nil {
+					return "", status.Errorf(status.ErrFailedPrecondition,
+						"barista prompt rendered outside a session")
+				}
+				order := sess.Custom()
+				if len(order.Drinks) == 0 {
+					return "You are a brisk, friendly barista. Take the customer's order one drink at a time, calling addToOrder for each. Keep every reply to a sentence.", nil
+				}
+				return fmt.Sprintf(
+					"You are a brisk, friendly barista. The customer has ordered so far: %s. Call addToOrder for anything they add, read the order back when they ask, and keep every reply to a sentence.",
+					strings.Join(order.Drinks, ", "),
+				), nil
+			}),
+		},
+		aix.WithSessionStore(mustStore[BaristaOrder](name)),
+		aix.WithDescription[BaristaOrder]("Coffee order taker (typed session state read back into the prompt)"),
+	)
+}

--- a/go/samples/basic-agents/chef.go
+++ b/go/samples/basic-agents/chef.go
@@ -46,7 +46,7 @@ func definePromptAgent(g *genkit.Genkit) *aix.Agent[any] {
 	// at definition time.
 	genkit.DefineSchemasFor(g, ChatPromptInput{})
 	return genkitx.DefinePromptAgent(g, name,
-		aix.WithSessionStore(mustStore(name)),
+		aix.WithSessionStore(mustStore[any](name)),
 		aix.WithDescription[any]("Michelin-starred chef (prompt loaded from ./prompts/chef.prompt)"),
 	)
 }

--- a/go/samples/basic-agents/cli.go
+++ b/go/samples/basic-agents/cli.go
@@ -153,16 +153,47 @@ func (s *spinner) stop() {
 // bubbles up through openAgent and breaks runCLI's outer loop.
 var errQuit = errors.New("quit")
 
-// agentEntry pairs an agent with the optional, agent-specific hooks the
-// generic CLI needs to drive it. The CLI itself knows nothing about any
-// particular agent: it lists them, streams their turns, and (when set)
-// routes tool interrupts to onInterrupt. Agents without interruptible
-// tools leave onInterrupt nil and the rest of the flow is identical. That
-// split is what lets this same cli.go back any future sample, with tool
-// interrupts or without.
+// agentEntry is the CLI's view of one agent, with its session-state type
+// erased. Each agent picks the state type that suits it (see barista.go for
+// one that carries a structured order), so a single list cannot hold them as
+// concrete values; it holds closures instead, and newEntry is the one place
+// the concrete type is captured. Everything the closures call is generic over
+// State, so nothing downstream loses the type.
+//
+// The CLI itself knows nothing about any particular agent: it lists them,
+// streams their turns, and (when set) routes tool interrupts to onInterrupt.
+// Agents without interruptible tools leave onInterrupt nil and the rest of the
+// flow is identical. That split is what lets this same cli.go back any future
+// sample, with tool interrupts or without.
 type agentEntry struct {
-	agent       *aix.Agent[any]
+	name        string
+	description string
+	// summarize renders the one-line status shown under the agent in the list.
+	summarize func(ctx context.Context, sessionID string) string
+	// open runs one visit to the agent, returning the session ID it ran under.
+	open func(ctx context.Context, inputCh <-chan string, lastSessionID string) (string, error)
+}
+
+// agentHooks is what the streaming path needs about an agent beyond its
+// connection: what to call it in messages, and how to resolve interrupts.
+type agentHooks struct {
+	name        string
 	onInterrupt InterruptHandler
+}
+
+// newEntry builds a list entry for an agent of any session-state type.
+func newEntry[State any](a *aix.Agent[State], onInterrupt InterruptHandler) agentEntry {
+	hooks := agentHooks{name: a.Name(), onInterrupt: onInterrupt}
+	return agentEntry{
+		name:        a.Name(),
+		description: a.Desc().Description,
+		summarize: func(ctx context.Context, sessionID string) string {
+			return summarizeLatest(ctx, a, sessionID)
+		},
+		open: func(ctx context.Context, inputCh <-chan string, lastSessionID string) (string, error) {
+			return openAgent(ctx, inputCh, a, hooks, lastSessionID)
+		},
+	}
 }
 
 // InterruptHandler resolves a single tool interrupt into a resume part. It
@@ -217,14 +248,14 @@ func runCLI(ctx context.Context, agents []agentEntry) error {
 			return nil
 		}
 		entry := agents[choice]
-		sessionID, err := openAgent(ctx, inputCh, entry, lastSession[entry.agent.Name()])
+		sessionID, err := entry.open(ctx, inputCh, lastSession[entry.name])
 		if err != nil {
 			if errors.Is(err, errQuit) {
 				return nil
 			}
 			return err
 		}
-		lastSession[entry.agent.Name()] = sessionID
+		lastSession[entry.name] = sessionID
 	}
 }
 
@@ -236,12 +267,11 @@ func pickAgent(ctx context.Context, inputCh <-chan string, agents []agentEntry, 
 		fmt.Println()
 		fmt.Println(style("Agents:", ansiBold))
 		for i, entry := range agents {
-			a := entry.agent
 			fmt.Printf("  %s %s %s\n",
 				style(fmt.Sprintf("%d.", i+1), ansiCyan),
-				style(a.Name(), ansiBold),
-				style("— "+a.Desc().Description, ansiDim))
-			if summary := summarizeLatest(ctx, a, lastSession[a.Name()]); summary != "" {
+				style(entry.name, ansiBold),
+				style("— "+entry.description, ansiDim))
+			if summary := entry.summarize(ctx, lastSession[entry.name]); summary != "" {
 				fmt.Printf("       %s\n", summary)
 			}
 		}
@@ -274,13 +304,12 @@ func pickAgent(ctx context.Context, inputCh <-chan string, agents []agentEntry, 
 // so the rest of the flow is uniform: ok=false means the user backed
 // out, otherwise hand the chosen snapshot (or nil for fresh) to
 // runChat.
-func openAgent(ctx context.Context, inputCh <-chan string, entry agentEntry, lastSessionID string) (string, error) {
-	a := entry.agent
+func openAgent[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent[State], hooks agentHooks, lastSessionID string) (string, error) {
 	// Resolve where the last conversation left off. With no tracked
 	// session (a first visit this run) there is nothing to resume;
 	// otherwise the store resolves the session's latest snapshot, which
 	// also surfaces a still-pending detached invocation.
-	var tip *aix.SessionSnapshot[any]
+	var tip *aix.SessionSnapshot[State]
 	if lastSessionID != "" {
 		var err error
 		tip, err = a.Store().GetLatestSnapshot(ctx, lastSessionID)
@@ -290,7 +319,7 @@ func openAgent(ctx context.Context, inputCh <-chan string, entry agentEntry, las
 	}
 
 	var (
-		resume *aix.SessionSnapshot[any]
+		resume *aix.SessionSnapshot[State]
 		ok     bool
 	)
 	if tip != nil && tip.Status == aix.SnapshotStatusPending {
@@ -305,7 +334,7 @@ func openAgent(ctx context.Context, inputCh <-chan string, entry agentEntry, las
 	if !ok {
 		return lastSessionID, nil
 	}
-	return runChat(ctx, inputCh, entry, resume, lastSessionID)
+	return runChat(ctx, inputCh, a, hooks, resume, lastSessionID)
 }
 
 // handlePending offers the three reasonable responses when a previous
@@ -323,7 +352,7 @@ func openAgent(ctx context.Context, inputCh <-chan string, entry agentEntry, las
 // snapshot directly so the caller can skip the resume / new prompt:
 // the user already committed to the choice by waiting, and re-asking
 // would be redundant.
-func handlePending(ctx context.Context, inputCh <-chan string, a *aix.Agent[any], pending *aix.SessionSnapshot[any]) (*aix.SessionSnapshot[any], bool) {
+func handlePending[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent[State], pending *aix.SessionSnapshot[State]) (*aix.SessionSnapshot[State], bool) {
 	for {
 		fmt.Printf("\nThe last %s session is still running in the background (%s).\n",
 			style(a.Name(), ansiBold), style(shortID(pending.SnapshotID), ansiDim))
@@ -373,7 +402,7 @@ func handlePending(ctx context.Context, inputCh <-chan string, a *aix.Agent[any]
 // offers two paths so the demo stays focused: resume from the most
 // recent terminal snapshot (returns the snapshot pointer), or start
 // fresh (returns nil).
-func pickSession(ctx context.Context, inputCh <-chan string, a *aix.Agent[any], latest *aix.SessionSnapshot[any]) (*aix.SessionSnapshot[any], bool) {
+func pickSession[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent[State], latest *aix.SessionSnapshot[State]) (*aix.SessionSnapshot[State], bool) {
 	if latest == nil || latest.Status != aix.SnapshotStatusCompleted {
 		fmt.Printf("\nStarting a new conversation with %s.\n", style(a.Name(), ansiBold))
 		return nil, true
@@ -408,15 +437,15 @@ func pickSession(ctx context.Context, inputCh <-chan string, a *aix.Agent[any], 
 // snapshot the user was just shown. Validating up front keeps the chat
 // from opening on a connection whose invocation already failed, which
 // would surface the error only after the user types a message.
-func resumeOption(ctx context.Context, a *aix.Agent[any], resume *aix.SessionSnapshot[any]) aix.InvocationOption[any] {
+func resumeOption[State any](ctx context.Context, a *aix.Agent[State], resume *aix.SessionSnapshot[State]) aix.InvocationOption[State] {
 	if resume.SessionID != "" {
 		tip, err := a.Store().GetLatestSnapshot(ctx, resume.SessionID)
 		if err == nil && tip != nil && tip.Status != aix.SnapshotStatusPending {
-			return aix.WithSessionID[any](resume.SessionID)
+			return aix.WithSessionID[State](resume.SessionID)
 		}
 		fmt.Println(style("(this conversation's session can't be resumed as a whole; continuing from the selected snapshot)", ansiDim))
 	}
-	return aix.WithSnapshotID[any](resume.SnapshotID)
+	return aix.WithSnapshotID[State](resume.SnapshotID)
 }
 
 // runChat opens the bidi connection (optionally resuming from a
@@ -427,8 +456,7 @@ func resumeOption(ctx context.Context, a *aix.Agent[any], resume *aix.SessionSna
 // detaches the connection, leaving a pending snapshot for the user to
 // observe. It returns the session ID the chat ran under (falling back to
 // prevSessionID) so the caller can offer to resume it later.
-func runChat(ctx context.Context, inputCh <-chan string, entry agentEntry, resume *aix.SessionSnapshot[any], prevSessionID string) (string, error) {
-	a := entry.agent
+func runChat[State any](ctx context.Context, inputCh <-chan string, a *aix.Agent[State], hooks agentHooks, resume *aix.SessionSnapshot[State], prevSessionID string) (string, error) {
 	prompter := &Prompter{ctx: ctx, inputCh: inputCh}
 	fmt.Printf("\n%s\n", style("=== Chatting with "+a.Name()+" ===", ansiBold, ansiCyan))
 	if resume != nil {
@@ -443,7 +471,7 @@ func runChat(ctx context.Context, inputCh <-chan string, entry agentEntry, resum
 	}
 	fmt.Println()
 
-	var opts []aix.InvocationOption[any]
+	var opts []aix.InvocationOption[State]
 	if resume != nil {
 		opts = append(opts, resumeOption(ctx, a, resume))
 	}
@@ -501,7 +529,7 @@ repl:
 			break
 		}
 		fmt.Println()
-		end, wrote, ok := streamReply(conn, entry, prompter)
+		end, wrote, ok := streamReply(conn, hooks, prompter)
 		if !ok {
 			// The stream errored or closed before the turn settled; the
 			// error was already reported. Output below reports the outcome.
@@ -610,7 +638,7 @@ repl:
 // It also reports whether any visible content (text or a tool call) was
 // printed, so the caller can space the turn footer correctly when a turn
 // produces nothing (e.g. an immediate failure).
-func streamReply(conn *aix.AgentConnection[any], entry agentEntry, p *Prompter) (end *aix.TurnEnd, wrote bool, ok bool) {
+func streamReply[State any](conn *aix.AgentConnection[State], hooks agentHooks, p *Prompter) (end *aix.TurnEnd, wrote bool, ok bool) {
 	for {
 		interrupts, e, w, sok := streamTurn(conn)
 		wrote = wrote || w
@@ -620,7 +648,7 @@ func streamReply(conn *aix.AgentConnection[any], entry agentEntry, p *Prompter) 
 		if len(interrupts) == 0 {
 			return e, wrote, true
 		}
-		resume := resolveInterrupts(entry, p, interrupts)
+		resume := resolveInterrupts(hooks, p, interrupts)
 		if resume == nil {
 			// Nothing could be resolved (no handler, or the handler declined
 			// every interrupt). Surface the interrupted turn as-is rather
@@ -651,7 +679,7 @@ func streamReply(conn *aix.AgentConnection[any], entry agentEntry, p *Prompter) 
 //
 // The spinner is stopped (and erased) the moment any visible content is about
 // to print, so the reply or tool line takes over the line it occupied.
-func streamTurn(conn *aix.AgentConnection[any]) (interrupts []*ai.Part, end *aix.TurnEnd, wrote bool, ok bool) {
+func streamTurn[State any](conn *aix.AgentConnection[State]) (interrupts []*ai.Part, end *aix.TurnEnd, wrote bool, ok bool) {
 	sp := startSpinner("Thinking")
 	stopSpinner := func() {
 		if sp != nil {
@@ -733,13 +761,13 @@ func formatToolInput(input any) string {
 // matching half of aix.ToolResume by part kind — a restart is a tool
 // request, a direct response is a tool response — so handlers never deal
 // with the wire shape. Returns nil when nothing could be resolved.
-func resolveInterrupts(entry agentEntry, p *Prompter, interrupts []*ai.Part) *aix.ToolResume {
-	if entry.onInterrupt == nil {
+func resolveInterrupts(hooks agentHooks, p *Prompter, interrupts []*ai.Part) *aix.ToolResume {
+	if hooks.onInterrupt == nil {
 		// An interruptible tool fired on an agent the CLI wasn't told how to
 		// resume. That's a wiring bug in the sample, not user input, so say
 		// so plainly instead of hanging on a prompt that never comes.
 		fmt.Printf("\n[%s paused on %d tool interrupt(s), but no interrupt handler is registered for it]\n",
-			entry.agent.Name(), len(interrupts))
+			hooks.name, len(interrupts))
 		return nil
 	}
 	// No separator needed here: the interrupting tool's request was already
@@ -747,7 +775,7 @@ func resolveInterrupts(entry agentEntry, p *Prompter, interrupts []*ai.Part) *ai
 	// sets the upcoming prompts apart from the reply.
 	resume := &aix.ToolResume{}
 	for _, interrupt := range interrupts {
-		part, err := entry.onInterrupt(p, interrupt)
+		part, err := hooks.onInterrupt(p, interrupt)
 		switch {
 		case err != nil:
 			fmt.Fprintf(os.Stderr, "Interrupt handler error: %v\n", err)
@@ -774,7 +802,7 @@ func resolveInterrupts(entry agentEntry, p *Prompter, interrupts []*ai.Part) *ai
 // detach highlighted in yellow. Each segment carries its own reset so the
 // yellow status doesn't bleed into the surrounding dim text. A pending
 // snapshot has no finalized messages yet, so its count is omitted.
-func summarizeLatest(ctx context.Context, a *aix.Agent[any], sessionID string) string {
+func summarizeLatest[State any](ctx context.Context, a *aix.Agent[State], sessionID string) string {
 	if sessionID == "" {
 		return ""
 	}
@@ -805,7 +833,7 @@ func summarizeLatest(ctx context.Context, a *aix.Agent[any], sessionID string) s
 // The status subscription is the optional SnapshotSubscriber capability of
 // the store contract. A store without it cannot stream background progress,
 // so we fall back to reading the snapshot once and returning it as-is.
-func waitForFinalize(ctx context.Context, a *aix.Agent[any], snapshotID string) (*aix.SessionSnapshot[any], error) {
+func waitForFinalize[State any](ctx context.Context, a *aix.Agent[State], snapshotID string) (*aix.SessionSnapshot[State], error) {
 	store := a.Store()
 	subscriber, ok := store.(aix.SnapshotSubscriber)
 	if !ok {

--- a/go/samples/basic-agents/coder.go
+++ b/go/samples/basic-agents/coder.go
@@ -62,7 +62,7 @@ func defineCustomAgent(g *genkit.Genkit) *aix.Agent[any] {
 			}
 			return sess.Result(), nil
 		},
-		aix.WithSessionStore(mustStore(name)),
+		aix.WithSessionStore(mustStore[any](name)),
 		aix.WithDescription[any]("Concise code helper (custom per-turn loop)"),
 	)
 }

--- a/go/samples/basic-agents/main.go
+++ b/go/samples/basic-agents/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This sample demonstrates Genkit's agent APIs by defining five agents in
+// This sample demonstrates Genkit's agent APIs by defining six agents in
 // different styles and exposing all of them through a single CLI. Each agent
 // lives in its own file so the styles can be compared side by side:
 //
@@ -28,6 +28,12 @@
 //     mid-turn to ask the user for approval before moving money, then
 //     resumes the tool with their answer. This exercises the tool
 //     interrupt / resume flow through the same CLI.
+//   - "barista" (barista.go) is the typed-session-state agent: an
+//     Agent[BaristaOrder] whose system instruction is a function rather than
+//     a fixed string. A tool writes the running order into session state and
+//     the prompt reads it back, so each turn is told what the earlier ones
+//     established. It is also why the CLI's agent list is type-erased (see
+//     agentEntry): the agents in it no longer share one state type.
 //   - "orchestrator" (orchestrator.go) uses the experimental Agents
 //     middleware to delegate to specialized sub-agents (researcher,
 //     engineer) through per-agent tools, merging their artifacts into its
@@ -37,7 +43,7 @@
 // turn, renders tool calls inline as the agent makes them, and routes tool
 // interrupts to the right handler.
 //
-// The first four agents persist their conversation state to a per-agent
+// The first five agents persist their conversation state to a per-agent
 // FileSessionStore under ./.genkit/snapshots/<agent>/; the orchestrator does
 // too, while its sub-agents run statelessly per delegation.
 //
@@ -69,6 +75,11 @@
 // balance) or "send $120 to bob" (a large transfer) to see the tool
 // interrupt flow: the turn pauses, the CLI asks you to approve or adjust,
 // and the tool resumes with your answer.
+//
+// Tip: pick "barista", order a drink, then ask "what have I ordered?" on a
+// later turn. The answer comes from session state written by a tool and read
+// back into the system instruction, not from the model re-reading the
+// transcript. /back and re-pick the agent to see it survive a resume.
 package main
 
 import (
@@ -110,11 +121,12 @@ func main() {
 	// only one that supplies an onInterrupt handler; the others leave it
 	// nil and the CLI streams them exactly as before.
 	agents := []agentEntry{
-		{agent: defineInlineAgent(g)},
-		{agent: definePromptAgent(g)},
-		{agent: defineCustomAgent(g)},
-		{agent: defineBankerAgent(g), onInterrupt: handleTransferInterrupt},
-		{agent: defineOrchestratorAgent(g)},
+		newEntry(defineInlineAgent(g), nil),
+		newEntry(definePromptAgent(g), nil),
+		newEntry(defineCustomAgent(g), nil),
+		newEntry(defineBankerAgent(g), handleTransferInterrupt),
+		newEntry(defineBaristaAgent(g), nil),
+		newEntry(defineOrchestratorAgent(g), nil),
 	}
 
 	if err := runCLI(ctx, agents); err != nil {
@@ -127,12 +139,16 @@ func main() {
 // ./.genkit/snapshots/, or exits the process on failure. Used during
 // agent setup where there's nowhere sensible to return an error.
 //
+// The store is typed by the agent's session state, so each agent gets a store
+// that reads and writes its own shape: mustStore[any] for the agents that keep
+// no custom state, mustStore[BaristaOrder] for the one that does.
+//
 // A dir per agent keeps each agent's snapshots on disk separately, which
 // is tidy for browsing but not required: resumes are resolved by session
 // ID (see SnapshotReader.GetLatestSnapshot), so one shared store would
 // work the same.
-func mustStore(agentName string) *localstore.FileSessionStore[any] {
-	store, err := localstore.NewFileSessionStore[any]("./.genkit/snapshots/" + agentName)
+func mustStore[State any](agentName string) *localstore.FileSessionStore[State] {
+	store, err := localstore.NewFileSessionStore[State]("./.genkit/snapshots/" + agentName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating store for %q: %v\n", agentName, err)
 		os.Exit(1)

--- a/go/samples/basic-agents/orchestrator.go
+++ b/go/samples/basic-agents/orchestrator.go
@@ -27,8 +27,7 @@ import (
 //
 // The middleware injects one delegation tool per sub-agent (delegate_to_<name>),
 // lists the sub-agents and their descriptions in the system prompt, and runs the
-// chosen sub-agent when the orchestrator model calls its tool. It mirrors the
-// JS "orchestrator" sample.
+// chosen sub-agent when the orchestrator model calls its tool.
 //
 // The two sub-agents (researcher, engineer) are client-managed (no session
 // store): each delegation runs them one-shot and leaves no snapshots behind, so
@@ -88,7 +87,7 @@ func defineOrchestratorAgent(g *genkit.Genkit) *aix.Agent[any] {
 				&middlewarex.Artifacts{Readonly: true},
 			),
 		},
-		aix.WithSessionStore(mustStore("orchestrator")),
+		aix.WithSessionStore(mustStore[any]("orchestrator")),
 		aix.WithDescription[any]("Coordinates research and coding sub-agents via the agents middleware"),
 	)
 }

--- a/go/samples/basic-agents/pirate.go
+++ b/go/samples/basic-agents/pirate.go
@@ -34,7 +34,7 @@ func defineInlineAgent(g *genkit.Genkit) *aix.Agent[any] {
 			ai.WithModel(flashModel),
 			ai.WithSystem("You are a sarcastic pirate. Keep every reply to a sentence or two, sharp and to the point."),
 		},
-		aix.WithSessionStore(mustStore(name)),
+		aix.WithSessionStore(mustStore[any](name)),
 		aix.WithDescription[any]("Sarcastic pirate (inline-defined prompt)"),
 	)
 }

--- a/go/samples/basic-prompt-content/main.go
+++ b/go/samples/basic-prompt-content/main.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This sample demonstrates how a prompt turns your own data into a request. It
+// fills all four of a prompt's content slots (system, conversation, user, and
+// context documents) from one typed input, then shows the template forms of the
+// same slots alongside.
+//
+// The rule it is built around: in a prompt, template text is yours, so it is
+// compiled, while anything a function returns is content you already produced,
+// so it is sent verbatim. Reach for a template when the wording is fixed and
+// only values vary, and for a function when the content itself depends on the
+// data: branching on a field, trimming a conversation, attaching an image, or
+// choosing documents.
+//
+// To run:
+//
+//	go run .
+//
+// In another terminal, answer a question with a conversation behind it:
+//
+//	curl -N -X POST http://localhost:8080/supportFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": {"request": {"area": "billing", "tier": "pro", "question": "Why was I charged twice this month?"}, "history": [{"role": "user", "text": "Hi, I have a question about my bill."}, {"role": "model", "text": "Happy to help. What is going on?"}]}}'
+//
+// Triage a ticket into a structured verdict. The question contains handlebars
+// syntax, which reaches the model as written:
+//
+//	curl -X POST http://localhost:8080/triageFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": {"request": {"area": "api", "tier": "free", "question": "How do I write {{#if}} in a prompt template?"}}}'
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/server"
+)
+
+// maxHistoryMessages is how many recent messages the support prompt keeps.
+// Everything older is replaced with a one-line note.
+const maxHistoryMessages = 6
+
+// SupportRequest is the prompt's input: the app's own shape, not a map. Every
+// content function below receives exactly this type, whether the prompt was
+// called in process, from the Dev UI, or over HTTP.
+type SupportRequest struct {
+	Area           string `json:"area" jsonschema:"description=The product area the question is about,enum=billing,enum=setup,enum=api,default=api"`
+	Tier           string `json:"tier" jsonschema:"description=The customer's support tier,enum=free,enum=pro,enum=enterprise,default=free"`
+	Question       string `json:"question" jsonschema:"description=The customer's question in their own words"`
+	Screenshot     string `json:"screenshot,omitempty" jsonschema:"description=Optional data: or https: URL of a screenshot the customer attached"`
+	ScreenshotType string `json:"screenshotType,omitempty" jsonschema:"description=Media type of the screenshot for example image/png"`
+}
+
+// Turn is one exchange in the conversation the client keeps. A real app would
+// read these from a session or a database; taking them as data keeps the flows
+// callable over HTTP.
+type Turn struct {
+	Role string `json:"role" jsonschema:"enum=user,enum=model"`
+	Text string `json:"text"`
+}
+
+// SupportTicket is what the flows receive. The conversation is separate from
+// the prompt's input because it is not part of the input schema: it is passed
+// to Execute, and the prompt reaches it either at {{history}} in a template or
+// through [ai.HistoryFromContext] in a function.
+type SupportTicket struct {
+	Request SupportRequest `json:"request"`
+	History []Turn         `json:"history,omitempty" jsonschema:"description=The conversation so far oldest first"`
+}
+
+// Triage is the structured verdict the triage prompt returns.
+type Triage struct {
+	Category string `json:"category" jsonschema:"enum=bug,enum=how-to,enum=billing,enum=other"`
+	Urgency  string `json:"urgency" jsonschema:"enum=low,enum=medium,enum=high"`
+	Summary  string `json:"summary" jsonschema:"description=One sentence restating the customer's problem"`
+}
+
+// knowledgeBase stands in for a retriever. WithDocsFn is the hook where a real
+// app would run a query built from the input.
+var knowledgeBase = map[string][]string{
+	"billing": {
+		"Invoices are issued on the first of the month and cover the previous month's usage.",
+		"A second charge in the same month is usually a pending authorization, which drops off within five business days.",
+	},
+	"setup": {
+		"Set GEMINI_API_KEY in the environment before calling genkit.Init.",
+		"The dev UI runs on port 4000 and the sample servers on port 8080.",
+	},
+	"api": {
+		"Prompt templates use handlebars syntax: {{field}} interpolates a value from the input.",
+		"Content returned by a content function is sent verbatim and is never compiled as a template.",
+	},
+}
+
+func main() {
+	ctx := context.Background()
+
+	// Initialize Genkit with the Google AI plugin. When you pass nil for the
+	// Config parameter, the Google AI plugin will get the API key from the
+	// GEMINI_API_KEY or GOOGLE_API_KEY environment variable, which is the
+	// recommended practice.
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+
+	DefineSupportAnswer(g)
+	DefineTriage(g)
+
+	// Optionally, start a web server to make the flows callable via HTTP.
+	mux := http.NewServeMux()
+	for _, a := range genkit.ListFlows(g) {
+		mux.HandleFunc("POST /"+a.Name(), genkit.Handler(a))
+	}
+	log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+}
+
+// DefineSupportAnswer demonstrates all four content functions working from one
+// input: system text chosen by branching, a trimmed conversation, multi-part
+// user content, and documents selected from a field.
+func DefineSupportAnswer(g *genkit.Genkit) {
+	supportPrompt := genkit.DefinePrompt(
+		g, "support",
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		// WithInputType fixes the type every content function below receives.
+		// Genkit converts whatever the caller passed into it, so one function
+		// covers the in-process call, the default input, and a run from the
+		// Dev UI. The values here are the defaults when a caller sends none.
+		ai.WithInputType(SupportRequest{Area: "api", Tier: "free"}),
+
+		// A function fits here because the instruction is built by branching on
+		// the data rather than by filling in blanks. Its result is used
+		// verbatim, so nothing in it has to be escaped.
+		ai.WithSystemFn(func(ctx context.Context, in SupportRequest) (string, error) {
+			var b strings.Builder
+			b.WriteString("You are a support agent. Answer from the reference material you were given, and say so plainly when it does not cover the question.")
+			switch in.Tier {
+			case "enterprise":
+				b.WriteString(" This is an enterprise customer: be thorough, and offer to escalate to an engineer.")
+			case "pro":
+				b.WriteString(" This is a pro customer: be direct and specific.")
+			default:
+				b.WriteString(" Keep the answer to a few sentences and point at the docs where you can.")
+			}
+			return b.String(), nil
+		}),
+
+		// The conversation slot. A prompt that declares it owns it: the messages
+		// passed to Execute are not spliced in behind your back, they arrive
+		// here through HistoryFromContext so the function can trim, summarize,
+		// or reorder them. Keeping the tail and replacing the rest with a note
+		// is what holds a long ticket inside the context window.
+		ai.WithMessagesFn(func(ctx context.Context, in SupportRequest) ([]*ai.Message, error) {
+			history := ai.HistoryFromContext(ctx)
+			if len(history) <= maxHistoryMessages {
+				return history, nil
+			}
+			// Drop forward to a user turn so what is kept starts with a whole
+			// exchange rather than an orphaned model reply.
+			dropped := len(history) - maxHistoryMessages
+			for dropped < len(history) && history[dropped].Role != ai.RoleUser {
+				dropped++
+			}
+			note := ai.NewUserTextMessage(fmt.Sprintf("(%d earlier messages in this ticket were omitted for brevity.)", dropped))
+			return append([]*ai.Message{note}, history[dropped:]...), nil
+		}),
+
+		// Multi-part user content: the question, plus the screenshot when the
+		// customer attached one. Returning parts is how a function reaches
+		// non-text content; a plain string function can only produce text.
+		ai.WithPromptPartsFn(func(ctx context.Context, in SupportRequest) ([]*ai.Part, error) {
+			// The question is used verbatim, so a customer asking about {{#if}}
+			// is quoted to the model rather than compiled as a template.
+			parts := []*ai.Part{ai.NewTextPart(in.Question)}
+			if in.Screenshot != "" {
+				parts = append(parts,
+					ai.NewTextPart("The customer attached this screenshot:"),
+					ai.NewMediaPart(in.ScreenshotType, in.Screenshot))
+			}
+			return parts, nil
+		}),
+
+		// Retrieval driven by the input. A real app would run a query against a
+		// retriever built from these fields; what comes back becomes the
+		// request's context documents.
+		ai.WithDocsFn(func(ctx context.Context, in SupportRequest) ([]*ai.Document, error) {
+			var docs []*ai.Document
+			for _, text := range knowledgeBase[in.Area] {
+				docs = append(docs, ai.DocumentFromText(text, map[string]any{"area": in.Area}))
+			}
+			return docs, nil
+		}),
+	)
+
+	genkit.DefineStreamingFlow(g, "supportFlow",
+		func(ctx context.Context, ticket SupportTicket, sendChunk core.StreamCallback[string]) (string, error) {
+			stream := supportPrompt.ExecuteStream(ctx,
+				ai.WithInput(ticket.Request),
+				// The conversation is passed per execution rather than baked
+				// into the prompt. WithMessagesFn above decides what to do with
+				// it; without a prompt that claims the slot, it would simply
+				// become the middle of the conversation.
+				ai.WithMessages(toMessages(ticket.History)...),
+			)
+
+			for result, err := range stream {
+				if err != nil {
+					return "", fmt.Errorf("could not answer the ticket: %w", err)
+				}
+				if result.Done {
+					return result.Response.Text(), nil
+				}
+				sendChunk(ctx, result.Chunk.Text())
+			}
+
+			return "", nil
+		},
+	)
+}
+
+// DefineTriage demonstrates the template side of the same split. The wording is
+// fixed and only values vary, so text is the right tool: one multi-turn template
+// carries a worked example and marks where the real conversation goes.
+func DefineTriage(g *genkit.Genkit) {
+	triagePrompt := genkit.DefineDataPrompt[SupportRequest, *Triage](
+		g, "triage",
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		// System and user text are compiled against the input, so they can
+		// reference its fields.
+		ai.WithSystem("You are a support triage assistant. Classify the {{area}} question from this {{tier}} customer."),
+		// Each {{role}} block starts a new message, so a single string can
+		// carry a worked example ahead of the real conversation. {{history}}
+		// is where the messages passed to Execute land. Without the marker
+		// they are inserted just before the final user turn.
+		ai.WithMessagesTemplate(`{{role "user"}}My deploys started failing with a 401 right after I rotated keys.
+{{role "model"}}{"category": "bug", "urgency": "high", "summary": "Deploys fail with a 401 after a key rotation."}
+{{history}}`),
+		// A value interpolated into a template is substituted, not compiled, so
+		// a question containing {{#if}} is safe here too. What was never safe
+		// was feeding computed text back through the compiler, which is why the
+		// function results above are verbatim.
+		ai.WithPrompt("{{question}}"),
+	)
+
+	genkit.DefineFlow(g, "triageFlow",
+		func(ctx context.Context, ticket SupportTicket) (*Triage, error) {
+			triage, _, err := triagePrompt.Execute(ctx, ticket.Request,
+				ai.WithMessages(toMessages(ticket.History)...))
+			if err != nil {
+				return nil, fmt.Errorf("could not triage the ticket: %w", err)
+			}
+			return triage, nil
+		},
+	)
+}
+
+// toMessages converts the app's own turns into Genkit messages. Message text is
+// used verbatim, so a customer who typed {{#if}} is quoted rather than compiled.
+func toMessages(turns []Turn) []*ai.Message {
+	messages := make([]*ai.Message, 0, len(turns))
+	for _, t := range turns {
+		if t.Role == "model" {
+			messages = append(messages, ai.NewModelTextMessage(t.Text))
+			continue
+		}
+		messages = append(messages, ai.NewUserTextMessage(t.Text))
+	}
+	return messages
+}

--- a/go/samples/basic-prompts/main.go
+++ b/go/samples/basic-prompts/main.go
@@ -43,6 +43,12 @@
 //	curl -N -X POST http://localhost:8080/assistantPromptFlow \
 //	  -H "Content-Type: application/json" \
 //	  -d '{"data": "what files are in my current directory?"}'
+//
+// Test a multi-turn chat flow, where the conversation is passed per execution:
+//
+//	curl -N -X POST http://localhost:8080/chatPromptFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": {"question": "What did I just ask you?", "history": [{"role": "user", "text": "How do I read a file in Go?"}, {"role": "model", "text": "Use os.ReadFile."}]}}'
 package main
 
 import (
@@ -98,6 +104,26 @@ type AssistantRequest struct {
 	Query string `json:"query" jsonschema:"description=The user's query or request"`
 }
 
+// ChatRequest is the chat prompt's input: just the new question. The
+// conversation is deliberately not in here, since it is passed to Execute and
+// placed by the prompt itself.
+type ChatRequest struct {
+	Question string `json:"question" jsonschema:"description=The new question to answer"`
+}
+
+// ChatTurn is one exchange in the conversation the client keeps.
+type ChatTurn struct {
+	Role string `json:"role" jsonschema:"enum=user,enum=model"`
+	Text string `json:"text"`
+}
+
+// ChatSession is what the chat flows receive: the new question plus the
+// conversation it continues.
+type ChatSession struct {
+	Question string     `json:"question"`
+	History  []ChatTurn `json:"history,omitempty" jsonschema:"description=The conversation so far oldest first"`
+}
+
 func main() {
 	ctx := context.Background()
 
@@ -110,7 +136,7 @@ func main() {
 	// Define schemas for the expected input and output types so that the Dotprompt files can reference them.
 	// Alternatively, you can specify the JSON schema by hand in the Dotprompt metadata.
 	// Code-defined prompts do not need to have schemas defined in advance but they too can reference them.
-	genkit.DefineSchemasFor(g, JokeRequest{}, Joke{}, RecipeRequest{}, Recipe{}, AssistantRequest{})
+	genkit.DefineSchemasFor(g, JokeRequest{}, Joke{}, RecipeRequest{}, Recipe{}, AssistantRequest{}, ChatRequest{})
 
 	// TODO: Include partials and helpers.
 
@@ -123,6 +149,8 @@ func main() {
 	DefineRecipeWithDotprompt(g)
 	DefineAssistantWithInlinePrompt(g)
 	DefineAssistantWithDotprompt(g)
+	DefineChatWithInlinePrompt(g)
+	DefineChatWithDotprompt(g)
 
 	// Optionally, start a web server to make the flows callable via HTTP.
 	mux := http.NewServeMux()
@@ -383,4 +411,82 @@ func DefineAssistantWithDotprompt(g *genkit.Genkit) {
 			return "", nil
 		},
 	)
+}
+
+// DefineChatWithInlinePrompt demonstrates the simplest multi-turn prompt: one that
+// declares no conversation of its own. The messages passed to Execute become the
+// whole middle of the request, between the system message and the user prompt, so
+// nothing has to say where they go.
+func DefineChatWithInlinePrompt(g *genkit.Genkit) {
+	chatPrompt := genkit.DefinePrompt(
+		g, "chat.code",
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithInputType(ChatRequest{}),
+		ai.WithSystem("You are a helpful AI assistant named Walt. Keep replies to a few sentences."),
+		ai.WithPrompt("{{question}}"),
+	)
+
+	genkit.DefineStreamingFlow(g, "chatPromptFlow",
+		func(ctx context.Context, session ChatSession, sendChunk core.StreamCallback[string]) (string, error) {
+			stream := chatPrompt.ExecuteStream(ctx,
+				ai.WithInput(ChatRequest{Question: session.Question}),
+				// Placed for us, because the prompt claims no conversation
+				// slot. A prompt that does claim one, as chat.prompt below
+				// does, decides where these land instead.
+				ai.WithMessages(chatMessages(session.History)...),
+			)
+			for result, err := range stream {
+				if err != nil {
+					return "", fmt.Errorf("chat error: %w", err)
+				}
+				if result.Done {
+					return result.Response.Text(), nil
+				}
+				sendChunk(ctx, result.Chunk.Text())
+			}
+			return "", nil
+		},
+	)
+}
+
+// DefineChatWithDotprompt demonstrates the other end: a prompt that does claim the
+// conversation slot. A .prompt file's body is a multi-turn template, which is what
+// ai.WithMessagesTemplate is in code, so chat.prompt can script an opening exchange
+// and then mark where the real conversation goes with {{history}}. Claiming the slot
+// means placing it: without the marker the caller's messages would be inserted before
+// the template's final user turn, and a template that ends elsewhere would drop them.
+func DefineChatWithDotprompt(g *genkit.Genkit) {
+	genkit.DefineStreamingFlow(g, "chatDotpromptFlow",
+		func(ctx context.Context, session ChatSession, sendChunk core.StreamCallback[string]) (string, error) {
+			chatPrompt := genkit.LookupPrompt(g, "chat")
+			stream := chatPrompt.ExecuteStream(ctx,
+				ai.WithInput(ChatRequest{Question: session.Question}),
+				ai.WithMessages(chatMessages(session.History)...),
+			)
+			for result, err := range stream {
+				if err != nil {
+					return "", fmt.Errorf("chat error: %w", err)
+				}
+				if result.Done {
+					return result.Response.Text(), nil
+				}
+				sendChunk(ctx, result.Chunk.Text())
+			}
+			return "", nil
+		},
+	)
+}
+
+// chatMessages converts the client's turns into Genkit messages. Message text is
+// used verbatim, so a user who typed {{#if}} is quoted rather than compiled.
+func chatMessages(turns []ChatTurn) []*ai.Message {
+	messages := make([]*ai.Message, 0, len(turns))
+	for _, t := range turns {
+		if t.Role == "model" {
+			messages = append(messages, ai.NewModelTextMessage(t.Text))
+			continue
+		}
+		messages = append(messages, ai.NewUserTextMessage(t.Text))
+	}
+	return messages
 }

--- a/go/samples/basic-prompts/prompts/chat.prompt
+++ b/go/samples/basic-prompts/prompts/chat.prompt
@@ -1,0 +1,18 @@
+---
+model: googleai/gemini-flash-latest
+input:
+  schema: ChatRequest
+---
+{{role "system"}}
+You are a helpful AI assistant named Walt. Keep replies to a few sentences.
+
+{{role "user"}}
+Who are you?
+
+{{role "model"}}
+I am Walt. Ask me anything.
+
+{{history}}
+
+{{role "user"}}
+{{question}}

--- a/go/samples/basic-structured/main.go
+++ b/go/samples/basic-structured/main.go
@@ -170,6 +170,20 @@ func DefineStructuredJoke(g *genkit.Genkit) {
 func DefineRecipe(g *genkit.Genkit) {
 	genkit.DefineStreamingFlow(g, "recipeFlow",
 		func(ctx context.Context, input RecipeRequest, sendChunk core.StreamCallback[[]*Ingredient]) (*Recipe, error) {
+			// Generate takes the request the caller already has in hand, so a
+			// prompt that needs string manipulation is simply built first. The
+			// content-function options (WithPromptFn and friends) exist for
+			// registered prompts, where the input arrives from the framework
+			// rather than from an enclosing scope; see the basic-prompt-content
+			// sample for what they buy you there.
+			prompt := fmt.Sprintf(
+				"Create a %s %s recipe for %d people that takes under %d minutes to prepare.",
+				input.Cuisine, input.Dish, input.ServingSize, input.MaxPrepMinutes,
+			)
+			if len(input.DietaryRestrictions) > 0 {
+				prompt += fmt.Sprintf(" Dietary restrictions: %v.", input.DietaryRestrictions)
+			}
+
 			stream := genkit.GenerateDataStream[*Recipe](ctx, g,
 				ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 					ThinkingConfig: &genai.ThinkingConfig{
@@ -177,18 +191,7 @@ func DefineRecipe(g *genkit.Genkit) {
 					},
 				})),
 				ai.WithSystem("You are an experienced chef. Come up with easy, creative recipes."),
-				// Here we are passing WithPromptFn() since our prompt takes some string manipulation to build.
-				// Alternatively, we could pass WithPrompt() with the complete prompt string.
-				ai.WithPromptFn(func(ctx context.Context, _ any) (string, error) {
-					prompt := fmt.Sprintf(
-						"Create a %s %s recipe for %d people that takes under %d minutes to prepare.",
-						input.Cuisine, input.Dish, input.ServingSize, input.MaxPrepMinutes,
-					)
-					if len(input.DietaryRestrictions) > 0 {
-						prompt += fmt.Sprintf(" Dietary restrictions: %v.", input.DietaryRestrictions)
-					}
-					return prompt, nil
-				}),
+				ai.WithPrompt(prompt),
 			)
 
 			for result, err := range stream {

--- a/go/samples/menu/s03.go
+++ b/go/samples/menu/s03.go
@@ -59,9 +59,10 @@ func (ch *chatHistoryStore) Retrieve(sessionID string) chatHistory {
 
 func setup03(g *genkit.Genkit, m ai.Model) error {
 	chatPreamblePrompt := genkit.DefinePrompt(g, "s03_chatPreamble",
-		ai.WithMessages(
-			ai.NewUserTextMessage("Hi. What's on the menu today?"),
-			ai.NewModelTextMessage(`
+		// The turns are a template, so the menu listing is rendered from the
+		// input. Values passed to WithMessages would be used verbatim.
+		ai.WithMessagesTemplate(`{{role "user"}}Hi. What's on the menu today?
+{{role "model"}}
 I am Walt, a helpful AI assistant here at the restaurant.
 I can answer questions about the food on the menu or any other questions
 you have about food in general. I probably can't help you with anything else.
@@ -71,7 +72,6 @@ Here is today's menu:
 {{this.description}}
 {{~/each}}
 Do you have any questions about the menu?`),
-		),
 		ai.WithModel(m),
 		ai.WithInputType(dataMenuQuestionInput{}),
 		ai.WithOutputFormat(ai.OutputFormatText),

--- a/go/samples/prompts/main.go
+++ b/go/samples/prompts/main.go
@@ -282,11 +282,16 @@ func PromptWithMessageHistory(ctx context.Context, g *genkit.Genkit) {
 }
 
 func PromptWithExecuteOverrides(ctx context.Context, g *genkit.Genkit) {
-	// Define prompt with default settings.
+	// Define prompt with default settings. A prompt that declares a
+	// conversation of its own places the caller's messages: {{history}} is
+	// where the ones passed to Execute go. Written with WithMessages, the
+	// opening turn would be the whole conversation and the messages below
+	// would have nowhere to land.
 	helloPrompt := genkit.DefinePrompt(
 		g, "PromptWithExecuteOverrides",
 		ai.WithSystem("You are a helpful AI assistant named Walt."),
-		ai.WithMessages(ai.NewUserTextMessage("Hi, my name is Bob!")),
+		ai.WithMessagesTemplate(`{{role "user"}}Hi, my name is Bob!
+{{history}}`),
 	)
 
 	// Call the model and add additional messages from the user.
@@ -307,15 +312,18 @@ func PromptWithFunctions(ctx context.Context, g *genkit.Genkit) {
 		Theme    string
 	}
 
-	// Define prompt with system and prompt functions.
+	// Define prompt with system and prompt functions. Declaring the input type
+	// on the function is all it takes: Genkit converts whatever the caller
+	// passed, so the same function works for an in-process call, a default
+	// input, and a run from the Dev UI.
 	helloPrompt := genkit.DefinePrompt(
 		g, "PromptWithFunctions",
 		ai.WithInputType(HelloPromptInput{Theme: "pirate"}),
-		ai.WithSystemFn(func(ctx context.Context, input any) (string, error) {
-			return fmt.Sprintf("You are a helpful AI assistant named Walt. Talk in the style of: %s", input.(HelloPromptInput).Theme), nil
+		ai.WithSystemFn(func(ctx context.Context, input HelloPromptInput) (string, error) {
+			return fmt.Sprintf("You are a helpful AI assistant named Walt. Talk in the style of: %s", input.Theme), nil
 		}),
-		ai.WithPromptFn(func(ctx context.Context, input any) (string, error) {
-			return fmt.Sprintf("Hello, my name is %s", input.(HelloPromptInput).UserName), nil
+		ai.WithPromptFn(func(ctx context.Context, input HelloPromptInput) (string, error) {
+			return fmt.Sprintf("Hello, my name is %s", input.UserName), nil
 		}),
 	)
 


### PR DESCRIPTION
Fixes #4108. Stacks on #5875, which relaxes option merging to accumulate or last-win. Every option added here follows its rules.

Reworks how a prompt assembles its messages. Three defects motivate it.

**The `any` argument to a content function had no stable type.** Its concrete Go type depended on how the prompt was invoked, so a function written against the prompt's input type worked in-process and panicked everywhere else:

| Call path | Type the function received |
|---|---|
| `p.Execute(ctx, ai.WithInput(HelloInput{...}))` | `HelloInput` |
| `p.Execute(ctx)`, default input from `WithInputType` | `map[string]any` |
| Dev UI, flows over HTTP, any reflection-API call | `map[string]any` |
| `genkit.Generate(ctx, g, ai.WithPromptFn(...))` | always `nil` |

`go/samples/prompts/main.go` demonstrated the pattern with a type assertion, so the documented usage panicked on two of the three prompt paths the moment anyone opened the Dev UI.

**Computed content was recompiled as a template.** Whatever a content function returned, and the text of every `WithMessages` value, was fed back through dotprompt. A user asking "how do I write `{{#if}}` in handlebars" failed the whole request with `Parse error on line 1: Expecting OpenEndBlock, got: 'EOF'`, text that merely resembled a placeholder was silently substituted, and MCP-fetched prompt messages became a template-injection surface.

**The conversation had no slot.** A `.prompt` file's body was loaded into `WithPrompt`, the slot for the final user turn, because Go had no string form for a multi-turn conversation. `{{history}}` therefore never worked, no prompt could decide where a caller's conversation goes, and prompt-backed agents spliced their session's messages in by hand after the whole rendered prompt.

## Content functions declare their input type

**Before:** the function receives `any`, and its concrete type depends on the caller.

```go
genkit.DefinePrompt(g, "greet",
	ai.WithInputType(HelloInput{Theme: "pirate"}),
	ai.WithPromptFn(func(ctx context.Context, input any) (string, error) {
		// panics from the Dev UI and on the default-input path,
		// where input is a map[string]any
		return "Hello, my name is " + input.(HelloInput).UserName, nil
	}),
)
```

**After:** the function declares the type and Genkit converts whatever arrived.

```go
genkit.DefinePrompt(g, "greet",
	ai.WithInputType(HelloInput{Theme: "pirate"}),
	ai.WithPromptFn(func(ctx context.Context, input HelloInput) (string, error) {
		return "Hello, my name is " + input.UserName, nil
	}),
)
```

`Generate` has no prompt input and passes the zero value rather than `nil`, so the same function is safe there.

The guarantee reaches the Go types inside the declared type, not just the type itself. A function declaring a loose `map[string]any` saw an `int64` for an integer field when the value arrived over the wire, because the reflection API normalizes against the input schema, and a `float64` when an in-process caller passed a struct, because nothing normalized that round trip. `WithInputType` had the same gap building its default input. Both normalize now, so the field has one type on every path.

## An input that cannot reach its content function is classified

The conversion can fail: an input that is neither the declared type nor decodable into it means the function is never called. That is a caller-supplied value going wrong at runtime, so it gets a sentinel rather than a string to match on.

```go
// ai/errors.go. Also matches status.ErrInvalidArgument.
ErrInputTypeMismatch = status.ErrInvalidArgument.Subtype("input type mismatch")
```

It is attached in `coerceFn`, the single point every typed content function's input passes through, so it covers all four slots and both ways the conversion fails (an unrelated struct, and a value that will not decode). The underlying error stays in the chain. It cannot be attached where it is raised: `internal/base` produces it, `core/status` imports `internal/base`, and users cannot import `internal/base` at all.

## Strings are templates, structured content is not

JS compiles `system`, `prompt`, and `messages` only in their **string** form. `Part`, `Part[]` and `MessageData[]` values, and every resolver result, go through `normalizeParts` untouched ([prompt.ts:598](https://github.com/genkit-ai/genkit/blob/main/js/ai/src/prompt.ts#L598)):

```ts
} else if (typeof options.messages === 'string') {
    promptCache.messages = await registry.dotprompt.compile(options.messages);
    ...
} else {
    messages.push(...options.messages);   // MessageData[]: verbatim
}
```

Go recompiled the structured forms and the function results, which JS never does, so this is a parity fix rather than a Go-specific policy. All three string forms now exist in Go and all three are compiled; everything else is content the caller already produced. The call sites do not change, only what they do: `ai.WithMessages(resp.History()...)`, the dominant usage across samples and plugins, used to fail outright on a turn containing `{{`.

Templating had been supplying message copies as a side effect, so removing it made the copying explicit: `renderMessages` clones every message it splices in, from any source. Messages from `WithMessages` live on the prompt and are reused by every execution, and messages from a content function or from execute-time history typically alias a session or the caller's own slice. Middleware stamping metadata is enough to corrupt either one.

## The prompt owns its conversation

JS loads a `.prompt` body into `messages` ([prompt.ts:911](https://github.com/genkit-ai/genkit/blob/main/js/ai/src/prompt.ts#L911)); Go had nowhere to put it. Four defects followed.

**`{{history}}` never worked.** Dotprompt places the caller's conversation at that marker, and inserts it before the template's final user message when the template does not say, but only if the render is handed the messages. Nothing ever passed them, so the marker always expanded to nothing.

```go
// The string form of messages, which Go was missing.
func WithMessagesTemplate(text string, args ...any) PromptOption
```

The `.prompt` loader uses it now, and history reaches it.

**Ownership was inverted.** Because no template could place history, `Prompt.Execute` spliced the caller's messages in at a fixed position, directly after the leading system messages and ahead of everything the prompt itself declared. A prompt that declares its conversation now places them itself, with `{{history}}` in a template or `HistoryFromContext` in a function; one that declares none still gets them in the middle, exactly where they went before. A `.prompt` file lands in the first case but keeps the old order anyway, since dotprompt inserts history before the template's final user message when the template does not say. That is why every existing `.prompt` file test passed unchanged.

**The single-message slots were not enforced.** `WithSystem` and `WithPrompt` each fill exactly one message whose role belongs to the slot, since the surrounding conversation is positioned against them. A `{{role}}` block that split the text took over the conversation; one that produced a single message had its role stamped back to the slot's, so `WithSystem("{{role \"user\"}}hello")` quietly became a system message. Both are now an error naming `WithMessagesTemplate`, as is a marker that merely restates the slot's own role: it means the same thing, that the author is writing turns. JS throws only on the split ([prompt.ts:751](https://github.com/genkit-ai/genkit/blob/main/js/ai/src/prompt.ts#L751)) and discards the role otherwise, so this is a deliberate tightening past parity that rejects only templates whose text already contradicted what they produced.

**Agents assembled their own messages.** `agentLoop` rendered the prompt and then appended `sess.Messages()` itself, so an agent's prompt could never place its conversation: `{{history}}` expanded to nothing and `HistoryFromContext` returned nil on every turn, which put trimming and summarizing an agent's history out of reach. It also mis-ordered a prompt with a user turn, producing `[system, user_prompt, ...history]` where JS pins `[system, ...history, user_prompt]` ([agent_test.ts:3022](https://github.com/genkit-ai/genkit/blob/main/js/ai/tests/agent_test.ts#L3022)).

The session's messages now go to `Render` on a scoped context and the prompt places them, matching what JS has been doing all along ([agent.ts:1498](https://github.com/genkit-ai/genkit/blob/main/js/ai/src/agent.ts#L1498)), internal tag name included. Because the stored conversation is what the prompt placed, an agent that compacts its history compacts its session too, rather than recomputing the compaction from a growing transcript every turn.

History keeps its identity across the render. `convertToPartPointers` handles only text and media, so sending messages through dotprompt and back would have turned tool requests and resources into nil parts and failed schema validation. The stand-ins are marked as history on the way in, and the originals are restored once dotprompt has decided where they go.

## Multi-part content no longer needs a template escape

Before this, the only way to get media out of a content function was to emit a `{{media url=...}}` string and rely on the re-templating defect to expand it.

```go
genkit.Generate(ctx, g,
	ai.WithModelName("googleai/gemini-flash-latest"),
	ai.WithPromptParts(
		ai.NewTextPart("What is in this image?"),
		ai.NewMediaPart("image/png", imageURL),
	),
)
```

```go
func WithSystemParts(parts ...*Part) PromptingOption
func WithPromptParts(parts ...*Part) PromptingOption
func WithSystemPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) PromptingOption
func WithPromptPartsFn[In any](fn func(context.Context, In) ([]*Part, error)) PromptingOption

// Input-driven document selection, the counterpart of the JS DocsResolver.
// DefinePrompt only, since that is the only place the documents are not yet
// known when the option is constructed.
func WithDocsFn[In any](fn func(context.Context, In) ([]*Document, error)) PromptOption
```

`ai.WithDocs` now also applies to `DefinePrompt`, which it previously did not.

## The conversation reaches content functions

```go
// The conversation the prompt was handed, for one that manages its own.
// Counterpart of the history argument JS hands a messages resolver.
func HistoryFromContext(ctx context.Context) []*ai.Message

// Attach a conversation for the next Render to place. Prompt.Execute does this
// itself; this is for callers pairing Render with GenerateWithRequest, which is
// how the agent runtime drives a prompt.
func NewHistoryContext(ctx context.Context, messages []*ai.Message) context.Context
```

A context accessor rather than an extra function argument, since `ctx` is already threaded. `HistoryFromContext` is the function-form counterpart of `{{history}}`: a prompt using `WithMessagesFn` owns the conversation and reads it here to summarize, truncate, or reorder rather than only prepend. `Prompt.Execute` scopes the context to the render alone, so the history does not ride the generate loop into tools and nested prompts.

## The new options merge; one combination is refused

#5875 removes the "cannot set X more than once" errors from `ai/option.go`, so each option added here needed a merge rule rather than a conflict.

**The system and prompt slots hold one message each**, so their four setters share a slot and the last one set wins:

```go
// The parts win the slot outright. They are not appended to the text.
ai.WithSystem("You are terse."),
ai.WithSystemParts(ai.NewTextPart("You are verbose."), logoPart),
```

The losing field is cleared rather than left behind, since both feed the same message and the renderer has to read them in some fixed order. Before this, a function beat text no matter which came first, silently.

**Documents accumulate**, so `WithDocsFn` adds to `WithDocs` and `WithTextDocs` rather than replacing them. Fixed documents resolve first, then computed ones.

**The conversation follows both rules, with one combination refused.** `WithMessages` and `WithMessagesFn` accumulate; `WithMessagesTemplate` is a slot whose last setter wins. Giving a template alongside either of the others in one `DefinePrompt` call panics:

```
ai.DefinePrompt: "chat" sets both WithMessagesTemplate and WithMessages/WithMessagesFn,
which have no meaningful combination: the template is the whole conversation.
```

A template lays the conversation out, down to where `{{history}}` puts the caller's, so separately supplied messages have no position relative to it: before it they are dropped, after it they land past the template's own final user turn, where few-shot examples are useless. Anything with a sensible position is already a `{{role}}` block in the template. This is a wiring mistake rather than two values competing for one slot, which is the class #5875 stopped rejecting, so it panics at definition where the offending call is, as `DefinePrompt` already does for a missing name and bad middleware.

The pairing that matters is protected by the type rather than a check: `WithMessagesTemplate` is a `PromptOption`, so it can never reach `Prompt.Execute`, which is where a caller's conversation comes from and how it reaches `{{history}}`.

## Source compatible; the runtime changes are the point

Nothing exported was removed or renamed, and `PromptFn` / `MessagesFn` still exist. The generic retrofit is source compatible: a function with the old `func(context.Context, any)` signature still satisfies the option with `In` inferred as `any`. The one construct that breaks is using `ai.WithPromptFn` as an un-instantiated function value, which no code in this repo does. `DocumentOption` gained a method, but all of its methods are unexported, so no external package can have implemented it.

Runtime impact is real and intended:

- Results of `WithSystemFn` / `WithPromptFn` / `WithMessagesFn`, and the text of `WithMessages` values, are no longer rendered as templates. This reaches exactly one class of input, text containing handlebars syntax that was previously expanded; text with no braces behaves identically. `go/samples/menu/s03.go` is the in-repo case: it built its chat preamble as a `{{#each menuData}}` template inside `WithMessages`, and moves to `WithMessagesTemplate`, which is what it always was.
- A content function returning `""` produces no message, where it previously produced an empty one that some providers reject.
- A `{{role}}` marker in `WithSystem` or `WithPrompt` is an error, including one that produced a single message and was previously overridden in silence. `.prompt` files are unaffected, since their bodies moved to the conversation slot.
- A prompt that declares messages no longer has execute-time history spliced in ahead of them, and places it with `{{history}}` or `HistoryFromContext` instead. A prompt that declares none is unchanged.
- The same rule reaches prompt-backed agents. A prompt with a user turn sees `[system, ...history, user_prompt]` rather than the conversation trailing it, and one that declares static `WithMessages` and never places the conversation no longer has one, which is what JS does too. `{{history}}` and `HistoryFromContext` work inside an agent for the first time.
- Loose targets receive schema-normalized values, so an integer field arrives as `int64` where an in-process caller previously saw `float64`. Normalization also drops null-valued keys, matching wire behavior.
- Via `base.ConvertTo`, three public lookups (`ai.ResumedValue`, `ai.OriginalInputAs`, `exp/tool.OriginalInput`) report `false` for an unrelated struct instead of `true` with a zeroed value.

## What this does not do

- **A template places history but cannot inspect it.** The messages handed to dotprompt are stand-ins carrying roles and the text of text parts; media, tool requests, and resources appear as empty text. The originals are restored after placement, so what reaches the model is intact, but a template that tries to read history sees text only.
- **Execute-time `WithDocs` replaces rather than accumulates.** When an execution supplies its own documents, `buildRequest` skips the prompt's `WithDocsFn` entirely rather than resolving and discarding it, since the retrieval it exists for costs a query.
- **No new session-state accessor.** A content function on an agent's prompt reaches the live session with `exp.SessionFromContext`, which hands back the concrete state with no round trip, and templates reach the same values as `{{@state}}` without naming a type at all.
- **The `{{role}}` check is a regex over template source.** Matching the rendered messages cannot work, since dotprompt's default role is `user`. A rendered role that disagrees with the slot is caught as a fallback, but a marker constructed at render time is not.

## Testing

Go 1.26.3, full `go test ./...` in `go/`: 41 packages pass, no failures. `-race` clean across `ai/...`, `genkit/...`, and `core/...` (10 packages), and `GOMAXPROCS=1 -count=3` clean on `ai/exp/...`. `TestAgentConformance`, which drives the shared `tests/specs/agent.yaml`, passes 10 consecutive runs.

`go/ai/prompt_fn_test.go` adds 26 test functions, `go/ai/exp/agent_history_test.go` 3, and `go/internal/base/convert_test.go` 3. They cover both call paths that used to panic, both ways the input conversion fails, and every placement form across multiple turns, asserting the model request and what the session is left holding. The copying tests fail when the clone is removed.

Two obsolete tests became coverage of the new rules: the text-versus-parts conflict test now asserts that the later option holds the slot and the earlier field is cleared, and the `WithMessages` normalization test became `TestConversationMergeSemantics`, which pins accumulation before and after a template and the template's own last-win.

`ai/exp` state-transform fixtures now build their errors with sentinels, and two additionally assert `errors.Is` on `AgentOutput.Error`. The runtime rebuilds a failure onto that field rather than passing the value through, and nothing pinned that the classification survived it.
