### PR TITLE
fix(go/ai): make `ModelResponse.History` nil-safe and stop aliasing request messages

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1131,12 +1131,21 @@ func (mr *ModelResponse) Text() string {
 }
 
 // History returns messages from the request combined with the response message
-// to represent the conversation history.
+// to represent the conversation history. The result is always freshly
+// allocated, so callers may retain or append to it without disturbing
+// Request.Messages.
 func (mr *ModelResponse) History() []*Message {
-	if mr == nil || mr.Message == nil {
-		return mr.Request.Messages
+	if mr == nil {
+		return nil
 	}
-	return append(mr.Request.Messages, mr.Message)
+	var reqMsgs []*Message
+	if mr.Request != nil {
+		reqMsgs = mr.Request.Messages
+	}
+	if mr.Message == nil {
+		return slices.Clone(reqMsgs)
+	}
+	return append(slices.Clone(reqMsgs), mr.Message)
 }
 
 // Reasoning concatenates all reasoning parts present in the message

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1145,7 +1145,10 @@ func (mr *ModelResponse) History() []*Message {
 	if mr.Message == nil {
 		return slices.Clone(reqMsgs)
 	}
-	return append(slices.Clone(reqMsgs), mr.Message)
+	history := make([]*Message, len(reqMsgs)+1)
+	copy(history, reqMsgs)
+	history[len(reqMsgs)] = mr.Message
+	return history
 }
 
 // Reasoning concatenates all reasoning parts present in the message

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2376,6 +2376,102 @@ func TestModelResponseReasoning(t *testing.T) {
 	})
 }
 
+func TestModelResponseHistory(t *testing.T) {
+	userMsg := NewUserTextMessage("question")
+	modelMsg := NewModelTextMessage("answer")
+
+	t.Run("combines request messages with the response message", func(t *testing.T) {
+		resp := &ModelResponse{
+			Request: &ModelRequest{Messages: []*Message{userMsg}},
+			Message: modelMsg,
+		}
+
+		history := resp.History()
+
+		if len(history) != 2 || history[0] != userMsg || history[1] != modelMsg {
+			t.Errorf("History() = %v, want [userMsg modelMsg]", history)
+		}
+	})
+
+	t.Run("returns nil for a nil response", func(t *testing.T) {
+		var resp *ModelResponse
+
+		if history := resp.History(); history != nil {
+			t.Errorf("History() = %v, want nil", history)
+		}
+	})
+
+	t.Run("returns the response message when request is nil", func(t *testing.T) {
+		resp := &ModelResponse{Message: modelMsg}
+
+		history := resp.History()
+
+		if len(history) != 1 || history[0] != modelMsg {
+			t.Errorf("History() = %v, want [modelMsg]", history)
+		}
+	})
+
+	t.Run("returns request messages when response message is nil", func(t *testing.T) {
+		resp := &ModelResponse{Request: &ModelRequest{Messages: []*Message{userMsg}}}
+
+		history := resp.History()
+
+		if len(history) != 1 || history[0] != userMsg {
+			t.Errorf("History() = %v, want [userMsg]", history)
+		}
+	})
+
+	t.Run("returns nil when request and response message are both nil", func(t *testing.T) {
+		resp := &ModelResponse{}
+
+		if history := resp.History(); history != nil {
+			t.Errorf("History() = %v, want nil", history)
+		}
+	})
+
+	// Request.Messages with spare capacity used to let History() append into the
+	// caller's backing array, so the result aliased whatever else pointed at it.
+	t.Run("does not write into spare capacity of request messages", func(t *testing.T) {
+		backing := make([]*Message, 3, 8)
+		backing[0], backing[1], backing[2] = userMsg, modelMsg, userMsg
+		sentinel := NewUserTextMessage("caller owns this slot")
+		extended := backing[:4]
+		extended[3] = sentinel
+
+		resp := &ModelResponse{
+			Request: &ModelRequest{Messages: backing},
+			Message: modelMsg,
+		}
+
+		resp.History()
+
+		if extended[3] != sentinel {
+			t.Errorf("History() overwrote the caller's backing array at index 3: got %v, want the sentinel", extended[3])
+		}
+	})
+
+	t.Run("successive calls return independent slices", func(t *testing.T) {
+		backing := make([]*Message, 3, 8)
+		backing[0], backing[1], backing[2] = userMsg, modelMsg, userMsg
+		resp := &ModelResponse{
+			Request: &ModelRequest{Messages: backing},
+			Message: modelMsg,
+		}
+
+		first := resp.History()
+		replacement := NewModelTextMessage("second answer")
+		resp.Message = replacement
+		second := resp.History()
+
+		if first[3] != modelMsg {
+			t.Errorf("first History() result was mutated by the second call: got %v, want the original model message", first[3])
+		}
+		if second[3] != replacement {
+			t.Errorf("second History() = %v at index 3, want the replacement message", second[3])
+		}
+	})
+}
+
 func TestModelResponseInterrupts(t *testing.T) {
 	t.Run("returns interrupt tool requests", func(t *testing.T) {
 		interruptPart := NewToolRequestPart(&ToolRequest{


### PR DESCRIPTION
Fixes three panic paths and a slice-aliasing defect in `ModelResponse.History`, found while verifying #4683.

The nil guard dereferenced the receiver it was checking: `if mr == nil` fell through to `return mr.Request.Messages`. `Request` is nil-able independently of the receiver and is nil in shipped code, since the Veo background model stashes its request in `Metadata["inputRequest"]` and never assigns it, so `op.Output.History()` panicked on any Veo operation. A response with neither field set panicked back in the guard.

Separately, `append(mr.Request.Messages, mr.Message)` reused spare capacity in `Request.Messages` when it had any, writing the response message into a slot the caller still owned. The result aliased anything else pointing into that array, and two calls on one response returned slices sharing the element each had just written.

`History` now returns early on a nil receiver, treats a nil `Request` as no prior messages, and builds the result with `slices.Clone`, which also preserves the old nil return for the empty case.

`TestModelResponseHistory` covers seven cases: five panic or fail on `main`, two pin behavior that already worked. Go 1.26.3, full `go test ./...` in `go/`: 40 packages pass, 0 fail.

Populating `Request` on every model path is a plugin-contract change and belongs with the `compat_oai` streaming gap in #5239.
