### PR TITLE
feat(cli): add -C/--directory option to genkit start

### DIFF
--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -40,28 +40,49 @@ interface RunOptions {
   directory?: string;
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function errorCode(err: unknown): string | undefined {
+  return (err as NodeJS.ErrnoException | undefined)?.code;
+}
+
 /**
  * Resolve `-C/--directory` like git/make: change the process working directory
  * so project-root discovery and spawned app processes run from that location.
- * Returns false when the path is missing or not a directory (error already logged).
+ * Returns false when the path cannot be used (error already logged).
  */
 function chdirIfRequested(directory: string | undefined): boolean {
   if (!directory) {
     return true;
   }
   const dir = path.resolve(directory);
-  let isDirectory = false;
   try {
-    isDirectory = fs.statSync(dir).isDirectory();
-  } catch {
-    logger.error(`Directory not found: ${directory}`);
+    const stat = fs.statSync(dir);
+    if (!stat.isDirectory()) {
+      logger.error(`"${directory}" is not a directory`);
+      return false;
+    }
+  } catch (err) {
+    if (errorCode(err) === 'ENOENT') {
+      logger.error(`Directory not found: ${directory}`);
+    } else {
+      logger.error(
+        `Failed to access directory "${directory}": ${errorMessage(err)}`
+      );
+    }
     return false;
   }
-  if (!isDirectory) {
-    logger.error(`"${directory}" is not a directory`);
+
+  try {
+    process.chdir(dir);
+  } catch (err) {
+    logger.error(
+      `Failed to change directory to "${directory}": ${errorMessage(err)}`
+    );
     return false;
   }
-  process.chdir(dir);
   return true;
 }
 

--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -21,6 +21,7 @@ import { Command } from 'commander';
 import fs from 'fs';
 import getPort, { makeRange } from 'get-port';
 import open from 'open';
+import path from 'path';
 import {
   getDevEnvVars,
   startDevProcessManager,
@@ -36,11 +37,41 @@ interface RunOptions {
   corsOrigin?: string;
   experimentalReflectionV2?: boolean;
   writeEnvFile?: string;
+  directory?: string;
+}
+
+/**
+ * Resolve `-C/--directory` like git/make: change the process working directory
+ * so project-root discovery and spawned app processes run from that location.
+ * Returns false when the path is missing or not a directory (error already logged).
+ */
+function chdirIfRequested(directory: string | undefined): boolean {
+  if (!directory) {
+    return true;
+  }
+  const dir = path.resolve(directory);
+  let isDirectory = false;
+  try {
+    isDirectory = fs.statSync(dir).isDirectory();
+  } catch {
+    logger.error(`Directory not found: ${directory}`);
+    return false;
+  }
+  if (!isDirectory) {
+    logger.error(`"${directory}" is not a directory`);
+    return false;
+  }
+  process.chdir(dir);
+  return true;
 }
 
 /** Command to run code in dev mode and/or the Dev UI. */
 export const start = new Command('start')
   .description('runs a command in Genkit dev mode')
+  .option(
+    '-C, --directory <dir>',
+    'run as if genkit was started in <dir> (change working directory first)'
+  )
   .option('-n, --noui', 'do not start the Dev UI', false)
   .option('-p, --port <port>', 'port for the Dev UI')
   .option(
@@ -66,6 +97,10 @@ export const start = new Command('start')
     'write environment variables in .env format to the provided file'
   )
   .action(async (options: RunOptions) => {
+    if (!chdirIfRequested(options.directory)) {
+      return;
+    }
+
     const projectRoot = await findProjectRoot();
     if (projectRoot.includes('/.Trash/')) {
       logger.warn(

--- a/genkit-tools/cli/tests/commands/start_test.ts
+++ b/genkit-tools/cli/tests/commands/start_test.ts
@@ -15,6 +15,7 @@
  */
 
 import { startServer } from '@genkit-ai/tools-common/server';
+import { logger } from '@genkit-ai/tools-common/utils';
 import {
   afterEach,
   beforeEach,
@@ -23,6 +24,8 @@ import {
   it,
   jest,
 } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
 import { start } from '../../src/commands/start';
 import * as managerUtils from '../../src/utils/manager-utils';
 
@@ -32,6 +35,7 @@ jest.mock('@genkit-ai/tools-common/utils', () => ({
   logger: {
     warn: jest.fn(),
     error: jest.fn(),
+    info: jest.fn(),
   },
 }));
 jest.mock('get-port', () => ({
@@ -144,5 +148,72 @@ describe('start command', () => {
       expect.anything(),
       expect.objectContaining({ disableRealtimeTelemetry: true })
     );
+  });
+
+  it('should chdir when -C/--directory is provided', async () => {
+    const dir = '/some/project';
+    const statSpy = jest.spyOn(fs, 'statSync').mockReturnValue({
+      isDirectory: () => true,
+    } as fs.Stats);
+    const chdirSpy = jest
+      .spyOn(process, 'chdir')
+      .mockImplementation(() => undefined as never);
+
+    try {
+      await start.parseAsync(['node', 'genkit', '-C', dir, 'run', 'app']);
+      expect(chdirSpy).toHaveBeenCalledWith(path.resolve(dir));
+      expect(startDevProcessManagerSpy).toHaveBeenCalledWith(
+        '/mock/root',
+        'run',
+        ['app'],
+        expect.anything()
+      );
+    } finally {
+      statSpy.mockRestore();
+      chdirSpy.mockRestore();
+    }
+  });
+
+  it('should error when -C directory does not exist', async () => {
+    const statSpy = jest.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    const chdirSpy = jest.spyOn(process, 'chdir');
+
+    try {
+      await start.parseAsync(['node', 'genkit', '-C', '/missing', '--noui']);
+      expect(logger.error).toHaveBeenCalledWith('Directory not found: /missing');
+      expect(chdirSpy).not.toHaveBeenCalled();
+      expect(startManagerSpy).not.toHaveBeenCalled();
+      expect(startDevProcessManagerSpy).not.toHaveBeenCalled();
+    } finally {
+      statSpy.mockRestore();
+      chdirSpy.mockRestore();
+    }
+  });
+
+  it('should error when -C path is not a directory', async () => {
+    const statSpy = jest.spyOn(fs, 'statSync').mockReturnValue({
+      isDirectory: () => false,
+    } as fs.Stats);
+    const chdirSpy = jest.spyOn(process, 'chdir');
+
+    try {
+      await start.parseAsync([
+        'node',
+        'genkit',
+        '-C',
+        '/tmp/file.txt',
+        '--noui',
+      ]);
+      expect(logger.error).toHaveBeenCalledWith(
+        '"/tmp/file.txt" is not a directory'
+      );
+      expect(chdirSpy).not.toHaveBeenCalled();
+      expect(startManagerSpy).not.toHaveBeenCalled();
+    } finally {
+      statSpy.mockRestore();
+      chdirSpy.mockRestore();
+    }
   });
 });

--- a/genkit-tools/cli/tests/commands/start_test.ts
+++ b/genkit-tools/cli/tests/commands/start_test.ts
@@ -216,4 +216,45 @@ describe('start command', () => {
       chdirSpy.mockRestore();
     }
   });
+
+  it('should surface non-ENOENT access errors for -C', async () => {
+    const statSpy = jest.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw Object.assign(new Error('EACCES: permission denied'), {
+        code: 'EACCES',
+      });
+    });
+    const chdirSpy = jest.spyOn(process, 'chdir');
+
+    try {
+      await start.parseAsync(['node', 'genkit', '-C', '/secret', '--noui']);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to access directory "/secret": EACCES: permission denied'
+      );
+      expect(chdirSpy).not.toHaveBeenCalled();
+      expect(startManagerSpy).not.toHaveBeenCalled();
+    } finally {
+      statSpy.mockRestore();
+      chdirSpy.mockRestore();
+    }
+  });
+
+  it('should surface chdir failures for -C', async () => {
+    const statSpy = jest.spyOn(fs, 'statSync').mockReturnValue({
+      isDirectory: () => true,
+    } as fs.Stats);
+    const chdirSpy = jest.spyOn(process, 'chdir').mockImplementation(() => {
+      throw new Error('ENOTDIR: not a directory');
+    });
+
+    try {
+      await start.parseAsync(['node', 'genkit', '-C', '/race', '--noui']);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to change directory to "/race": ENOTDIR: not a directory'
+      );
+      expect(startManagerSpy).not.toHaveBeenCalled();
+    } finally {
+      statSpy.mockRestore();
+      chdirSpy.mockRestore();
+    }
+  });
 });

--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -32,8 +32,11 @@ export interface DevToolsInfo {
  * Finds the project root by walking up the directory tree looking for a file
  * that marks the root of a supported runtime's project (for example
  * `package.json` for JS or `pubspec.yaml` for Dart).
+ *
+ * @param startDir Optional directory to start the search from. Defaults to
+ *   `process.cwd()`. Useful for `genkit start -C <dir>` and tests.
  */
-export async function findProjectRoot(): Promise<string> {
+export async function findProjectRoot(startDir?: string): Promise<string> {
   const projectMarkers = [
     'package.json',
     'go.mod',
@@ -44,7 +47,8 @@ export async function findProjectRoot(): Promise<string> {
     'pubspec.yaml',
   ];
 
-  let currentDir = process.cwd();
+  const fallback = path.resolve(startDir ?? process.cwd());
+  let currentDir = fallback;
   while (currentDir !== path.parse(currentDir).root) {
     const results = await Promise.all(
       projectMarkers.map((file) => markerExists(path.join(currentDir, file)))
@@ -54,7 +58,7 @@ export async function findProjectRoot(): Promise<string> {
     }
     currentDir = path.dirname(currentDir);
   }
-  return process.cwd();
+  return fallback;
 }
 
 /**

--- a/genkit-tools/common/tests/utils/utils_test.ts
+++ b/genkit-tools/common/tests/utils/utils_test.ts
@@ -79,6 +79,23 @@ describe('utils', () => {
         cwdSpy.mockRestore();
       }
     });
+
+    it('honors an explicit startDir independent of process.cwd()', async () => {
+      const projectDir = path.join(tmpDir, 'js-app');
+      const nestedDir = path.join(projectDir, 'src');
+      const otherCwd = path.join(tmpDir, 'elsewhere');
+      fs.mkdirSync(nestedDir, { recursive: true });
+      fs.mkdirSync(otherCwd, { recursive: true });
+      fs.writeFileSync(path.join(projectDir, 'package.json'), '{}');
+
+      const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(otherCwd);
+
+      try {
+        expect(await findProjectRoot(nestedDir)).toEqual(projectDir);
+      } finally {
+        cwdSpy.mockRestore();
+      }
+    });
   });
 
   describe('projectNameFromGenkitFilePath', () => {


### PR DESCRIPTION
## Summary
- Adds `-C, --directory <dir>` to `genkit start` so the CLI can run as if started in another directory (git/make-style `chdir` before project-root discovery).
- Validates that the path exists and is a directory; errors clearly otherwise.
- Extends `findProjectRoot(startDir?)` for explicit start-dir support.
- Adds unit tests for success and failure paths.

Fixes #2191

## Test plan
- [x] `jest` `genkit-tools/cli/tests/commands/start_test.ts` (7 passing) — `-C/--directory` success and validation failures
- [x] `jest` `genkit-tools/common/tests/utils/utils_test.ts` (7 passing) — `findProjectRoot(startDir?)`
- [ ] Manual: from outside a project, `genkit start -C /path/to/app --noui` resolves that app root

