### PR TITLE
fix(go/ai/exp): scope resume validation to the pending model response

### DIFF
--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2498,12 +2498,14 @@ func validateUserMessage(m *ai.Message) error {
 }
 
 // ValidateResumeAgainstHistory ensures every restart and respond entry on a
-// resume payload references a tool request the model actually issued, so a
+// resume payload references a tool request that is actually pending, so a
 // caller cannot drive a tool the model never asked for and interrupted on.
 // For restart entries it additionally checks the input is unchanged from the
 // original request, preventing a client from forging tool inputs on the
 // interrupted call. The whole history is searched (every model message), not
-// just the last turn. On a violation it returns an INVALID_ARGUMENT error.
+// just the last turn, and newest-first: when a tool name + ref recurs across
+// turns, the entry is validated against the most recent one rather than a
+// stale earlier call. On a violation it returns an INVALID_ARGUMENT error.
 //
 // The prompt-backed agent loop ([DefineAgent]) calls this automatically. A
 // custom agent ([DefineCustomAgent]) that accepts an [AgentInput.Resume] from
@@ -2519,22 +2521,24 @@ func ValidateResumeAgainstHistory(resume *ToolResume, history []*ai.Message) err
 		return nil
 	}
 
-	// Collect every tool request from all model messages in history.
-	var requests []*ai.ToolRequest
-	for _, msg := range history {
-		if msg == nil || msg.Role != ai.RoleModel {
-			continue
-		}
-		for _, p := range msg.Content {
-			if p.IsToolRequest() && p.ToolRequest != nil {
-				requests = append(requests, p.ToolRequest)
-			}
-		}
-	}
+	// Search every model message in history newest-first, so a resume entry
+	// resolves against the most recent tool request carrying that name + ref.
+	// Refs are only made unique within a single model response, so the same
+	// name + ref recurs across turns; matching the oldest occurrence would
+	// both reject a legitimate restart of the pending interrupt and accept a
+	// restart whose input was forged from a stale turn.
 	find := func(name, ref string) *ai.ToolRequest {
-		for _, req := range requests {
-			if req.Name == name && req.Ref == ref {
-				return req
+		for i := len(history) - 1; i >= 0; i-- {
+			msg := history[i]
+			if msg == nil || msg.Role != ai.RoleModel {
+				continue
+			}
+			for j := len(msg.Content) - 1; j >= 0; j-- {
+				p := msg.Content[j]
+				if p.IsToolRequest() && p.ToolRequest != nil &&
+					p.ToolRequest.Name == name && p.ToolRequest.Ref == ref {
+					return p.ToolRequest
+				}
 			}
 		}
 		return nil

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2502,10 +2502,17 @@ func validateUserMessage(m *ai.Message) error {
 // caller cannot drive a tool the model never asked for and interrupted on.
 // For restart entries it additionally checks the input is unchanged from the
 // original request, preventing a client from forging tool inputs on the
-// interrupted call. The whole history is searched (every model message), not
-// just the last turn, and newest-first: when a tool name + ref recurs across
-// turns, the entry is validated against the most recent one rather than a
-// stale earlier call. On a violation it returns an INVALID_ARGUMENT error.
+// interrupted call.
+//
+// Only the most recent model message in history is searched, and within it
+// newest-first. Resume handling resolves exactly that response's tool
+// requests, so an entry aimed at an earlier turn does nothing downstream;
+// worse, because refs are only made unique within a single response, a tool
+// name + ref recurs across turns, and searching further back would let a
+// client validate a restart whose input was forged from an already-settled
+// call. An entry naming an earlier turn is rejected as stale, separately
+// from one naming a tool request that never existed. On a violation it
+// returns an INVALID_ARGUMENT error.
 //
 // The prompt-backed agent loop ([DefineAgent]) calls this automatically. A
 // custom agent ([DefineCustomAgent]) that accepts an [AgentInput.Resume] from
@@ -2521,43 +2528,69 @@ func ValidateResumeAgainstHistory(resume *ToolResume, history []*ai.Message) err
 		return nil
 	}
 
-	// Search every model message in history newest-first, so a resume entry
-	// resolves against the most recent tool request carrying that name + ref.
-	// Refs are only made unique within a single model response, so the same
-	// name + ref recurs across turns; matching the oldest occurrence would
-	// both reject a legitimate restart of the pending interrupt and accept a
-	// restart whose input was forged from a stale turn.
-	find := func(name, ref string) *ai.ToolRequest {
-		for i := len(history) - 1; i >= 0; i-- {
-			msg := history[i]
-			if msg == nil || msg.Role != ai.RoleModel {
-				continue
-			}
-			for j := len(msg.Content) - 1; j >= 0; j-- {
-				p := msg.Content[j]
-				if p.IsToolRequest() && p.ToolRequest != nil &&
-					p.ToolRequest.Name == name && p.ToolRequest.Ref == ref {
-					return p.ToolRequest
-				}
+	// The pending response is the last model message. Trailing non-model
+	// messages are skipped rather than treated as "nothing pending": a
+	// caller that sends a turn message alongside a resume payload leaves a
+	// user message last, and that combination must keep failing downstream
+	// on generate's own precondition instead of being rejected here.
+	pending := -1
+	for i := len(history) - 1; i >= 0; i-- {
+		if msg := history[i]; msg != nil && msg.Role == ai.RoleModel {
+			pending = i
+			break
+		}
+	}
+
+	// findIn searches one model message's tool requests newest-first, so a
+	// malformed response repeating a name + ref resolves to its most recent
+	// occurrence.
+	findIn := func(idx int, name, ref string) *ai.ToolRequest {
+		if idx < 0 {
+			return nil
+		}
+		msg := history[idx]
+		if msg == nil || msg.Role != ai.RoleModel {
+			return nil
+		}
+		for j := len(msg.Content) - 1; j >= 0; j-- {
+			p := msg.Content[j]
+			if p.IsToolRequest() && p.ToolRequest != nil &&
+				p.ToolRequest.Name == name && p.ToolRequest.Ref == ref {
+				return p.ToolRequest
 			}
 		}
 		return nil
 	}
 
-	// Restart entries: name + ref must exist and the input must match the
-	// original request exactly. IsToolRequest only checks the part kind, so
-	// guard the pointer too: a hand-built NewToolRequestPart(nil) is kind
+	// unresolved renders the rejection for an entry that matches nothing in
+	// the pending response. Earlier turns are consulted only to pick the
+	// message: a caller replaying a settled payload should not be told the
+	// tool request never existed.
+	unresolved := func(field, name, ref string) error {
+		for i := pending - 1; i >= 0; i-- {
+			if findIn(i, name, ref) != nil {
+				return status.Errorf(status.ErrInvalidArgument,
+					"resume.%s references tool %q%s from an earlier turn which is no longer pending; only tool requests from the most recent model response can be resumed",
+					field, name, toolRefSuffix(ref))
+			}
+		}
+		return status.Errorf(status.ErrInvalidArgument,
+			"resume.%s references tool %q%s which was not found in session history",
+			field, name, toolRefSuffix(ref))
+	}
+
+	// Restart entries: name + ref must be pending and the input must match
+	// the original request exactly. IsToolRequest only checks the part kind,
+	// so guard the pointer too: a hand-built NewToolRequestPart(nil) is kind
 	// PartToolRequest with a nil ToolRequest.
 	for _, p := range resume.Restart {
 		if !p.IsToolRequest() || p.ToolRequest == nil {
 			continue
 		}
 		req := p.ToolRequest
-		match := find(req.Name, req.Ref)
+		match := findIn(pending, req.Name, req.Ref)
 		if match == nil {
-			return status.Errorf(status.ErrInvalidArgument,
-				"resume.restart references tool %q%s which was not found in session history",
-				req.Name, toolRefSuffix(req.Ref))
+			return unresolved("restart", req.Name, req.Ref)
 		}
 		if !jsonEqual(normalizeJSON(req.Input), normalizeJSON(match.Input)) {
 			return status.Errorf(status.ErrInvalidArgument,
@@ -2566,16 +2599,14 @@ func ValidateResumeAgainstHistory(resume *ToolResume, history []*ai.Message) err
 		}
 	}
 
-	// Respond entries: name + ref must match a tool request in history.
+	// Respond entries: name + ref must match a pending tool request.
 	for _, p := range resume.Respond {
 		if !p.IsToolResponse() || p.ToolResponse == nil {
 			continue
 		}
 		resp := p.ToolResponse
-		if find(resp.Name, resp.Ref) == nil {
-			return status.Errorf(status.ErrInvalidArgument,
-				"resume.respond references tool %q%s which was not found in session history",
-				resp.Name, toolRefSuffix(resp.Ref))
+		if findIn(pending, resp.Name, resp.Ref) == nil {
+			return unresolved("respond", resp.Name, resp.Ref)
 		}
 	}
 

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -2440,8 +2440,9 @@ func TestPromptAgent_RejectsInvalidInputMessage(t *testing.T) {
 
 func TestValidateResumeAgainstHistory(t *testing.T) {
 	// History spans two model messages (each carrying a tool request) plus a
-	// user message that must be ignored. The whole history is searched, not
-	// just the last turn.
+	// user message. Only the last model message is pending, so entries
+	// targeting "second" resolve and entries targeting the settled "first"
+	// do not.
 	history := []*ai.Message{
 		{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart("hi")}},
 		{Role: ai.RoleModel, Content: []*ai.Part{
@@ -2450,6 +2451,7 @@ func TestValidateResumeAgainstHistory(t *testing.T) {
 		{Role: ai.RoleModel, Content: []*ai.Part{
 			ai.NewTextPart("thinking"),
 			ai.NewToolRequestPart(&ai.ToolRequest{Name: "second", Ref: "r2", Input: map[string]any{"b": "x"}}),
+			ai.NewToolRequestPart(&ai.ToolRequest{Name: "numeric", Ref: "r3", Input: map[string]any{"a": float64(1)}}),
 		}},
 	}
 
@@ -2467,9 +2469,21 @@ func TestValidateResumeAgainstHistory(t *testing.T) {
 	}{
 		{name: "nil resume", resume: nil},
 		{name: "empty resume", resume: &ToolResume{}},
-		{name: "respond matches first model message", resume: &ToolResume{Respond: respond("first", "r1")}},
-		{name: "respond matches a later model message", resume: &ToolResume{Respond: respond("second", "r2")}},
-		{name: "restart matches input exactly", resume: &ToolResume{Restart: restart("first", "r1", map[string]any{"a": float64(1)})}},
+		{name: "respond matches the pending model message", resume: &ToolResume{Respond: respond("second", "r2")}},
+		{name: "restart matches input exactly", resume: &ToolResume{Restart: restart("second", "r2", map[string]any{"b": "x"})}},
+		{
+			// Only the last model message is pending. "first" was issued and
+			// settled a turn earlier, so resume handling would never resolve
+			// it; saying so beats claiming it was never requested.
+			name:    "respond references a settled earlier turn",
+			resume:  &ToolResume{Respond: respond("first", "r1")},
+			wantErr: "from an earlier turn which is no longer pending",
+		},
+		{
+			name:    "restart references a settled earlier turn",
+			resume:  &ToolResume{Restart: restart("first", "r1", map[string]any{"a": float64(1)})},
+			wantErr: "from an earlier turn which is no longer pending",
+		},
 		{
 			name:    "respond references unknown tool",
 			resume:  &ToolResume{Respond: respond("ghost", "r1")},
@@ -2477,7 +2491,7 @@ func TestValidateResumeAgainstHistory(t *testing.T) {
 		},
 		{
 			name:    "respond references known tool with wrong ref",
-			resume:  &ToolResume{Respond: respond("first", "wrong")},
+			resume:  &ToolResume{Respond: respond("second", "wrong")},
 			wantErr: "not found in session history",
 		},
 		{
@@ -2487,14 +2501,14 @@ func TestValidateResumeAgainstHistory(t *testing.T) {
 		},
 		{
 			name:    "restart forges modified input",
-			resume:  &ToolResume{Restart: restart("first", "r1", map[string]any{"a": float64(2)})},
+			resume:  &ToolResume{Restart: restart("second", "r2", map[string]any{"b": "forged"})},
 			wantErr: "modified inputs",
 		},
 		{
 			// An int 1 normalizes to the same JSON shape as the stored float64
 			// 1, so a faithful restart is not mistaken for a forgery.
 			name:   "restart input matches across json number types",
-			resume: &ToolResume{Restart: restart("first", "r1", map[string]any{"a": 1})},
+			resume: &ToolResume{Restart: restart("numeric", "r3", map[string]any{"a": 1})},
 		},
 		{
 			// A kind-PartToolRequest part with a nil ToolRequest pointer (e.g.
@@ -2595,6 +2609,39 @@ func TestValidateResumeAgainstHistory_RecurringRefs(t *testing.T) {
 		}}
 		if err := ValidateResumeAgainstHistory(resume, history); err != nil {
 			t.Fatalf("expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("a trailing user message does not hide the pending response", func(t *testing.T) {
+		// Sending a turn message alongside a resume payload leaves a user
+		// message last. Validation still resolves against the pending model
+		// response so the combination keeps failing on generate's own
+		// precondition rather than being rejected here as a forgery.
+		withTurnMessage := append(append([]*ai.Message{}, history...),
+			&ai.Message{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart("and also")}})
+		if err := ValidateResumeAgainstHistory(restart(currentInput), withTurnMessage); err != nil {
+			t.Fatalf("pending response hidden by a trailing user message: %v", err)
+		}
+		if err := ValidateResumeAgainstHistory(restart(staleInput), withTurnMessage); err == nil {
+			t.Fatal("stale input accepted when a user message trails history")
+		}
+	})
+
+	t.Run("a settled turn is rejected as stale, not as unknown", func(t *testing.T) {
+		// The tool ran to completion, so the last model message carries no
+		// tool requests at all and nothing is pending.
+		settled := append(append([]*ai.Message{}, history...),
+			&ai.Message{Role: ai.RoleTool, Content: []*ai.Part{
+				ai.NewToolResponsePart(&ai.ToolResponse{Name: "transfer", Ref: "r1", Output: "done"}),
+			}},
+			&ai.Message{Role: ai.RoleModel, Content: []*ai.Part{ai.NewTextPart("transferred")}},
+		)
+		err := ValidateResumeAgainstHistory(restart(currentInput), settled)
+		if err == nil {
+			t.Fatal("restart of an already-completed tool call accepted, want INVALID_ARGUMENT")
+		}
+		if !strings.Contains(err.Error(), "no longer pending") {
+			t.Fatalf("error %q does not contain %q", err.Error(), "no longer pending")
 		}
 	})
 }

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -2530,6 +2530,75 @@ func TestValidateResumeAgainstHistory(t *testing.T) {
 	}
 }
 
+// TestValidateResumeAgainstHistory_RecurringRefs covers the case where the same
+// tool name + ref appears in more than one model message. Refs are only made
+// unique within a single model response, so a multi-turn session routinely
+// reuses them. Validation must resolve against the newest occurrence: matching
+// the oldest rejects a legitimate restart of the pending interrupt and accepts
+// a restart whose input was forged from a stale turn.
+func TestValidateResumeAgainstHistory_RecurringRefs(t *testing.T) {
+	staleInput := map[string]any{"amount": float64(10)}
+	currentInput := map[string]any{"amount": float64(1000000)}
+
+	// Both model messages carry transfer/r1; only the last one is pending.
+	history := []*ai.Message{
+		{Role: ai.RoleModel, Content: []*ai.Part{
+			ai.NewToolRequestPart(&ai.ToolRequest{Name: "transfer", Ref: "r1", Input: staleInput}),
+		}},
+		{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart("again")}},
+		{Role: ai.RoleModel, Content: []*ai.Part{
+			ai.NewToolRequestPart(&ai.ToolRequest{Name: "transfer", Ref: "r1", Input: currentInput}),
+		}},
+	}
+	restart := func(input any) *ToolResume {
+		return &ToolResume{Restart: []*ai.Part{
+			ai.NewToolRequestPart(&ai.ToolRequest{Name: "transfer", Ref: "r1", Input: input}),
+		}}
+	}
+
+	t.Run("restart matching the newest request is accepted", func(t *testing.T) {
+		if err := ValidateResumeAgainstHistory(restart(currentInput), history); err != nil {
+			t.Fatalf("legitimate restart of the pending interrupt rejected: %v", err)
+		}
+	})
+
+	t.Run("restart forged from a stale request is rejected", func(t *testing.T) {
+		err := ValidateResumeAgainstHistory(restart(staleInput), history)
+		if err == nil {
+			t.Fatal("restart carrying a stale turn's input was accepted, want INVALID_ARGUMENT")
+		}
+		if !strings.Contains(err.Error(), "modified inputs") {
+			t.Fatalf("error %q does not contain %q", err.Error(), "modified inputs")
+		}
+		if ge := core.AsGenkitError(err); ge.Status != core.INVALID_ARGUMENT {
+			t.Fatalf("expected status %q, got %q", core.INVALID_ARGUMENT, ge.Status)
+		}
+	})
+
+	t.Run("newest occurrence within a single message wins", func(t *testing.T) {
+		// A malformed model response repeating one ref still resolves to the
+		// most recent request, keeping the newest-first rule consistent.
+		oneMessage := []*ai.Message{
+			{Role: ai.RoleModel, Content: []*ai.Part{
+				ai.NewToolRequestPart(&ai.ToolRequest{Name: "transfer", Ref: "r1", Input: staleInput}),
+				ai.NewToolRequestPart(&ai.ToolRequest{Name: "transfer", Ref: "r1", Input: currentInput}),
+			}},
+		}
+		if err := ValidateResumeAgainstHistory(restart(currentInput), oneMessage); err != nil {
+			t.Fatalf("restart matching the last request in the message rejected: %v", err)
+		}
+	})
+
+	t.Run("respond still matches on name and ref alone", func(t *testing.T) {
+		resume := &ToolResume{Respond: []*ai.Part{
+			ai.NewToolResponsePart(&ai.ToolResponse{Name: "transfer", Ref: "r1", Output: "ok"}),
+		}}
+		if err := ValidateResumeAgainstHistory(resume, history); err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+	})
+}
+
 // TestPromptAgent_RejectsResumeForUnrequestedTool proves the resume validation
 // is wired into the prompt-backed loop: a caller cannot resume a tool the model
 // never requested, and the forged turn fails before the model is re-invoked.


### PR DESCRIPTION
Fixes a resume-validation hole in `ValidateResumeAgainstHistory`, mirroring JS [#5832](https://github.com/genkit-ai/genkit/pull/5832) on the ordering half and going further on scope.

The function flattened the tool requests from every model message in session history into one slice, then matched each resume entry against the first hit. `ensureToolRequestRefs` only fills in empty refs, and only within a single response, so a provider-supplied ref recurs across turns and the first hit is the oldest occurrence rather than the pending one. A client restarting the interrupted call had its input compared against a settled turn's request: a faithful restart was rejected as "modified inputs", while a restart carrying an input forged from that older call validated clean.

Ordering alone is not the whole fix. `handleResumeOption` resolves exactly the tool requests of `messages[len-1]` and requires it to be a model message carrying at least one, so an entry aimed at an earlier turn resolves to nothing downstream. Validation now searches only the last model message, newest-first within it, and reports an entry naming an earlier turn as stale rather than as a tool request that was never made. Trailing non-model messages are skipped rather than read as nothing-pending, since `AgentInput` permits a turn message alongside a resume payload and that combination must keep failing on generate's own `FAILED_PRECONDITION`.

## Behavior change worth noting

A client that resends an accumulated resume payload each turn, valid entries for the pending call plus settled ones from earlier turns, now gets `INVALID_ARGUMENT` where the stale entries were previously accepted and silently ignored downstream. JS still searches the whole history, so the two diverge here.

## Verification

Go 1.26.3, `go test ./...` in `go/`: 41 packages pass, no failures. Conformance harness 40/40, including the forged-restart and unknown-tool specs in `tests/specs/agent.yaml`. `GOMAXPROCS=1 go test ./ai/exp/ -race -count=2` clean.

`TestValidateResumeAgainstHistory_RecurringRefs` pins both original symptoms and every subtest fails on `main`. `TestValidateResumeAgainstHistory` needed its fixture retargeted, since it asserted cross-turn matching as correct.
