### PR TITLE
fix(py): surface interrupt reason on nested tool restart errors

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -39,7 +39,7 @@ from genkit._ai._model import (
     text_from_content,
 )
 from genkit._ai._resource import ResourceArgument, ResourceInput, find_matching_resource, resolve_resources
-from genkit._ai._tools import Interrupt, Tool, run_tool_after_restart, run_tool_request
+from genkit._ai._tools import Interrupt, Tool, restart_interrupt_error, run_tool_after_restart, run_tool_request
 from genkit._core._action import (
     GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR,
     Action,
@@ -1540,14 +1540,14 @@ async def _run_restart_through_middleware(
     try:
         multipart = await dispatch_tool(mw_list, params, mw_pipeline.ctx, next_fn)
     except Exception as e:
-        if _interrupt_from_tool_exc(e) is not None:
+        intr = _interrupt_from_tool_exc(e)
+        if intr is not None:
             # Re-interrupting during restart is a hard error — same as the legacy
             # run_tool_after_restart path, which raises FAILED_PRECONDITION when
-            # the inner tool throws an Interrupt during restart.
-            raise GenkitError(
-                status='FAILED_PRECONDITION',
-                message='Tool interrupted again during a restart execution; not supported yet.',
-            ) from e
+            # the inner tool throws an Interrupt during restart. Surface the
+            # underlying interrupt reason so callers know why (e.g. missing
+            # toolApproved metadata for ToolApproval).
+            raise restart_interrupt_error(intr) from e
         raise
 
     return ToolResponsePart(

--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -277,7 +277,15 @@ def restart_interrupt_error(interrupt: Interrupt) -> GenkitError:
     interrupt reason (e.g. ToolApproval's ``Tool not in approved list: ...``) so the
     error points at missing approval metadata instead of sounding like a missing SDK feature.
     """
-    reason = interrupt.metadata.get('message') if interrupt.metadata else None
+    metadata = interrupt.metadata
+    if isinstance(metadata, dict):
+        reason = metadata.get('message')
+    elif isinstance(metadata, str):
+        # Defensive: Interrupt is typed as dict metadata, but a plain string
+        # argument would land here and must not AttributeError on .get().
+        reason = metadata
+    else:
+        reason = None
     if isinstance(reason, str) and reason.strip():
         message = f'Tool interrupted again during restart: {reason}'
     else:

--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -270,6 +270,21 @@ async def run_tool_request(
         _tool_original_input.reset(token_input)
 
 
+def restart_interrupt_error(interrupt: Interrupt) -> GenkitError:
+    """Build the FAILED_PRECONDITION error for an Interrupt raised during tool restart.
+
+    Nested interrupts during restart are not supported yet. Include the underlying
+    interrupt reason (e.g. ToolApproval's ``Tool not in approved list: ...``) so the
+    error points at missing approval metadata instead of sounding like a missing SDK feature.
+    """
+    reason = interrupt.metadata.get('message') if interrupt.metadata else None
+    if isinstance(reason, str) and reason.strip():
+        message = f'Tool interrupted again during restart: {reason}'
+    else:
+        message = 'Tool interrupted again during a restart execution; not supported yet.'
+    return GenkitError(status='FAILED_PRECONDITION', message=message, cause=interrupt)
+
+
 async def run_tool_after_restart(
     *,
     tool: Action,
@@ -290,11 +305,7 @@ async def run_tool_after_restart(
             else (e if isinstance(e, Interrupt) else None)
         )
         if intr is not None:
-            raise GenkitError(
-                status='FAILED_PRECONDITION',
-                message='Tool interrupted again during a restart execution; not supported yet.',
-                cause=intr,
-            ) from e
+            raise restart_interrupt_error(intr) from e
         raise
 
     return ToolResponsePart(

--- a/py/packages/genkit/tests/genkit/ai/_tools_test.py
+++ b/py/packages/genkit/tests/genkit/ai/_tools_test.py
@@ -12,6 +12,7 @@ from genkit._ai._tools import (
     _tool_original_input,
     _tool_resumed_metadata,
     respond_to_interrupt,
+    restart_interrupt_error,
     restart_tool,
     run_tool_after_restart,
 )
@@ -178,6 +179,14 @@ async def test_run_tool_after_restart_nested_interrupt_raises() -> None:
     assert ei.value.status == 'FAILED_PRECONDITION'
     assert 'interrupted again' in ei.value.original_message.lower()
     assert isinstance(ei.value.cause, Interrupt)
+
+
+def test_restart_interrupt_error_accepts_string_metadata() -> None:
+    """Plain-string Interrupt metadata must not crash; use it as the reason."""
+    intr = Interrupt('plain string reason')  # type: ignore[arg-type]
+    err = restart_interrupt_error(intr)
+    assert err.status == 'FAILED_PRECONDITION'
+    assert err.original_message == 'Tool interrupted again during restart: plain string reason'
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/_tools_test.py
+++ b/py/packages/genkit/tests/genkit/ai/_tools_test.py
@@ -177,6 +177,32 @@ async def test_run_tool_after_restart_nested_interrupt_raises() -> None:
         await run_tool_after_restart(tool=action, restart_trp=restart_trp)
     assert ei.value.status == 'FAILED_PRECONDITION'
     assert 'interrupted again' in ei.value.original_message.lower()
+    assert isinstance(ei.value.cause, Interrupt)
+
+
+@pytest.mark.asyncio
+async def test_run_tool_after_restart_nested_interrupt_includes_reason() -> None:
+    """Nested restart Interrupt with ``metadata.message`` is surfaced in the GenkitError text."""
+    ai = Genkit()
+
+    @ai.tool(name='t3')
+    async def t3(inp: dict, ctx: ToolRunContext) -> str:  # noqa: ARG001
+        raise Interrupt({'message': 'Tool not in approved list: t3'})
+
+    action = await ai.registry.resolve_action(kind=ActionKind.TOOL, name='t3')
+    assert action is not None
+
+    restart_trp = ToolRequestPart(
+        tool_request=ToolRequest(name='t3', ref='x', input={}),
+        metadata={'resumed': True},
+    )
+    with pytest.raises(GenkitError) as ei:
+        await run_tool_after_restart(tool=action, restart_trp=restart_trp)
+    assert ei.value.status == 'FAILED_PRECONDITION'
+    assert ei.value.original_message == (
+        'Tool interrupted again during restart: Tool not in approved list: t3'
+    )
+    assert isinstance(ei.value.cause, Interrupt)
 
 
 def test_respond_to_interrupt_wire_format_basic() -> None:

--- a/py/packages/genkit/tests/genkit/ai/_tools_test.py
+++ b/py/packages/genkit/tests/genkit/ai/_tools_test.py
@@ -208,9 +208,7 @@ async def test_run_tool_after_restart_nested_interrupt_includes_reason() -> None
     with pytest.raises(GenkitError) as ei:
         await run_tool_after_restart(tool=action, restart_trp=restart_trp)
     assert ei.value.status == 'FAILED_PRECONDITION'
-    assert ei.value.original_message == (
-        'Tool interrupted again during restart: Tool not in approved list: t3'
-    )
+    assert ei.value.original_message == ('Tool interrupted again during restart: Tool not in approved list: t3')
     assert isinstance(ei.value.cause, Interrupt)
 
 

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -23,6 +23,7 @@ from genkit._ai._testing import (
     define_programmable_model,
 )
 from genkit._ai._tools import Interrupt, ToolRunContext, define_tool
+from genkit._core._error import GenkitError
 from genkit._core._model import GenerateActionOptions, ModelRequest
 from genkit._core._registry import Registry
 from genkit._core._typing import (
@@ -1760,6 +1761,70 @@ async def test_restart_path_routes_through_wrap_tool_middleware() -> None:
     )
     assert response.text == 'final'
     assert invocations == ['approveMe'], f'expected wrap_tool to fire once on restart, saw: {invocations}'
+
+
+@pytest.mark.asyncio
+async def test_restart_reinterrupt_surfaces_underlying_reason() -> None:
+    """Middleware Interrupt during restart includes the interrupt reason in GenkitError.
+
+    Regression for missing ToolApproval metadata: restart without ``toolApproved``
+    used to raise a generic "not supported yet" message that hid the real cause.
+    """
+    ai = Genkit()
+
+    @ai.middleware(name='approval_mw')
+    class ApprovalMW(BaseMiddleware):
+        async def wrap_tool(
+            self,
+            params: ToolHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
+        ) -> MultipartToolResponse:
+            metadata = params.tool_request_part.metadata or {}
+            resumed = metadata.get('resumed')
+            if isinstance(resumed, dict) and resumed.get('toolApproved'):
+                return await next_fn(params, ctx)
+            raise Interrupt({'message': f'Tool not in approved list: {params.tool.name}'})
+
+    define_programmable_model(ai)
+
+    @ai.tool(name='sensitiveTool')
+    async def sensitive_tool() -> str:
+        return 'done'
+
+    interrupt_part = ToolRequestPart(
+        tool_request=ToolRequest(name='sensitiveTool', input={}, ref='r1'),
+        metadata={'interrupt': True},
+    )
+
+    with pytest.raises(GenkitError) as ei:
+        await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='programmableModel',
+                messages=[
+                    Message(role=Role.USER, content=[Part(TextPart(text='do it'))]),
+                    Message(role=Role.MODEL, content=[Part(root=interrupt_part)]),
+                ],
+                tools=['sensitiveTool'],
+                use=[MiddlewareRef(name='approval_mw')],
+                resume=Resume(
+                    # Restart without toolApproved — middleware re-interrupts.
+                    restart=[
+                        ToolRequestPart(
+                            tool_request=ToolRequest(name='sensitiveTool', input={}, ref='r1'),
+                            metadata={'resumed': True},
+                        )
+                    ],
+                ),
+            ),
+        )
+
+    assert ei.value.status == 'FAILED_PRECONDITION'
+    assert ei.value.original_message == (
+        'Tool interrupted again during restart: Tool not in approved list: sensitiveTool'
+    )
+    assert isinstance(ei.value.cause, Interrupt)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- When a tool restarts and middleware/`Interrupt` fires again (e.g. `ToolApproval` without `toolApproved: True`), include the underlying interrupt reason in the `FAILED_PRECONDITION` error instead of only saying restart interrupts are unsupported.
- Shared via `restart_interrupt_error()` in both `_tools.py` and `_generate.py`; middleware path now also sets `cause=Interrupt`.
- Adds regression tests for the tool-restart path and the wrap_tool middleware restart path.

Fixes #5873

## Test plan
- [x] `pytest` nested restart interrupt unit tests
- [x] `pytest` middleware restart re-interrupt regression test
- [ ] Confirm CLA check passes