### PR TITLE
feat(ollama): detect model capabilities dynamically

### DIFF
--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -164,8 +164,16 @@ func (o *Ollama) listLocalModels(ctx context.Context) ([]ollamaLocalModel, error
 }
 
 func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.ModelOptions) ai.Model {
-	// Detect capabilities before acquiring the lock to avoid holding it
-	// during HTTP I/O.
+	// Check the init guard first under a brief lock — before any I/O — so
+	// that a forgotten Init() panics immediately rather than after a timeout.
+	o.mu.Lock()
+	if !o.initted {
+		o.mu.Unlock()
+		panic("ollama.Init not called")
+	}
+	o.mu.Unlock()
+
+	// Detect capabilities outside the lock to avoid holding it during HTTP I/O.
 	var modelOpts ai.ModelOptions
 	if opts != nil {
 		modelOpts = *opts
@@ -184,11 +192,9 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		}
 	}
 
+	// Re-acquire lock for the registration step.
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	if !o.initted {
-		panic("ollama.Init not called")
-	}
 	meta := &ai.ModelOptions{
 		Label:        "Ollama - " + model.Name,
 		Supports:     modelOpts.Supports,

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -164,13 +164,9 @@ func (o *Ollama) listLocalModels(ctx context.Context) ([]ollamaLocalModel, error
 }
 
 func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.ModelOptions) ai.Model {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	if !o.initted {
-		panic("ollama.Init not called")
-	}
+	// Detect capabilities before acquiring the lock to avoid holding it
+	// during HTTP I/O.
 	var modelOpts ai.ModelOptions
-
 	if opts != nil {
 		modelOpts = *opts
 	} else {
@@ -178,12 +174,20 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		// /api/show. This replaces the hardcoded allowlist approach so that
 		// newly released models (e.g. gemma4) work automatically without
 		// code changes. Falls back to the static list for older servers.
-		caps := o.getModelCapabilities(context.Background(), model.Name)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout)*time.Second)
+		defer cancel()
+		caps := o.getModelCapabilities(ctx, model.Name)
 		modelOpts = ai.ModelOptions{
 			Label:    model.Name,
 			Supports: modelSupportsFromCapabilities(caps, model.Name),
 			Versions: []string{},
 		}
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if !o.initted {
+		panic("ollama.Init not called")
 	}
 	meta := &ai.ModelOptions{
 		Label:        "Ollama - " + model.Name,
@@ -425,6 +429,10 @@ func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 		if strings.Contains(name, "embed") {
 			continue
 		}
+		// Check for context cancellation before each potentially slow HTTP call.
+		if ctx.Err() != nil {
+			break
+		}
 		// Query each model's actual capabilities from the Ollama server.
 		caps := o.getModelCapabilities(ctx, name)
 		supports := modelSupportsFromCapabilities(caps, name)
@@ -442,7 +450,9 @@ func (o *Ollama) ResolveAction(atype api.ActionType, name string) api.Action {
 		return nil
 	}
 	// Query the model's actual capabilities from the Ollama server.
-	caps := o.getModelCapabilities(context.Background(), name)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout)*time.Second)
+	defer cancel()
+	caps := o.getModelCapabilities(ctx, name)
 	supports := modelSupportsFromCapabilities(caps, name)
 	model := o.newModel(name, ai.ModelOptions{Supports: supports})
 	if action, ok := model.(api.Action); ok {

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -80,10 +80,64 @@ type ollamaTagsResponse struct {
 	Models []ollamaLocalModel `json:"models"`
 }
 
-// ollamaLocalModel represents a locally available Ollama model.
+// ollamaLocalModel represents a locally available Ollama model from /api/tags.
 type ollamaLocalModel struct {
 	Name  string `json:"name"`
 	Model string `json:"model"`
+}
+
+// ollamaShowResponse represents the response from POST /api/show.
+type ollamaShowResponse struct {
+	Capabilities []string `json:"capabilities"`
+}
+
+// getModelCapabilities calls POST /api/show to retrieve the model's capabilities.
+// Returns nil if the endpoint is unavailable or the model doesn't report capabilities.
+func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) []string {
+	body, err := json.Marshal(map[string]string{"model": modelName})
+	if err != nil {
+		return nil
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", o.ServerAddress+"/api/show", bytes.NewReader(body))
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	var showResp ollamaShowResponse
+	if err := json.NewDecoder(resp.Body).Decode(&showResp); err != nil {
+		return nil
+	}
+	return showResp.Capabilities
+}
+
+// modelSupportsFromCapabilities derives ModelSupports from capabilities reported
+// by the Ollama /api/show endpoint. Falls back to the static allowlists when
+// the server doesn't report capabilities (older Ollama versions).
+func modelSupportsFromCapabilities(caps []string, modelName string) *ai.ModelSupports {
+	if len(caps) > 0 {
+		return &ai.ModelSupports{
+			Multiturn:  true,
+			SystemRole: true,
+			Tools:      slices.Contains(caps, "tools"),
+			Media:      slices.Contains(caps, "vision") || slices.Contains(caps, "audio"),
+		}
+	}
+	// Fallback: use static allowlists for older Ollama servers that don't
+	// report capabilities via /api/show.
+	return &ai.ModelSupports{
+		Multiturn:  true,
+		SystemRole: true,
+		Tools:      slices.Contains(toolSupportedModels, modelName),
+		Media:      slices.Contains(mediaSupportedModels, modelName),
+	}
 }
 
 // listLocalModels calls GET /api/tags to list locally installed Ollama models.
@@ -120,16 +174,14 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 	if opts != nil {
 		modelOpts = *opts
 	} else {
-		// Check if the model supports tools (must be a chat model and in the supported list)
-		supportsTools := model.Type == "chat" && slices.Contains(toolSupportedModels, model.Name)
+		// Query the Ollama server for the model's actual capabilities via
+		// /api/show. This replaces the hardcoded allowlist approach so that
+		// newly released models (e.g. gemma4) work automatically without
+		// code changes. Falls back to the static list for older servers.
+		caps := o.getModelCapabilities(context.Background(), model.Name)
 		modelOpts = ai.ModelOptions{
-			Label: model.Name,
-			Supports: &ai.ModelSupports{
-				Multiturn:  true,
-				SystemRole: true,
-				Media:      slices.Contains(mediaSupportedModels, model.Name),
-				Tools:      supportsTools,
-			},
+			Label:    model.Name,
+			Supports: modelSupportsFromCapabilities(caps, model.Name),
 			Versions: []string{},
 		}
 	}
@@ -373,7 +425,10 @@ func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 		if strings.Contains(name, "embed") {
 			continue
 		}
-		model := o.newModel(name, ai.ModelOptions{Supports: &defaultOllamaSupports})
+		// Query each model's actual capabilities from the Ollama server.
+		caps := o.getModelCapabilities(ctx, name)
+		supports := modelSupportsFromCapabilities(caps, name)
+		model := o.newModel(name, ai.ModelOptions{Supports: supports})
 		if action, ok := model.(api.Action); ok {
 			actions = append(actions, action.Desc())
 		}
@@ -386,7 +441,10 @@ func (o *Ollama) ResolveAction(atype api.ActionType, name string) api.Action {
 	if atype != api.ActionTypeModel {
 		return nil
 	}
-	model := o.newModel(name, ai.ModelOptions{Supports: &defaultOllamaSupports})
+	// Query the model's actual capabilities from the Ollama server.
+	caps := o.getModelCapabilities(context.Background(), name)
+	supports := modelSupportsFromCapabilities(caps, name)
+	model := o.newModel(name, ai.ModelOptions{Supports: supports})
 	if action, ok := model.(api.Action); ok {
 		return action
 	}

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -44,6 +44,7 @@ const (
 	provider                       = "ollama"
 	modelCapabilitiesTimeout       = 5 * time.Second
 	capabilityFailureCacheLifetime = 30 * time.Second
+	maxConcurrentCapabilityQueries = 4
 )
 
 var (
@@ -92,7 +93,7 @@ type ollamaLocalModel struct {
 
 // ollamaShowResponse represents the response from POST /api/show.
 type ollamaShowResponse struct {
-	Capabilities *[]string `json:"capabilities"`
+	Capabilities []string `json:"capabilities"`
 }
 
 // getModelCapabilities calls POST /api/show to retrieve the model's capabilities.
@@ -125,7 +126,7 @@ func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) ([]
 	if showResp.Capabilities == nil {
 		return nil, fmt.Errorf("ollama /api/show response for %q omitted capabilities", modelName)
 	}
-	return *showResp.Capabilities, nil
+	return showResp.Capabilities, nil
 }
 
 func (o *Ollama) endpoint(path string) string {
@@ -189,8 +190,8 @@ func (o *Ollama) listLocalModels(ctx context.Context) ([]ollamaLocalModel, error
 }
 
 func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.ModelOptions) ai.Model {
-	// Check the init guard first under a brief lock — before any I/O — so
-	// that a forgotten Init() panics immediately rather than after a timeout.
+	// Check the init guard under a separate brief lock. The lock must be
+	// released before cachedModelCapabilities below, which acquires it again.
 	o.mu.Lock()
 	if !o.initted {
 		o.mu.Unlock()
@@ -440,14 +441,15 @@ func (o *Ollama) Init(ctx context.Context) []api.Action {
 }
 
 func (o *Ollama) cachedModelCapabilities(name, digest string) (modelCapabilitiesCacheEntry, bool) {
+	key := normalizeModelName(name)
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	entry, ok := o.capabilitiesCache[name]
+	entry, ok := o.capabilitiesCache[key]
 	if !ok || (digest != "" && entry.digest != digest) {
 		return modelCapabilitiesCacheEntry{}, false
 	}
 	if !entry.expires.IsZero() && time.Now().After(entry.expires) {
-		delete(o.capabilitiesCache, name)
+		delete(o.capabilitiesCache, key)
 		return modelCapabilitiesCacheEntry{}, false
 	}
 	return entry, true
@@ -461,14 +463,21 @@ func (o *Ollama) cacheModelSupports(name, digest string, supports *ai.ModelSuppo
 	if !detected {
 		expires = time.Now().Add(capabilityFailureCacheLifetime)
 	}
+	key := normalizeModelName(name)
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.capabilitiesCache == nil {
 		o.capabilitiesCache = make(map[string]modelCapabilitiesCacheEntry)
 	}
-	o.capabilitiesCache[name] = modelCapabilitiesCacheEntry{
+	o.capabilitiesCache[key] = modelCapabilitiesCacheEntry{
 		digest: digest, supports: *supports, detected: detected, expires: expires,
 	}
+}
+
+// normalizeModelName makes Ollama's implicit latest tag use the same cache key
+// as the explicit name returned by /api/tags.
+func normalizeModelName(name string) string {
+	return strings.TrimSuffix(name, ":latest")
 }
 
 // newModel creates an Ollama model without registering it in the Genkit registry.
@@ -507,15 +516,24 @@ func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 
 	supports := make([]*ai.ModelSupports, len(filtered))
 	var wg sync.WaitGroup
+	querySlots := make(chan struct{}, maxConcurrentCapabilityQueries)
+
+scheduleQueries:
 	for i, m := range filtered {
 		if cached, ok := o.cachedModelCapabilities(m.Name, m.Digest); ok {
 			cachedSupports := cached.supports
 			supports[i] = &cachedSupports
 			continue
 		}
+		select {
+		case querySlots <- struct{}{}:
+		case <-ctx.Done():
+			break scheduleQueries
+		}
 		wg.Add(1)
 		go func(i int, m ollamaLocalModel) {
 			defer wg.Done()
+			defer func() { <-querySlots }()
 			capabilityCtx, cancel := o.modelCapabilitiesContext(ctx)
 			defer cancel()
 			caps, err := o.getModelCapabilities(capabilityCtx, m.Name)

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -40,7 +40,10 @@ import (
 	"github.com/invopop/jsonschema"
 )
 
-const provider = "ollama"
+const (
+	provider                 = "ollama"
+	modelCapabilitiesTimeout = 5 * time.Second
+)
 
 var (
 	mediaSupportedModels = []string{"llava", "bakllava", "llava-llama3", "llava:13b", "llava:7b", "llava:latest", "gemma3:4b", "gemma3:12b", "gemma3:27b"}
@@ -59,9 +62,8 @@ var (
 		ai.RoleSystem: "system",
 		ai.RoleTool:   "tool",
 	}
-	// defaultOllamaSupports defines the default capabilities for dynamically
-	// discovered Ollama models. All capabilities are enabled since local models
-	// vary widely and we can't query their capabilities individually.
+	// defaultOllamaSupports preserves the historical fallback for dynamically
+	// discovered Ollama models when capability detection is unavailable.
 	defaultOllamaSupports = ai.ModelSupports{
 		Multiturn:  true,
 		Media:      true,
@@ -88,55 +90,74 @@ type ollamaLocalModel struct {
 
 // ollamaShowResponse represents the response from POST /api/show.
 type ollamaShowResponse struct {
-	Capabilities []string `json:"capabilities"`
+	Capabilities *[]string `json:"capabilities"`
 }
 
 // getModelCapabilities calls POST /api/show to retrieve the model's capabilities.
-// Returns nil if the endpoint is unavailable or the model doesn't report capabilities.
-func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) []string {
+// The boolean reports whether the server returned a capabilities field, allowing
+// callers to distinguish an explicitly empty list from an unavailable endpoint.
+func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) ([]string, bool) {
 	body, err := json.Marshal(map[string]string{"model": modelName})
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	req, err := http.NewRequestWithContext(ctx, "POST", o.ServerAddress+"/api/show", bytes.NewReader(body))
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := o.client.Do(req)
+	client := o.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil
+		return nil, false
 	}
 	var showResp ollamaShowResponse
 	if err := json.NewDecoder(resp.Body).Decode(&showResp); err != nil {
-		return nil
+		return nil, false
 	}
-	return showResp.Capabilities
+	if showResp.Capabilities == nil {
+		return nil, false
+	}
+	return *showResp.Capabilities, true
+}
+
+// modelCapabilitiesContext bounds metadata lookups independently from the
+// potentially longer generation timeout. A smaller configured timeout is honored.
+func (o *Ollama) modelCapabilitiesContext(parent context.Context) (context.Context, context.CancelFunc) {
+	timeout := time.Duration(o.Timeout) * time.Second
+	if timeout <= 0 || timeout > modelCapabilitiesTimeout {
+		timeout = modelCapabilitiesTimeout
+	}
+	return context.WithTimeout(parent, timeout)
 }
 
 // modelSupportsFromCapabilities derives ModelSupports from capabilities reported
-// by the Ollama /api/show endpoint. Falls back to the static allowlists when
-// the server doesn't report capabilities (older Ollama versions).
-func modelSupportsFromCapabilities(caps []string, modelName string) *ai.ModelSupports {
-	if len(caps) > 0 {
-		return &ai.ModelSupports{
-			Multiturn:  true,
-			SystemRole: true,
-			Tools:      slices.Contains(caps, "tools"),
-			Media:      slices.Contains(caps, "vision") || slices.Contains(caps, "audio"),
-		}
-	}
-	// Fallback: use static allowlists for older Ollama servers that don't
-	// report capabilities via /api/show.
+// by the Ollama /api/show endpoint.
+func modelSupportsFromCapabilities(caps []string) *ai.ModelSupports {
 	return &ai.ModelSupports{
 		Multiturn:  true,
 		SystemRole: true,
-		Tools:      slices.Contains(toolSupportedModels, modelName),
-		Media:      slices.Contains(mediaSupportedModels, modelName),
+		Tools:      slices.Contains(caps, "tools"),
+		Media:      slices.Contains(caps, "vision") || slices.Contains(caps, "audio"),
+	}
+}
+
+// modelSupportsFromStaticLists preserves the fallback used by explicitly
+// defined models when the server does not report capabilities.
+func modelSupportsFromStaticLists(modelName string) *ai.ModelSupports {
+	baseName, _, _ := strings.Cut(modelName, ":")
+	return &ai.ModelSupports{
+		Multiturn:  true,
+		SystemRole: true,
+		Tools:      slices.Contains(toolSupportedModels, baseName) || slices.Contains(toolSupportedModels, modelName),
+		Media:      slices.Contains(mediaSupportedModels, baseName) || slices.Contains(mediaSupportedModels, modelName),
 	}
 }
 
@@ -182,12 +203,18 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		// /api/show. This replaces the hardcoded allowlist approach so that
 		// newly released models (e.g. gemma4) work automatically without
 		// code changes. Falls back to the static list for older servers.
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout)*time.Second)
+		ctx, cancel := o.modelCapabilitiesContext(context.Background())
 		defer cancel()
-		caps := o.getModelCapabilities(ctx, model.Name)
+		caps, detected := o.getModelCapabilities(ctx, model.Name)
+		supports := modelSupportsFromStaticLists(model.Name)
+		if detected {
+			supports = modelSupportsFromCapabilities(caps)
+		}
+		// Only chat models use /api/chat, which is the endpoint that accepts tools.
+		supports.Tools = model.Type == "chat" && supports.Tools
 		modelOpts = ai.ModelOptions{
 			Label:    model.Name,
-			Supports: modelSupportsFromCapabilities(caps, model.Name),
+			Supports: supports,
 			Versions: []string{},
 		}
 	}
@@ -440,8 +467,13 @@ func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 			break
 		}
 		// Query each model's actual capabilities from the Ollama server.
-		caps := o.getModelCapabilities(ctx, name)
-		supports := modelSupportsFromCapabilities(caps, name)
+		capabilityCtx, cancel := o.modelCapabilitiesContext(ctx)
+		caps, detected := o.getModelCapabilities(capabilityCtx, name)
+		cancel()
+		supports := &defaultOllamaSupports
+		if detected {
+			supports = modelSupportsFromCapabilities(caps)
+		}
 		model := o.newModel(name, ai.ModelOptions{Supports: supports})
 		if action, ok := model.(api.Action); ok {
 			actions = append(actions, action.Desc())
@@ -456,10 +488,13 @@ func (o *Ollama) ResolveAction(atype api.ActionType, name string) api.Action {
 		return nil
 	}
 	// Query the model's actual capabilities from the Ollama server.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout)*time.Second)
+	ctx, cancel := o.modelCapabilitiesContext(context.Background())
 	defer cancel()
-	caps := o.getModelCapabilities(ctx, name)
-	supports := modelSupportsFromCapabilities(caps, name)
+	caps, detected := o.getModelCapabilities(ctx, name)
+	supports := &defaultOllamaSupports
+	if detected {
+		supports = modelSupportsFromCapabilities(caps)
+	}
 	model := o.newModel(name, ai.ModelOptions{Supports: supports})
 	if action, ok := model.(api.Action); ok {
 		return action

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -41,8 +41,9 @@ import (
 )
 
 const (
-	provider                 = "ollama"
-	modelCapabilitiesTimeout = 5 * time.Second
+	provider                       = "ollama"
+	modelCapabilitiesTimeout       = 5 * time.Second
+	capabilityFailureCacheLifetime = 30 * time.Second
 )
 
 var (
@@ -84,8 +85,9 @@ type ollamaTagsResponse struct {
 
 // ollamaLocalModel represents a locally available Ollama model from /api/tags.
 type ollamaLocalModel struct {
-	Name  string `json:"name"`
-	Model string `json:"model"`
+	Name   string `json:"name"`
+	Model  string `json:"model"`
+	Digest string `json:"digest"`
 }
 
 // ollamaShowResponse represents the response from POST /api/show.
@@ -94,16 +96,14 @@ type ollamaShowResponse struct {
 }
 
 // getModelCapabilities calls POST /api/show to retrieve the model's capabilities.
-// The boolean reports whether the server returned a capabilities field, allowing
-// callers to distinguish an explicitly empty list from an unavailable endpoint.
-func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) ([]string, bool) {
+func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) ([]string, error) {
 	body, err := json.Marshal(map[string]string{"model": modelName})
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("failed to encode /api/show request for %q: %w", modelName, err)
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", o.ServerAddress+"/api/show", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", o.endpoint("/api/show"), bytes.NewReader(body))
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("failed to create /api/show request for %q: %w", modelName, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	client := o.client
@@ -112,20 +112,24 @@ func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) ([]
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("failed to query capabilities for %q: %w", modelName, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, false
+		return nil, fmt.Errorf("ollama /api/show returned status %d for %q", resp.StatusCode, modelName)
 	}
 	var showResp ollamaShowResponse
 	if err := json.NewDecoder(resp.Body).Decode(&showResp); err != nil {
-		return nil, false
+		return nil, fmt.Errorf("failed to decode /api/show response for %q: %w", modelName, err)
 	}
 	if showResp.Capabilities == nil {
-		return nil, false
+		return nil, fmt.Errorf("ollama /api/show response for %q omitted capabilities", modelName)
 	}
-	return *showResp.Capabilities, true
+	return *showResp.Capabilities, nil
+}
+
+func (o *Ollama) endpoint(path string) string {
+	return strings.TrimRight(o.ServerAddress, "/") + path
 }
 
 // modelCapabilitiesContext bounds metadata lookups independently from the
@@ -145,25 +149,25 @@ func modelSupportsFromCapabilities(caps []string) *ai.ModelSupports {
 		Multiturn:  true,
 		SystemRole: true,
 		Tools:      slices.Contains(caps, "tools"),
-		Media:      slices.Contains(caps, "vision") || slices.Contains(caps, "audio"),
+		// concatImages only forwards image parts; audio input is not supported.
+		Media: slices.Contains(caps, "vision"),
 	}
 }
 
 // modelSupportsFromStaticLists preserves the fallback used by explicitly
 // defined models when the server does not report capabilities.
 func modelSupportsFromStaticLists(modelName string) *ai.ModelSupports {
-	baseName, _, _ := strings.Cut(modelName, ":")
 	return &ai.ModelSupports{
 		Multiturn:  true,
 		SystemRole: true,
-		Tools:      slices.Contains(toolSupportedModels, baseName) || slices.Contains(toolSupportedModels, modelName),
-		Media:      slices.Contains(mediaSupportedModels, baseName) || slices.Contains(mediaSupportedModels, modelName),
+		Tools:      slices.Contains(toolSupportedModels, modelName),
+		Media:      slices.Contains(mediaSupportedModels, modelName),
 	}
 }
 
 // listLocalModels calls GET /api/tags to list locally installed Ollama models.
 func (o *Ollama) listLocalModels(ctx context.Context) ([]ollamaLocalModel, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", o.ServerAddress+"/api/tags", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", o.endpoint("/api/tags"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -194,21 +198,17 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 	}
 	o.mu.Unlock()
 
-	// Detect capabilities outside the lock to avoid holding it during HTTP I/O.
 	var modelOpts ai.ModelOptions
 	if opts != nil {
 		modelOpts = *opts
 	} else {
-		// Query the Ollama server for the model's actual capabilities via
-		// /api/show. This replaces the hardcoded allowlist approach so that
-		// newly released models (e.g. gemma4) work automatically without
-		// code changes. Falls back to the static list for older servers.
-		ctx, cancel := o.modelCapabilitiesContext(context.Background())
-		defer cancel()
-		caps, detected := o.getModelCapabilities(ctx, model.Name)
+		// Explicitly registered models retain the static capability fallback used
+		// before dynamic discovery was added. Reuse successful discovery results
+		// when available without doing network I/O during registration.
 		supports := modelSupportsFromStaticLists(model.Name)
-		if detected {
-			supports = modelSupportsFromCapabilities(caps)
+		if cached, ok := o.cachedModelCapabilities(model.Name, ""); ok && cached.detected {
+			cachedSupports := cached.supports
+			supports = &cachedSupports
 		}
 		// Only chat models use /api/chat, which is the endpoint that accepts tools.
 		supports.Tools = model.Type == "chat" && supports.Tools
@@ -401,9 +401,17 @@ type Ollama struct {
 	ServerAddress string // Server address of oLLama.
 	Timeout       int    // Response timeout in seconds (defaulted to 30 seconds)
 
-	mu      sync.Mutex   // Mutex to control access.
-	initted bool         // Whether the plugin has been initialized.
-	client  *http.Client // Shared HTTP client for API calls (e.g., /api/tags).
+	mu                sync.Mutex   // Mutex to control access.
+	initted           bool         // Whether the plugin has been initialized.
+	client            *http.Client // Shared HTTP client for API calls (e.g., /api/tags).
+	capabilitiesCache map[string]modelCapabilitiesCacheEntry
+}
+
+type modelCapabilitiesCacheEntry struct {
+	digest   string
+	supports ai.ModelSupports
+	detected bool
+	expires  time.Time
 }
 
 func (o *Ollama) Name() string {
@@ -427,7 +435,40 @@ func (o *Ollama) Init(ctx context.Context) []api.Action {
 		o.Timeout = 30
 	}
 	o.client = &http.Client{}
+	o.capabilitiesCache = make(map[string]modelCapabilitiesCacheEntry)
 	return []api.Action{}
+}
+
+func (o *Ollama) cachedModelCapabilities(name, digest string) (modelCapabilitiesCacheEntry, bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	entry, ok := o.capabilitiesCache[name]
+	if !ok || (digest != "" && entry.digest != digest) {
+		return modelCapabilitiesCacheEntry{}, false
+	}
+	if !entry.expires.IsZero() && time.Now().After(entry.expires) {
+		delete(o.capabilitiesCache, name)
+		return modelCapabilitiesCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (o *Ollama) cacheModelSupports(name, digest string, supports *ai.ModelSupports, detected bool) {
+	if supports == nil {
+		return
+	}
+	var expires time.Time
+	if !detected {
+		expires = time.Now().Add(capabilityFailureCacheLifetime)
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.capabilitiesCache == nil {
+		o.capabilitiesCache = make(map[string]modelCapabilitiesCacheEntry)
+	}
+	o.capabilitiesCache[name] = modelCapabilitiesCacheEntry{
+		digest: digest, supports: *supports, detected: detected, expires: expires,
+	}
 }
 
 // newModel creates an Ollama model without registering it in the Genkit registry.
@@ -455,26 +496,52 @@ func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 		return nil
 	}
 
-	var actions []api.ActionDesc
+	filtered := make([]ollamaLocalModel, 0, len(models))
 	for _, m := range models {
-		name := m.Name
 		// Filter out embedding models (following JS: !m.model.includes('embed'))
-		if strings.Contains(name, "embed") {
+		if strings.Contains(m.Name, "embed") {
 			continue
 		}
-		// Check for context cancellation before each potentially slow HTTP call.
-		if ctx.Err() != nil {
-			break
+		filtered = append(filtered, m)
+	}
+
+	supports := make([]*ai.ModelSupports, len(filtered))
+	var wg sync.WaitGroup
+	for i, m := range filtered {
+		if cached, ok := o.cachedModelCapabilities(m.Name, m.Digest); ok {
+			cachedSupports := cached.supports
+			supports[i] = &cachedSupports
+			continue
 		}
-		// Query each model's actual capabilities from the Ollama server.
-		capabilityCtx, cancel := o.modelCapabilitiesContext(ctx)
-		caps, detected := o.getModelCapabilities(capabilityCtx, name)
-		cancel()
-		supports := &defaultOllamaSupports
-		if detected {
-			supports = modelSupportsFromCapabilities(caps)
-		}
-		model := o.newModel(name, ai.ModelOptions{Supports: supports})
+		wg.Add(1)
+		go func(i int, m ollamaLocalModel) {
+			defer wg.Done()
+			capabilityCtx, cancel := o.modelCapabilitiesContext(ctx)
+			defer cancel()
+			caps, err := o.getModelCapabilities(capabilityCtx, m.Name)
+			modelSupports := &defaultOllamaSupports
+			if err != nil {
+				if ctx.Err() == nil {
+					slog.Warn("unable to detect ollama model capabilities", "model", m.Name, "error", err)
+				}
+			} else {
+				modelSupports = modelSupportsFromCapabilities(caps)
+			}
+			supports[i] = modelSupports
+			if ctx.Err() == nil {
+				o.cacheModelSupports(m.Name, m.Digest, modelSupports, err == nil)
+			}
+		}(i, m)
+	}
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		slog.Warn("ollama model discovery canceled", "error", err)
+		return nil
+	}
+
+	actions := make([]api.ActionDesc, 0, len(filtered))
+	for i, m := range filtered {
+		model := o.newModel(m.Name, ai.ModelOptions{Supports: supports[i]})
 		if action, ok := model.(api.Action); ok {
 			actions = append(actions, action.Desc())
 		}
@@ -487,13 +554,10 @@ func (o *Ollama) ResolveAction(atype api.ActionType, name string) api.Action {
 	if atype != api.ActionTypeModel {
 		return nil
 	}
-	// Query the model's actual capabilities from the Ollama server.
-	ctx, cancel := o.modelCapabilitiesContext(context.Background())
-	defer cancel()
-	caps, detected := o.getModelCapabilities(ctx, name)
 	supports := &defaultOllamaSupports
-	if detected {
-		supports = modelSupportsFromCapabilities(caps)
+	if cached, ok := o.cachedModelCapabilities(name, ""); ok {
+		cachedSupports := cached.supports
+		supports = &cachedSupports
 	}
 	model := o.newModel(name, ai.ModelOptions{Supports: supports})
 	if action, ok := model.(api.Action); ok {

--- a/go/plugins/ollama/ollama_live_test.go
+++ b/go/plugins/ollama/ollama_live_test.go
@@ -17,11 +17,18 @@
 package ollama_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
+	"net/http"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	ollamaPlugin "github.com/firebase/genkit/go/plugins/ollama"
 )
@@ -30,21 +37,99 @@ var (
 	serverAddress    = flag.String("server-address", "http://localhost:11434", "Ollama server address")
 	modelName        = flag.String("model-name", "tinyllama", "model name")
 	dynamicModelName = flag.String("dynamic-model-name", "moondream", "model name for dynamic discovery test (must not be in hardcoded lists)")
+	liveTimeout      = flag.Duration("live-timeout", 2*time.Minute, "timeout for live Ollama requests")
 	testLive         = flag.Bool("test-live", false, "run live tests")
 )
 
-/*
-To run this test, you need to have the Ollama server running. You can set the server address using the OLLAMA_SERVER_ADDRESS environment variable.
-If the environment variable is not set, the test will default to http://localhost:11434 (the default address for the Ollama server).
-*/
+type liveShowResponse struct {
+	Capabilities *[]string `json:"capabilities"`
+}
+
+func getLiveModelCapabilities(t *testing.T, ctx context.Context, modelName string) ([]string, bool) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"model": modelName})
+	if err != nil {
+		t.Fatalf("failed to encode /api/show request: %v", err)
+	}
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		strings.TrimRight(*serverAddress, "/")+"/api/show",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("failed to create /api/show request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to call /api/show for model %q: %v", modelName, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Logf("/api/show returned status %d for model %q; expecting fallback capabilities", resp.StatusCode, modelName)
+		return nil, false
+	}
+
+	var showResp liveShowResponse
+	if err := json.NewDecoder(resp.Body).Decode(&showResp); err != nil {
+		t.Fatalf("failed to decode /api/show response for model %q: %v", modelName, err)
+	}
+	if showResp.Capabilities == nil {
+		return nil, false
+	}
+	return *showResp.Capabilities, true
+}
+
+func assertLiveCapabilities(t *testing.T, desc api.ActionDesc, capabilities []string, detected bool) {
+	t.Helper()
+
+	modelMetadata, ok := desc.Metadata["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("model metadata for %q has type %T, want map[string]any", desc.Name, desc.Metadata["model"])
+	}
+	supports, ok := modelMetadata["supports"].(map[string]any)
+	if !ok {
+		t.Fatalf("supports metadata for %q has type %T, want map[string]any", desc.Name, modelMetadata["supports"])
+	}
+
+	// ListActions and ResolveAction historically enabled tools and media when
+	// capability detection was unavailable.
+	wantTools := true
+	wantMedia := true
+	if detected {
+		wantTools = slices.Contains(capabilities, "tools")
+		wantMedia = slices.Contains(capabilities, "vision") || slices.Contains(capabilities, "audio")
+	}
+	if got, ok := supports["tools"].(bool); !ok || got != wantTools {
+		t.Errorf("%q tools support = %v, want %v from /api/show capabilities %v", desc.Name, supports["tools"], wantTools, capabilities)
+	}
+	if got, ok := supports["media"].(bool); !ok || got != wantMedia {
+		t.Errorf("%q media support = %v, want %v from /api/show capabilities %v", desc.Name, supports["media"], wantMedia, capabilities)
+	}
+}
+
+func sameLiveModelName(got, want string) bool {
+	got = strings.TrimPrefix(got, "ollama/")
+	return got == want || got == want+":latest" || got+":latest" == want
+}
+
+// Live tests require a running Ollama server. Use -server-address to override
+// the default http://localhost:11434 endpoint.
 func TestLive(t *testing.T) {
 	if !*testLive {
 		t.Skip("skipping go/plugins/ollama live test")
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), *liveTimeout)
+	defer cancel()
 
-	o := &ollamaPlugin.Ollama{ServerAddress: *serverAddress, Timeout: 60}
+	o := &ollamaPlugin.Ollama{
+		ServerAddress: *serverAddress,
+		Timeout:       int(liveTimeout.Seconds()),
+	}
 	g := genkit.Init(ctx, genkit.WithPlugins(o))
 
 	// Define the model
@@ -87,9 +172,15 @@ func TestLiveDynamicDiscovery(t *testing.T) {
 		t.Skip("skipping go/plugins/ollama live dynamic discovery test")
 	}
 
-	ctx := context.Background()
-	o := &ollamaPlugin.Ollama{ServerAddress: *serverAddress}
+	ctx, cancel := context.WithTimeout(context.Background(), *liveTimeout)
+	defer cancel()
+	o := &ollamaPlugin.Ollama{
+		ServerAddress: *serverAddress,
+		Timeout:       int(liveTimeout.Seconds()),
+	}
 	g := genkit.Init(ctx, genkit.WithPlugins(o))
+	capabilities, detected := getLiveModelCapabilities(t, ctx, *dynamicModelName)
+	t.Logf("/api/show capabilities for %q: %v (detected: %v)", *dynamicModelName, capabilities, detected)
 
 	// Verify ListActions discovers local models
 	actions := o.ListActions(ctx)
@@ -100,6 +191,17 @@ func TestLiveDynamicDiscovery(t *testing.T) {
 	for _, a := range actions {
 		t.Logf("  - %s", a.Name)
 	}
+	var discovered *api.ActionDesc
+	for i := range actions {
+		if sameLiveModelName(actions[i].Name, *dynamicModelName) {
+			discovered = &actions[i]
+			break
+		}
+	}
+	if discovered == nil {
+		t.Fatalf("ListActions() did not include dynamic model %q", *dynamicModelName)
+	}
+	assertLiveCapabilities(t, *discovered, capabilities, detected)
 
 	// Use a model that is NOT in the hardcoded lists via LookupModel,
 	// which triggers ResolveAction under the hood.
@@ -107,6 +209,11 @@ func TestLiveDynamicDiscovery(t *testing.T) {
 	if m == nil {
 		t.Fatalf("Model(%q) returned nil — ResolveAction did not work", *dynamicModelName)
 	}
+	resolvedAction, ok := m.(api.Action)
+	if !ok {
+		t.Fatalf("resolved model %q does not implement api.Action", *dynamicModelName)
+	}
+	assertLiveCapabilities(t, resolvedAction.Desc(), capabilities, detected)
 
 	// Generate a response from the dynamically resolved model
 	resp, err := genkit.Generate(ctx, g,

--- a/go/plugins/ollama/ollama_live_test.go
+++ b/go/plugins/ollama/ollama_live_test.go
@@ -101,7 +101,7 @@ func assertLiveCapabilities(t *testing.T, desc api.ActionDesc, capabilities []st
 	wantMedia := true
 	if detected {
 		wantTools = slices.Contains(capabilities, "tools")
-		wantMedia = slices.Contains(capabilities, "vision") || slices.Contains(capabilities, "audio")
+		wantMedia = slices.Contains(capabilities, "vision")
 	}
 	if got, ok := supports["tools"].(bool); !ok || got != wantTools {
 		t.Errorf("%q tools support = %v, want %v from /api/show capabilities %v", desc.Name, supports["tools"], wantTools, capabilities)

--- a/go/plugins/ollama/ollama_test.go
+++ b/go/plugins/ollama/ollama_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
@@ -494,4 +495,78 @@ func TestTranslateChatResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetModelCapabilities(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			var req map[string]string
+			json.NewDecoder(r.Body).Decode(&req)
+			caps := map[string][]string{
+				"gemma4:e2b":  {"completion", "vision", "audio", "tools", "thinking"},
+				"llama3.2":    {"completion", "tools"},
+				"nomic-embed": {"embedding"},
+			}
+			json.NewEncoder(w).Encode(map[string]any{"capabilities": caps[req["model"]]})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	o := &Ollama{ServerAddress: server.URL, client: &http.Client{}, initted: true}
+
+	t.Run("gemma4 reports tools capability", func(t *testing.T) {
+		caps := o.getModelCapabilities(context.Background(), "gemma4:e2b")
+		if !slices.Contains(caps, "tools") {
+			t.Errorf("expected 'tools' in capabilities, got %v", caps)
+		}
+	})
+
+	t.Run("embed model has no tools", func(t *testing.T) {
+		caps := o.getModelCapabilities(context.Background(), "nomic-embed")
+		if slices.Contains(caps, "tools") {
+			t.Error("embed model should not have tools capability")
+		}
+	})
+
+	t.Run("unknown model returns empty", func(t *testing.T) {
+		caps := o.getModelCapabilities(context.Background(), "unknown-model")
+		if len(caps) > 0 {
+			t.Errorf("expected empty capabilities for unknown model, got %v", caps)
+		}
+	})
+}
+
+func TestModelSupportsFromCapabilities(t *testing.T) {
+	t.Run("dynamic capabilities with tools and vision", func(t *testing.T) {
+		s := modelSupportsFromCapabilities([]string{"completion", "vision", "tools"}, "gemma4")
+		if !s.Tools {
+			t.Error("expected Tools=true")
+		}
+		if !s.Media {
+			t.Error("expected Media=true (vision)")
+		}
+	})
+
+	t.Run("no tools in capabilities", func(t *testing.T) {
+		s := modelSupportsFromCapabilities([]string{"completion"}, "some-model")
+		if s.Tools {
+			t.Error("expected Tools=false")
+		}
+	})
+
+	t.Run("fallback to static list for qwen2.5", func(t *testing.T) {
+		s := modelSupportsFromCapabilities(nil, "qwen2.5")
+		if !s.Tools {
+			t.Error("expected Tools=true from static fallback")
+		}
+	})
+
+	t.Run("fallback for unknown model", func(t *testing.T) {
+		s := modelSupportsFromCapabilities(nil, "brand-new-model")
+		if s.Tools {
+			t.Error("expected Tools=false for unknown model")
+		}
+	})
 }

--- a/go/plugins/ollama/ollama_test.go
+++ b/go/plugins/ollama/ollama_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -322,6 +323,181 @@ func TestDynamicPlugin(t *testing.T) {
 				t.Errorf("supports = %v, want tools and media disabled", supports)
 			}
 		})
+
+		t.Run("caches capabilities by model digest", func(t *testing.T) {
+			var tagsCalls atomic.Int32
+			var showCalls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					digest := "digest-1"
+					if tagsCalls.Add(1) == 3 {
+						digest = "digest-2"
+					}
+					_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{{
+						Name: "qwen2.5", Digest: digest,
+					}}})
+				case "/api/show":
+					showCalls.Add(1)
+					_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion", "tools"}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			o := newTestOllama(server.URL)
+			for range 3 {
+				if actions := o.ListActions(t.Context()); len(actions) != 1 {
+					t.Fatalf("ListActions() returned %d actions, want 1", len(actions))
+				}
+			}
+			if got := showCalls.Load(); got != 2 {
+				t.Fatalf("/api/show calls = %d, want 2 (initial digest and changed digest)", got)
+			}
+		})
+
+		t.Run("shares discovered capabilities with ResolveAction", func(t *testing.T) {
+			var showCalls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{{
+						Name: "dynamic-model", Digest: "digest-1",
+					}}})
+				case "/api/show":
+					showCalls.Add(1)
+					_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion"}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			o := newTestOllama(server.URL)
+			if actions := o.ListActions(t.Context()); len(actions) != 1 {
+				t.Fatalf("ListActions() returned %d actions, want 1", len(actions))
+			}
+			action := o.ResolveAction(api.ActionTypeModel, "dynamic-model")
+			if action == nil {
+				t.Fatal("ResolveAction() returned nil")
+			}
+			supports := modelSupportsMetadata(t, action.Desc())
+			if supports["tools"] != false || supports["media"] != false {
+				t.Errorf("resolved supports = %v, want discovered capabilities", supports)
+			}
+			if got := showCalls.Load(); got != 1 {
+				t.Errorf("/api/show calls = %d, want 1", got)
+			}
+		})
+
+		t.Run("retries capability detection after a cached failure expires", func(t *testing.T) {
+			var showCalls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{{
+						Name: "recovering-model", Digest: "digest-1",
+					}}})
+				case "/api/show":
+					if showCalls.Add(1) == 1 {
+						http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion"}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			o := newTestOllama(server.URL)
+			for range 2 {
+				actions := o.ListActions(t.Context())
+				if len(actions) != 1 {
+					t.Fatalf("ListActions() returned %d actions, want 1", len(actions))
+				}
+				if got := modelSupportsMetadata(t, actions[0])["tools"]; got != true {
+					t.Fatalf("fallback tools support = %v, want true", got)
+				}
+			}
+			if got := showCalls.Load(); got != 1 {
+				t.Fatalf("/api/show calls before cache expiry = %d, want 1", got)
+			}
+
+			o.mu.Lock()
+			entry := o.capabilitiesCache["recovering-model"]
+			entry.expires = time.Now().Add(-time.Second)
+			o.capabilitiesCache["recovering-model"] = entry
+			o.mu.Unlock()
+
+			actions := o.ListActions(t.Context())
+			if len(actions) != 1 {
+				t.Fatalf("ListActions() after recovery returned %d actions, want 1", len(actions))
+			}
+			if got := modelSupportsMetadata(t, actions[0])["tools"]; got != false {
+				t.Errorf("detected tools support after recovery = %v, want false", got)
+			}
+			if got := showCalls.Load(); got != 2 {
+				t.Errorf("/api/show calls after cache expiry = %d, want 2", got)
+			}
+		})
+
+		t.Run("queries uncached models concurrently", func(t *testing.T) {
+			started := make(chan struct{}, 2)
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{
+						{Name: "model-a", Digest: "a"},
+						{Name: "model-b", Digest: "b"},
+					}})
+				case "/api/show":
+					started <- struct{}{}
+					<-release
+					_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion"}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			result := make(chan []api.ActionDesc, 1)
+			go func() { result <- newTestOllama(server.URL).ListActions(t.Context()) }()
+			for range 2 {
+				select {
+				case <-started:
+				case <-time.After(time.Second):
+					close(release)
+					t.Fatal("capability requests did not run concurrently")
+				}
+			}
+			close(release)
+			if actions := <-result; len(actions) != 2 {
+				t.Fatalf("ListActions() returned %d actions, want 2", len(actions))
+			}
+		})
+
+		t.Run("cancellation does not return a partial list", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{
+						{Name: "model-a", Digest: "a"}, {Name: "model-b", Digest: "b"},
+					}})
+				case "/api/show":
+					cancel()
+					_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion"}})
+				}
+			}))
+			defer server.Close()
+
+			if actions := newTestOllama(server.URL).ListActions(ctx); actions != nil {
+				t.Fatalf("ListActions() returned partial actions after cancellation: %v", actions)
+			}
+		})
 	})
 
 	t.Run("ResolveAction", func(t *testing.T) {
@@ -360,8 +536,10 @@ func TestDynamicPlugin(t *testing.T) {
 		})
 
 		t.Run("works before Init", func(t *testing.T) {
+			var called atomic.Bool
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion", "tools"}})
+				called.Store(true)
+				http.Error(w, "unexpected request", http.StatusInternalServerError)
 			}))
 			defer server.Close()
 
@@ -372,7 +550,10 @@ func TestDynamicPlugin(t *testing.T) {
 			}
 			supports := modelSupportsMetadata(t, action.Desc())
 			if supports["tools"] != true {
-				t.Errorf("resolved model supports = %v, want tools enabled", supports)
+				t.Errorf("resolved model supports = %v, want historical dynamic defaults", supports)
+			}
+			if called.Load() {
+				t.Error("ResolveAction() performed network I/O")
 			}
 		})
 	})
@@ -611,9 +792,9 @@ func TestGetModelCapabilities(t *testing.T) {
 	o := &Ollama{ServerAddress: server.URL, client: &http.Client{}, initted: true}
 
 	t.Run("gemma4 reports tools capability", func(t *testing.T) {
-		caps, detected := o.getModelCapabilities(context.Background(), "gemma4:e2b")
-		if !detected {
-			t.Fatal("expected capabilities to be detected")
+		caps, err := o.getModelCapabilities(context.Background(), "gemma4:e2b")
+		if err != nil {
+			t.Fatalf("getModelCapabilities() error = %v", err)
 		}
 		if !slices.Contains(caps, "tools") {
 			t.Errorf("expected 'tools' in capabilities, got %v", caps)
@@ -621,9 +802,9 @@ func TestGetModelCapabilities(t *testing.T) {
 	})
 
 	t.Run("embed model has no tools", func(t *testing.T) {
-		caps, detected := o.getModelCapabilities(context.Background(), "nomic-embed")
-		if !detected {
-			t.Fatal("expected capabilities to be detected")
+		caps, err := o.getModelCapabilities(context.Background(), "nomic-embed")
+		if err != nil {
+			t.Fatalf("getModelCapabilities() error = %v", err)
 		}
 		if slices.Contains(caps, "tools") {
 			t.Error("embed model should not have tools capability")
@@ -631,9 +812,9 @@ func TestGetModelCapabilities(t *testing.T) {
 	})
 
 	t.Run("empty capabilities are detected", func(t *testing.T) {
-		caps, detected := o.getModelCapabilities(context.Background(), "empty-model")
-		if !detected {
-			t.Fatal("expected an explicitly empty capabilities list to be detected")
+		caps, err := o.getModelCapabilities(context.Background(), "empty-model")
+		if err != nil {
+			t.Fatalf("getModelCapabilities() error = %v", err)
 		}
 		if len(caps) != 0 {
 			t.Errorf("expected empty capabilities, got %v", caps)
@@ -641,17 +822,25 @@ func TestGetModelCapabilities(t *testing.T) {
 	})
 
 	t.Run("missing capabilities are not detected", func(t *testing.T) {
-		caps, detected := o.getModelCapabilities(context.Background(), "unknown-model")
-		if detected {
-			t.Errorf("expected missing capabilities not to be detected, got %v", caps)
+		caps, err := o.getModelCapabilities(context.Background(), "unknown-model")
+		if err == nil {
+			t.Errorf("expected missing capabilities to return an error, got %v", caps)
 		}
 	})
 
 	t.Run("uses default HTTP client before Init", func(t *testing.T) {
 		uninitialized := &Ollama{ServerAddress: server.URL}
-		caps, detected := uninitialized.getModelCapabilities(context.Background(), "llama3.2")
-		if !detected || !slices.Contains(caps, "tools") {
-			t.Errorf("capabilities = %v, detected = %v; want tools detected", caps, detected)
+		caps, err := uninitialized.getModelCapabilities(context.Background(), "llama3.2")
+		if err != nil || !slices.Contains(caps, "tools") {
+			t.Errorf("capabilities = %v, error = %v; want tools detected", caps, err)
+		}
+	})
+
+	t.Run("normalizes trailing slash", func(t *testing.T) {
+		withSlash := &Ollama{ServerAddress: server.URL + "/"}
+		caps, err := withSlash.getModelCapabilities(context.Background(), "llama3.2")
+		if err != nil || !slices.Contains(caps, "tools") {
+			t.Errorf("capabilities = %v, error = %v; want tools detected", caps, err)
 		}
 	})
 }
@@ -703,6 +892,13 @@ func TestModelSupportsFromCapabilities(t *testing.T) {
 		}
 	})
 
+	t.Run("audio alone does not advertise unsupported media input", func(t *testing.T) {
+		s := modelSupportsFromCapabilities([]string{"completion", "audio"})
+		if s.Media {
+			t.Error("expected Media=false when only audio is reported")
+		}
+	})
+
 	t.Run("empty capabilities do not fall back", func(t *testing.T) {
 		s := modelSupportsFromCapabilities([]string{})
 		if s.Tools || s.Media {
@@ -726,54 +922,96 @@ func TestModelSupportsFromStaticLists(t *testing.T) {
 		}
 	})
 
-	t.Run("tagged tool model uses base name", func(t *testing.T) {
+	t.Run("tagged tool model preserves exact-match fallback", func(t *testing.T) {
 		s := modelSupportsFromStaticLists("qwen2.5:7b")
-		if !s.Tools {
-			t.Error("expected tagged qwen2.5 model to support tools")
+		if s.Tools {
+			t.Error("expected tagged qwen2.5 model to preserve legacy Tools=false fallback")
 		}
 	})
 
-	t.Run("tagged media model uses base name", func(t *testing.T) {
+	t.Run("tagged media model preserves exact-match fallback", func(t *testing.T) {
 		s := modelSupportsFromStaticLists("llava:34b")
-		if !s.Media {
-			t.Error("expected tagged llava model to support media")
+		if s.Media {
+			t.Error("expected tagged llava model to preserve legacy Media=false fallback")
 		}
 	})
 }
 
 func TestDefineModelNonChatDoesNotSupportTools(t *testing.T) {
-	tests := []struct {
-		name    string
-		handler http.Handler
-	}{
-		{
-			name: "reported capabilities",
-			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion", "tools"}})
-			}),
-		},
-		{
-			name:    "static fallback",
-			handler: http.NotFoundHandler(),
-		},
+	var called atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	o := newTestOllama(server.URL)
+	g := genkit.Init(context.Background())
+	model := o.DefineModel(g, ModelDefinition{Name: "qwen2.5", Type: "generate"}, nil)
+	action, ok := model.(api.Action)
+	if !ok {
+		t.Fatal("defined model does not implement api.Action")
 	}
+	supports := modelSupportsMetadata(t, action.Desc())
+	if supports["tools"] != false {
+		t.Errorf("non-chat model supports tools: %v", supports)
+	}
+	if called.Load() {
+		t.Error("DefineModel() performed network I/O")
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(tt.handler)
-			defer server.Close()
+func TestDefineModelPreservesStaticFallback(t *testing.T) {
+	o := newTestOllama("http://localhost:11434")
+	// An unavailable capability response uses the static fallback for explicitly
+	// registered models, not the permissive dynamic fallback.
+	o.cacheModelSupports("qwen2.5", "digest-1", &defaultOllamaSupports, false)
+	g := genkit.Init(t.Context())
+	model := o.DefineModel(g, ModelDefinition{Name: "qwen2.5", Type: "chat"}, nil)
+	action, ok := model.(api.Action)
+	if !ok {
+		t.Fatal("defined model does not implement api.Action")
+	}
+	supports := modelSupportsMetadata(t, action.Desc())
+	if supports["tools"] != true {
+		t.Errorf("defined model supports = %v, want static tools fallback", supports)
+	}
+}
 
-			o := newTestOllama(server.URL)
-			g := genkit.Init(context.Background())
-			model := o.DefineModel(g, ModelDefinition{Name: "qwen2.5", Type: "generate"}, nil)
-			action, ok := model.(api.Action)
-			if !ok {
-				t.Fatal("defined model does not implement api.Action")
-			}
-			supports := modelSupportsMetadata(t, action.Desc())
-			if supports["tools"] != false {
-				t.Errorf("non-chat model supports tools: %v", supports)
-			}
-		})
+func TestDefineModelReusesDiscoveredCapabilities(t *testing.T) {
+	var showCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{{
+				Name: "brand-new-model", Digest: "digest-1",
+			}}})
+		case "/api/show":
+			showCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"capabilities": []string{"completion", "tools"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	o := newTestOllama(server.URL)
+	if actions := o.ListActions(t.Context()); len(actions) != 1 {
+		t.Fatalf("ListActions() returned %d actions, want 1", len(actions))
+	}
+	g := genkit.Init(t.Context())
+	model := o.DefineModel(g, ModelDefinition{Name: "brand-new-model", Type: "chat"}, nil)
+	action, ok := model.(api.Action)
+	if !ok {
+		t.Fatal("defined model does not implement api.Action")
+	}
+	supports := modelSupportsMetadata(t, action.Desc())
+	if supports["tools"] != true {
+		t.Errorf("defined model supports = %v, want discovered tools capability", supports)
+	}
+	if got := showCalls.Load(); got != 1 {
+		t.Errorf("/api/show calls = %d, want 1; DefineModel must not perform I/O", got)
 	}
 }

--- a/go/plugins/ollama/ollama_test.go
+++ b/go/plugins/ollama/ollama_test.go
@@ -23,9 +23,11 @@ import (
 	"net/http/httptest"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
 )
 
 var _ api.Plugin = (*Ollama)(nil)
@@ -154,6 +156,19 @@ func newTestOllama(serverAddress string) *Ollama {
 	return o
 }
 
+func modelSupportsMetadata(t *testing.T, desc api.ActionDesc) map[string]any {
+	t.Helper()
+	modelMetadata, ok := desc.Metadata["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("model metadata has type %T, want map[string]any", desc.Metadata["model"])
+	}
+	supports, ok := modelMetadata["supports"].(map[string]any)
+	if !ok {
+		t.Fatalf("model supports metadata has type %T, want map[string]any", modelMetadata["supports"])
+	}
+	return supports
+}
+
 func TestDynamicPlugin(t *testing.T) {
 	t.Run("listLocalModels", func(t *testing.T) {
 		tests := []struct {
@@ -260,6 +275,53 @@ func TestDynamicPlugin(t *testing.T) {
 				t.Errorf("ListActions() should return nil when server is unreachable, got %v", actions)
 			}
 		})
+
+		t.Run("preserves dynamic model defaults when capabilities are unavailable", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/tags" {
+					json.NewEncoder(w).Encode(ollamaTagsResponse{
+						Models: []ollamaLocalModel{{Name: "brand-new-model"}},
+					})
+					return
+				}
+				http.NotFound(w, r)
+			}))
+			defer server.Close()
+
+			actions := newTestOllama(server.URL).ListActions(context.Background())
+			if len(actions) != 1 {
+				t.Fatalf("ListActions() returned %d actions, want 1", len(actions))
+			}
+			supports := modelSupportsMetadata(t, actions[0])
+			if supports["tools"] != true || supports["media"] != true {
+				t.Errorf("fallback supports = %v, want tools and media enabled", supports)
+			}
+		})
+
+		t.Run("does not fall back for an explicitly empty capabilities list", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					json.NewEncoder(w).Encode(ollamaTagsResponse{
+						Models: []ollamaLocalModel{{Name: "qwen2.5"}},
+					})
+				case "/api/show":
+					json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			actions := newTestOllama(server.URL).ListActions(context.Background())
+			if len(actions) != 1 {
+				t.Fatalf("ListActions() returned %d actions, want 1", len(actions))
+			}
+			supports := modelSupportsMetadata(t, actions[0])
+			if supports["tools"] != false || supports["media"] != false {
+				t.Errorf("supports = %v, want tools and media disabled", supports)
+			}
+		})
 	})
 
 	t.Run("ResolveAction", func(t *testing.T) {
@@ -280,6 +342,37 @@ func TestDynamicPlugin(t *testing.T) {
 			action := o.ResolveAction(api.ActionTypeExecutablePrompt, "llama3:latest")
 			if action != nil {
 				t.Error("ResolveAction() should return nil for non-model action type")
+			}
+		})
+
+		t.Run("preserves dynamic model defaults when capabilities are unavailable", func(t *testing.T) {
+			server := httptest.NewServer(http.NotFoundHandler())
+			defer server.Close()
+
+			action := newTestOllama(server.URL).ResolveAction(api.ActionTypeModel, "brand-new-model")
+			if action == nil {
+				t.Fatal("ResolveAction() returned nil for model type")
+			}
+			supports := modelSupportsMetadata(t, action.Desc())
+			if supports["tools"] != true || supports["media"] != true {
+				t.Errorf("fallback supports = %v, want tools and media enabled", supports)
+			}
+		})
+
+		t.Run("works before Init", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion", "tools"}})
+			}))
+			defer server.Close()
+
+			o := &Ollama{ServerAddress: server.URL}
+			action := o.ResolveAction(api.ActionTypeModel, "new-model")
+			if action == nil {
+				t.Fatal("ResolveAction() returned nil for model type")
+			}
+			supports := modelSupportsMetadata(t, action.Desc())
+			if supports["tools"] != true {
+				t.Errorf("resolved model supports = %v, want tools enabled", supports)
 			}
 		})
 	})
@@ -506,6 +599,7 @@ func TestGetModelCapabilities(t *testing.T) {
 				"gemma4:e2b":  {"completion", "vision", "audio", "tools", "thinking"},
 				"llama3.2":    {"completion", "tools"},
 				"nomic-embed": {"embedding"},
+				"empty-model": {},
 			}
 			json.NewEncoder(w).Encode(map[string]any{"capabilities": caps[req["model"]]})
 			return
@@ -517,30 +611,83 @@ func TestGetModelCapabilities(t *testing.T) {
 	o := &Ollama{ServerAddress: server.URL, client: &http.Client{}, initted: true}
 
 	t.Run("gemma4 reports tools capability", func(t *testing.T) {
-		caps := o.getModelCapabilities(context.Background(), "gemma4:e2b")
+		caps, detected := o.getModelCapabilities(context.Background(), "gemma4:e2b")
+		if !detected {
+			t.Fatal("expected capabilities to be detected")
+		}
 		if !slices.Contains(caps, "tools") {
 			t.Errorf("expected 'tools' in capabilities, got %v", caps)
 		}
 	})
 
 	t.Run("embed model has no tools", func(t *testing.T) {
-		caps := o.getModelCapabilities(context.Background(), "nomic-embed")
+		caps, detected := o.getModelCapabilities(context.Background(), "nomic-embed")
+		if !detected {
+			t.Fatal("expected capabilities to be detected")
+		}
 		if slices.Contains(caps, "tools") {
 			t.Error("embed model should not have tools capability")
 		}
 	})
 
-	t.Run("unknown model returns empty", func(t *testing.T) {
-		caps := o.getModelCapabilities(context.Background(), "unknown-model")
-		if len(caps) > 0 {
-			t.Errorf("expected empty capabilities for unknown model, got %v", caps)
+	t.Run("empty capabilities are detected", func(t *testing.T) {
+		caps, detected := o.getModelCapabilities(context.Background(), "empty-model")
+		if !detected {
+			t.Fatal("expected an explicitly empty capabilities list to be detected")
+		}
+		if len(caps) != 0 {
+			t.Errorf("expected empty capabilities, got %v", caps)
+		}
+	})
+
+	t.Run("missing capabilities are not detected", func(t *testing.T) {
+		caps, detected := o.getModelCapabilities(context.Background(), "unknown-model")
+		if detected {
+			t.Errorf("expected missing capabilities not to be detected, got %v", caps)
+		}
+	})
+
+	t.Run("uses default HTTP client before Init", func(t *testing.T) {
+		uninitialized := &Ollama{ServerAddress: server.URL}
+		caps, detected := uninitialized.getModelCapabilities(context.Background(), "llama3.2")
+		if !detected || !slices.Contains(caps, "tools") {
+			t.Errorf("capabilities = %v, detected = %v; want tools detected", caps, detected)
 		}
 	})
 }
 
+func TestModelCapabilitiesContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeout     int
+		wantTimeout time.Duration
+	}{
+		{name: "unset timeout", timeout: 0, wantTimeout: modelCapabilitiesTimeout},
+		{name: "long generation timeout", timeout: 30, wantTimeout: modelCapabilitiesTimeout},
+		{name: "short configured timeout", timeout: 2, wantTimeout: 2 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &Ollama{Timeout: tt.timeout}
+			ctx, cancel := o.modelCapabilitiesContext(context.Background())
+			defer cancel()
+
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("capability context has no deadline")
+			}
+			remaining := time.Until(deadline)
+			if remaining > tt.wantTimeout || remaining < tt.wantTimeout-time.Second {
+				t.Errorf("capability timeout = %v, want approximately %v", remaining, tt.wantTimeout)
+			}
+		})
+	}
+}
+
 func TestModelSupportsFromCapabilities(t *testing.T) {
 	t.Run("dynamic capabilities with tools and vision", func(t *testing.T) {
-		s := modelSupportsFromCapabilities([]string{"completion", "vision", "tools"}, "gemma4")
+		s := modelSupportsFromCapabilities([]string{"completion", "vision", "tools"})
 		if !s.Tools {
 			t.Error("expected Tools=true")
 		}
@@ -550,23 +697,83 @@ func TestModelSupportsFromCapabilities(t *testing.T) {
 	})
 
 	t.Run("no tools in capabilities", func(t *testing.T) {
-		s := modelSupportsFromCapabilities([]string{"completion"}, "some-model")
+		s := modelSupportsFromCapabilities([]string{"completion"})
 		if s.Tools {
 			t.Error("expected Tools=false")
 		}
 	})
 
-	t.Run("fallback to static list for qwen2.5", func(t *testing.T) {
-		s := modelSupportsFromCapabilities(nil, "qwen2.5")
+	t.Run("empty capabilities do not fall back", func(t *testing.T) {
+		s := modelSupportsFromCapabilities([]string{})
+		if s.Tools || s.Media {
+			t.Errorf("expected empty capabilities to disable tools and media, got %+v", s)
+		}
+	})
+}
+
+func TestModelSupportsFromStaticLists(t *testing.T) {
+	t.Run("qwen2.5 supports tools", func(t *testing.T) {
+		s := modelSupportsFromStaticLists("qwen2.5")
 		if !s.Tools {
 			t.Error("expected Tools=true from static fallback")
 		}
 	})
 
-	t.Run("fallback for unknown model", func(t *testing.T) {
-		s := modelSupportsFromCapabilities(nil, "brand-new-model")
+	t.Run("unknown model has no optional capabilities", func(t *testing.T) {
+		s := modelSupportsFromStaticLists("brand-new-model")
 		if s.Tools {
 			t.Error("expected Tools=false for unknown model")
 		}
 	})
+
+	t.Run("tagged tool model uses base name", func(t *testing.T) {
+		s := modelSupportsFromStaticLists("qwen2.5:7b")
+		if !s.Tools {
+			t.Error("expected tagged qwen2.5 model to support tools")
+		}
+	})
+
+	t.Run("tagged media model uses base name", func(t *testing.T) {
+		s := modelSupportsFromStaticLists("llava:34b")
+		if !s.Media {
+			t.Error("expected tagged llava model to support media")
+		}
+	})
+}
+
+func TestDefineModelNonChatDoesNotSupportTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.Handler
+	}{
+		{
+			name: "reported capabilities",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion", "tools"}})
+			}),
+		},
+		{
+			name:    "static fallback",
+			handler: http.NotFoundHandler(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			o := newTestOllama(server.URL)
+			g := genkit.Init(context.Background())
+			model := o.DefineModel(g, ModelDefinition{Name: "qwen2.5", Type: "generate"}, nil)
+			action, ok := model.(api.Action)
+			if !ok {
+				t.Fatal("defined model does not implement api.Action")
+			}
+			supports := modelSupportsMetadata(t, action.Desc())
+			if supports["tools"] != false {
+				t.Errorf("non-chat model supports tools: %v", supports)
+			}
+		})
+	}
 }

--- a/go/plugins/ollama/ollama_test.go
+++ b/go/plugins/ollama/ollama_test.go
@@ -19,6 +19,7 @@ package ollama
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -391,6 +392,54 @@ func TestDynamicPlugin(t *testing.T) {
 			}
 		})
 
+		t.Run("shares latest-tag capabilities with bare model names", func(t *testing.T) {
+			var showCalls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{{
+						Name: "moondream:latest", Digest: "digest-1",
+					}}})
+				case "/api/show":
+					showCalls.Add(1)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"capabilities": []string{"completion", "vision"},
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			o := newTestOllama(server.URL)
+			if actions := o.ListActions(t.Context()); len(actions) != 1 {
+				t.Fatalf("ListActions() returned %d actions, want 1", len(actions))
+			}
+
+			resolved := o.ResolveAction(api.ActionTypeModel, "moondream")
+			if resolved == nil {
+				t.Fatal("ResolveAction() returned nil")
+			}
+			resolvedSupports := modelSupportsMetadata(t, resolved.Desc())
+			if resolvedSupports["tools"] != false || resolvedSupports["media"] != true {
+				t.Errorf("resolved supports = %v, want detected tools=false and media=true", resolvedSupports)
+			}
+
+			g := genkit.Init(t.Context())
+			defined := o.DefineModel(g, ModelDefinition{Name: "moondream", Type: "chat"}, nil)
+			definedAction, ok := defined.(api.Action)
+			if !ok {
+				t.Fatal("defined model does not implement api.Action")
+			}
+			definedSupports := modelSupportsMetadata(t, definedAction.Desc())
+			if definedSupports["tools"] != false || definedSupports["media"] != true {
+				t.Errorf("defined supports = %v, want detected tools=false and media=true", definedSupports)
+			}
+			if got := showCalls.Load(); got != 1 {
+				t.Errorf("/api/show calls = %d, want 1", got)
+			}
+		})
+
 		t.Run("retries capability detection after a cached failure expires", func(t *testing.T) {
 			var showCalls atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -476,6 +525,65 @@ func TestDynamicPlugin(t *testing.T) {
 			close(release)
 			if actions := <-result; len(actions) != 2 {
 				t.Fatalf("ListActions() returned %d actions, want 2", len(actions))
+			}
+		})
+
+		t.Run("bounds concurrent capability queries", func(t *testing.T) {
+			var active atomic.Int32
+			var peak atomic.Int32
+			release := make(chan struct{})
+			started := make(chan struct{}, maxConcurrentCapabilityQueries+1)
+			models := make([]ollamaLocalModel, maxConcurrentCapabilityQueries+2)
+			for i := range models {
+				models[i] = ollamaLocalModel{
+					Name: fmt.Sprintf("model-%d", i), Digest: fmt.Sprintf("digest-%d", i),
+				}
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: models})
+				case "/api/show":
+					current := active.Add(1)
+					for {
+						previous := peak.Load()
+						if current <= previous || peak.CompareAndSwap(previous, current) {
+							break
+						}
+					}
+					started <- struct{}{}
+					<-release
+					active.Add(-1)
+					_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"completion"}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			result := make(chan []api.ActionDesc, 1)
+			go func() { result <- newTestOllama(server.URL).ListActions(t.Context()) }()
+			for range maxConcurrentCapabilityQueries {
+				select {
+				case <-started:
+				case <-time.After(time.Second):
+					close(release)
+					t.Fatal("capability queries did not reach the concurrency limit")
+				}
+			}
+			select {
+			case <-started:
+				close(release)
+				t.Fatalf("more than %d capability queries ran concurrently", maxConcurrentCapabilityQueries)
+			case <-time.After(50 * time.Millisecond):
+			}
+			close(release)
+			if actions := <-result; len(actions) != len(models) {
+				t.Fatalf("ListActions() returned %d actions, want %d", len(actions), len(models))
+			}
+			if got := peak.Load(); got != maxConcurrentCapabilityQueries {
+				t.Errorf("peak concurrent queries = %d, want %d", got, maxConcurrentCapabilityQueries)
 			}
 		})
 


### PR DESCRIPTION
This PR introduces detection of model capabilities dynamically via /api/show. 
Here is the initial contributor's PR #5114

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
