### PR TITLE
feat(go/compat-oai): add xAI plugin

### DIFF
--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -61,6 +61,7 @@ export ANTHROPIC_API_KEY=<your-anthropic-key>
 export DASHSCOPE_API_KEY=<your-dashscope-key>
 export ZAI_API_KEY=<your-zai-key>
 export KIMI_API_KEY=<your-kimi-key>
+export XAI_API_KEY=<your-xai-key>
 ```
 
 Run all tests:
@@ -84,6 +85,9 @@ go test -v ./zai
 
 # Kimi tests
 go test -v ./kimi
+
+# xAI tests
+go test -v ./xai
 ```
 
 Note: Tests will be skipped if the required API keys are not set.

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -68,6 +68,10 @@ type OpenAICompatible struct {
 	// Should be lowercase and match the plugin's Name() method.
 	Provider string
 
+	// ConfigAliases maps Genkit-facing configuration names to the field names
+	// expected by the provider's OpenAI-compatible API.
+	ConfigAliases map[string]string
+
 	// API key to use with the desired plugin.
 	APIKey string
 
@@ -121,6 +125,7 @@ func (o *OpenAICompatible) DefineModel(provider, id string, opts ai.ModelOptions
 	) (*ai.ModelResponse, error) {
 		// Configure the response generator with input
 		generator := NewModelGenerator(o.client, id).
+			WithConfigAliases(o.ConfigAliases).
 			WithMessages(input.Messages).
 			WithConfig(input.Config).
 			WithTools(input.Tools).

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -17,6 +17,7 @@ package compat_oai
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
@@ -69,8 +70,10 @@ type OpenAICompatible struct {
 	Provider string
 
 	// ConfigAliases maps Genkit-facing configuration names to the field names
-	// expected by the provider's OpenAI-compatible API.
+	// expected by the provider's OpenAI-compatible API. Configure it before
+	// calling Init; Init snapshots the map for concurrent model requests.
 	ConfigAliases map[string]string
+	configAliases map[string]string
 
 	// API key to use with the desired plugin.
 	APIKey string
@@ -100,6 +103,7 @@ func (o *OpenAICompatible) Init(ctx context.Context) []api.Action {
 	// create client
 	client := openai.NewClient(o.Opts...)
 	o.client = &client
+	o.configAliases = maps.Clone(o.ConfigAliases)
 	o.initted = true
 
 	return []api.Action{}
@@ -125,7 +129,7 @@ func (o *OpenAICompatible) DefineModel(provider, id string, opts ai.ModelOptions
 	) (*ai.ModelResponse, error) {
 		// Configure the response generator with input
 		generator := NewModelGenerator(o.client, id).
-			WithConfigAliases(o.ConfigAliases).
+			WithConfigAliases(o.configAliases).
 			WithMessages(input.Messages).
 			WithConfig(input.Config).
 			WithTools(input.Tools).

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -36,8 +36,17 @@ type ModelGenerator struct {
 	request   *openai.ChatCompletionNewParams
 	messages  []openai.ChatCompletionMessageParamUnion
 	tools     []openai.ChatCompletionToolParam
+	// configAliases contains provider-specific config name translations.
+	configAliases map[string]string
 	// Store any errors that occur during building
 	err error
+}
+
+// WithConfigAliases configures provider-specific translations from
+// Genkit-facing config names to OpenAI-compatible request field names.
+func (g *ModelGenerator) WithConfigAliases(aliases map[string]string) *ModelGenerator {
+	g.configAliases = aliases
+	return g
 }
 
 // chatCompletionParamFields contains every field serialized by the OpenAI SDK.
@@ -187,6 +196,7 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		openaiConfig = *cfg
 	case map[string]any:
 		normalizedConfig := make(map[string]any, len(cfg))
+		providerFields := make(map[string]struct{}, len(g.configAliases))
 		for key, value := range cfg {
 			normalizedConfig[key] = value
 		}
@@ -201,6 +211,13 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 			if value, ok := normalizedConfig[source]; ok {
 				normalizedConfig[target] = value
 				delete(normalizedConfig, source)
+			}
+		}
+		for source, target := range g.configAliases {
+			if value, ok := normalizedConfig[source]; ok {
+				normalizedConfig[target] = value
+				delete(normalizedConfig, source)
+				providerFields[target] = struct{}{}
 			}
 		}
 		// These Genkit common fields are handled outside the provider request
@@ -223,7 +240,8 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		// are excluded to prevent config from overriding request construction.
 		extraFields := make(map[string]any, len(normalizedConfig))
 		for key, value := range normalizedConfig {
-			if _, standard := chatCompletionParamFields[key]; standard {
+			_, providerField := providerFields[key]
+			if _, standard := chatCompletionParamFields[key]; standard && !providerField {
 				continue
 			}
 			extraFields[key] = value

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -215,7 +215,9 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		for source, target := range g.configAliases {
 			if value, ok := normalizedConfig[source]; ok {
 				normalizedConfig[target] = value
-				delete(normalizedConfig, source)
+				if source != target {
+					delete(normalizedConfig, source)
+				}
 			}
 		}
 		// These Genkit common fields are handled outside the provider request

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -196,7 +196,6 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		openaiConfig = *cfg
 	case map[string]any:
 		normalizedConfig := make(map[string]any, len(cfg))
-		providerFields := make(map[string]struct{}, len(g.configAliases))
 		for key, value := range cfg {
 			normalizedConfig[key] = value
 		}
@@ -217,7 +216,6 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 			if value, ok := normalizedConfig[source]; ok {
 				normalizedConfig[target] = value
 				delete(normalizedConfig, source)
-				providerFields[target] = struct{}{}
 			}
 		}
 		// These Genkit common fields are handled outside the provider request
@@ -240,8 +238,7 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		// are excluded to prevent config from overriding request construction.
 		extraFields := make(map[string]any, len(normalizedConfig))
 		for key, value := range normalizedConfig {
-			_, providerField := providerFields[key]
-			if _, standard := chatCompletionParamFields[key]; standard && !providerField {
+			if _, standard := chatCompletionParamFields[key]; standard {
 				continue
 			}
 			extraFields[key] = value

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -84,6 +84,48 @@ func newStubGen(t *testing.T, contentType, body string) *ModelGenerator {
 	return NewModelGenerator(&client, "test-model")
 }
 
+func TestOpenAICompatibleSnapshotsConfigAliasesAtInit(t *testing.T) {
+	aliases := map[string]string{"maxTokens": "max_tokens"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if got := body["max_tokens"]; got != float64(64) {
+			t.Errorf("max_tokens = %v, want 64", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-1",
+			"object":"chat.completion",
+			"created":1,
+			"model":"test-model",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`)
+	}))
+	defer server.Close()
+
+	plugin := &OpenAICompatible{
+		Provider:      "snapshot",
+		APIKey:        "test-key",
+		BaseURL:       server.URL,
+		ConfigAliases: aliases,
+	}
+	plugin.Init(context.Background())
+	aliases["maxTokens"] = "changed_after_init"
+
+	model := plugin.DefineModel("snapshot", "test-model", ai.ModelOptions{})
+	_, err := model.Generate(context.Background(), &ai.ModelRequest{
+		Messages: []*ai.Message{ai.NewUserTextMessage("hello")},
+		Config:   map[string]any{"maxTokens": 64},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+}
+
 // Regression test for #4683: the streaming path used to leave Request as an
 // empty &ai.ModelRequest{}, so History() dropped every input message.
 func TestGeneratePreservesRequest(t *testing.T) {
@@ -287,7 +329,7 @@ func TestWithConfigAppliesProviderAliases(t *testing.T) {
 		WithConfig(map[string]any{
 			"deferred":         true,
 			"reasoningEffort":  "high",
-			"webSearchOptions": map[string]any{"mode": "on"},
+			"webSearchOptions": map[string]any{"search_context_size": "high"},
 		})
 	if g.err != nil {
 		t.Fatalf("WithConfig() error = %v", g.err)
@@ -308,8 +350,8 @@ func TestWithConfigAppliesProviderAliases(t *testing.T) {
 	if !ok {
 		t.Fatalf("web_search_options = %#v, want object", request["web_search_options"])
 	}
-	if got := webSearch["mode"]; got != "on" {
-		t.Errorf("web_search_options.mode = %v, want on", got)
+	if got := webSearch["search_context_size"]; got != "high" {
+		t.Errorf("web_search_options.search_context_size = %v, want high", got)
 	}
 	if got := request["deferred"]; got != true {
 		t.Errorf("deferred = %v, want true", got)
@@ -317,6 +359,11 @@ func TestWithConfigAppliesProviderAliases(t *testing.T) {
 	for _, name := range []string{"reasoningEffort", "webSearchOptions"} {
 		if _, ok := request[name]; ok {
 			t.Errorf("request contains unconverted %s field", name)
+		}
+	}
+	for _, name := range []string{"reasoning_effort", "web_search_options"} {
+		if _, ok := g.GetRequest().ExtraFields()[name]; ok {
+			t.Errorf("SDK-supported field %s was retained as an extra", name)
 		}
 	}
 }

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -368,6 +368,27 @@ func TestWithConfigAppliesProviderAliases(t *testing.T) {
 	}
 }
 
+func TestWithConfigPreservesIdentityAlias(t *testing.T) {
+	g := newGen().
+		WithConfigAliases(map[string]string{"deferred": "deferred"}).
+		WithConfig(map[string]any{"deferred": true})
+	if g.err != nil {
+		t.Fatalf("WithConfig() error = %v", g.err)
+	}
+
+	data, err := json.Marshal(g.GetRequest())
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got := request["deferred"]; got != true {
+		t.Errorf("deferred = %v, want true", got)
+	}
+}
+
 func TestWithConfigIgnoresNilPointer(t *testing.T) {
 	var config *openai.ChatCompletionNewParams
 	g := newGen().WithConfig(config)

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -278,6 +278,49 @@ func TestWithConfigPreservesProviderSpecificFields(t *testing.T) {
 	}
 }
 
+func TestWithConfigAppliesProviderAliases(t *testing.T) {
+	g := newGen().
+		WithConfigAliases(map[string]string{
+			"reasoningEffort":  "reasoning_effort",
+			"webSearchOptions": "web_search_options",
+		}).
+		WithConfig(map[string]any{
+			"deferred":         true,
+			"reasoningEffort":  "high",
+			"webSearchOptions": map[string]any{"mode": "on"},
+		})
+	if g.err != nil {
+		t.Fatalf("WithConfig() error = %v", g.err)
+	}
+
+	data, err := json.Marshal(g.GetRequest())
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got := request["reasoning_effort"]; got != "high" {
+		t.Errorf("reasoning_effort = %v, want high", got)
+	}
+	webSearch, ok := request["web_search_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("web_search_options = %#v, want object", request["web_search_options"])
+	}
+	if got := webSearch["mode"]; got != "on" {
+		t.Errorf("web_search_options.mode = %v, want on", got)
+	}
+	if got := request["deferred"]; got != true {
+		t.Errorf("deferred = %v, want true", got)
+	}
+	for _, name := range []string{"reasoningEffort", "webSearchOptions"} {
+		if _, ok := request[name]; ok {
+			t.Errorf("request contains unconverted %s field", name)
+		}
+	}
+}
+
 func TestWithConfigIgnoresNilPointer(t *testing.T) {
 	var config *openai.ChatCompletionNewParams
 	g := newGen().WithConfig(config)

--- a/go/plugins/compat_oai/xai/README.md
+++ b/go/plugins/compat_oai/xai/README.md
@@ -1,0 +1,72 @@
+# xAI Plugin
+
+This plugin provides Genkit support for xAI's OpenAI-compatible Grok language
+and vision models.
+
+## Supported models
+
+- `grok-3`
+- `grok-3-fast`
+- `grok-3-mini`
+- `grok-3-mini-fast`
+- `grok-2-vision-1212`
+
+Image generation models are not included because the Go OpenAI-compatible
+adapter does not yet support image generation.
+
+## Usage
+
+Set an xAI API key:
+
+```bash
+export XAI_API_KEY=<your-api-key>
+```
+
+The plugin uses `https://api.x.ai/v1` by default. Set `XAI_BASE_URL` to use
+another xAI-compatible endpoint.
+
+```go
+import (
+    "context"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/xai"
+)
+
+ctx := context.Background()
+plugin := &xai.XAI{}
+g := genkit.Init(
+    ctx,
+    genkit.WithPlugins(plugin),
+    genkit.WithDefaultModel("xai/"+xai.ModelGrok3),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain mixture-of-experts models."))
+```
+
+xAI-specific options use Genkit's camel-case config names and are translated
+to the provider's API fields:
+
+```go
+response, err := genkit.Generate(
+    ctx,
+    g,
+    ai.WithPrompt("Summarize recent developments in fusion energy."),
+    ai.WithConfig(map[string]any{
+        "deferred": true,
+        "reasoningEffort": "high",
+        "webSearchOptions": map[string]any{
+            "search_context_size": "high",
+        },
+    }),
+)
+```
+
+## Tests
+
+The package tests use a local HTTP server and do not require an API key:
+
+```bash
+go test -v ./plugins/compat_oai/xai
+```

--- a/go/plugins/compat_oai/xai/xai.go
+++ b/go/plugins/compat_oai/xai/xai.go
@@ -27,9 +27,9 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
-// ChatCompletionConfig describes configuration accepted by xAI chat
+// chatCompletionConfig describes the schema accepted by xAI chat
 // completions. WebSearchOptions permits xAI-specific web search fields.
-type ChatCompletionConfig struct {
+type chatCompletionConfig struct {
 	ai.GenerationCommonConfig
 	Deferred         *bool          `json:"deferred,omitempty"`
 	FrequencyPenalty *float64       `json:"frequencyPenalty,omitempty" jsonschema:"minimum=-2,maximum=2"`
@@ -56,32 +56,36 @@ const (
 	ModelGrok2Vision1212 = "grok-2-vision-1212"
 )
 
-var supportedModels = map[string]ai.ModelOptions{
-	ModelGrok3:         modelOptions(ModelGrok3, "xAI Grok 3", false, true, true),
-	ModelGrok3Fast:     modelOptions(ModelGrok3Fast, "xAI Grok 3 Fast", false, true, true),
-	ModelGrok3Mini:     modelOptions(ModelGrok3Mini, "xAI Grok 3 Mini", false, true, true),
-	ModelGrok3MiniFast: modelOptions(ModelGrok3MiniFast, "xAI Grok 3 Mini Fast", false, true, true),
-	ModelGrok2Vision1212: modelOptions(
-		ModelGrok2Vision1212,
-		"xAI Grok 2 Vision 1212",
-		true,
-		false,
-		false,
-	),
-}
+var (
+	textModelSupports = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		SystemRole: true,
+		Media:      false,
+		Output:     []string{"text", "json"},
+	}
+	visionModelSupports = ai.ModelSupports{
+		Multiturn:  false,
+		Tools:      true,
+		SystemRole: false,
+		Media:      true,
+		Output:     []string{"text", "json"},
+	}
+	supportedModels = map[string]ai.ModelOptions{
+		ModelGrok3:           modelOptions(ModelGrok3, "xAI Grok 3", textModelSupports),
+		ModelGrok3Fast:       modelOptions(ModelGrok3Fast, "xAI Grok 3 Fast", textModelSupports),
+		ModelGrok3Mini:       modelOptions(ModelGrok3Mini, "xAI Grok 3 Mini", textModelSupports),
+		ModelGrok3MiniFast:   modelOptions(ModelGrok3MiniFast, "xAI Grok 3 Mini Fast", textModelSupports),
+		ModelGrok2Vision1212: modelOptions(ModelGrok2Vision1212, "xAI Grok 2 Vision 1212", visionModelSupports),
+	}
+)
 
-func modelOptions(id, label string, media, multiturn, systemRole bool) ai.ModelOptions {
+func modelOptions(id, label string, supports ai.ModelSupports) ai.ModelOptions {
 	return ai.ModelOptions{
 		Label:        label,
-		ConfigSchema: core.InferSchemaMap(ChatCompletionConfig{}),
-		Supports: &ai.ModelSupports{
-			Multiturn:  multiturn,
-			Tools:      true,
-			SystemRole: systemRole,
-			Media:      media,
-			Output:     []string{"text", "json"},
-		},
-		Versions: []string{id},
+		ConfigSchema: core.InferSchemaMap(chatCompletionConfig{}),
+		Supports:     &supports,
+		Versions:     []string{id},
 	}
 }
 

--- a/go/plugins/compat_oai/xai/xai.go
+++ b/go/plugins/compat_oai/xai/xai.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xai provides a Genkit plugin for xAI's Grok language models.
+package xai
+
+import (
+	"context"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go/option"
+)
+
+// ChatCompletionConfig describes configuration accepted by xAI chat
+// completions. WebSearchOptions permits xAI-specific web search fields.
+type ChatCompletionConfig struct {
+	ai.GenerationCommonConfig
+	Deferred         *bool          `json:"deferred,omitempty"`
+	FrequencyPenalty *float64       `json:"frequencyPenalty,omitempty" jsonschema:"minimum=-2,maximum=2"`
+	LogProbs         *bool          `json:"logProbs,omitempty"`
+	PresencePenalty  *float64       `json:"presencePenalty,omitempty" jsonschema:"minimum=-2,maximum=2"`
+	ReasoningEffort  *string        `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=medium,enum=high"`
+	TopLogProbs      *int           `json:"topLogProbs,omitempty" jsonschema:"minimum=0,maximum=20"`
+	WebSearchOptions map[string]any `json:"webSearchOptions,omitempty"`
+}
+
+const (
+	provider       = "xai"
+	defaultBaseURL = "https://api.x.ai/v1"
+
+	// ModelGrok3 is xAI's Grok 3 language model.
+	ModelGrok3 = "grok-3"
+	// ModelGrok3Fast is the low-latency Grok 3 language model.
+	ModelGrok3Fast = "grok-3-fast"
+	// ModelGrok3Mini is xAI's compact Grok 3 reasoning model.
+	ModelGrok3Mini = "grok-3-mini"
+	// ModelGrok3MiniFast is the low-latency Grok 3 Mini model.
+	ModelGrok3MiniFast = "grok-3-mini-fast"
+	// ModelGrok2Vision1212 is xAI's Grok 2 vision model.
+	ModelGrok2Vision1212 = "grok-2-vision-1212"
+)
+
+var supportedModels = map[string]ai.ModelOptions{
+	ModelGrok3:         modelOptions(ModelGrok3, "xAI Grok 3", false, true, true),
+	ModelGrok3Fast:     modelOptions(ModelGrok3Fast, "xAI Grok 3 Fast", false, true, true),
+	ModelGrok3Mini:     modelOptions(ModelGrok3Mini, "xAI Grok 3 Mini", false, true, true),
+	ModelGrok3MiniFast: modelOptions(ModelGrok3MiniFast, "xAI Grok 3 Mini Fast", false, true, true),
+	ModelGrok2Vision1212: modelOptions(
+		ModelGrok2Vision1212,
+		"xAI Grok 2 Vision 1212",
+		true,
+		false,
+		false,
+	),
+}
+
+func modelOptions(id, label string, media, multiturn, systemRole bool) ai.ModelOptions {
+	return ai.ModelOptions{
+		Label:        label,
+		ConfigSchema: core.InferSchemaMap(ChatCompletionConfig{}),
+		Supports: &ai.ModelSupports{
+			Multiturn:  multiturn,
+			Tools:      true,
+			SystemRole: systemRole,
+			Media:      media,
+			Output:     []string{"text", "json"},
+		},
+		Versions: []string{id},
+	}
+}
+
+// XAI configures the xAI Grok plugin.
+type XAI struct {
+	// APIKey is the xAI API key. If empty, XAI_API_KEY is consulted.
+	APIKey string
+	// BaseURL overrides the xAI API endpoint. If empty, XAI_BASE_URL and then
+	// the default endpoint are used.
+	BaseURL string
+	// Opts contains additional OpenAI client request options. Options supplied
+	// here are applied after the plugin defaults.
+	Opts []option.RequestOption
+
+	openAICompatible compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (x *XAI) Name() string {
+	return provider
+}
+
+// Init implements genkit.Plugin.
+func (x *XAI) Init(ctx context.Context) []api.Action {
+	baseURL := x.BaseURL
+	if baseURL == "" {
+		baseURL = os.Getenv("XAI_BASE_URL")
+	}
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiKey := x.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("XAI_API_KEY")
+	}
+	if apiKey == "" {
+		panic("xai plugin initialization failed: apiKey is required")
+	}
+
+	opts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL),
+	}
+	opts = append(opts, x.Opts...)
+
+	x.openAICompatible.Provider = provider
+	x.openAICompatible.ConfigAliases = map[string]string{
+		"reasoningEffort":  "reasoning_effort",
+		"webSearchOptions": "web_search_options",
+	}
+	x.openAICompatible.Opts = opts
+	actions := x.openAICompatible.Init(ctx)
+
+	for model, modelOpts := range supportedModels {
+		actions = append(actions, x.DefineModel(model, modelOpts).(api.Action))
+	}
+	return actions
+}
+
+// Model returns a registered xAI model.
+func (x *XAI) Model(g *genkit.Genkit, id string) ai.Model {
+	return x.openAICompatible.Model(g, api.NewName(provider, id))
+}
+
+// DefineModel registers an xAI model, including models not in the built-in list.
+func (x *XAI) DefineModel(id string, opts ai.ModelOptions) ai.Model {
+	return x.openAICompatible.DefineModel(provider, id, opts)
+}
+
+// ListActions lists models exposed by the configured xAI endpoint.
+func (x *XAI) ListActions(ctx context.Context) []api.ActionDesc {
+	return x.openAICompatible.ListActions(ctx)
+}
+
+// ResolveAction dynamically registers a model exposed by the xAI endpoint.
+func (x *XAI) ResolveAction(atype api.ActionType, name string) api.Action {
+	return x.openAICompatible.ResolveAction(atype, name)
+}

--- a/go/plugins/compat_oai/xai/xai.go
+++ b/go/plugins/compat_oai/xai/xai.go
@@ -65,7 +65,7 @@ var (
 		Output:     []string{"text", "json"},
 	}
 	visionModelSupports = ai.ModelSupports{
-		Multiturn:  true,
+		Multiturn:  false,
 		Tools:      true,
 		SystemRole: false,
 		Media:      true,

--- a/go/plugins/compat_oai/xai/xai.go
+++ b/go/plugins/compat_oai/xai/xai.go
@@ -65,7 +65,7 @@ var (
 		Output:     []string{"text", "json"},
 	}
 	visionModelSupports = ai.ModelSupports{
-		Multiturn:  false,
+		Multiturn:  true,
 		Tools:      true,
 		SystemRole: false,
 		Media:      true,

--- a/go/plugins/compat_oai/xai/xai_test.go
+++ b/go/plugins/compat_oai/xai/xai_test.go
@@ -59,7 +59,7 @@ func TestPluginRegistersModels(t *testing.T) {
 		{model: xai.ModelGrok3Fast, wantMultiturn: true, wantSystemRole: true},
 		{model: xai.ModelGrok3Mini, wantMultiturn: true, wantSystemRole: true},
 		{model: xai.ModelGrok3MiniFast, wantMultiturn: true, wantSystemRole: true},
-		{model: xai.ModelGrok2Vision1212, wantMultiturn: true, wantMedia: true},
+		{model: xai.ModelGrok2Vision1212, wantMedia: true},
 	} {
 		t.Run(tc.model, func(t *testing.T) {
 			model := plugin.Model(g, tc.model)

--- a/go/plugins/compat_oai/xai/xai_test.go
+++ b/go/plugins/compat_oai/xai/xai_test.go
@@ -41,7 +41,73 @@ func TestPluginRequiresAPIKey(t *testing.T) {
 	(&xai.XAI{}).Init(context.Background())
 }
 
-func TestPluginRegistersModelsAndTranslatesConfig(t *testing.T) {
+func TestPluginRegistersModels(t *testing.T) {
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key"}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	if got := plugin.Name(); got != "xai" {
+		t.Fatalf("Name() = %q, want xai", got)
+	}
+	for _, tc := range []struct {
+		model          string
+		wantMedia      bool
+		wantMultiturn  bool
+		wantSystemRole bool
+	}{
+		{model: xai.ModelGrok3, wantMultiturn: true, wantSystemRole: true},
+		{model: xai.ModelGrok3Fast, wantMultiturn: true, wantSystemRole: true},
+		{model: xai.ModelGrok3Mini, wantMultiturn: true, wantSystemRole: true},
+		{model: xai.ModelGrok3MiniFast, wantMultiturn: true, wantSystemRole: true},
+		{model: xai.ModelGrok2Vision1212, wantMedia: true},
+	} {
+		t.Run(tc.model, func(t *testing.T) {
+			model := plugin.Model(g, tc.model)
+			if model == nil {
+				t.Fatalf("Model(%q) = nil", tc.model)
+			}
+			desc := model.(api.Action).Desc()
+			if got, want := desc.Name, "xai/"+tc.model; got != want {
+				t.Errorf("Desc().Name = %q, want %q", got, want)
+			}
+			metadata := desc.Metadata["model"].(map[string]any)
+			supports := metadata["supports"].(map[string]any)
+			for _, support := range []struct {
+				name string
+				want bool
+			}{
+				{name: "media", want: tc.wantMedia},
+				{name: "multiturn", want: tc.wantMultiturn},
+				{name: "systemRole", want: tc.wantSystemRole},
+				{name: "tools", want: true},
+				{name: "toolChoice", want: false},
+			} {
+				got, ok := supports[support.name].(bool)
+				if !ok || got != support.want {
+					t.Errorf("%s support = %v, want %v", support.name, supports[support.name], support.want)
+				}
+			}
+			output, _ := supports["output"].([]string)
+			if !slices.Equal(output, []string{"text", "json"}) {
+				t.Errorf("output = %v, want [text json]", output)
+			}
+		})
+	}
+
+	metadata := plugin.Model(g, xai.ModelGrok3).(api.Action).Desc().Metadata["model"].(map[string]any)
+	properties := metadata["customOptions"].(map[string]any)["properties"].(map[string]any)
+	reasoningEffort := properties["reasoningEffort"].(map[string]any)
+	if enumValues, _ := reasoningEffort["enum"].([]any); !slices.Equal(enumValues, []any{"low", "medium", "high"}) {
+		t.Errorf("reasoningEffort enum = %v, want [low medium high]", enumValues)
+	}
+	for _, name := range []string{"deferred", "webSearchOptions"} {
+		if _, ok := properties[name]; !ok {
+			t.Errorf("config schema is missing %s", name)
+		}
+	}
+}
+
+func TestPluginTranslatesConfig(t *testing.T) {
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
@@ -52,28 +118,42 @@ func TestPluginRegistersModelsAndTranslatesConfig(t *testing.T) {
 			t.Errorf("Authorization = %q, want bearer token", got)
 		}
 
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode request: %v", err)
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request: %v", err)
+			return
 		}
-		if got := body["model"]; got != xai.ModelGrok3Mini {
-			t.Errorf("model = %v, want %q", got, xai.ModelGrok3Mini)
+		var body struct {
+			Model            string `json:"model"`
+			Deferred         bool   `json:"deferred"`
+			ReasoningEffort  string `json:"reasoning_effort"`
+			WebSearchOptions struct {
+				SearchContextSize string `json:"search_context_size"`
+			} `json:"web_search_options"`
 		}
-		if got := body["deferred"]; got != true {
-			t.Errorf("deferred = %v, want true", got)
+		if err := json.Unmarshal(data, &body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
 		}
-		if got := body["reasoning_effort"]; got != "high" {
-			t.Errorf("reasoning_effort = %v, want high", got)
+		if body.Model != xai.ModelGrok3Mini {
+			t.Errorf("model = %q, want %q", body.Model, xai.ModelGrok3Mini)
 		}
-		webSearch, ok := body["web_search_options"].(map[string]any)
-		if !ok {
-			t.Fatalf("web_search_options = %#v, want object", body["web_search_options"])
+		if !body.Deferred {
+			t.Error("deferred = false, want true")
 		}
-		if got := webSearch["search_context_size"]; got != "high" {
-			t.Errorf("web_search_options.search_context_size = %v, want high", got)
+		if body.ReasoningEffort != "high" {
+			t.Errorf("reasoning_effort = %q, want high", body.ReasoningEffort)
+		}
+		if got := body.WebSearchOptions.SearchContextSize; got != "high" {
+			t.Errorf("web_search_options.search_context_size = %q, want high", got)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(data, &fields); err != nil {
+			t.Errorf("decode request fields: %v", err)
+			return
 		}
 		for _, name := range []string{"reasoningEffort", "webSearchOptions"} {
-			if _, ok := body[name]; ok {
+			if _, ok := fields[name]; ok {
 				t.Errorf("request contains unconverted %s field", name)
 			}
 		}
@@ -101,72 +181,6 @@ func TestPluginRegistersModelsAndTranslatesConfig(t *testing.T) {
 		genkit.WithPlugins(plugin),
 		genkit.WithDefaultModel("xai/"+xai.ModelGrok3Mini),
 	)
-
-	if got := plugin.Name(); got != "xai" {
-		t.Fatalf("Name() = %q, want xai", got)
-	}
-	textModels := []string{
-		xai.ModelGrok3,
-		xai.ModelGrok3Fast,
-		xai.ModelGrok3Mini,
-		xai.ModelGrok3MiniFast,
-	}
-	visionModels := []string{xai.ModelGrok2Vision1212}
-	for _, group := range []struct {
-		models         []string
-		wantMedia      bool
-		wantMultiturn  bool
-		wantSystemRole bool
-	}{
-		{models: textModels, wantMedia: false, wantMultiturn: true, wantSystemRole: true},
-		{models: visionModels, wantMedia: true, wantMultiturn: false, wantSystemRole: false},
-	} {
-		for _, modelID := range group.models {
-			model := plugin.Model(g, modelID)
-			if model == nil {
-				t.Errorf("Model(%q) = nil", modelID)
-				continue
-			}
-			desc := model.(api.Action).Desc()
-			if got, want := desc.Name, "xai/"+modelID; got != want {
-				t.Errorf("%s Desc().Name = %q, want %q", modelID, got, want)
-			}
-			metadata := desc.Metadata["model"].(map[string]any)
-			supports := metadata["supports"].(map[string]any)
-			for name, check := range map[string]struct {
-				got  any
-				want any
-			}{
-				"media":      {got: supports["media"], want: group.wantMedia},
-				"multiturn":  {got: supports["multiturn"], want: group.wantMultiturn},
-				"systemRole": {got: supports["systemRole"], want: group.wantSystemRole},
-				"tools":      {got: supports["tools"], want: true},
-				"toolChoice": {got: supports["toolChoice"], want: false},
-			} {
-				if check.got != check.want {
-					t.Errorf("%s %s support = %v, want %v", modelID, name, check.got, check.want)
-				}
-			}
-			output, _ := supports["output"].([]string)
-			if !slices.Equal(output, []string{"text", "json"}) {
-				t.Errorf("%s output = %v, want [text json]", modelID, output)
-			}
-
-			configSchema := metadata["customOptions"].(map[string]any)
-			properties := configSchema["properties"].(map[string]any)
-			reasoningEffort := properties["reasoningEffort"].(map[string]any)
-			enumValues, _ := reasoningEffort["enum"].([]any)
-			if !slices.Equal(enumValues, []any{"low", "medium", "high"}) {
-				t.Errorf("%s reasoningEffort enum = %v, want [low medium high]", modelID, enumValues)
-			}
-			if _, ok := properties["deferred"]; !ok {
-				t.Errorf("%s config schema is missing deferred", modelID)
-			}
-			if _, ok := properties["webSearchOptions"]; !ok {
-				t.Errorf("%s config schema is missing webSearchOptions", modelID)
-			}
-		}
-	}
 
 	resp, err := genkit.Generate(
 		ctx,

--- a/go/plugins/compat_oai/xai/xai_test.go
+++ b/go/plugins/compat_oai/xai/xai_test.go
@@ -59,7 +59,7 @@ func TestPluginRegistersModels(t *testing.T) {
 		{model: xai.ModelGrok3Fast, wantMultiturn: true, wantSystemRole: true},
 		{model: xai.ModelGrok3Mini, wantMultiturn: true, wantSystemRole: true},
 		{model: xai.ModelGrok3MiniFast, wantMultiturn: true, wantSystemRole: true},
-		{model: xai.ModelGrok2Vision1212, wantMedia: true},
+		{model: xai.ModelGrok2Vision1212, wantMultiturn: true, wantMedia: true},
 	} {
 		t.Run(tc.model, func(t *testing.T) {
 			model := plugin.Model(g, tc.model)

--- a/go/plugins/compat_oai/xai/xai_test.go
+++ b/go/plugins/compat_oai/xai/xai_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xai_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/xai"
+)
+
+func TestPluginRequiresAPIKey(t *testing.T) {
+	t.Setenv("XAI_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+
+	defer func() {
+		if got := recover(); got != "xai plugin initialization failed: apiKey is required" {
+			t.Fatalf("panic = %v, want missing API key error", got)
+		}
+	}()
+	(&xai.XAI{}).Init(context.Background())
+}
+
+func TestPluginRegistersModelsAndTranslatesConfig(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q, want %q", r.URL.Path, "/v1/chat/completions")
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := body["model"]; got != xai.ModelGrok3Mini {
+			t.Errorf("model = %v, want %q", got, xai.ModelGrok3Mini)
+		}
+		if got := body["deferred"]; got != true {
+			t.Errorf("deferred = %v, want true", got)
+		}
+		if got := body["reasoning_effort"]; got != "high" {
+			t.Errorf("reasoning_effort = %v, want high", got)
+		}
+		webSearch, ok := body["web_search_options"].(map[string]any)
+		if !ok {
+			t.Fatalf("web_search_options = %#v, want object", body["web_search_options"])
+		}
+		if got := webSearch["search_context_size"]; got != "high" {
+			t.Errorf("web_search_options.search_context_size = %v, want high", got)
+		}
+		for _, name := range []string{"reasoningEffort", "webSearchOptions"} {
+			if _, ok := body[name]; ok {
+				t.Errorf("request contains unconverted %s field", name)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-1",
+			"object":"chat.completion",
+			"created":1,
+			"model":"grok-3-mini",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"Grok works"},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":2,"completion_tokens":2,"total_tokens":4}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key", BaseURL: server.URL + "/v1"}
+	g := genkit.Init(
+		ctx,
+		genkit.WithPlugins(plugin),
+		genkit.WithDefaultModel("xai/"+xai.ModelGrok3Mini),
+	)
+
+	if got := plugin.Name(); got != "xai" {
+		t.Fatalf("Name() = %q, want xai", got)
+	}
+	textModels := []string{
+		xai.ModelGrok3,
+		xai.ModelGrok3Fast,
+		xai.ModelGrok3Mini,
+		xai.ModelGrok3MiniFast,
+	}
+	visionModels := []string{xai.ModelGrok2Vision1212}
+	for _, group := range []struct {
+		models         []string
+		wantMedia      bool
+		wantMultiturn  bool
+		wantSystemRole bool
+	}{
+		{models: textModels, wantMedia: false, wantMultiturn: true, wantSystemRole: true},
+		{models: visionModels, wantMedia: true, wantMultiturn: false, wantSystemRole: false},
+	} {
+		for _, modelID := range group.models {
+			model := plugin.Model(g, modelID)
+			if model == nil {
+				t.Errorf("Model(%q) = nil", modelID)
+				continue
+			}
+			desc := model.(api.Action).Desc()
+			if got, want := desc.Name, "xai/"+modelID; got != want {
+				t.Errorf("%s Desc().Name = %q, want %q", modelID, got, want)
+			}
+			metadata := desc.Metadata["model"].(map[string]any)
+			supports := metadata["supports"].(map[string]any)
+			for name, check := range map[string]struct {
+				got  any
+				want any
+			}{
+				"media":      {got: supports["media"], want: group.wantMedia},
+				"multiturn":  {got: supports["multiturn"], want: group.wantMultiturn},
+				"systemRole": {got: supports["systemRole"], want: group.wantSystemRole},
+				"tools":      {got: supports["tools"], want: true},
+				"toolChoice": {got: supports["toolChoice"], want: false},
+			} {
+				if check.got != check.want {
+					t.Errorf("%s %s support = %v, want %v", modelID, name, check.got, check.want)
+				}
+			}
+			output, _ := supports["output"].([]string)
+			if !slices.Equal(output, []string{"text", "json"}) {
+				t.Errorf("%s output = %v, want [text json]", modelID, output)
+			}
+
+			configSchema := metadata["customOptions"].(map[string]any)
+			properties := configSchema["properties"].(map[string]any)
+			reasoningEffort := properties["reasoningEffort"].(map[string]any)
+			enumValues, _ := reasoningEffort["enum"].([]any)
+			if !slices.Equal(enumValues, []any{"low", "medium", "high"}) {
+				t.Errorf("%s reasoningEffort enum = %v, want [low medium high]", modelID, enumValues)
+			}
+			if _, ok := properties["deferred"]; !ok {
+				t.Errorf("%s config schema is missing deferred", modelID)
+			}
+			if _, ok := properties["webSearchOptions"]; !ok {
+				t.Errorf("%s config schema is missing webSearchOptions", modelID)
+			}
+		}
+	}
+
+	resp, err := genkit.Generate(
+		ctx,
+		g,
+		ai.WithPrompt("Say hi."),
+		ai.WithConfig(map[string]any{
+			"deferred":        true,
+			"reasoningEffort": "high",
+			"webSearchOptions": map[string]any{
+				"search_context_size": "high",
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Text(); got != "Grok works" {
+		t.Fatalf("Text() = %q, want %q", got, "Grok works")
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+}


### PR DESCRIPTION
Adds the Go xAI chat/vision slice from #5900. It registers the five canonical JS language models, uses the `xai` namespace, `https://api.x.ai/v1`, and `XAI_API_KEY`, preserves model-specific capability metadata, and maps `reasoningEffort` and `webSearchOptions` to the provider request. Offline tests cover registration, schemas, authentication, emitted request fields, and response conversion.

Grok image registration is intentionally deferred until the Go image support in #5937 lands. This draft also depends on the config-alias helper introduced in #5936 and will be rebased after that PR merges to remove the overlapping shared hunk.

This remains a draft pending the model-catalog decision raised in #5900: xAI has retired or removed several IDs requested by the existing JS catalog. The implementation currently preserves literal issue/JS parity.

Part of #5900.

Checklist (if applicable):
- [x] PR title follows Conventional Commits
- [x] Tested (`go test ./... -count=1`, `go vet ./...`, formatting and diff checks)
- [x] Docs updated