### PR TITLE
chore(js/plugins/firebase): Allow @google-cloud/firestore v8

### DIFF
--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -34,7 +34,7 @@
     "@genkit-ai/google-cloud": "workspace:^"
   },
   "peerDependencies": {
-    "@google-cloud/firestore": ^7.11.0 || ^8.0.0",
+    "@google-cloud/firestore": "^7.11.0 || ^8.0.0",
     "firebase": ">=11.5.0",
     "firebase-admin": ">=12.2",
     "genkit": "workspace:^"

--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -34,7 +34,7 @@
     "@genkit-ai/google-cloud": "workspace:^"
   },
   "peerDependencies": {
-    "@google-cloud/firestore": "^7.11.0",
+    "@google-cloud/firestore": "^8.7.0",
     "firebase": ">=11.5.0",
     "firebase-admin": ">=12.2",
     "genkit": "workspace:^"

--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -34,7 +34,7 @@
     "@genkit-ai/google-cloud": "workspace:^"
   },
   "peerDependencies": {
-    "@google-cloud/firestore": "^8.7.0",
+    "@google-cloud/firestore": ^7.11.0 || ^8.0.0",
     "firebase": ">=11.5.0",
     "firebase-admin": ">=12.2",
     "genkit": "workspace:^"


### PR DESCRIPTION
Update peer dependency `@google-cloud/firestore` to also allow v8 in `@genkit-ai/firebase`.

None of the breaking changes in Firestore v8 impact the Firebase plugin.

Breaking changes: https://github.com/googleapis/nodejs-firestore/blob/main/CHANGELOG.md#800-2025-10-29