### PR TITLE
feat(go/compat-oai): add DeepSeek plugin

### DIFF
--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -59,6 +59,7 @@ Set your API keys:
 export OPENAI_API_KEY=<your-openai-key>
 export ANTHROPIC_API_KEY=<your-anthropic-key>
 export DASHSCOPE_API_KEY=<your-dashscope-key>
+export DEEPSEEK_API_KEY=<your-deepseek-key>
 export ZAI_API_KEY=<your-zai-key>
 export KIMI_API_KEY=<your-kimi-key>
 ```
@@ -78,6 +79,9 @@ go test -v ./anthropic
 
 # DashScope tests
 go test -v ./dashscope
+
+# DeepSeek tests
+go test -v ./deepseek
 
 # Z.ai tests
 go test -v ./zai

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -68,6 +68,10 @@ type OpenAICompatible struct {
 	// Should be lowercase and match the plugin's Name() method.
 	Provider string
 
+	// ConfigAliases maps Genkit-facing configuration names to the field names
+	// expected by the provider's OpenAI-compatible API.
+	ConfigAliases map[string]string
+
 	// API key to use with the desired plugin.
 	APIKey string
 
@@ -121,6 +125,7 @@ func (o *OpenAICompatible) DefineModel(provider, id string, opts ai.ModelOptions
 	) (*ai.ModelResponse, error) {
 		// Configure the response generator with input
 		generator := NewModelGenerator(o.client, id).
+			WithConfigAliases(o.ConfigAliases).
 			WithMessages(input.Messages).
 			WithConfig(input.Config).
 			WithTools(input.Tools).

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -17,6 +17,7 @@ package compat_oai
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
@@ -69,8 +70,10 @@ type OpenAICompatible struct {
 	Provider string
 
 	// ConfigAliases maps Genkit-facing configuration names to the field names
-	// expected by the provider's OpenAI-compatible API.
+	// expected by the provider's OpenAI-compatible API. Configure it before
+	// calling Init; Init snapshots the map for concurrent model requests.
 	ConfigAliases map[string]string
+	configAliases map[string]string
 
 	// API key to use with the desired plugin.
 	APIKey string
@@ -100,6 +103,7 @@ func (o *OpenAICompatible) Init(ctx context.Context) []api.Action {
 	// create client
 	client := openai.NewClient(o.Opts...)
 	o.client = &client
+	o.configAliases = maps.Clone(o.ConfigAliases)
 	o.initted = true
 
 	return []api.Action{}
@@ -125,7 +129,7 @@ func (o *OpenAICompatible) DefineModel(provider, id string, opts ai.ModelOptions
 	) (*ai.ModelResponse, error) {
 		// Configure the response generator with input
 		generator := NewModelGenerator(o.client, id).
-			WithConfigAliases(o.ConfigAliases).
+			WithConfigAliases(o.configAliases).
 			WithMessages(input.Messages).
 			WithConfig(input.Config).
 			WithTools(input.Tools).

--- a/go/plugins/compat_oai/deepseek/README.md
+++ b/go/plugins/compat_oai/deepseek/README.md
@@ -34,15 +34,15 @@ g := genkit.Init(
 response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain mixture-of-experts models."))
 ```
 
-DeepSeek's `maxTokens` option accepts values from 1 through 8192 and is sent
-to the API as `max_tokens`:
+Genkit's standard `maxOutputTokens` option is sent to the DeepSeek API as
+`max_tokens`:
 
 ```go
 response, err := genkit.Generate(
     ctx,
     g,
     ai.WithPrompt("Answer concisely."),
-    ai.WithConfig(map[string]any{"maxTokens": 1024}),
+    ai.WithConfig(map[string]any{"maxOutputTokens": 1024}),
 )
 ```
 

--- a/go/plugins/compat_oai/deepseek/README.md
+++ b/go/plugins/compat_oai/deepseek/README.md
@@ -1,0 +1,58 @@
+# DeepSeek Plugin
+
+This plugin provides Genkit support for the OpenAI-compatible DeepSeek API,
+including the `deepseek-chat` and `deepseek-reasoner` models.
+
+## Usage
+
+Set a DeepSeek API key:
+
+```bash
+export DEEPSEEK_API_KEY=<your-api-key>
+```
+
+The plugin uses `https://api.deepseek.com` by default. Set
+`DEEPSEEK_BASE_URL` to use another DeepSeek-compatible endpoint.
+
+```go
+import (
+    "context"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
+)
+
+ctx := context.Background()
+plugin := &deepseek.DeepSeek{}
+g := genkit.Init(
+    ctx,
+    genkit.WithPlugins(plugin),
+    genkit.WithDefaultModel("deepseek/"+deepseek.ModelDeepSeekChat),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain mixture-of-experts models."))
+```
+
+DeepSeek's `maxTokens` option accepts values from 1 through 8192 and is sent
+to the API as `max_tokens`:
+
+```go
+response, err := genkit.Generate(
+    ctx,
+    g,
+    ai.WithPrompt("Answer concisely."),
+    ai.WithConfig(map[string]any{"maxTokens": 1024}),
+)
+```
+
+The `deepseek-reasoner` model's `reasoning_content` output is returned as
+Genkit reasoning parts and is available through `response.Reasoning()`.
+
+## Live tests
+
+Live tests are skipped unless `DEEPSEEK_API_KEY` is set:
+
+```bash
+go test -v ./plugins/compat_oai/deepseek
+```

--- a/go/plugins/compat_oai/deepseek/deepseek.go
+++ b/go/plugins/compat_oai/deepseek/deepseek.go
@@ -30,10 +30,9 @@ import (
 )
 
 // chatCompletionConfig describes the schema accepted by DeepSeek chat
-// completions. MaxTokens is DeepSeek's provider-specific output token limit.
+// completions.
 type chatCompletionConfig struct {
 	ai.GenerationCommonConfig
-	MaxTokens        *int     `json:"maxTokens,omitempty" jsonschema:"minimum=1,maximum=8192"`
 	FrequencyPenalty *float64 `json:"frequencyPenalty,omitempty" jsonschema:"minimum=-2,maximum=2"`
 	LogProbs         *bool    `json:"logProbs,omitempty"`
 	PresencePenalty  *float64 `json:"presencePenalty,omitempty" jsonschema:"minimum=-2,maximum=2"`
@@ -115,7 +114,7 @@ func (d *DeepSeek) Init(ctx context.Context) []api.Action {
 
 	d.openAICompatible.Provider = provider
 	d.openAICompatible.ConfigAliases = map[string]string{
-		"maxTokens": "max_tokens",
+		"maxOutputTokens": "max_tokens",
 	}
 	d.openAICompatible.Opts = opts
 	actions := d.openAICompatible.Init(ctx)

--- a/go/plugins/compat_oai/deepseek/deepseek.go
+++ b/go/plugins/compat_oai/deepseek/deepseek.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deepseek provides a Genkit plugin for DeepSeek models.
+package deepseek
+
+import (
+	"context"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go/option"
+)
+
+// ChatCompletionConfig describes configuration accepted by DeepSeek chat
+// completions. MaxTokens is DeepSeek's provider-specific output token limit.
+type ChatCompletionConfig struct {
+	ai.GenerationCommonConfig
+	MaxTokens        *int     `json:"maxTokens,omitempty" jsonschema:"minimum=1,maximum=8192"`
+	FrequencyPenalty *float64 `json:"frequencyPenalty,omitempty" jsonschema:"minimum=-2,maximum=2"`
+	LogProbs         *bool    `json:"logProbs,omitempty"`
+	PresencePenalty  *float64 `json:"presencePenalty,omitempty" jsonschema:"minimum=-2,maximum=2"`
+	TopLogProbs      *int     `json:"topLogProbs,omitempty" jsonschema:"minimum=0,maximum=20"`
+}
+
+const (
+	provider       = "deepseek"
+	defaultBaseURL = "https://api.deepseek.com"
+
+	// ModelDeepSeekChat is DeepSeek's general-purpose chat model.
+	ModelDeepSeekChat = "deepseek-chat"
+	// ModelDeepSeekReasoner is DeepSeek's reasoning model.
+	ModelDeepSeekReasoner = "deepseek-reasoner"
+)
+
+var supportedModels = map[string]ai.ModelOptions{
+	ModelDeepSeekChat:     modelOptions(ModelDeepSeekChat, "DeepSeek Chat"),
+	ModelDeepSeekReasoner: modelOptions(ModelDeepSeekReasoner, "DeepSeek Reasoner"),
+}
+
+func modelOptions(id, label string) ai.ModelOptions {
+	return ai.ModelOptions{
+		Label:        label,
+		ConfigSchema: core.InferSchemaMap(ChatCompletionConfig{}),
+		Supports: &ai.ModelSupports{
+			Multiturn:  true,
+			Tools:      true,
+			SystemRole: true,
+			Media:      false,
+			Output:     []string{"text", "json"},
+		},
+		Versions: []string{id},
+	}
+}
+
+// DeepSeek configures the DeepSeek plugin.
+type DeepSeek struct {
+	// APIKey is the DeepSeek API key. If empty, DEEPSEEK_API_KEY is consulted.
+	APIKey string
+	// BaseURL overrides the DeepSeek API endpoint. If empty,
+	// DEEPSEEK_BASE_URL and then the default endpoint are used.
+	BaseURL string
+	// Opts contains additional OpenAI client request options. Options supplied
+	// here are applied after the plugin defaults.
+	Opts []option.RequestOption
+
+	openAICompatible compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (d *DeepSeek) Name() string {
+	return provider
+}
+
+// Init implements genkit.Plugin.
+func (d *DeepSeek) Init(ctx context.Context) []api.Action {
+	baseURL := d.BaseURL
+	if baseURL == "" {
+		baseURL = os.Getenv("DEEPSEEK_BASE_URL")
+	}
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiKey := d.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("DEEPSEEK_API_KEY")
+	}
+	if apiKey == "" {
+		panic("deepseek plugin initialization failed: apiKey is required")
+	}
+
+	opts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL),
+	}
+	opts = append(opts, d.Opts...)
+
+	d.openAICompatible.Provider = provider
+	d.openAICompatible.ConfigAliases = map[string]string{
+		"maxTokens": "max_tokens",
+	}
+	d.openAICompatible.Opts = opts
+	actions := d.openAICompatible.Init(ctx)
+
+	for model, modelOpts := range supportedModels {
+		actions = append(actions, d.DefineModel(model, modelOpts).(api.Action))
+	}
+	return actions
+}
+
+// Model returns a registered DeepSeek model.
+func (d *DeepSeek) Model(g *genkit.Genkit, id string) ai.Model {
+	return d.openAICompatible.Model(g, api.NewName(provider, id))
+}
+
+// DefineModel registers a DeepSeek model, including models not in the built-in list.
+func (d *DeepSeek) DefineModel(id string, opts ai.ModelOptions) ai.Model {
+	return d.openAICompatible.DefineModel(provider, id, opts)
+}
+
+// ListActions lists models exposed by the configured DeepSeek endpoint.
+func (d *DeepSeek) ListActions(ctx context.Context) []api.ActionDesc {
+	return d.openAICompatible.ListActions(ctx)
+}
+
+// ResolveAction dynamically registers a model exposed by the DeepSeek endpoint.
+func (d *DeepSeek) ResolveAction(atype api.ActionType, name string) api.Action {
+	return d.openAICompatible.ResolveAction(atype, name)
+}

--- a/go/plugins/compat_oai/deepseek/deepseek.go
+++ b/go/plugins/compat_oai/deepseek/deepseek.go
@@ -17,7 +17,9 @@ package deepseek
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
@@ -136,10 +138,25 @@ func (d *DeepSeek) DefineModel(id string, opts ai.ModelOptions) ai.Model {
 
 // ListActions lists models exposed by the configured DeepSeek endpoint.
 func (d *DeepSeek) ListActions(ctx context.Context) []api.ActionDesc {
-	return d.openAICompatible.ListActions(ctx)
+	actions := d.openAICompatible.ListActions(ctx)
+	for i := range actions {
+		name := strings.TrimPrefix(actions[i].Name, provider+"/")
+		actions[i] = d.DefineModel(name, optionsForModel(name)).(api.Action).Desc()
+	}
+	return actions
 }
 
 // ResolveAction dynamically registers a model exposed by the DeepSeek endpoint.
 func (d *DeepSeek) ResolveAction(atype api.ActionType, name string) api.Action {
-	return d.openAICompatible.ResolveAction(atype, name)
+	if atype != api.ActionTypeModel {
+		return nil
+	}
+	return d.DefineModel(name, optionsForModel(name)).(api.Action)
+}
+
+func optionsForModel(name string) ai.ModelOptions {
+	if opts, ok := supportedModels[name]; ok {
+		return opts
+	}
+	return modelOptions(name, fmt.Sprintf("DeepSeek - %s", name))
 }

--- a/go/plugins/compat_oai/deepseek/deepseek.go
+++ b/go/plugins/compat_oai/deepseek/deepseek.go
@@ -27,9 +27,9 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
-// ChatCompletionConfig describes configuration accepted by DeepSeek chat
+// chatCompletionConfig describes the schema accepted by DeepSeek chat
 // completions. MaxTokens is DeepSeek's provider-specific output token limit.
-type ChatCompletionConfig struct {
+type chatCompletionConfig struct {
 	ai.GenerationCommonConfig
 	MaxTokens        *int     `json:"maxTokens,omitempty" jsonschema:"minimum=1,maximum=8192"`
 	FrequencyPenalty *float64 `json:"frequencyPenalty,omitempty" jsonschema:"minimum=-2,maximum=2"`
@@ -56,7 +56,7 @@ var supportedModels = map[string]ai.ModelOptions{
 func modelOptions(id, label string) ai.ModelOptions {
 	return ai.ModelOptions{
 		Label:        label,
-		ConfigSchema: core.InferSchemaMap(ChatCompletionConfig{}),
+		ConfigSchema: core.InferSchemaMap(chatCompletionConfig{}),
 		Supports: &ai.ModelSupports{
 			Multiturn:  true,
 			Tools:      true,

--- a/go/plugins/compat_oai/deepseek/deepseek_live_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_live_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deepseek_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
+)
+
+func TestPluginLive(t *testing.T) {
+	if os.Getenv("DEEPSEEK_API_KEY") == "" {
+		t.Skip("DEEPSEEK_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	plugin := &deepseek.DeepSeek{}
+	g := genkit.Init(
+		ctx,
+		genkit.WithPlugins(plugin),
+		genkit.WithDefaultModel("deepseek/"+deepseek.ModelDeepSeekChat),
+	)
+
+	t.Run("chat", func(t *testing.T) {
+		resp, err := genkit.Generate(
+			ctx,
+			g,
+			ai.WithPrompt("What is the capital of France? Answer with the city only."),
+		)
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if !strings.Contains(strings.ToLower(resp.Text()), "paris") {
+			t.Fatalf("Text() = %q, want Paris", resp.Text())
+		}
+	})
+
+	t.Run("streaming reasoning", func(t *testing.T) {
+		var reasoning, text strings.Builder
+		resp, err := genkit.Generate(
+			ctx,
+			g,
+			ai.WithModel(plugin.Model(g, deepseek.ModelDeepSeekReasoner)),
+			ai.WithPrompt("Explain briefly why the sky appears blue."),
+			ai.WithStreaming(func(_ context.Context, chunk *ai.ModelResponseChunk) error {
+				reasoning.WriteString(chunk.Reasoning())
+				text.WriteString(chunk.Text())
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if reasoning.String() == "" {
+			t.Fatal("streamed reasoning is empty")
+		}
+		if text.String() == "" {
+			t.Fatal("streamed text is empty")
+		}
+		if resp.Reasoning() != reasoning.String() {
+			t.Fatalf("final reasoning = %q, want streamed %q", resp.Reasoning(), reasoning.String())
+		}
+		if resp.Text() != text.String() {
+			t.Fatalf("final text = %q, want streamed %q", resp.Text(), text.String())
+		}
+	})
+}

--- a/go/plugins/compat_oai/deepseek/deepseek_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_test.go
@@ -188,3 +188,50 @@ func TestPluginRequiresAPIKey(t *testing.T) {
 	}()
 	(&deepseek.DeepSeek{}).Init(context.Background())
 }
+
+func TestDynamicModelsUseDeepSeekMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %q, want %q", r.URL.Path, "/models")
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","data":[{"id":"deepseek-custom","object":"model","created":1,"owned_by":"deepseek"}]}`)
+	}))
+	defer server.Close()
+
+	plugin := &deepseek.DeepSeek{APIKey: "test-key", BaseURL: server.URL}
+	plugin.Init(context.Background())
+
+	descs := plugin.ListActions(context.Background())
+	if len(descs) != 1 {
+		t.Fatalf("ListActions() returned %d actions, want 1", len(descs))
+	}
+	assertDeepSeekMetadata(t, descs[0])
+
+	resolved := plugin.ResolveAction(api.ActionTypeModel, "deepseek-custom")
+	if resolved == nil {
+		t.Fatal("ResolveAction(model) = nil")
+	}
+	assertDeepSeekMetadata(t, resolved.Desc())
+	if got := plugin.ResolveAction(api.ActionTypeEmbedder, "deepseek-custom"); got != nil {
+		t.Errorf("ResolveAction(embedder) = %v, want nil", got)
+	}
+}
+
+func assertDeepSeekMetadata(t *testing.T, desc api.ActionDesc) {
+	t.Helper()
+	metadata := desc.Metadata["model"].(map[string]any)
+	supports := metadata["supports"].(map[string]any)
+	if got := supports["media"]; got != false {
+		t.Errorf("media support = %v, want false", got)
+	}
+	if got := supports["tools"]; got != true {
+		t.Errorf("tools support = %v, want true", got)
+	}
+	properties := metadata["customOptions"].(map[string]any)["properties"].(map[string]any)
+	if _, ok := properties["maxTokens"]; !ok {
+		t.Error("customOptions does not contain maxTokens")
+	}
+}

--- a/go/plugins/compat_oai/deepseek/deepseek_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deepseek_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
+)
+
+func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %q, want %q", r.URL.Path, "/chat/completions")
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+
+		var body struct {
+			Model     string `json:"model"`
+			Stream    bool   `json:"stream"`
+			MaxTokens int    `json:"max_tokens"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if body.Model != deepseek.ModelDeepSeekReasoner {
+			t.Errorf("model = %q, want %q", body.Model, deepseek.ModelDeepSeekReasoner)
+		}
+		if body.MaxTokens != 8192 {
+			t.Errorf("max_tokens = %d, want 8192", body.MaxTokens)
+		}
+
+		if body.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			for _, event := range []string{
+				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Think "},"finish_reason":null}]}`,
+				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"reasoning_content":"carefully."},"finish_reason":null}]}`,
+				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"content":"Final answer"},"finish_reason":null}]}`,
+				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			} {
+				_, _ = io.WriteString(w, "data: "+event+"\n\n")
+			}
+			_, _ = io.WriteString(w, "data: [DONE]\n\n")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-1",
+			"object":"chat.completion",
+			"created":1,
+			"model":"deepseek-reasoner",
+			"choices":[{
+				"index":0,
+				"message":{
+					"role":"assistant",
+					"reasoning_content":"Think carefully.",
+					"content":"Final answer"
+				},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}
+		}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("DEEPSEEK_BASE_URL", server.URL)
+
+	ctx := context.Background()
+	plugin := &deepseek.DeepSeek{}
+	g := genkit.Init(
+		ctx,
+		genkit.WithPlugins(plugin),
+		genkit.WithDefaultModel("deepseek/"+deepseek.ModelDeepSeekReasoner),
+	)
+
+	if plugin.Name() != "deepseek" {
+		t.Fatalf("Name() = %q, want %q", plugin.Name(), "deepseek")
+	}
+	for _, modelName := range []string{deepseek.ModelDeepSeekChat, deepseek.ModelDeepSeekReasoner} {
+		model := plugin.Model(g, modelName)
+		if model == nil {
+			t.Errorf("Model(%q) = nil", modelName)
+			continue
+		}
+		metadata := model.(api.Action).Desc().Metadata["model"].(map[string]any)
+		supports := metadata["supports"].(map[string]any)
+		if got := supports["media"]; got != false {
+			t.Errorf("%s media support = %v, want false", modelName, got)
+		}
+		if got := supports["tools"]; got != true {
+			t.Errorf("%s tools support = %v, want true", modelName, got)
+		}
+		configSchema := metadata["customOptions"].(map[string]any)
+		properties := configSchema["properties"].(map[string]any)
+		maxTokens := properties["maxTokens"].(map[string]any)
+		if got := maxTokens["minimum"]; got != float64(1) {
+			t.Errorf("%s maxTokens minimum = %v, want 1", modelName, got)
+		}
+		if got := maxTokens["maximum"]; got != float64(8192) {
+			t.Errorf("%s maxTokens maximum = %v, want 8192", modelName, got)
+		}
+	}
+	config := map[string]any{"maxTokens": 8192}
+
+	t.Run("complete", func(t *testing.T) {
+		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Solve this."), ai.WithConfig(config))
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if got := resp.Reasoning(); got != "Think carefully." {
+			t.Fatalf("Reasoning() = %q, want %q", got, "Think carefully.")
+		}
+		if got := resp.Text(); got != "Final answer" {
+			t.Fatalf("Text() = %q, want %q", got, "Final answer")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		var reasoning, text strings.Builder
+		resp, err := genkit.Generate(
+			ctx,
+			g,
+			ai.WithPrompt("Solve this."),
+			ai.WithConfig(config),
+			ai.WithStreaming(func(_ context.Context, chunk *ai.ModelResponseChunk) error {
+				reasoning.WriteString(chunk.Reasoning())
+				text.WriteString(chunk.Text())
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if got := reasoning.String(); got != "Think carefully." {
+			t.Fatalf("streamed reasoning = %q, want %q", got, "Think carefully.")
+		}
+		if got := text.String(); got != "Final answer" {
+			t.Fatalf("streamed text = %q, want %q", got, "Final answer")
+		}
+		if resp.Reasoning() != reasoning.String() {
+			t.Fatalf("final reasoning = %q, want streamed %q", resp.Reasoning(), reasoning.String())
+		}
+		if resp.Text() != text.String() {
+			t.Fatalf("final text = %q, want streamed %q", resp.Text(), text.String())
+		}
+	})
+
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestPluginRequiresAPIKey(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "")
+
+	defer func() {
+		if got := recover(); got != "deepseek plugin initialization failed: apiKey is required" {
+			t.Fatalf("panic = %v, want missing API key error", got)
+		}
+	}()
+	(&deepseek.DeepSeek{}).Init(context.Background())
+}

--- a/go/plugins/compat_oai/deepseek/deepseek_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_test.go
@@ -120,15 +120,11 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 		}
 		configSchema := metadata["customOptions"].(map[string]any)
 		properties := configSchema["properties"].(map[string]any)
-		maxTokens := properties["maxTokens"].(map[string]any)
-		if got := maxTokens["minimum"]; got != float64(1) {
-			t.Errorf("%s maxTokens minimum = %v, want 1", modelName, got)
-		}
-		if got := maxTokens["maximum"]; got != float64(8192) {
-			t.Errorf("%s maxTokens maximum = %v, want 8192", modelName, got)
+		if _, ok := properties["maxOutputTokens"]; !ok {
+			t.Errorf("%s customOptions does not contain maxOutputTokens", modelName)
 		}
 	}
-	config := map[string]any{"maxTokens": 8192}
+	config := map[string]any{"maxOutputTokens": 8192}
 
 	t.Run("complete", func(t *testing.T) {
 		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Solve this."), ai.WithConfig(config))
@@ -231,7 +227,7 @@ func assertDeepSeekMetadata(t *testing.T, desc api.ActionDesc) {
 		t.Errorf("tools support = %v, want true", got)
 	}
 	properties := metadata["customOptions"].(map[string]any)["properties"].(map[string]any)
-	if _, ok := properties["maxTokens"]; !ok {
-		t.Error("customOptions does not contain maxTokens")
+	if _, ok := properties["maxOutputTokens"]; !ok {
+		t.Error("customOptions does not contain maxOutputTokens")
 	}
 }

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -36,8 +36,17 @@ type ModelGenerator struct {
 	request   *openai.ChatCompletionNewParams
 	messages  []openai.ChatCompletionMessageParamUnion
 	tools     []openai.ChatCompletionToolParam
+	// configAliases contains provider-specific config name translations.
+	configAliases map[string]string
 	// Store any errors that occur during building
 	err error
+}
+
+// WithConfigAliases configures provider-specific translations from
+// Genkit-facing config names to OpenAI-compatible request field names.
+func (g *ModelGenerator) WithConfigAliases(aliases map[string]string) *ModelGenerator {
+	g.configAliases = aliases
+	return g
 }
 
 // chatCompletionParamFields contains every field serialized by the OpenAI SDK.
@@ -198,6 +207,12 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 			"topLogProbs":      "top_logprobs",
 			"topP":             "top_p",
 		} {
+			if value, ok := normalizedConfig[source]; ok {
+				normalizedConfig[target] = value
+				delete(normalizedConfig, source)
+			}
+		}
+		for source, target := range g.configAliases {
 			if value, ok := normalizedConfig[source]; ok {
 				normalizedConfig[target] = value
 				delete(normalizedConfig, source)

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -215,7 +215,9 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		for source, target := range g.configAliases {
 			if value, ok := normalizedConfig[source]; ok {
 				normalizedConfig[target] = value
-				delete(normalizedConfig, source)
+				if source != target {
+					delete(normalizedConfig, source)
+				}
 			}
 		}
 		// These Genkit common fields are handled outside the provider request

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -278,6 +278,33 @@ func TestWithConfigPreservesProviderSpecificFields(t *testing.T) {
 	}
 }
 
+func TestWithConfigAppliesProviderAliases(t *testing.T) {
+	g := newGen().
+		WithConfigAliases(map[string]string{"maxTokens": "max_tokens"}).
+		WithConfig(map[string]any{"maxTokens": 8192})
+	if g.err != nil {
+		t.Fatalf("WithConfig() error = %v", g.err)
+	}
+
+	data, err := json.Marshal(g.GetRequest())
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got := request["max_tokens"]; got != float64(8192) {
+		t.Errorf("max_tokens = %v, want 8192", got)
+	}
+	if _, ok := request["maxTokens"]; ok {
+		t.Error("request contains unconverted maxTokens field")
+	}
+	if _, ok := g.GetRequest().ExtraFields()["max_tokens"]; ok {
+		t.Error("max_tokens was added as an extra field")
+	}
+}
+
 func TestWithConfigIgnoresNilPointer(t *testing.T) {
 	var config *openai.ChatCompletionNewParams
 	g := newGen().WithConfig(config)

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -84,6 +84,48 @@ func newStubGen(t *testing.T, contentType, body string) *ModelGenerator {
 	return NewModelGenerator(&client, "test-model")
 }
 
+func TestOpenAICompatibleSnapshotsConfigAliasesAtInit(t *testing.T) {
+	aliases := map[string]string{"maxTokens": "max_tokens"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if got := body["max_tokens"]; got != float64(64) {
+			t.Errorf("max_tokens = %v, want 64", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-1",
+			"object":"chat.completion",
+			"created":1,
+			"model":"test-model",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`)
+	}))
+	defer server.Close()
+
+	plugin := &OpenAICompatible{
+		Provider:      "snapshot",
+		APIKey:        "test-key",
+		BaseURL:       server.URL,
+		ConfigAliases: aliases,
+	}
+	plugin.Init(context.Background())
+	aliases["maxTokens"] = "changed_after_init"
+
+	model := plugin.DefineModel("snapshot", "test-model", ai.ModelOptions{})
+	_, err := model.Generate(context.Background(), &ai.ModelRequest{
+		Messages: []*ai.Message{ai.NewUserTextMessage("hello")},
+		Config:   map[string]any{"maxTokens": 64},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+}
+
 // Regression test for #4683: the streaming path used to leave Request as an
 // empty &ai.ModelRequest{}, so History() dropped every input message.
 func TestGeneratePreservesRequest(t *testing.T) {

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -347,6 +347,27 @@ func TestWithConfigAppliesProviderAliases(t *testing.T) {
 	}
 }
 
+func TestWithConfigPreservesIdentityAlias(t *testing.T) {
+	g := newGen().
+		WithConfigAliases(map[string]string{"deferred": "deferred"}).
+		WithConfig(map[string]any{"deferred": true})
+	if g.err != nil {
+		t.Fatalf("WithConfig() error = %v", g.err)
+	}
+
+	data, err := json.Marshal(g.GetRequest())
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got := request["deferred"]; got != true {
+		t.Errorf("deferred = %v, want true", got)
+	}
+}
+
 func TestWithConfigIgnoresNilPointer(t *testing.T) {
 	var config *openai.ChatCompletionNewParams
 	g := newGen().WithConfig(config)


### PR DESCRIPTION
Adds the Go DeepSeek subplugin described in #5900. It registers `deepseek-chat` and `deepseek-reasoner`, uses the canonical `DEEPSEEK_API_KEY` and endpoint defaults, preserves `reasoning_content` for complete and streaming responses, and maps the JS-facing `maxTokens` option to DeepSeek's `max_tokens` field with the same 1–8192 schema bounds.

Usage and opt-in live-test documentation are included. Offline tests use a local HTTP server and cover authentication, model registration and metadata, request mapping, complete responses, streaming reasoning, and missing-key handling.

Part of #5900.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (`go test ./plugins/compat_oai/...`, repository-wide `go test -v ./...`, focused `go vet`)
- [x] Docs updated