### PR TITLE
feat(go/ai): attribute `WrapTool` short-circuits to the tool in traces

### DIFF
--- a/go/ai/format_test.go
+++ b/go/ai/format_test.go
@@ -792,6 +792,7 @@ func (bananaHandler) Config() ModelOutputConfig {
 }
 
 func TestDefineFormatsCustom(t *testing.T) {
+	r := childRegistry(t)
 	DefineFormats(r, bananaFormatter{})
 
 	t.Run("resolves a custom format by its name", func(t *testing.T) {
@@ -1028,6 +1029,8 @@ func TestStreamingFormatHandlerInterface(t *testing.T) {
 }
 
 func TestConstrainedGenerateWithFormats(t *testing.T) {
+	r := childRegistry(t)
+
 	type FooBar struct {
 		Foo string `json:"foo"`
 	}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -551,6 +551,14 @@ func buildModelChain(mws []*Hooks, fn ModelFunc) ModelFunc {
 	return chain
 }
 
+// toolRanKey carries a per-call flag that the innermost runner sets when it
+// actually executes the tool, letting the engine attribute a hook that
+// short-circuits the call to the tool in traces. It rides the context rather
+// than ToolParams so that a WrapTool hook which rebuilds the params struct (to
+// rewrite the request, say) cannot silently lose it: every hook that derives
+// its context from the one it was handed keeps the flag.
+var toolRanKey = base.NewContextKey[*bool]()
+
 // buildToolRunner composes the WrapTool hooks from mws (outer-to-inner) into
 // a single function that executes a tool. The returned function is safe to
 // invoke from concurrent goroutines; each invocation threads its own params
@@ -570,7 +578,9 @@ func buildToolRunner(mws []*Hooks) func(ctx context.Context, tool Tool, req *Too
 		}
 	}
 	chain := func(ctx context.Context, params *ToolParams) (*MultipartToolResponse, error) {
-		params.ran = true
+		if ran := toolRanKey.FromContext(ctx); ran != nil {
+			*ran = true
+		}
 		return params.Tool.RunRawMultipart(ctx, params.Request.Input)
 	}
 	for i := len(mws) - 1; i >= 0; i-- {
@@ -585,9 +595,9 @@ func buildToolRunner(mws []*Hooks) func(ctx context.Context, tool Tool, req *Too
 		}
 	}
 	return func(ctx context.Context, tool Tool, req *ToolRequest) (*MultipartToolResponse, error) {
-		params := &ToolParams{Request: req, Tool: tool}
-		resp, err := chain(ctx, params)
-		if !params.ran {
+		ran := false
+		resp, err := chain(toolRanKey.NewContext(ctx, &ran), &ToolParams{Request: req, Tool: tool})
+		if !ran {
 			return recordToolShortCircuit(ctx, tool.Name(), req.Input, resp, err)
 		}
 		return resp, err

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -570,6 +570,7 @@ func buildToolRunner(mws []*Hooks) func(ctx context.Context, tool Tool, req *Too
 		}
 	}
 	chain := func(ctx context.Context, params *ToolParams) (*MultipartToolResponse, error) {
+		params.ran = true
 		return params.Tool.RunRawMultipart(ctx, params.Request.Input)
 	}
 	for i := len(mws) - 1; i >= 0; i-- {
@@ -584,8 +585,34 @@ func buildToolRunner(mws []*Hooks) func(ctx context.Context, tool Tool, req *Too
 		}
 	}
 	return func(ctx context.Context, tool Tool, req *ToolRequest) (*MultipartToolResponse, error) {
-		return chain(ctx, &ToolParams{Request: req, Tool: tool})
+		params := &ToolParams{Request: req, Tool: tool}
+		resp, err := chain(ctx, params)
+		if !params.ran {
+			return recordToolShortCircuit(ctx, tool.Name(), req.Input, resp, err)
+		}
+		return resp, err
 	}
+}
+
+// recordToolShortCircuit emits the tool-shaped span that core/action.go would
+// have created, attributing a WrapTool outcome (interrupt, cached response,
+// injected error) to the tool in traces even though the tool never ran. The
+// span wraps the already-known outcome and returns it unchanged, so it records
+// what the tool call resolved to rather than how long the hooks took to
+// resolve it.
+func recordToolShortCircuit(ctx context.Context, name string, input any, resp *MultipartToolResponse, err error) (*MultipartToolResponse, error) {
+	spanMeta := &tracing.SpanMetadata{
+		Name:            name,
+		Type:            "action",
+		Subtype:         "tool",
+		Metadata:        map[string]string{},
+		TelemetryLabels: tracing.TelemetryLabelsFromContext(ctx),
+	}
+	if flowName := core.FlowNameFromContext(ctx); flowName != "" {
+		spanMeta.Metadata["flow:name"] = flowName
+	}
+	return tracing.RunInNewSpan(ctx, spanMeta, input,
+		func(context.Context, any) (*MultipartToolResponse, error) { return resp, err })
 }
 
 // Generate generates a model response based on the provided options.

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -95,6 +95,7 @@ var gablorkenTool = DefineTool(r, "gablorken", "use when need to calculate a gab
 func TestStreamingChunksHaveRoleAndIndex(t *testing.T) {
 	t.Parallel()
 
+	r := childRegistry(t)
 	ctx := context.Background()
 
 	convertTempTool := DefineTool(r, "convertTemp", "converts temperature",
@@ -362,6 +363,7 @@ func TestValidMessage(t *testing.T) {
 }
 
 func TestGenerate(t *testing.T) {
+	r := childRegistry(t)
 	JSON := "{\"subject\": \"bananas\", \"location\": \"tropics\"}"
 	JSONmd := "```json" + JSON + "```"
 
@@ -748,6 +750,11 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("registers dynamic tools", func(t *testing.T) {
+		// A root registry, not the enclosing child: Generate only quarantines
+		// dynamic tools in a child of its own when the caller hands it a root,
+		// which is the isolation this subtest asserts.
+		r := newTestRegistry(t)
+
 		// Create a tool that is NOT registered in the global registry
 		dynamicTool := NewTool("dynamicTestTool", "a tool that is dynamically registered",
 			func(ctx *ToolContext, input struct {
@@ -1006,6 +1013,7 @@ type resumableToolInput struct {
 }
 
 func TestToolInterruptsAndResume(t *testing.T) {
+	r := childRegistry(t)
 	conditionalTool := DefineTool(r, "conditional", "tool that may interrupt based on input",
 		func(ctx *ToolContext, input conditionalToolInput) (string, error) {
 			if input.Interrupt {

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -42,10 +42,7 @@ type Hooks struct {
 	// WrapTool wraps each tool execution. It may be called concurrently when
 	// multiple tools execute in parallel for the same Generate() call; any
 	// state closed over from the enclosing scope that this hook mutates must
-	// be guarded with sync primitives. Pass the received params through to
-	// next (mutate its fields rather than replacing the struct): the engine
-	// carries per-call state on it, e.g. to attribute short-circuits in
-	// traces.
+	// be guarded with sync primitives.
 	WrapTool func(ctx context.Context, params *ToolParams, next ToolNext) (*MultipartToolResponse, error)
 }
 
@@ -82,11 +79,6 @@ type ToolParams struct {
 	Request *ToolRequest
 	// Tool is the resolved tool being called.
 	Tool Tool
-
-	// ran records whether the innermost runner actually executed the tool,
-	// letting the engine attribute hook short-circuits (interrupts, cached
-	// responses) to the tool in traces.
-	ran bool
 }
 
 // GenerateNext is the next function in the WrapGenerate hook chain.

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -42,7 +42,10 @@ type Hooks struct {
 	// WrapTool wraps each tool execution. It may be called concurrently when
 	// multiple tools execute in parallel for the same Generate() call; any
 	// state closed over from the enclosing scope that this hook mutates must
-	// be guarded with sync primitives.
+	// be guarded with sync primitives. Pass the received params through to
+	// next (mutate its fields rather than replacing the struct): the engine
+	// carries per-call state on it, e.g. to attribute short-circuits in
+	// traces.
 	WrapTool func(ctx context.Context, params *ToolParams, next ToolNext) (*MultipartToolResponse, error)
 }
 
@@ -79,6 +82,11 @@ type ToolParams struct {
 	Request *ToolRequest
 	// Tool is the resolved tool being called.
 	Tool Tool
+
+	// ran records whether the innermost runner actually executed the tool,
+	// letting the engine attribute hook short-circuits (interrupts, cached
+	// responses) to the tool in traces.
+	ran bool
 }
 
 // GenerateNext is the next function in the WrapGenerate hook chain.

--- a/go/ai/middleware_test.go
+++ b/go/ai/middleware_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 )
 
 // --- counter: a config whose BuildMiddleware tracks hook invocations ---
@@ -524,6 +525,150 @@ func TestWrapToolInterrupts(t *testing.T) {
 	if len(resp.Interrupts()) == 0 {
 		t.Error("expected at least one interrupt part in response")
 	}
+}
+
+// --- WrapTool short-circuits are attributed to the tool in traces ---
+
+// defineCountingTool defines a tool that records how many times its function
+// body ran, so a test can tell a short-circuited call from a real one.
+func defineCountingTool(t *testing.T, r api.Registry, name string, calls *int32) Tool {
+	t.Helper()
+	return DefineTool(r, name, "A test tool",
+		func(ctx *ToolContext, input struct {
+			Value string `json:"value"`
+		}) (string, error) {
+			atomic.AddInt32(calls, 1)
+			return "tool result: " + input.Value, nil
+		})
+}
+
+// TestWrapToolShortCircuitEmitsToolSpan verifies that a WrapTool hook which
+// resolves a call without invoking next (cached response, interrupt) is still
+// attributed to the tool in traces, with the span core/action.go would have
+// emitted had the tool run. Middleware therefore does not hand-roll its own.
+func TestWrapToolShortCircuitEmitsToolSpan(t *testing.T) {
+	tests := []struct {
+		name      string
+		hook      func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error)
+		wantState string
+		// wantGenerateErr is true for the case that fails the whole call
+		// rather than resolving the turn; the span is recorded either way.
+		wantGenerateErr bool
+	}{
+		{
+			name: "cached response",
+			hook: func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error) {
+				return &MultipartToolResponse{Output: "from cache"}, nil
+			},
+			wantState: "success",
+		},
+		{
+			name: "interrupt",
+			hook: func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error) {
+				return nil, NewToolInterruptError(map[string]any{"reason": "blocked"})
+			},
+			wantState: "error",
+		},
+		{
+			name: "injected error",
+			hook: func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error) {
+				return nil, errors.New("denied")
+			},
+			wantState:       "error",
+			wantGenerateErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry(t)
+			defineFakeModel(t, r, fakeModelConfig{
+				name:    "test/toolModel",
+				handler: toolCallingModelHandler("myTool", map[string]any{"value": "x"}, "done"),
+			})
+			var toolCalls int32
+			tool := defineCountingTool(t, r, "myTool", &toolCalls)
+			spans := collectSpans(t)
+
+			shortCircuit := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+				return &Hooks{WrapTool: tt.hook}, nil
+			})
+
+			_, err := Generate(testCtx, r,
+				WithModelName("test/toolModel"),
+				WithPrompt("use it"),
+				WithTools(tool),
+				WithUse(shortCircuit),
+			)
+			if tt.wantGenerateErr {
+				if err == nil {
+					t.Fatal("expected the injected error to fail the call, got nil")
+				}
+			} else {
+				assertNoError(t, err)
+			}
+
+			if got := atomic.LoadInt32(&toolCalls); got != 0 {
+				t.Errorf("tool ran %d times, want 0 (hook short-circuited)", got)
+			}
+
+			toolSpans := spans.allByName(tool.Name())
+			if len(toolSpans) != 1 {
+				t.Fatalf("got %d spans named %q, want exactly 1", len(toolSpans), tool.Name())
+			}
+			span := toolSpans[0]
+			assertSpanAttr(t, span, "genkit:type", "action")
+			assertSpanAttr(t, span, "genkit:metadata:subtype", "tool")
+			assertSpanAttr(t, span, "genkit:state", tt.wantState)
+			assertSpanAttr(t, span, "genkit:input", `{"value":"x"}`)
+		})
+	}
+}
+
+// TestWrapToolPassThroughEmitsSingleToolSpan verifies the engine does not
+// double-count a hook that runs the tool: the action's own span is the only
+// one recorded for the call.
+func TestWrapToolPassThroughEmitsSingleToolSpan(t *testing.T) {
+	r := newTestRegistry(t)
+	defineFakeModel(t, r, fakeModelConfig{
+		name:    "test/toolModel",
+		handler: toolCallingModelHandler("myTool", map[string]any{"value": "x"}, "done"),
+	})
+	var toolCalls int32
+	tool := defineCountingTool(t, r, "myTool", &toolCalls)
+	spans := collectSpans(t)
+
+	// Rewrites the request in place, the pass-through contract documented on
+	// Hooks.WrapTool, and runs the tool.
+	rewriter := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+		return &Hooks{
+			WrapTool: func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error) {
+				p.Request = &ToolRequest{
+					Name:  p.Request.Name,
+					Ref:   p.Request.Ref,
+					Input: map[string]any{"value": "rewritten"},
+				}
+				return next(ctx, p)
+			},
+		}, nil
+	})
+
+	_, err := Generate(testCtx, r,
+		WithModelName("test/toolModel"),
+		WithPrompt("use it"),
+		WithTools(tool),
+		WithUse(rewriter),
+	)
+	assertNoError(t, err)
+
+	if got := atomic.LoadInt32(&toolCalls); got != 1 {
+		t.Errorf("tool ran %d times, want 1", got)
+	}
+	toolSpans := spans.allByName(tool.Name())
+	if len(toolSpans) != 1 {
+		t.Fatalf("got %d spans named %q, want exactly 1", len(toolSpans), tool.Name())
+	}
+	assertSpanAttr(t, toolSpans[0], "genkit:input", `{"value":"rewritten"}`)
 }
 
 // --- WrapTool validation errors returned to model ---

--- a/go/ai/middleware_test.go
+++ b/go/ai/middleware_test.go
@@ -627,48 +627,67 @@ func TestWrapToolShortCircuitEmitsToolSpan(t *testing.T) {
 
 // TestWrapToolPassThroughEmitsSingleToolSpan verifies the engine does not
 // double-count a hook that runs the tool: the action's own span is the only
-// one recorded for the call.
+// one recorded, however the hook chose to hand the call down. The rebuilt-params
+// case is why the ran flag rides the context and not ToolParams, which a hook
+// is free to replace.
 func TestWrapToolPassThroughEmitsSingleToolSpan(t *testing.T) {
-	r := newTestRegistry(t)
-	defineFakeModel(t, r, fakeModelConfig{
-		name:    "test/toolModel",
-		handler: toolCallingModelHandler("myTool", map[string]any{"value": "x"}, "done"),
-	})
-	var toolCalls int32
-	tool := defineCountingTool(t, r, "myTool", &toolCalls)
-	spans := collectSpans(t)
+	rewritten := map[string]any{"value": "rewritten"}
 
-	// Rewrites the request in place, the pass-through contract documented on
-	// Hooks.WrapTool, and runs the tool.
-	rewriter := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
-		return &Hooks{
-			WrapTool: func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error) {
-				p.Request = &ToolRequest{
-					Name:  p.Request.Name,
-					Ref:   p.Request.Ref,
-					Input: map[string]any{"value": "rewritten"},
-				}
+	tests := []struct {
+		name string
+		hook func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error)
+	}{
+		{
+			name: "mutates the params it was handed",
+			hook: func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error) {
+				p.Request = &ToolRequest{Name: p.Request.Name, Ref: p.Request.Ref, Input: rewritten}
 				return next(ctx, p)
 			},
-		}, nil
-	})
-
-	_, err := Generate(testCtx, r,
-		WithModelName("test/toolModel"),
-		WithPrompt("use it"),
-		WithTools(tool),
-		WithUse(rewriter),
-	)
-	assertNoError(t, err)
-
-	if got := atomic.LoadInt32(&toolCalls); got != 1 {
-		t.Errorf("tool ran %d times, want 1", got)
+		},
+		{
+			name: "hands next a params struct of its own",
+			hook: func(ctx context.Context, p *ToolParams, next ToolNext) (*MultipartToolResponse, error) {
+				return next(ctx, &ToolParams{
+					Request: &ToolRequest{Name: p.Request.Name, Ref: p.Request.Ref, Input: rewritten},
+					Tool:    p.Tool,
+				})
+			},
+		},
 	}
-	toolSpans := spans.allByName(tool.Name())
-	if len(toolSpans) != 1 {
-		t.Fatalf("got %d spans named %q, want exactly 1", len(toolSpans), tool.Name())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry(t)
+			defineFakeModel(t, r, fakeModelConfig{
+				name:    "test/toolModel",
+				handler: toolCallingModelHandler("myTool", map[string]any{"value": "x"}, "done"),
+			})
+			var toolCalls int32
+			tool := defineCountingTool(t, r, "myTool", &toolCalls)
+			spans := collectSpans(t)
+
+			rewriter := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+				return &Hooks{WrapTool: tt.hook}, nil
+			})
+
+			_, err := Generate(testCtx, r,
+				WithModelName("test/toolModel"),
+				WithPrompt("use it"),
+				WithTools(tool),
+				WithUse(rewriter),
+			)
+			assertNoError(t, err)
+
+			if got := atomic.LoadInt32(&toolCalls); got != 1 {
+				t.Errorf("tool ran %d times, want 1", got)
+			}
+			toolSpans := spans.allByName(tool.Name())
+			if len(toolSpans) != 1 {
+				t.Fatalf("got %d spans named %q, want exactly 1", len(toolSpans), tool.Name())
+			}
+			assertSpanAttr(t, toolSpans[0], "genkit:input", `{"value":"rewritten"}`)
+		})
 	}
-	assertSpanAttr(t, toolSpans[0], "genkit:input", `{"value":"rewritten"}`)
 }
 
 // --- WrapTool validation errors returned to model ---

--- a/go/ai/testutil_test.go
+++ b/go/ai/testutil_test.go
@@ -38,6 +38,20 @@ func newTestRegistry(t *testing.T) api.Registry {
 	return r
 }
 
+// childRegistry returns a per-test child of the package-level registry r. It
+// inherits r's fixtures (echoModel, gablorkenTool, the configured formats) by
+// lookup fallback, while anything the test defines lands in the child and is
+// discarded with it.
+//
+// Shadow r with it (`r := childRegistry(t)`) in any test that registers into
+// the package-level registry: r is built once per process, so a test that
+// registers directly into it panics on the second pass of `go test -count=N`,
+// which is how ordering and scheduling bugs get shaken out locally.
+func childRegistry(t *testing.T) api.Registry {
+	t.Helper()
+	return r.NewChild()
+}
+
 // fakeModelConfig holds configuration for creating a fake model.
 type fakeModelConfig struct {
 	name     string

--- a/go/ai/testutil_test.go
+++ b/go/ai/testutil_test.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/registry"
 	"github.com/google/go-cmp/cmp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // newTestRegistry creates a fresh registry for testing with formats configured.
@@ -281,6 +284,72 @@ func defineFakeTool(t *testing.T, r api.Registry, name, description string) Tool
 		}) (string, error) {
 			return "tool result: " + input.Value, nil
 		})
+}
+
+// spanCollector is a minimal sdktrace.SpanExporter that records finished
+// spans so a test can assert on their attributes.
+type spanCollector struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (c *spanCollector) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.spans = append(c.spans, spans...)
+	return nil
+}
+
+func (c *spanCollector) Shutdown(context.Context) error { return nil }
+
+// allByName returns every recorded span with the given name.
+func (c *spanCollector) allByName(name string) []sdktrace.ReadOnlySpan {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range c.spans {
+		if s.Name() == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// collectSpans registers an in-memory exporter on the global tracer provider
+// (the one tracing.RunInNewSpan writes through) for the duration of the test.
+// The SimpleSpanProcessor exports each span synchronously as it ends, so by
+// the time the call under test returns its spans are already recorded.
+func collectSpans(t *testing.T) *spanCollector {
+	t.Helper()
+	c := &spanCollector{}
+	sp := sdktrace.NewSimpleSpanProcessor(c)
+	tp := tracing.TracerProvider()
+	tp.RegisterSpanProcessor(sp)
+	t.Cleanup(func() { tp.UnregisterSpanProcessor(sp) })
+	return c
+}
+
+// spanAttr returns the string value of the named span attribute, if present.
+func spanAttr(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// assertSpanAttr fails the test unless span carries key with value want.
+func assertSpanAttr(t *testing.T, span sdktrace.ReadOnlySpan, key, want string) {
+	t.Helper()
+	got, ok := spanAttr(span, key)
+	if !ok {
+		t.Errorf("span %q: missing attribute %q", span.Name(), key)
+		return
+	}
+	if got != want {
+		t.Errorf("span %q: %s = %q, want %q", span.Name(), key, got, want)
+	}
 }
 
 // defineFakeEmbedder creates a simple embedder for testing.

--- a/go/plugins/middleware/tool_approval.go
+++ b/go/plugins/middleware/tool_approval.go
@@ -21,8 +21,6 @@ import (
 	"slices"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
-	"github.com/firebase/genkit/go/core/tracing"
 )
 
 // ToolApproval is a middleware that interrupts tool execution unless the tool
@@ -73,22 +71,9 @@ func (t *ToolApproval) wrapTool(ctx context.Context, params *ai.ToolParams, next
 		return next(ctx, params)
 	}
 
-	// Emit a tool-shaped span so the interrupt is attributed to the tool in traces,
-	// mirroring the span that core/action.go would create if the tool had run.
-	spanMeta := &tracing.SpanMetadata{
-		Name:     name,
-		Type:     "action",
-		Subtype:  "tool",
-		Metadata: map[string]string{},
-	}
-	if flowName := core.FlowNameFromContext(ctx); flowName != "" {
-		spanMeta.Metadata["flow:name"] = flowName
-	}
-	_, err := tracing.RunInNewSpan(ctx, spanMeta, params.Request.Input,
-		func(ctx context.Context, _ any) (any, error) {
-			return nil, ai.NewToolInterruptError(map[string]any{
-				"message": "Tool not in approved list: " + name,
-			})
-		})
-	return nil, err
+	// No span is emitted here: the generate engine attributes a hook that
+	// short-circuits the tool to the tool itself in traces.
+	return nil, ai.NewToolInterruptError(map[string]any{
+		"message": "Tool not in approved list: " + name,
+	})
 }

--- a/go/plugins/middleware/tool_approval_test.go
+++ b/go/plugins/middleware/tool_approval_test.go
@@ -18,11 +18,14 @@ package middleware
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/registry"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func defineToolModel(t *testing.T, r *registry.Registry, name string, fn ai.ModelFunc) ai.Model {
@@ -40,6 +43,45 @@ func defineTool(t *testing.T, r api.Registry, name string) ai.Tool {
 		}) (string, error) {
 			return "result:" + input.V, nil
 		})
+}
+
+// spanCollector is a minimal sdktrace.SpanExporter that records finished
+// spans so a test can assert on them.
+type spanCollector struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (c *spanCollector) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.spans = append(c.spans, spans...)
+	return nil
+}
+
+func (c *spanCollector) Shutdown(context.Context) error { return nil }
+
+// byName returns every recorded span with the given name.
+func (c *spanCollector) byName(name string) []sdktrace.ReadOnlySpan {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range c.spans {
+		if s.Name() == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// spanAttr returns the string value of the named span attribute, if present.
+func spanAttr(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
 }
 
 // twoToolModelHandler returns a model handler that requests two tools on the first call,
@@ -135,6 +177,47 @@ func TestToolApprovalInterruptsUnapprovedTools(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected interrupt for 'dangerous' tool")
+	}
+}
+
+// TestToolApprovalInterruptIsTracedOnce verifies the interrupt lands in the
+// trace as exactly one span named for the blocked tool. ToolApproval emits no
+// span of its own: the generate engine attributes a short-circuited tool call
+// to the tool, so hand-rolling one here would double-count it.
+func TestToolApprovalInterruptIsTracedOnce(t *testing.T) {
+	r := newTestRegistry(t)
+
+	m := defineToolModel(t, r, "test/twotools", twoToolModelHandler("safe", "dangerous"))
+	safe := defineTool(t, r, "safe")
+	dangerous := defineTool(t, r, "dangerous")
+
+	collector := &spanCollector{}
+	sp := sdktrace.NewSimpleSpanProcessor(collector)
+	tp := tracing.TracerProvider()
+	tp.RegisterSpanProcessor(sp)
+	t.Cleanup(func() { tp.UnregisterSpanProcessor(sp) })
+
+	ta := &ToolApproval{AllowedTools: []string{"safe"}}
+	if _, err := ai.Generate(ctx, r,
+		ai.WithModel(m),
+		ai.WithPrompt("go"),
+		ai.WithTools(safe, dangerous),
+		ai.WithUse(ta),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	spans := collector.byName("dangerous")
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans named %q, want exactly 1", len(spans), "dangerous")
+	}
+	const subtypeKey = "genkit:metadata:subtype"
+	subtype, ok := spanAttr(spans[0], subtypeKey)
+	if !ok {
+		t.Fatalf("span %q: missing attribute %q", "dangerous", subtypeKey)
+	}
+	if subtype != "tool" {
+		t.Errorf("span %q: %s = %q, want %q", "dangerous", subtypeKey, subtype, "tool")
 	}
 }
 


### PR DESCRIPTION
Ports the trace-attribution change from §4 of the Go V2 branch ([#5814](https://github.com/genkit-ai/genkit/pull/5814)). No exported API changes, so it lands in a minor.

A `WrapTool` hook that resolved a tool call without invoking `next` left no trace of the call at all. The tool's action never ran, so no tool span was emitted and the outcome (an interrupt, a cached response, an injected error) was invisible in the Dev UI and in exported telemetry. The only recourse was for the middleware to build a tool-shaped span itself, which is what `ToolApproval` did.

The engine now tracks whether the innermost runner actually executed the tool and wraps a short-circuited outcome in the span `core/action.go` would have emitted: same name, `genkit:type=action`, `genkit:metadata:subtype=tool`, flow name and telemetry labels, with the hook's response or error as the span outcome. The flag rides the context, so a hook that hands `next` a params struct of its own is still recorded as having run the tool. The span wraps an already-computed result, so its duration is ~0: the tool did not run, and charging the middleware's own time to it would be worse.

`ToolApproval` drops its hand-rolled span and is back to pure policy: check the allow list, check the resume flag, interrupt. Third-party middleware that copied that pattern will now emit two tool spans for one blocked call, its own nested inside the engine's. The engine's is the correct one and the fix is to delete the hand-rolled span.

The typed `ApprovalRequest` / `Approval` payloads bundled into the same V2 section are not ported. They change `ToolApproval`'s interrupt and resume shapes and depend on `tool.ResumeData`, which does not exist on this line.

## Verification

Go 1.26.3, full `go test ./...` in `go/`: 41 packages pass, no failures. `go/ai` also passes at `-count=5`, with `-race`, and under `GOMAXPROCS=1`; every test in the package passes individually at `-count=2`.

New coverage pins the span for each short-circuit shape (cached response, interrupt, injected error) and pins that a hook which rewrites the request and calls `next` still yields exactly one tool span, whether it mutates the params it was handed or gives `next` a struct of its own. All three short-circuit cases fail on `main` with `got 0 spans named "myTool"`. `tool_approval_test.go` pins exactly one span for a blocked tool, which catches a re-added hand-rolled span as well as a lost one.
