### PR TITLE
fix(js): record span exceptions only at the failure source

### DIFF
--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -52,11 +52,12 @@ interface RunInNewSpanOpts {
  * Tracks errors that have already been recorded via ``recordException`` / marked
  * as ``isFailureSource`` while bubbling up nested ``runInNewSpan`` catches.
  *
- * Using a WeakSet avoids mutating caller-owned Error objects with Genkit-specific
- * properties (the old ``ignoreFailedSpan`` flag) that could leak into external
- * loggers or other telemetry systems.
+ * Maps error object → OpenTelemetry ``traceId`` so:
+ * - We avoid mutating caller-owned Error objects (old ``ignoreFailedSpan`` flag).
+ * - Shared/sentinel errors reused across independent traces are still recorded
+ *   once per trace (a global WeakSet would suppress later traces).
  */
-const failureSourceErrors = new WeakSet<object>();
+const failureSourceErrors = new WeakMap<object, string>();
 
 type RunInNewSpanFn<T> = (
   metadata: SpanMetadata,
@@ -173,14 +174,15 @@ export async function runInNewSpan<T>(
 
         // Mark the first failing span as the source of failure. Prevent parent
         // spans that catch re-thrown exceptions from also claiming to be the
-        // source or re-recording the same exception timeEvent.
+        // source or re-recording the same exception timeEvent within this trace.
         if (e !== null && typeof e === 'object') {
-          if (!failureSourceErrors.has(e)) {
+          const traceId = otSpan.spanContext().traceId;
+          if (failureSourceErrors.get(e) !== traceId) {
             opts.metadata.isFailureSource = true;
             if (e instanceof Error) {
               otSpan.recordException(e);
             }
-            failureSourceErrors.add(e);
+            failureSourceErrors.set(e, traceId);
           }
         }
 

--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -48,6 +48,16 @@ interface RunInNewSpanOpts {
   links?: Link[];
 }
 
+/**
+ * Tracks errors that have already been recorded via ``recordException`` / marked
+ * as ``isFailureSource`` while bubbling up nested ``runInNewSpan`` catches.
+ *
+ * Using a WeakSet avoids mutating caller-owned Error objects with Genkit-specific
+ * properties (the old ``ignoreFailedSpan`` flag) that could leak into external
+ * loggers or other telemetry systems.
+ */
+const failureSourceErrors = new WeakSet<object>();
+
 type RunInNewSpanFn<T> = (
   metadata: SpanMetadata,
   otSpan: ApiSpan,
@@ -153,22 +163,25 @@ export async function runInNewSpan<T>(
       } catch (e) {
         recordPath(opts.metadata, spanContext, e);
         opts.metadata.state = 'error';
+        // Parent spans still get ERROR status as the failure bubbles up; only
+        // the original failure-source span should record the exception event
+        // (matches Go's isErrorAlreadyMarked / RecordError gating).
         otSpan.setStatus({
           code: SpanStatusCode.ERROR,
           message: getErrorMessage(e),
         });
-        if (e instanceof Error) {
-          otSpan.recordException(e);
-        }
 
         // Mark the first failing span as the source of failure. Prevent parent
         // spans that catch re-thrown exceptions from also claiming to be the
-        // source.
-        if (typeof e === 'object') {
-          if (!(e as any).ignoreFailedSpan) {
+        // source or re-recording the same exception timeEvent.
+        if (e !== null && typeof e === 'object') {
+          if (!failureSourceErrors.has(e)) {
             opts.metadata.isFailureSource = true;
+            if (e instanceof Error) {
+              otSpan.recordException(e);
+            }
+            failureSourceErrors.add(e);
           }
-          (e as any).ignoreFailedSpan = true;
         }
 
         throw e;

--- a/js/core/tests/instrumentation_test.ts
+++ b/js/core/tests/instrumentation_test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SpanStatusCode } from '@opentelemetry/api';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
+import { beforeEach, describe, it } from 'node:test';
+import { initNodeFeatures } from '../src/node.js';
+import { enableTelemetry } from '../src/tracing.js';
+import { runInNewSpan } from '../src/tracing/instrumentation.js';
+import { TestSpanExporter } from './utils.js';
+
+initNodeFeatures();
+
+const spanExporter = new TestSpanExporter();
+enableTelemetry({
+  spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+});
+
+function exceptionEvents(span: {
+  timeEvents?: { timeEvent?: Array<{ annotation?: { description?: string } }> };
+}) {
+  return (span.timeEvents?.timeEvent || []).filter(
+    (e) => e.annotation?.description === 'exception'
+  );
+}
+
+describe('runInNewSpan exception recording', () => {
+  beforeEach(() => {
+    spanExporter.exportedSpans = [];
+  });
+
+  it('records exception only on the failure-source span when nested spans rethrow', async () => {
+    const err = new Error('boom');
+
+    await assert.rejects(
+      () =>
+        runInNewSpan({ metadata: { name: 'parent' } }, async () =>
+          runInNewSpan({ metadata: { name: 'child' } }, async () => {
+            throw err;
+          })
+        ),
+      (e: unknown) => e === err
+    );
+
+    // Wait a tick for span export.
+    await new Promise((r) => setImmediate(r));
+
+    const spans = spanExporter.exportedSpans;
+    assert.strictEqual(spans.length, 2);
+
+    const child = spans.find((s) => s.displayName === 'child');
+    const parent = spans.find((s) => s.displayName === 'parent');
+    assert.ok(child, 'expected child span');
+    assert.ok(parent, 'expected parent span');
+
+    // Both spans are ERROR status (failure bubbled).
+    assert.strictEqual(child.status.code, SpanStatusCode.ERROR);
+    assert.strictEqual(parent.status.code, SpanStatusCode.ERROR);
+
+    // Only the deepest (failure source) span records the exception event.
+    assert.strictEqual(exceptionEvents(child).length, 1);
+    assert.strictEqual(exceptionEvents(parent).length, 0);
+
+    assert.strictEqual(child.attributes['genkit:isFailureSource'], true);
+    assert.notStrictEqual(parent.attributes['genkit:isFailureSource'], true);
+
+    // Error object itself is not polluted with Genkit markers.
+    assert.strictEqual(
+      Object.prototype.hasOwnProperty.call(err, 'ignoreFailedSpan'),
+      false
+    );
+  });
+
+  it('still records exception once for a single failing span', async () => {
+    const err = new Error('solo');
+
+    await assert.rejects(
+      () =>
+        runInNewSpan({ metadata: { name: 'solo' } }, async () => {
+          throw err;
+        }),
+      (e: unknown) => e === err
+    );
+
+    await new Promise((r) => setImmediate(r));
+
+    assert.strictEqual(spanExporter.exportedSpans.length, 1);
+    const span = spanExporter.exportedSpans[0];
+    assert.strictEqual(exceptionEvents(span).length, 1);
+    assert.strictEqual(span.attributes['genkit:isFailureSource'], true);
+  });
+});

--- a/js/core/tests/instrumentation_test.ts
+++ b/js/core/tests/instrumentation_test.ts
@@ -103,4 +103,40 @@ describe('runInNewSpan exception recording', () => {
     assert.strictEqual(exceptionEvents(span).length, 1);
     assert.strictEqual(span.attributes['genkit:isFailureSource'], true);
   });
+
+  it('records shared sentinel errors once per independent trace', async () => {
+    const sentinelErr = new Error('sentinel');
+
+    await assert.rejects(
+      () =>
+        runInNewSpan({ metadata: { name: 'trace1' } }, async () => {
+          throw sentinelErr;
+        }),
+      (e: unknown) => e === sentinelErr
+    );
+
+    await assert.rejects(
+      () =>
+        runInNewSpan({ metadata: { name: 'trace2' } }, async () => {
+          throw sentinelErr;
+        }),
+      (e: unknown) => e === sentinelErr
+    );
+
+    await new Promise((r) => setImmediate(r));
+
+    const spans = spanExporter.exportedSpans;
+    assert.strictEqual(spans.length, 2);
+
+    const trace1Span = spans.find((s) => s.displayName === 'trace1');
+    const trace2Span = spans.find((s) => s.displayName === 'trace2');
+    assert.ok(trace1Span);
+    assert.ok(trace2Span);
+
+    assert.strictEqual(exceptionEvents(trace1Span).length, 1);
+    assert.strictEqual(exceptionEvents(trace2Span).length, 1);
+    assert.strictEqual(trace1Span.attributes['genkit:isFailureSource'], true);
+    assert.strictEqual(trace2Span.attributes['genkit:isFailureSource'], true);
+    assert.notStrictEqual(trace1Span.traceId, trace2Span.traceId);
+  });
 });


### PR DESCRIPTION
## Summary
- Nested `runInNewSpan` catches no longer call `recordException` on every ancestor span when the same error is rethrown.
- Only the original failure-source span records the exception timeEvent; parents still get `ERROR` status.
- Replaces mutating `error.ignoreFailedSpan` with a module-level `WeakSet` so Genkit markers do not leak onto caller-owned Error objects.
- Adds regression tests for nested and single-span failure paths.

Fixes #5152

## Test plan
- [x] `node --import tsx --test tests/instrumentation_test.ts` in `js/core` (2 passing)
- [x] Covers nested `runInNewSpan` so only the failure-source span records the exception timeEvent
- [ ] Manual (optional): Dev UI / exporters show a single exception event on the deepest failing span

