### PR TITLE
feat(go/plugins/ollama): populate token usage from Ollama response

### DIFF
--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -391,12 +391,25 @@ type ollamaChatResponse struct {
 		Thinking  string           `json:"thinking"`
 		ToolCalls []ollamaToolCall `json:"tool_calls,omitempty"`
 	} `json:"message"`
+	PromptEvalCount int `json:"prompt_eval_count,omitempty"`
+	EvalCount       int `json:"eval_count,omitempty"`
 }
 
 type ollamaModelResponse struct {
-	Model     string `json:"model"`
-	CreatedAt string `json:"created_at"`
-	Response  string `json:"response"`
+	Model           string `json:"model"`
+	CreatedAt       string `json:"created_at"`
+	Response        string `json:"response"`
+	PromptEvalCount int    `json:"prompt_eval_count,omitempty"`
+	EvalCount       int    `json:"eval_count,omitempty"`
+}
+
+// ollamaUsage maps Ollama token counts into Genkit GenerationUsage.
+func ollamaUsage(promptEvalCount, evalCount int) *ai.GenerationUsage {
+	return &ai.GenerationUsage{
+		InputTokens:  promptEvalCount,
+		OutputTokens: evalCount,
+		TotalTokens:  promptEvalCount + evalCount,
+	}
 }
 
 // Ollama provides configuration options for the Init function.
@@ -711,6 +724,8 @@ func (g *generator) generate(ctx context.Context, input *ai.ModelRequest, cb fun
 		var chunks []*ai.ModelResponseChunk
 		decoder := json.NewDecoder(resp.Body)
 		chunkCount := 0
+		// Ollama reports prompt_eval_count / eval_count on the final stream chunk.
+		usage := &ai.GenerationUsage{}
 
 		for {
 			var raw json.RawMessage
@@ -732,6 +747,16 @@ func (g *generator) generate(ctx context.Context, input *ai.ModelRequest, cb fun
 			}
 			chunks = append(chunks, chunk)
 			cb(ctx, chunk)
+
+			var counts struct {
+				PromptEvalCount int `json:"prompt_eval_count"`
+				EvalCount       int `json:"eval_count"`
+			}
+			if err := json.Unmarshal(raw, &counts); err == nil {
+				if counts.PromptEvalCount > 0 || counts.EvalCount > 0 {
+					usage = ollamaUsage(counts.PromptEvalCount, counts.EvalCount)
+				}
+			}
 		}
 
 		// Create a final response with the merged chunks
@@ -741,6 +766,7 @@ func (g *generator) generate(ctx context.Context, input *ai.ModelRequest, cb fun
 			Message: &ai.Message{
 				Role: ai.RoleModel,
 			},
+			Usage: usage,
 		}
 		// Add all the merged content to the final response's candidate
 		for _, chunk := range chunks {
@@ -868,6 +894,7 @@ func translateChatResponse(responseData []byte, thinkingEnabled bool) (*ai.Model
 		modelResponse.Message.Content = append(modelResponse.Message.Content, aiPart)
 	}
 
+	modelResponse.Usage = ollamaUsage(response.PromptEvalCount, response.EvalCount)
 	return modelResponse, nil
 }
 
@@ -888,7 +915,7 @@ func translateModelResponse(responseData []byte) (*ai.ModelResponse, error) {
 
 	aiPart := ai.NewTextPart(response.Response)
 	modelResponse.Message.Content = append(modelResponse.Message.Content, aiPart)
-	modelResponse.Usage = &ai.GenerationUsage{} // TODO: can we get any of this info?
+	modelResponse.Usage = ollamaUsage(response.PromptEvalCount, response.EvalCount)
 	return modelResponse, nil
 }
 

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -748,13 +748,15 @@ func (g *generator) generate(ctx context.Context, input *ai.ModelRequest, cb fun
 			chunks = append(chunks, chunk)
 			cb(ctx, chunk)
 
-			var counts struct {
-				PromptEvalCount int `json:"prompt_eval_count"`
-				EvalCount       int `json:"eval_count"`
-			}
-			if err := json.Unmarshal(raw, &counts); err == nil {
-				if counts.PromptEvalCount > 0 || counts.EvalCount > 0 {
-					usage = ollamaUsage(counts.PromptEvalCount, counts.EvalCount)
+			if bytes.Contains(raw, []byte(`"prompt_eval_count"`)) || bytes.Contains(raw, []byte(`"eval_count"`)) {
+				var counts struct {
+					PromptEvalCount int `json:"prompt_eval_count"`
+					EvalCount       int `json:"eval_count"`
+				}
+				if err := json.Unmarshal(raw, &counts); err == nil {
+					if counts.PromptEvalCount > 0 || counts.EvalCount > 0 {
+						usage = ollamaUsage(counts.PromptEvalCount, counts.EvalCount)
+					}
 				}
 			}
 		}

--- a/go/plugins/ollama/ollama_test.go
+++ b/go/plugins/ollama/ollama_test.go
@@ -1123,3 +1123,99 @@ func TestDefineModelReusesDiscoveredCapabilities(t *testing.T) {
 		t.Errorf("/api/show calls = %d, want 1; DefineModel must not perform I/O", got)
 	}
 }
+
+func TestOllamaUsageMapping(t *testing.T) {
+	t.Run("chat response", func(t *testing.T) {
+		input := `{
+			"model": "llama3",
+			"created_at": "2024-06-20T12:34:56Z",
+			"message": {"role": "assistant", "content": "Hello"},
+			"prompt_eval_count": 26,
+			"eval_count": 12
+		}`
+		got, err := translateChatResponse([]byte(input), false)
+		if err != nil {
+			t.Fatalf("translateChatResponse() error = %v", err)
+		}
+		if got.Usage == nil {
+			t.Fatal("translateChatResponse() Usage is nil")
+		}
+		if got.Usage.InputTokens != 26 {
+			t.Errorf("InputTokens = %d, want 26", got.Usage.InputTokens)
+		}
+		if got.Usage.OutputTokens != 12 {
+			t.Errorf("OutputTokens = %d, want 12", got.Usage.OutputTokens)
+		}
+		if got.Usage.TotalTokens != 38 {
+			t.Errorf("TotalTokens = %d, want 38", got.Usage.TotalTokens)
+		}
+	})
+
+	t.Run("generate response", func(t *testing.T) {
+		input := `{
+			"model": "llama3",
+			"created_at": "2024-06-20T12:34:56Z",
+			"response": "Hello",
+			"prompt_eval_count": 10,
+			"eval_count": 5
+		}`
+		got, err := translateModelResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("translateModelResponse() error = %v", err)
+		}
+		if got.Usage == nil {
+			t.Fatal("translateModelResponse() Usage is nil")
+		}
+		if got.Usage.InputTokens != 10 {
+			t.Errorf("InputTokens = %d, want 10", got.Usage.InputTokens)
+		}
+		if got.Usage.OutputTokens != 5 {
+			t.Errorf("OutputTokens = %d, want 5", got.Usage.OutputTokens)
+		}
+		if got.Usage.TotalTokens != 15 {
+			t.Errorf("TotalTokens = %d, want 15", got.Usage.TotalTokens)
+		}
+	})
+
+	t.Run("stream final chunk carries usage", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/chat" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"model":"llama3","message":{"role":"assistant","content":"Hi"},"done":false}` + "\n"))
+			_, _ = w.Write([]byte(`{"model":"llama3","message":{"role":"assistant","content":"!"},"done":true,"prompt_eval_count":20,"eval_count":3}` + "\n"))
+		}))
+		defer server.Close()
+
+		g := &generator{
+			model:         ModelDefinition{Name: "llama3", Type: "chat"},
+			serverAddress: server.URL,
+			timeout:       30,
+		}
+		req := &ai.ModelRequest{
+			Messages: []*ai.Message{
+				{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart("hello")}},
+			},
+		}
+		resp, err := g.generate(context.Background(), req, func(context.Context, *ai.ModelResponseChunk) error {
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("generate() error = %v", err)
+		}
+		if resp.Usage == nil {
+			t.Fatal("generate() Usage is nil")
+		}
+		if resp.Usage.InputTokens != 20 {
+			t.Errorf("InputTokens = %d, want 20", resp.Usage.InputTokens)
+		}
+		if resp.Usage.OutputTokens != 3 {
+			t.Errorf("OutputTokens = %d, want 3", resp.Usage.OutputTokens)
+		}
+		if resp.Usage.TotalTokens != 23 {
+			t.Errorf("TotalTokens = %d, want 23", resp.Usage.TotalTokens)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Map Ollama `prompt_eval_count` / `eval_count` into `GenerationUsage` (`InputTokens`, `OutputTokens`, `TotalTokens`).
- Covers the chat and generate response translators, and the final streaming chunk (Ollama only reports counts on the last NDJSON line).
- Removes the `TODO: can we get any of this info?` on the generate path.

Fixes #5469

Reopened after this was closed on Aug 4. Rebased onto current `main`.

## Test plan
- [x] Unit tests for chat + generate usage mapping
- [x] Streaming test that the final chunk supplies usage
- [ ] `go test ./go/plugins/ollama/`
- [ ] CLA check