### PR TITLE
feat(tools): format exported output schema as Picoschema

### DIFF
--- a/genkit-tools/common/src/types/apis.ts
+++ b/genkit-tools/common/src/types/apis.ts
@@ -178,6 +178,7 @@ export const CreatePromptRequestSchema = z.object({
   config: GenerationCommonConfigSchema.passthrough().optional(),
   tools: z.array(ToolDefinitionSchema).optional(),
   use: z.array(MiddlewareRefSchema).optional(),
+  picoSchema: z.boolean().optional(),
   input: z
     .object({
       schema: z.unknown().optional(),

--- a/genkit-tools/common/src/utils/prompt.ts
+++ b/genkit-tools/common/src/utils/prompt.ts
@@ -18,12 +18,128 @@ import { stringify } from 'yaml';
 import type { MessageData, Part } from '../types/model';
 import type { PromptFrontmatter } from '../types/prompt';
 
-function toFrontmatterSchema(config?: {
-  schema?: unknown;
-  jsonSchema?: unknown;
-}): unknown | undefined {
+/** A JSON Schema-ish object. */
+type JsonSchema = Record<string, any>;
+
+function getPrimaryType(
+  schema: JsonSchema | null | undefined
+): string | undefined {
+  const type = schema?.type;
+  if (Array.isArray(type)) {
+    const nonNullTypes = type.filter((t) => t !== 'null');
+    if (nonNullTypes.length === 1) {
+      return nonNullTypes[0];
+    }
+    if (nonNullTypes.length === 0 && type.includes('null')) {
+      return 'null';
+    }
+    return undefined;
+  }
+  return typeof type === 'string' ? type : undefined;
+}
+
+function scalarType(schema: JsonSchema | null | undefined): string {
+  const type = getPrimaryType(schema);
+  switch (type) {
+    case 'string':
+    case 'integer':
+    case 'number':
+    case 'boolean':
+    case 'null':
+      return type;
+    default:
+      return 'any';
+  }
+}
+
+/** Wraps a type kind with an optional description, e.g. `(array, the tags)`. */
+function wrap(kind: string, description?: string): string {
+  return description ? `(${kind}, ${description})` : `(${kind})`;
+}
+
+/**
+ * Encodes a single property as a Picoschema key suffix and value. Scalars carry
+ * their description after a comma in the value (`string, the title`); wrapped
+ * kinds (object, array, enum) carry it inside the parentheses on the key.
+ */
+function picoEntry(schema: JsonSchema): { suffix: string; value: any } {
+  const description =
+    typeof schema?.description === 'string' ? schema.description : undefined;
+
+  if (Array.isArray(schema?.enum)) {
+    return { suffix: wrap('enum', description), value: schema.enum };
+  }
+  const type = getPrimaryType(schema);
+  if (type === 'array') {
+    const items: JsonSchema = schema.items ?? {};
+    const itemType = getPrimaryType(items);
+    const value =
+      itemType === 'object' || items.properties
+        ? picoObject(items)
+        : scalarType(items);
+    return { suffix: wrap('array', description), value };
+  }
+  if (type === 'object' || schema?.properties) {
+    return { suffix: wrap('object', description), value: picoObject(schema) };
+  }
+  const scalar = scalarType(schema);
+  return {
+    suffix: '',
+    value: description ? `${scalar}, ${description}` : scalar,
+  };
+}
+
+/** Converts an object JSON Schema into a Picoschema object structure. */
+function picoObject(schema: JsonSchema): Record<string, any> {
+  const required = new Set<string>(
+    Array.isArray(schema.required) ? schema.required : []
+  );
+  const out: Record<string, any> = {};
+  for (const [name, propSchema] of Object.entries<any>(
+    schema.properties ?? {}
+  )) {
+    const optional = required.has(name) ? '' : '?';
+    const { suffix, value } = picoEntry(propSchema);
+    out[`${name}${optional}${suffix}`] = value;
+  }
+  const additional = schema.additionalProperties;
+  if (additional && typeof additional === 'object') {
+    const { suffix, value } = picoEntry(additional);
+    out[`(*)${suffix}`] = value;
+  }
+  return out;
+}
+
+/**
+ * Converts a JSON Schema into the equivalent Picoschema for a `.prompt` file.
+ * Object schemas become the compact Picoschema form. Non-object top-level
+ * schemas (a bare array or scalar) have no Picoschema form, so the JSON Schema
+ * is returned unchanged; Dotprompt accepts raw JSON Schema there too.
+ */
+export function jsonSchemaToPicoschema(schema: unknown): any {
+  if (!schema || typeof schema !== 'object') {
+    return schema;
+  }
+  const s = schema as JsonSchema;
+  const type = getPrimaryType(s);
+  if (type === 'object' || s.properties) {
+    return picoObject(s);
+  }
+  return schema;
+}
+
+function toFrontmatterSchema(
+  config?: {
+    schema?: unknown;
+    jsonSchema?: unknown;
+  },
+  picoSchema?: boolean
+): unknown | undefined {
   const schema = config?.jsonSchema ?? config?.schema;
-  return schema && typeof schema === 'object' ? schema : undefined;
+  if (!schema || typeof schema !== 'object') {
+    return undefined;
+  }
+  return picoSchema ? jsonSchemaToPicoschema(schema) : schema;
 }
 
 /**
@@ -32,11 +148,14 @@ function toFrontmatterSchema(config?: {
  * formats (json, jsonl, array, enum) map onto `json`. Returns undefined when
  * there is nothing to record.
  */
-export function toFrontmatterOutput(output?: {
-  format?: string;
-  jsonSchema?: unknown;
-  schema?: unknown;
-}): PromptFrontmatter['output'] | undefined {
+export function toFrontmatterOutput(
+  output?: {
+    format?: string;
+    jsonSchema?: unknown;
+    schema?: unknown;
+  },
+  picoSchema?: boolean
+): PromptFrontmatter['output'] | undefined {
   if (!output) return undefined;
   const result: NonNullable<PromptFrontmatter['output']> = {};
   if (output.format === 'text') {
@@ -46,7 +165,7 @@ export function toFrontmatterOutput(output?: {
   } else if (output.format) {
     result.format = 'json';
   }
-  const schema = toFrontmatterSchema(output);
+  const schema = toFrontmatterSchema(output, picoSchema);
   if (schema !== undefined) {
     result.schema = schema;
   }
@@ -57,14 +176,17 @@ export function toFrontmatterOutput(output?: {
  * Maps a request's input config onto `.prompt` frontmatter. Returns undefined
  * when there is nothing to record.
  */
-export function toFrontmatterInput(input?: {
-  schema?: unknown;
-  jsonSchema?: unknown;
-  default?: unknown;
-}): PromptFrontmatter['input'] | undefined {
+export function toFrontmatterInput(
+  input?: {
+    schema?: unknown;
+    jsonSchema?: unknown;
+    default?: unknown;
+  },
+  picoSchema?: boolean
+): PromptFrontmatter['input'] | undefined {
   if (!input) return undefined;
   const result: NonNullable<PromptFrontmatter['input']> = {
-    schema: toFrontmatterSchema(input),
+    schema: toFrontmatterSchema(input, picoSchema),
     default: input.default,
   };
   return result.schema || result.default !== undefined ? result : undefined;
@@ -79,6 +201,7 @@ export function toPromptFile(request: {
   config?: Record<string, unknown>;
   tools?: { name: string }[];
   use?: PromptFrontmatter['use'];
+  picoSchema?: boolean;
   input?: {
     schema?: unknown;
     jsonSchema?: unknown;
@@ -95,8 +218,8 @@ export function toPromptFile(request: {
     config: request.config,
     tools: request.tools?.map((toolDefinition) => toolDefinition.name),
     use: request.use,
-    input: toFrontmatterInput(request.input),
-    output: toFrontmatterOutput(request.output),
+    input: toFrontmatterInput(request.input, request.picoSchema),
+    output: toFrontmatterOutput(request.output, request.picoSchema),
   };
   return renderPromptFile(frontmatter, request.messages);
 }

--- a/genkit-tools/common/tests/utils/prompt_test.ts
+++ b/genkit-tools/common/tests/utils/prompt_test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from '@jest/globals';
 import type { MessageData } from '../../src/types/model';
 import { PromptFrontmatter } from '../../src/types/prompt';
 import {
+  jsonSchemaToPicoschema,
   renderPromptFile,
   toFrontmatterInput,
   toFrontmatterOutput,
@@ -188,6 +189,143 @@ describe('renderPromptFile', () => {
   });
 });
 
+describe('jsonSchemaToPicoschema', () => {
+  it('converts an object schema with required, optional, and described fields', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        subtitle: { type: 'string', description: 'optional subtitle' },
+        servings: { type: 'integer' },
+      },
+      required: ['title', 'servings'],
+    };
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      title: 'string',
+      'subtitle?': 'string, optional subtitle',
+      servings: 'integer',
+    });
+  });
+
+  it('encodes an enum', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          enum: ['PENDING', 'APPROVED'],
+          description: 'approval status',
+        },
+      },
+      required: ['status'],
+    };
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      'status(enum, approval status)': ['PENDING', 'APPROVED'],
+    });
+  });
+
+  it('encodes an array of scalars', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'relevant tags',
+        },
+      },
+      required: ['tags'],
+    };
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      'tags(array, relevant tags)': 'string',
+    });
+  });
+
+  it('encodes an array of objects', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        authors: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          },
+        },
+      },
+      required: ['authors'],
+    };
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      'authors(array)': { name: 'string' },
+    });
+  });
+
+  it('encodes a nested object, marking optional fields', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        metadata: {
+          type: 'object',
+          properties: { updatedAt: { type: 'string' } },
+        },
+      },
+    };
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      'metadata?(object)': { 'updatedAt?': 'string' },
+    });
+  });
+
+  it('encodes additionalProperties as a wildcard field', () => {
+    const schema = {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+      required: ['id'],
+      additionalProperties: { type: 'number' },
+    };
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      id: 'string',
+      '(*)': 'number',
+    });
+  });
+
+  it('passes non-object top-level schemas through unchanged', () => {
+    const arraySchema = { type: 'array', items: { type: 'string' } };
+    expect(jsonSchemaToPicoschema(arraySchema)).toBe(arraySchema);
+  });
+
+  it('returns any for null or malformed properties', () => {
+    const schema = {
+      type: 'object',
+      properties: { id: { type: 'string' }, broken: null, items: {} },
+      required: ['id'],
+    };
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      id: 'string',
+      'broken?': 'any',
+      'items?': 'any',
+    });
+  });
+
+  it('handles nullable types (union with null)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        title: { type: ['string', 'null'] },
+        tags: {
+          type: ['array', 'null'],
+          items: { type: ['string', 'null'] },
+        },
+      },
+      required: ['title'],
+    };
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      title: 'string',
+      'tags?(array)': 'string',
+    });
+  });
+});
+
 describe('toFrontmatterInput', () => {
   const SCHEMA = {
     type: 'object',
@@ -198,11 +336,20 @@ describe('toFrontmatterInput', () => {
     expect(toFrontmatterInput(undefined)).toBeUndefined();
   });
 
-  it('maps schema and default values', () => {
+  it('maps schema and default values as raw schema by default', () => {
     expect(
       toFrontmatterInput({ schema: SCHEMA, default: { name: 'World' } })
     ).toEqual({
       schema: SCHEMA,
+      default: { name: 'World' },
+    });
+  });
+
+  it('converts schema to picoschema when picoSchema is true', () => {
+    expect(
+      toFrontmatterInput({ schema: SCHEMA, default: { name: 'World' } }, true)
+    ).toEqual({
+      schema: { 'name?': 'string' },
       default: { name: 'World' },
     });
   });
@@ -219,10 +366,16 @@ describe('toFrontmatterOutput', () => {
     expect(toFrontmatterOutput(undefined)).toBeUndefined();
   });
 
-  it('reads the schema from jsonSchema and maps json formats', () => {
+  it('reads the schema from jsonSchema and maps json formats as raw schema by default', () => {
     expect(toFrontmatterOutput({ format: 'json', jsonSchema: SCHEMA })).toEqual(
       { format: 'json', schema: SCHEMA }
     );
+  });
+
+  it('converts schema to picoschema when picoSchema is true', () => {
+    expect(
+      toFrontmatterOutput({ format: 'json', jsonSchema: SCHEMA }, true)
+    ).toEqual({ format: 'json', schema: { title: 'string' } });
   });
 
   it('reads the schema from the schema field (model request shape)', () => {
@@ -250,20 +403,21 @@ describe('toFrontmatterOutput', () => {
 });
 
 describe('toPromptFile', () => {
-  it('converts a request object into a .prompt template string', () => {
-    const request = {
-      model: '/model/googleai/gemini-pro',
-      config: { temperature: 0.7 },
-      tools: [{ name: 'getWeather' }],
-      messages: [{ role: 'user' as const, content: [{ text: 'Hello' }] }],
-      input: {
-        schema: { type: 'object', properties: { name: { type: 'string' } } },
-      },
-      output: {
-        format: 'json',
-        schema: { type: 'object', properties: { answer: { type: 'string' } } },
-      },
-    };
+  const request = {
+    model: '/model/googleai/gemini-pro',
+    config: { temperature: 0.7 },
+    tools: [{ name: 'getWeather' }],
+    messages: [{ role: 'user' as const, content: [{ text: 'Hello' }] }],
+    input: {
+      schema: { type: 'object', properties: { name: { type: 'string' } } },
+    },
+    output: {
+      format: 'json',
+      schema: { type: 'object', properties: { answer: { type: 'string' } } },
+    },
+  };
+
+  it('converts a request object into a .prompt template string with raw schemas by default', () => {
     const expected =
       '---\n' +
       'model: googleai/gemini-pro\n' +
@@ -289,5 +443,29 @@ describe('toPromptFile', () => {
       '{{role "user"}}\n' +
       'Hello\n';
     expect(toPromptFile(request)).toStrictEqual(expected);
+  });
+
+  it('formats schemas as picoschema when picoSchema is true', () => {
+    const expected =
+      '---\n' +
+      'model: googleai/gemini-pro\n' +
+      'config:\n' +
+      '  temperature: 0.7\n' +
+      'tools:\n' +
+      '  - getWeather\n' +
+      'input:\n' +
+      '  schema:\n' +
+      '    name?: string\n' +
+      'output:\n' +
+      '  format: json\n' +
+      '  schema:\n' +
+      '    answer?: string\n' +
+      '---\n' +
+      '\n' +
+      '{{role "user"}}\n' +
+      'Hello\n';
+    expect(toPromptFile({ ...request, picoSchema: true })).toStrictEqual(
+      expected
+    );
   });
 });


### PR DESCRIPTION
Stacked on top of #5506. Adds Picoschema conversion (`jsonSchemaToPicoschema`) when exporting structured output schemas in `.prompt` files.