### PR TITLE
fix(go): complete partial JSON by nesting order, not by brace counts

### DIFF
--- a/go/ai/format_test.go
+++ b/go/ai/format_test.go
@@ -249,6 +249,36 @@ func TestJSONFormatter(t *testing.T) {
 		}
 	})
 
+	t.Run("ParseChunk streams an array of objects", func(t *testing.T) {
+		// Completing the containers by type rather than by nesting order turned
+		// `[{"name": "Jo` into `[{"name": "Jo"]}`, which failed to parse and
+		// left every chunk of an array of objects empty until the array closed.
+		handler, _ := jsonFormatter{}.Handler(nil)
+		sfh := handler.(StreamingFormatHandler)
+
+		chunks := []string{`[{"name": "Jo`, `hn"}, {"nam`, `e": "Jane"}]`}
+		want := []any{
+			[]any{map[string]any{"name": "Jo"}},
+			// The second object has been opened but holds nothing yet: its key
+			// is still arriving, so there is no member to report.
+			[]any{map[string]any{"name": "John"}, map[string]any{}},
+			[]any{map[string]any{"name": "John"}, map[string]any{"name": "Jane"}},
+		}
+
+		for i, chunk := range chunks {
+			got, err := sfh.ParseChunk(&ModelResponseChunk{
+				Content: []*Part{NewTextPart(chunk)},
+				Index:   0,
+			})
+			if err != nil {
+				t.Fatalf("ParseChunk(%q) error = %v", chunk, err)
+			}
+			if diff := cmp.Diff(want[i], got); diff != "" {
+				t.Errorf("ParseChunk(%q) mismatch (-want +got):\n%s", chunk, diff)
+			}
+		}
+	})
+
 	t.Run("ParseMessage validates JSON and creates JSON part", func(t *testing.T) {
 		handler, _ := jsonFormatter{}.Handler(schema)
 

--- a/go/internal/base/extract.go
+++ b/go/internal/base/extract.go
@@ -17,6 +17,7 @@ package base
 import (
 	"encoding/json"
 	"strings"
+	"unicode/utf8"
 )
 
 // ExtractJSON extracts JSON from string with lenient parsing rules.
@@ -110,68 +111,196 @@ func ParsePartialJSON(jsonStr string) (any, error) {
 	return result, err
 }
 
+// jsonFrame is a container left open by a truncated JSON document.
+type jsonFrame struct {
+	closer    byte // '}' or ']'
+	expectKey bool // the next string in this object is a key, not a value
+}
+
 // CompleteJSON attempts to complete an incomplete JSON string.
+//
+// Containers are closed innermost first, so an object nested in an array is
+// closed before the array. A string value cut off mid-stream is kept and
+// closed, minus any dangling escape sequence, and a truncated keyword is
+// finished because only one keyword can start with a given letter. A tail that
+// cannot be finished without inventing a value is dropped instead: a
+// half-written key, a key whose value has not arrived yet, or a truncated
+// number such as "1.". Input that is malformed rather than merely truncated is
+// cut back to the last position that was still well formed.
 func CompleteJSON(jsonStr string) string {
-	jsonStr = strings.TrimSpace(jsonStr)
-	if jsonStr == "" {
+	s := strings.TrimSpace(jsonStr)
+	if s == "" {
 		return "{}"
 	}
 
-	// Count unclosed structures
-	var openBraces, openBrackets int
-	inString := false
-	escapeNext := false
+	var stack []jsonFrame
+	// safe is the length of the prefix that becomes valid JSON once the closers
+	// for stack are appended. It only advances past a completed value, so a
+	// truncated tail is discarded by rewinding to it.
+	safe := 0
 
-	for _, char := range jsonStr {
-		if escapeNext {
-			escapeNext = false
-			continue
-		}
+	for i := 0; i < len(s); {
+		switch c := s[i]; c {
+		case ' ', '\t', '\n', '\r':
+			i++
 
-		if char == '\\' {
-			escapeNext = true
-			continue
-		}
+		case '{', '[':
+			closer := byte('}')
+			if c == '[' {
+				closer = ']'
+			}
+			stack = append(stack, jsonFrame{closer: closer, expectKey: c == '{'})
+			i++
+			safe = i
 
-		if char == '"' {
-			inString = !inString
-			continue
-		}
+		case '}', ']':
+			if len(stack) == 0 || stack[len(stack)-1].closer != c {
+				return closeJSON(s[:safe], stack)
+			}
+			stack = stack[:len(stack)-1]
+			i++
+			safe = i
+			if len(stack) == 0 {
+				// Root value is complete; anything after it is not ours.
+				return s[:safe]
+			}
 
-		if inString {
-			continue
-		}
+		case ',':
+			if len(stack) > 0 {
+				stack[len(stack)-1].expectKey = stack[len(stack)-1].closer == '}'
+			}
+			i++
 
-		switch char {
-		case '{':
-			openBraces++
-		case '}':
-			openBraces--
-		case '[':
-			openBrackets++
-		case ']':
-			openBrackets--
+		case ':':
+			if len(stack) > 0 {
+				stack[len(stack)-1].expectKey = false
+			}
+			i++
+
+		case '"':
+			isKey := len(stack) > 0 && stack[len(stack)-1].expectKey
+			end, cut := scanJSONString(s, i)
+			if end < 0 {
+				// The string is still streaming. A partial value is worth
+				// keeping; a partial key has no value to attach to.
+				if isKey {
+					return closeJSON(s[:safe], stack)
+				}
+				return closeJSON(trimPartialRune(s[:cut])+`"`, stack)
+			}
+			i = end
+			if !isKey {
+				safe = i
+				if len(stack) == 0 {
+					return s[:safe]
+				}
+			}
+
+		default:
+			if len(stack) > 0 && stack[len(stack)-1].expectKey {
+				return closeJSON(s[:safe], stack) // A number or keyword cannot be a key.
+			}
+			end := scanJSONAtom(s, i)
+			if !json.Valid([]byte(s[i:end])) {
+				if kw := completeKeyword(s[i:end]); kw != "" && end == len(s) {
+					return closeJSON(s[:i]+kw, stack)
+				}
+				// A truncated number would have to be guessed at, so the whole
+				// member goes instead.
+				return closeJSON(s[:safe], stack)
+			}
+			i = end
+			safe = i
+			if len(stack) == 0 {
+				return s[:safe]
+			}
 		}
 	}
 
-	// Close any unclosed string
-	if inString {
-		jsonStr += "\""
+	return closeJSON(s[:safe], stack)
+}
+
+// closeJSON appends the closers for the containers left open in stack,
+// innermost first.
+func closeJSON(prefix string, stack []jsonFrame) string {
+	if prefix == "" && len(stack) == 0 {
+		return "{}"
 	}
 
-	// Remove trailing comma if present (before closing)
-	jsonStr = strings.TrimRight(jsonStr, " \t\n\r")
-	jsonStr = strings.TrimSuffix(jsonStr, ",")
-
-	// Close open structures
-	for i := 0; i < openBrackets; i++ {
-		jsonStr += "]"
+	var b strings.Builder
+	b.Grow(len(prefix) + len(stack))
+	b.WriteString(prefix)
+	for i := len(stack) - 1; i >= 0; i-- {
+		b.WriteByte(stack[i].closer)
 	}
-	for i := 0; i < openBraces; i++ {
-		jsonStr += "}"
-	}
+	return b.String()
+}
 
-	return jsonStr
+// scanJSONString scans the string literal starting at s[start], which is the
+// opening quote. It returns the index just past the closing quote, or -1 if the
+// literal is truncated along with cut, the length of the prefix that stays
+// valid once a closing quote is appended.
+func scanJSONString(s string, start int) (end, cut int) {
+	for i := start + 1; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			return i + 1, 0
+		case '\\':
+			// The escape and everything it consumes must both have arrived, or
+			// the quote we append would be swallowed by the escape.
+			if i+1 >= len(s) {
+				return -1, i
+			}
+			if s[i+1] == 'u' {
+				if i+5 >= len(s) {
+					return -1, i
+				}
+				i += 4 // Skip \uXXXX; the loop's i++ accounts for the 'u'.
+			}
+			i++
+		}
+	}
+	return -1, len(s)
+}
+
+// completeKeyword returns the JSON keyword that tok is an unfinished prefix of.
+// No two keywords share a first letter, so the keyword a truncated one was
+// going to become is the only one it could have become.
+func completeKeyword(tok string) string {
+	if tok == "" {
+		return ""
+	}
+	for _, kw := range []string{"true", "false", "null"} {
+		if len(tok) < len(kw) && strings.HasPrefix(kw, tok) {
+			return kw
+		}
+	}
+	return ""
+}
+
+// trimPartialRune drops a trailing UTF-8 sequence that a chunk boundary cut in
+// half, so the closed string does not decode to a replacement character.
+func trimPartialRune(s string) string {
+	for i := 0; i < utf8.UTFMax && s != ""; i++ {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if size == 0 || r != utf8.RuneError || size > 1 {
+			// size > 1 means the input really does encode U+FFFD.
+			break
+		}
+		s = s[:len(s)-size]
+	}
+	return s
+}
+
+// scanJSONAtom returns the end of the number or keyword starting at s[start].
+func scanJSONAtom(s string, start int) int {
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case ',', ':', '{', '}', '[', ']', '"', ' ', '\t', '\n', '\r':
+			return i
+		}
+	}
+	return len(s)
 }
 
 // ExtractItemsResult contains the result of extracting items from an array.

--- a/go/internal/base/extract.go
+++ b/go/internal/base/extract.go
@@ -111,13 +111,26 @@ func ParsePartialJSON(jsonStr string) (any, error) {
 	return result, err
 }
 
-// jsonFrame is a container left open by a truncated JSON document.
+// What the grammar allows at the current position. A token that is not allowed
+// where it appears means the document is malformed rather than truncated, and
+// completion rewinds instead of trying to make sense of it.
+const (
+	allowValue = 1 << iota // a value may start here
+	allowKey               // an object key may start here
+	allowColon             // the ':' between a key and its value
+	allowComma             // the ',' between members
+	allowClose             // this container's own closer
+)
+
+// jsonFrame is a container the scan is currently inside. The outermost frame is
+// the document itself, which has no closer and holds exactly one value.
 type jsonFrame struct {
-	closer    byte // '}' or ']'
-	expectKey bool // the next string in this object is a key, not a value
+	closer byte // '}' or ']', or 0 for the document
+	allow  uint8
 }
 
-// CompleteJSON attempts to complete an incomplete JSON string.
+// CompleteJSON attempts to complete an incomplete JSON string. The result is
+// always valid JSON.
 //
 // Containers are closed innermost first, so an object nested in an array is
 // closed before the array. A string value cut off mid-stream is kept and
@@ -125,60 +138,87 @@ type jsonFrame struct {
 // finished because only one keyword can start with a given letter. A tail that
 // cannot be finished without inventing a value is dropped instead: a
 // half-written key, a key whose value has not arrived yet, or a truncated
-// number such as "1.". Input that is malformed rather than merely truncated is
-// cut back to the last position that was still well formed.
+// number such as "1.".
+//
+// Input that is malformed rather than truncated is cut back to the last
+// position that was still well formed, which is why the grammar is tracked at
+// all: a trailing comma before a closer, a container opened where a key
+// belongs, or a raw control character inside a string all end the scan and take
+// everything after them with it.
 func CompleteJSON(jsonStr string) string {
 	s := strings.TrimSpace(jsonStr)
 	if s == "" {
 		return "{}"
 	}
 
-	var stack []jsonFrame
+	stack := []jsonFrame{{allow: allowValue}}
 	// safe is the length of the prefix that becomes valid JSON once the closers
 	// for stack are appended. It only advances past a completed value, so a
-	// truncated tail is discarded by rewinding to it.
+	// truncated or malformed tail is discarded by rewinding to it.
 	safe := 0
 
+	// valueDone records that a complete value ended at end, leaving its
+	// container ready for a separator and the document ready for nothing.
+	valueDone := func(end int) {
+		top := &stack[len(stack)-1]
+		if top.closer == 0 {
+			top.allow = 0
+		} else {
+			top.allow = allowComma | allowClose
+		}
+		safe = end
+	}
+
 	for i := 0; i < len(s); {
+		top := &stack[len(stack)-1]
+
 		switch c := s[i]; c {
 		case ' ', '\t', '\n', '\r':
 			i++
 
 		case '{', '[':
-			closer := byte('}')
-			if c == '[' {
-				closer = ']'
+			if top.allow&allowValue == 0 {
+				return closeJSON(s[:safe], stack)
 			}
-			stack = append(stack, jsonFrame{closer: closer, expectKey: c == '{'})
+			frame := jsonFrame{closer: '}', allow: allowKey | allowClose}
+			if c == '[' {
+				frame = jsonFrame{closer: ']', allow: allowValue | allowClose}
+			}
+			stack = append(stack, frame)
 			i++
 			safe = i
 
 		case '}', ']':
-			if len(stack) == 0 || stack[len(stack)-1].closer != c {
+			if top.allow&allowClose == 0 || top.closer != c {
 				return closeJSON(s[:safe], stack)
 			}
 			stack = stack[:len(stack)-1]
 			i++
-			safe = i
-			if len(stack) == 0 {
-				// Root value is complete; anything after it is not ours.
-				return s[:safe]
-			}
+			valueDone(i)
 
 		case ',':
-			if len(stack) > 0 {
-				stack[len(stack)-1].expectKey = stack[len(stack)-1].closer == '}'
+			if top.allow&allowComma == 0 {
+				return closeJSON(s[:safe], stack)
+			}
+			if top.closer == '}' {
+				top.allow = allowKey
+			} else {
+				top.allow = allowValue
 			}
 			i++
 
 		case ':':
-			if len(stack) > 0 {
-				stack[len(stack)-1].expectKey = false
+			if top.allow&allowColon == 0 {
+				return closeJSON(s[:safe], stack)
 			}
+			top.allow = allowValue
 			i++
 
 		case '"':
-			isKey := len(stack) > 0 && stack[len(stack)-1].expectKey
+			isKey := top.allow&allowKey != 0
+			if !isKey && top.allow&allowValue == 0 {
+				return closeJSON(s[:safe], stack)
+			}
 			end, cut := scanJSONString(s, i)
 			if end < 0 {
 				// The string is still streaming. A partial value is worth
@@ -189,16 +229,15 @@ func CompleteJSON(jsonStr string) string {
 				return closeJSON(trimPartialRune(s[:cut])+`"`, stack)
 			}
 			i = end
-			if !isKey {
-				safe = i
-				if len(stack) == 0 {
-					return s[:safe]
-				}
+			if isKey {
+				top.allow = allowColon
+			} else {
+				valueDone(i)
 			}
 
 		default:
-			if len(stack) > 0 && stack[len(stack)-1].expectKey {
-				return closeJSON(s[:safe], stack) // A number or keyword cannot be a key.
+			if top.allow&allowValue == 0 {
+				return closeJSON(s[:safe], stack)
 			}
 			end := scanJSONAtom(s, i)
 			if !json.Valid([]byte(s[i:end])) {
@@ -210,10 +249,7 @@ func CompleteJSON(jsonStr string) string {
 				return closeJSON(s[:safe], stack)
 			}
 			i = end
-			safe = i
-			if len(stack) == 0 {
-				return s[:safe]
-			}
+			valueDone(i)
 		}
 	}
 
@@ -221,46 +257,67 @@ func CompleteJSON(jsonStr string) string {
 }
 
 // closeJSON appends the closers for the containers left open in stack,
-// innermost first.
+// innermost first. The document frame has no closer to append.
 func closeJSON(prefix string, stack []jsonFrame) string {
-	if prefix == "" && len(stack) == 0 {
-		return "{}"
-	}
-
 	var b strings.Builder
 	b.Grow(len(prefix) + len(stack))
 	b.WriteString(prefix)
 	for i := len(stack) - 1; i >= 0; i-- {
-		b.WriteByte(stack[i].closer)
+		if stack[i].closer != 0 {
+			b.WriteByte(stack[i].closer)
+		}
+	}
+	if b.Len() == 0 {
+		return "{}"
 	}
 	return b.String()
 }
 
 // scanJSONString scans the string literal starting at s[start], which is the
 // opening quote. It returns the index just past the closing quote, or -1 if the
-// literal is truncated along with cut, the length of the prefix that stays
-// valid once a closing quote is appended.
+// literal does not end there along with cut, the length of the prefix that
+// stays valid once a closing quote is appended.
+//
+// Content JSON does not permit inside a string ends the literal early, at the
+// offending byte, rather than being carried into the result. A closing quote
+// later in the input cannot rescue it: the bytes before that quote would still
+// be illegal.
 func scanJSONString(s string, start int) (end, cut int) {
 	for i := start + 1; i < len(s); i++ {
-		switch s[i] {
-		case '"':
+		switch c := s[i]; {
+		case c == '"':
 			return i + 1, 0
-		case '\\':
+
+		case c < 0x20:
+			// A raw control character. Models emit these for newlines inside
+			// string values, where JSON requires \n.
+			return -1, i
+
+		case c == '\\':
 			// The escape and everything it consumes must both have arrived, or
 			// the quote we append would be swallowed by the escape.
 			if i+1 >= len(s) {
 				return -1, i
 			}
-			if s[i+1] == 'u' {
-				if i+5 >= len(s) {
+			switch s[i+1] {
+			case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+			case 'u':
+				if i+5 >= len(s) || !isHex(s[i+2]) || !isHex(s[i+3]) || !isHex(s[i+4]) || !isHex(s[i+5]) {
 					return -1, i
 				}
 				i += 4 // Skip \uXXXX; the loop's i++ accounts for the 'u'.
+			default:
+				return -1, i // Not an escape JSON recognizes.
 			}
 			i++
 		}
 	}
 	return -1, len(s)
+}
+
+// isHex reports whether c is a hexadecimal digit.
+func isHex(c byte) bool {
+	return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
 }
 
 // completeKeyword returns the JSON keyword that tok is an unfinished prefix of.

--- a/go/internal/base/extract_test.go
+++ b/go/internal/base/extract_test.go
@@ -16,7 +16,9 @@ package base
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -173,6 +175,169 @@ func TestCompleteJSON(t *testing.T) {
 			input: "",
 			want:  "{}",
 		},
+		{
+			// Containers must be closed innermost first. Closing by type
+			// instead produced `[{"a": 1]}` and broke every streamed array of
+			// objects, the most common structured output shape.
+			name:  "object unclosed inside array",
+			input: `[{"a": 1`,
+			want:  `[{"a": 1}]`,
+		},
+		{
+			name:  "second object unclosed inside array",
+			input: `[{"a": 1}, {"b": 2`,
+			want:  `[{"a": 1}, {"b": 2}]`,
+		},
+		{
+			name:  "array unclosed inside object",
+			input: `{"a": [1, 2`,
+			want:  `{"a": [1, 2]}`,
+		},
+		{
+			name:  "deeply alternating containers",
+			input: `{"a": [{"b": [{"c": "d`,
+			want:  `{"a": [{"b": [{"c": "d"}]}]}`,
+		},
+		{
+			name:  "empty containers",
+			input: `{"a": [{`,
+			want:  `{"a": [{}]}`,
+		},
+		{
+			// A trailing backslash would escape the quote used to close the
+			// string, leaving it open.
+			name:  "dangling escape",
+			input: `{"a": "x\`,
+			want:  `{"a": "x"}`,
+		},
+		{
+			name:  "truncated unicode escape",
+			input: `{"a": "x\u26`,
+			want:  `{"a": "x"}`,
+		},
+		{
+			name:  "complete escapes are kept",
+			input: `{"a": "x\"y\\`,
+			want:  `{"a": "x\"y\\"}`,
+		},
+		{
+			name:  "escaped quote does not close the string",
+			input: `{"a": "x\"`,
+			want:  `{"a": "x\""}`,
+		},
+		{
+			name:  "rune split by chunk boundary",
+			input: "{\"a\": \"hi \xe4\xb8",
+			want:  `{"a": "hi "}`,
+		},
+		{
+			// A key with no value yet cannot be completed without inventing
+			// one, so the whole member is dropped.
+			name:  "key without colon",
+			input: `{"a": 1, "b"`,
+			want:  `{"a": 1}`,
+		},
+		{
+			name:  "key without value",
+			input: `{"a": 1, "b":`,
+			want:  `{"a": 1}`,
+		},
+		{
+			name:  "partial key",
+			input: `{"a": 1, "b`,
+			want:  `{"a": 1}`,
+		},
+		{
+			name:  "only a key",
+			input: `{"a"`,
+			want:  `{}`,
+		},
+		{
+			name:  "missing value in nested object",
+			input: `{"a": {"b": 1, "c":`,
+			want:  `{"a": {"b": 1}}`,
+		},
+		{
+			// Unambiguous: nothing else in JSON starts with "tr".
+			name:  "truncated keyword",
+			input: `{"a": tr`,
+			want:  `{"a": true}`,
+		},
+		{
+			name:  "truncated keyword false",
+			input: `[fals`,
+			want:  `[false]`,
+		},
+		{
+			name:  "truncated keyword null",
+			input: `{"a": n`,
+			want:  `{"a": null}`,
+		},
+		{
+			name:  "complete keyword",
+			input: `{"a": true`,
+			want:  `{"a": true}`,
+		},
+		{
+			name:  "keyword truncated by a delimiter is not a keyword",
+			input: `{"a": tr,`,
+			want:  `{}`,
+		},
+		{
+			name:  "truncated number",
+			input: `{"a": 1.`,
+			want:  `{}`,
+		},
+		{
+			name:  "lone minus sign",
+			input: `[1, -`,
+			want:  `[1]`,
+		},
+		{
+			name:  "truncated exponent",
+			input: `[1e`,
+			want:  `[]`,
+		},
+		{
+			name:  "float value",
+			input: `{"a": 1.5`,
+			want:  `{"a": 1.5}`,
+		},
+		{
+			name:  "trailing comma in array",
+			input: `[1, 2,`,
+			want:  `[1, 2]`,
+		},
+		{
+			name:  "root scalar",
+			input: `123`,
+			want:  `123`,
+		},
+		{
+			name:  "root string",
+			input: `"abc`,
+			want:  `"abc"`,
+		},
+		{
+			name:  "nothing salvageable",
+			input: `xy`,
+			want:  `{}`,
+		},
+		{
+			name:  "trailing text after complete value",
+			input: `{"a": 1} and then some prose`,
+			want:  `{"a": 1}`,
+		},
+		{
+			name:  "mismatched closer",
+			input: `[1, 2}`,
+			want:  `[1, 2]`,
+		},
+		{
+			name:  "structural characters inside strings are ignored",
+			input: `{"a": "}]{[", "b": [{"c": "\"[`,
+			want:  `{"a": "}]{[", "b": [{"c": "\"["}]}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -190,4 +355,154 @@ func TestCompleteJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+// jsonPrefixCorpus holds documents whose every byte prefix models a point at
+// which a stream could be cut.
+var jsonPrefixCorpus = []string{
+	`{"name": "John", "age": 30, "admin": true, "tags": null}`,
+	`[{"id": 1, "name": "Jo\"hn"}, {"id": 2, "name": "Jane"}]`,
+	`{"items": [{"n": [1.5, -2, 3e4]}, {"n": []}], "done": false}`,
+	`[[[1], [2, [3]]], {"a": {"b": {"c": [{"d": "e"}]}}}]`,
+	`{"text": "braces {} and brackets [] and a quote \" and é and 世界"}`,
+	`[1, 2, 3]`,
+	`{}`,
+	`"just a string"`,
+	`-12.5e-3`,
+}
+
+// TestCompleteJSONPrefixes checks the invariant the streaming path depends on:
+// every prefix of a valid document completes to something that parses.
+func TestCompleteJSONPrefixes(t *testing.T) {
+	for _, doc := range jsonPrefixCorpus {
+		t.Run(doc, func(t *testing.T) {
+			for n := 0; n <= len(doc); n++ {
+				prefix := doc[:n]
+				completed := CompleteJSON(prefix)
+
+				var result any
+				if err := json.Unmarshal([]byte(completed), &result); err != nil {
+					t.Errorf("CompleteJSON(%q) = %q, invalid JSON: %v", prefix, completed, err)
+					continue
+				}
+				if strings.ContainsRune(completed, utf8.RuneError) && !strings.ContainsRune(doc, utf8.RuneError) {
+					t.Errorf("CompleteJSON(%q) = %q, introduced a replacement character", prefix, completed)
+				}
+			}
+		})
+	}
+}
+
+// TestCompleteJSONPrefixesConverge checks that a completed prefix never
+// contradicts the finished document, so a consumer that renders every chunk
+// only ever sees values grow. Completion may not invent a member, reorder one,
+// or report a string or number whose text the document later diverges from.
+func TestCompleteJSONPrefixesConverge(t *testing.T) {
+	for _, doc := range jsonPrefixCorpus {
+		want, err := decodeJSON(doc)
+		if err != nil {
+			t.Fatalf("corpus document %q is not valid JSON: %v", doc, err)
+		}
+
+		t.Run(doc, func(t *testing.T) {
+			for n := 1; n <= len(doc); n++ {
+				prefix := doc[:n]
+				completed := CompleteJSON(prefix)
+				if completed == "{}" {
+					// Nothing in the prefix could be completed, so CompleteJSON
+					// fell back to reporting no value at all. That is not a
+					// claim about the document, so there is nothing to check.
+					continue
+				}
+
+				got, err := decodeJSON(completed)
+				if err != nil {
+					continue // Already reported by TestCompleteJSONPrefixes.
+				}
+				if !isJSONPrefixOf(got, want) {
+					t.Errorf("CompleteJSON(%q) = %q, which is not a snapshot of %q", prefix, completed, doc)
+				}
+			}
+		})
+	}
+}
+
+// decodeJSON decodes into any, keeping numbers as their source text so a
+// partially streamed number stays comparable to the finished one.
+func decodeJSON(s string) (any, error) {
+	dec := json.NewDecoder(strings.NewReader(s))
+	dec.UseNumber()
+
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// isJSONPrefixOf reports whether got could be an earlier snapshot of want. A
+// string or number that is still streaming shows up as a text prefix of its
+// final value; containers may be missing trailing members.
+func isJSONPrefixOf(got, want any) bool {
+	switch g := got.(type) {
+	case map[string]any:
+		w, ok := want.(map[string]any)
+		if !ok {
+			return false
+		}
+		for k, gv := range g {
+			wv, ok := w[k]
+			if !ok || !isJSONPrefixOf(gv, wv) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		w, ok := want.([]any)
+		if !ok || len(g) > len(w) {
+			return false
+		}
+		for i, gv := range g {
+			if !isJSONPrefixOf(gv, w[i]) {
+				return false
+			}
+		}
+		return true
+	case string:
+		w, ok := want.(string)
+		return ok && strings.HasPrefix(w, g)
+	case json.Number:
+		w, ok := want.(json.Number)
+		return ok && strings.HasPrefix(w.String(), g.String())
+	default:
+		// Booleans and null arrive whole or not at all.
+		return got == want
+	}
+}
+
+// FuzzCompleteJSON explores documents beyond the fixed corpus, cutting each one
+// at an arbitrary point. Documents that are not themselves valid JSON are
+// skipped: completion only promises to repair truncation, not corruption.
+func FuzzCompleteJSON(f *testing.F) {
+	for _, doc := range jsonPrefixCorpus {
+		for _, n := range []uint{0, 1, 5, uint(len(doc))} {
+			f.Add(doc, n)
+		}
+	}
+	// Syntactically valid but too large for float64: the promise is that the
+	// output parses, not that every document maps onto a Go value.
+	f.Add("1E0007000", uint(128))
+
+	f.Fuzz(func(t *testing.T, doc string, n uint) {
+		if !json.Valid([]byte(doc)) {
+			t.Skip()
+		}
+
+		prefix := doc[:int(n)%(len(doc)+1)]
+		completed := CompleteJSON(prefix)
+
+		if !json.Valid([]byte(completed)) {
+			t.Errorf("CompleteJSON(%q) = %q, which is not valid JSON", prefix, completed)
+		}
+	})
 }

--- a/go/internal/base/extract_test.go
+++ b/go/internal/base/extract_test.go
@@ -338,6 +338,72 @@ func TestCompleteJSON(t *testing.T) {
 			input: `{"a": "}]{[", "b": [{"c": "\"[`,
 			want:  `{"a": "}]{[", "b": [{"c": "\"["}]}`,
 		},
+		{
+			// Malformed rather than truncated: a container cannot open where a
+			// key belongs, so the scan ends and takes the rest with it.
+			name:  "object opened where a key belongs",
+			input: `{"a": 1, {`,
+			want:  `{"a": 1}`,
+		},
+		{
+			name:  "array opened where a key belongs",
+			input: `{"a": 1, [`,
+			want:  `{"a": 1}`,
+		},
+		{
+			name:  "container opened immediately inside an object",
+			input: `{{`,
+			want:  `{}`,
+		},
+		{
+			// The closer arrives, but a trailing comma means the container is
+			// not closable at that point, so it is closed at the last value.
+			name:  "trailing comma before an explicit closer",
+			input: `[1, 2,]`,
+			want:  `[1, 2]`,
+		},
+		{
+			name:  "trailing comma before an explicit brace",
+			input: `{"a": 1,}`,
+			want:  `{"a": 1}`,
+		},
+		{
+			name:  "colon where a key belongs",
+			input: `{:}`,
+			want:  `{}`,
+		},
+		{
+			name:  "key with no value before the closer",
+			input: `{"a"}`,
+			want:  `{}`,
+		},
+		{
+			name:  "comma where a key belongs",
+			input: `{,}`,
+			want:  `{}`,
+		},
+		{
+			name:  "value with no separator",
+			input: `[1 2]`,
+			want:  `[1]`,
+		},
+		{
+			// A raw newline is illegal inside a JSON string, and a closing
+			// quote further on cannot make the bytes before it legal.
+			name:  "raw control character inside a string",
+			input: "{\"a\": \"line1\nline2\", \"b\": 2}",
+			want:  `{"a": "line1"}`,
+		},
+		{
+			name:  "unrecognized escape",
+			input: `{"a": "x\q"}`,
+			want:  `{"a": "x"}`,
+		},
+		{
+			name:  "non-hex unicode escape",
+			input: `{"a": "x\u12zz"}`,
+			want:  `{"a": "x"}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -480,9 +546,35 @@ func isJSONPrefixOf(got, want any) bool {
 	}
 }
 
+// FuzzCompleteJSONArbitrary asserts the whole contract against unconstrained
+// input: whatever it is handed, the result parses. Truncation is only half of
+// what reaches this function, and a corpus of well-formed documents cannot
+// reach the other half, so this target takes the input as given rather than
+// deriving it from something already valid.
+func FuzzCompleteJSONArbitrary(f *testing.F) {
+	f.Add(`{"a": 1, {`)
+	f.Add(`[1, 2,]`)
+	f.Add(`{"a"}`)
+	f.Add(`[1 2]`)
+	f.Add("{\"a\": \"raw\ncontrol\"}")
+	f.Add(`{"a": "x\q"}`)
+	for _, doc := range jsonPrefixCorpus {
+		f.Add(doc)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		completed := CompleteJSON(s)
+
+		if !json.Valid([]byte(completed)) {
+			t.Errorf("CompleteJSON(%q) = %q, which is not valid JSON", s, completed)
+		}
+	})
+}
+
 // FuzzCompleteJSON explores documents beyond the fixed corpus, cutting each one
-// at an arbitrary point. Documents that are not themselves valid JSON are
-// skipped: completion only promises to repair truncation, not corruption.
+// at an arbitrary point. Where FuzzCompleteJSONArbitrary only pins validity,
+// this one holds the input to being a genuine prefix, which is what lets the
+// corpus tests above check that the content is right and not merely parseable.
 func FuzzCompleteJSON(f *testing.F) {
 	for _, doc := range jsonPrefixCorpus {
 		for _, n := range []uint{0, 1, 5, uint(len(doc))} {


### PR DESCRIPTION
Rewrites `CompleteJSON` as a scanner. It completed truncated documents by counting braces and brackets independently, which produced invalid JSON for the most common streaming shape and for four other classes of truncated tail. `parseJSON` in `go/ai/format.go` discards the resulting parse error and returns `nil`, so a bad completion never surfaces as an error: the chunk is silently dropped. The streaming example in `go/README.md` reads `result.Chunk.Ingredients[0].Name`, an object holding an array of objects, which yielded no chunk at all until the array closed.

The replacement keeps a stack of open containers and a rollback offset, the last position at which the document could legally be closed. Closers pop LIFO, and a tail that cannot be finished without inventing data rewinds to the rollback offset rather than being closed in place. The scanner also tracks what the grammar allows at each position, so input that is malformed rather than truncated rewinds the same way. The result is always valid JSON.

## Bugs fixed

**Containers were closed by type instead of by nesting order.** All open brackets were appended before all open braces, so `[{"a": 1` became `[{"a": 1]}`. Counters cannot recover the order the containers were opened in. This hit every array of objects and every object holding one.

**A dangling escape swallowed the closing quote.** A chunk ending mid-escape had a quote appended to it, so `{"a": "x\` became `{"a": "x\"}` and the string stayed open. Half-arrived `\uXXXX` sequences failed the same way.

**A key whose value had not arrived became a bare key.** `{"a": 1, "b"` became `{"a": 1, "b"}`, and `{"a": 1, "b":` became `{"a": 1, "b":}`. Both now drop the unfinished member.

**Truncated numbers and keywords were emitted raw**, giving `{"a": tr}`, `{"a": 1.}`, and `{"a": -}`. Keywords now complete: no two JSON keywords share a first letter, so `tr` can only have been going to become `true`. Numbers drop the member instead, since `1.` gives no way to know what follows.

**A multi-byte rune split across a chunk boundary decoded to `U+FFFD`.** Those trailing bytes are legal inside a JSON string, so this one passes `json.Valid` and is invisible to a validity check. It shows up only as a replacement character in the decoded value.

## Malformed input rewinds rather than completing in place

Truncation is only half of what reaches this function. A document can also be structurally wrong, and completing that in place produces invalid JSON just as surely: `{"a": 1, {` became `{"a": 1, {}}`, `[1, 2,]` became itself, and `{:}`, `{"a"}`, `{,}`, and `[1 2]` likewise. Tracking the grammar turns all of these into a rewind to the last well-formed offset, which is what `partial-json` does with them.

Raw control characters and unrecognized escapes inside strings are the same class. A literal newline is illegal inside a JSON string and a closing quote further along cannot make the preceding bytes legal, so the string ends at the offending byte and `{"a": "line1<newline>line2", "b": 2}` completes to `{"a": "line1"}`.

## Verification

Go 1.26.3, `go test ./...` in `go/`: 41 packages with tests pass, no failures.

`FuzzCompleteJSONArbitrary` takes its input as given and asserts only that the result parses: 15.7M executions, no failures. `FuzzCompleteJSON` holds the input to being a genuine prefix of a valid document, which is what lets the corpus tests check content rather than mere parseability: 7.8M executions, no failures. The second found one real problem, in the test rather than the code, since `1E0007000` is valid JSON that overflows `float64` and the assertion had to be `json.Valid` rather than unmarshalability. That input is kept as a seed.

Two property tests carry more weight than the table-driven cases: every byte prefix of a corpus document completes to valid JSON, and every completed prefix is a *snapshot* of the finished document, so no chunk reports something the finished document goes on to contradict. The second is what catches the `U+FFFD` case.

Behavior was diffed against `partial-json`, the package `js/ai/src/extract.ts` uses, at all 259 byte-cut points of five documents: no differences once key order is canonicalized. The keyword completion above was the one divergence before this change.
