### PR TITLE
fix(js/ai): clarify parts template single-message error

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -749,7 +749,11 @@ async function renderDotpromptToParts<
     },
   });
   if (renderred.messages.length !== 1) {
-    throw new Error('parts tempate must produce only one message');
+    throw new Error(
+      `Prompt parts template must produce exactly one message, but produced ${renderred.messages.length}. ` +
+        'String values for `system`/`prompt` are rendered as message parts and must not expand into multiple messages. ' +
+        'Use `messages` (or a multi-message prompt) when you need more than one message.'
+    );
   }
   return renderred.messages[0].content;
 }

--- a/js/ai/tests/prompt/prompt_test.ts
+++ b/js/ai/tests/prompt/prompt_test.ts
@@ -900,6 +900,30 @@ describe('prompt', () => {
       'Manual AbortSignal should be an AbortSignal instance'
     );
   });
+
+  it('throws a clear error when a parts template produces multiple messages', async () => {
+    // Regression for #3762: string `prompt`/`system` values are rendered as
+    // parts and must expand to exactly one message.
+    const prompt = definePrompt(registry, {
+      name: 'multiMessagePartsPrompt',
+      model: 'echoModel',
+      prompt: '{{role "user"}}hello\n{{role "model"}}world',
+    });
+
+    await assert.rejects(
+      () => prompt.render({}),
+      (err: any) => {
+        assert.ok(err instanceof Error);
+        assert.match(
+          err.message,
+          /Prompt parts template must produce exactly one message, but produced 2/
+        );
+        assert.doesNotMatch(err.message, /tempate/);
+        assert.match(err.message, /Use `messages`/);
+        return true;
+      }
+    );
+  });
 });
 
 function stripUndefined(input: any) {


### PR DESCRIPTION
## Summary
- Fix the misspelled `parts tempate` error thrown when a string `system`/`prompt` template renders to something other than exactly one message.
- Include the actual message count and point users toward `messages` for multi-message prompts.
- Add a regression test covering the multi-message case.

Fixes #3762

## Test plan
- [x] `node --import tsx --test ./tests/prompt/prompt_test.ts` in `js/ai` (27 passing)
- [x] Regression test for multi-message template case (clearer error + fixed spelling)

