### PR TITLE
feat(go/plugins/ollama): support static and dynamic request headers

### DIFF
--- a/go/plugins/ollama/README.md
+++ b/go/plugins/ollama/README.md
@@ -40,6 +40,26 @@ func main() {
 }
 ```
 
+Hosted or proxied Ollama servers can send extra headers on every request
+(`/api/chat`, `/api/generate`, `/api/embed`, `/api/tags`, and `/api/show`):
+
+```go
+o := &ollama.Ollama{
+ ServerAddress: "https://ollama.example.com",
+ RequestHeaders: map[string]string{
+  "Authorization": "Bearer <token>",
+ },
+}
+
+// Or generate headers per request (takes precedence over RequestHeaders):
+o.RequestHeaderFunc = func(ctx context.Context, params ollama.HeaderParams) (map[string]string, error) {
+ return map[string]string{"Authorization": "Bearer <token>"}, nil
+}
+```
+
+`HeaderParams` fields other than `ServerAddress` may be nil depending on the
+call site (for example `/api/tags` has no model).
+
 ## Language Models
 
 Because Ollama models are locally hosted and the available models depend on what the user has pulled (`ollama pull <model>`), the plugin doesn't pre-initialize any default models. You must define them explicitly.

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -44,7 +44,7 @@ type ollamaEmbedResponse struct {
 	Embeddings [][]float32 `json:"embeddings"`
 }
 
-func embed(ctx context.Context, serverAddress string, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+func embed(ctx context.Context, serverAddress string, req *ai.EmbedRequest, staticHeaders map[string]string, headerFunc RequestHeaderFunc) (*ai.EmbedResponse, error) {
 	options, ok := req.Options.(*EmbedOptions)
 	if !ok && req.Options != nil {
 		return nil, fmt.Errorf("invalid options type: expected *EmbedOptions")
@@ -64,7 +64,16 @@ func embed(ctx context.Context, serverAddress string, req *ai.EmbedRequest) (*ai
 		return nil, fmt.Errorf("failed to marshal embed request: %w", err)
 	}
 
-	resp, err := sendEmbedRequest(ctx, serverAddress, jsonData)
+	headers, err := resolveHeaders(ctx, staticHeaders, headerFunc, HeaderParams{
+		ServerAddress: serverAddress,
+		Model:         &ModelDefinition{Name: options.Model},
+		EmbedRequest:  req,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve request headers: %w", err)
+	}
+
+	resp, err := sendEmbedRequest(ctx, serverAddress, jsonData, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -82,13 +91,14 @@ func embed(ctx context.Context, serverAddress string, req *ai.EmbedRequest) (*ai
 	return newEmbedResponse(ollamaResp.Embeddings), nil
 }
 
-func sendEmbedRequest(ctx context.Context, serverAddress string, jsonData []byte) (*http.Response, error) {
+func sendEmbedRequest(ctx context.Context, serverAddress string, jsonData []byte, headers map[string]string) (*http.Response, error) {
 	client := &http.Client{}
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", serverAddress+"/api/embed", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	applyHeaders(httpReq, headers)
 	return client.Do(httpReq)
 }
 
@@ -183,7 +193,7 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, 
 			}
 		}
 
-		return embed(ctx, o.ServerAddress, &normalizedReq)
+		return embed(ctx, o.ServerAddress, &normalizedReq, o.RequestHeaders, o.RequestHeaderFunc)
 	})
 }
 

--- a/go/plugins/ollama/embed_test.go
+++ b/go/plugins/ollama/embed_test.go
@@ -46,7 +46,7 @@ func TestEmbedValidRequest(t *testing.T) {
 		Options: &EmbedOptions{Model: "all-minilm"},
 	}
 
-	resp, err := embed(context.Background(), server.URL, req)
+	resp, err := embed(context.Background(), server.URL, req, nil, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -64,7 +64,7 @@ func TestEmbedInvalidServerAddress(t *testing.T) {
 		Options: &EmbedOptions{Model: "all-minilm"},
 	}
 
-	_, err := embed(context.Background(), "", req)
+	_, err := embed(context.Background(), "", req, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "invalid server address") {
 		t.Fatalf("expected invalid server address error, got %v", err)
 	}

--- a/go/plugins/ollama/headers.go
+++ b/go/plugins/ollama/headers.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ollama
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+// HeaderParams carries context passed to [RequestHeaderFunc] when resolving
+// dynamic auth or proxy headers for an Ollama HTTP request.
+//
+// Optional fields may be nil depending on the call site — for example,
+// /api/tags discovery only sets ServerAddress. Implementations must nil-check
+// before dereferencing Model, ModelRequest, or EmbedRequest.
+type HeaderParams struct {
+	ServerAddress string
+	Model         *ModelDefinition // may be nil (e.g. /api/tags discovery)
+	ModelRequest  *ai.ModelRequest // may be nil (e.g. embed or /api/tags)
+	EmbedRequest  *ai.EmbedRequest // may be nil (e.g. generate or /api/tags)
+}
+
+// RequestHeaderFunc generates request headers dynamically (for example, to
+// fetch a short-lived auth token against a hosted or proxied Ollama deployment).
+// Returning a nil map is treated as no extra headers.
+type RequestHeaderFunc func(ctx context.Context, params HeaderParams) (map[string]string, error)
+
+// resolveHeaders returns static or dynamic headers for an Ollama request.
+// When headerFunc is set it takes precedence over staticHeaders, matching the
+// JS plugin's static-map-or-function union.
+func resolveHeaders(ctx context.Context, staticHeaders map[string]string, headerFunc RequestHeaderFunc, params HeaderParams) (map[string]string, error) {
+	if headerFunc != nil {
+		return headerFunc(ctx, params)
+	}
+	return staticHeaders, nil
+}
+
+func (o *Ollama) resolveHeaders(ctx context.Context, params HeaderParams) (map[string]string, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return resolveHeaders(ctx, o.RequestHeaders, o.RequestHeaderFunc, params)
+}
+
+func (g *generator) resolveHeaders(ctx context.Context, params HeaderParams) (map[string]string, error) {
+	return resolveHeaders(ctx, g.requestHeaders, g.requestHeaderFunc, params)
+}
+
+func applyHeaders(req *http.Request, headers map[string]string) {
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+}

--- a/go/plugins/ollama/headers_test.go
+++ b/go/plugins/ollama/headers_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+func TestStaticRequestHeadersOnTags(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{}})
+	}))
+	defer server.Close()
+
+	o := newTestOllama(server.URL)
+	o.RequestHeaders = map[string]string{"Authorization": "Bearer static-token"}
+
+	if _, err := o.listLocalModels(context.Background()); err != nil {
+		t.Fatalf("listLocalModels() error = %v", err)
+	}
+	if gotAuth != "Bearer static-token" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer static-token")
+	}
+}
+
+func TestDynamicRequestHeadersOnGenerate(t *testing.T) {
+	var gotAuth, gotModel string
+	var sawContentType bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		gotModel = r.Header.Get("X-Model")
+		sawContentType = r.Header.Get("Content-Type") == "application/json"
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"model":"llama3","message":{"role":"assistant","content":"hi"},"done":true}`))
+	}))
+	defer server.Close()
+
+	g := &generator{
+		model:         ModelDefinition{Name: "llama3", Type: "chat"},
+		serverAddress: server.URL,
+		timeout:       30,
+		requestHeaderFunc: func(ctx context.Context, params HeaderParams) (map[string]string, error) {
+			if params.ServerAddress != server.URL {
+				t.Errorf("ServerAddress = %q, want %q", params.ServerAddress, server.URL)
+			}
+			if params.Model == nil || params.Model.Name != "llama3" {
+				t.Errorf("Model = %+v, want llama3", params.Model)
+			}
+			if params.ModelRequest == nil {
+				t.Error("ModelRequest is nil")
+			}
+			return map[string]string{
+				"Authorization": "Bearer dynamic-token",
+				"X-Model":       params.Model.Name,
+			}, nil
+		},
+	}
+
+	req := &ai.ModelRequest{
+		Messages: []*ai.Message{
+			{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart("hello")}},
+		},
+	}
+	if _, err := g.generate(context.Background(), req, nil); err != nil {
+		t.Fatalf("generate() error = %v", err)
+	}
+	if !sawContentType {
+		t.Fatal("expected Content-Type application/json")
+	}
+	if gotAuth != "Bearer dynamic-token" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer dynamic-token")
+	}
+	if gotModel != "llama3" {
+		t.Fatalf("X-Model = %q, want llama3", gotModel)
+	}
+}
+
+func TestRequestHeaderFuncTakesPrecedenceOverStatic(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(ollamaTagsResponse{Models: []ollamaLocalModel{}})
+	}))
+	defer server.Close()
+
+	o := newTestOllama(server.URL)
+	o.RequestHeaders = map[string]string{"Authorization": "Bearer static-token"}
+	o.RequestHeaderFunc = func(ctx context.Context, params HeaderParams) (map[string]string, error) {
+		return map[string]string{"Authorization": "Bearer from-func"}, nil
+	}
+
+	if _, err := o.listLocalModels(context.Background()); err != nil {
+		t.Fatalf("listLocalModels() error = %v", err)
+	}
+	if gotAuth != "Bearer from-func" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer from-func")
+	}
+}
+
+func TestStaticRequestHeadersOnEmbed(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Embeddings: [][]float32{{0.1, 0.2}},
+		})
+	}))
+	defer server.Close()
+
+	req := &ai.EmbedRequest{
+		Input:   []*ai.Document{ai.DocumentFromText("test", nil)},
+		Options: &EmbedOptions{Model: "all-minilm"},
+	}
+	headers := map[string]string{"Authorization": "Bearer embed-token"}
+	if _, err := embed(context.Background(), server.URL, req, headers, nil); err != nil {
+		t.Fatalf("embed() error = %v", err)
+	}
+	if gotAuth != "Bearer embed-token" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer embed-token")
+	}
+}
+
+func TestDynamicRequestHeadersOnEmbed(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Embeddings: [][]float32{{0.1}},
+		})
+	}))
+	defer server.Close()
+
+	req := &ai.EmbedRequest{
+		Input:   []*ai.Document{ai.DocumentFromText("test", nil)},
+		Options: &EmbedOptions{Model: "all-minilm"},
+	}
+	headerFunc := func(ctx context.Context, params HeaderParams) (map[string]string, error) {
+		if params.EmbedRequest == nil {
+			t.Error("EmbedRequest is nil")
+		}
+		if params.Model == nil || params.Model.Name != "all-minilm" {
+			t.Errorf("Model = %+v, want all-minilm", params.Model)
+		}
+		return map[string]string{"Authorization": "Bearer embed-dyn"}, nil
+	}
+	if _, err := embed(context.Background(), server.URL, req, map[string]string{"Authorization": "ignored"}, headerFunc); err != nil {
+		t.Fatalf("embed() error = %v", err)
+	}
+	if gotAuth != "Bearer embed-dyn" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer embed-dyn")
+	}
+}
+
+func TestStaticRequestHeadersOnShow(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/show" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(ollamaShowResponse{Capabilities: []string{"completion"}})
+	}))
+	defer server.Close()
+
+	o := newTestOllama(server.URL)
+	o.RequestHeaders = map[string]string{"Authorization": "Bearer show-token"}
+
+	if _, err := o.getModelCapabilities(context.Background(), "llama3"); err != nil {
+		t.Fatalf("getModelCapabilities() error = %v", err)
+	}
+	if gotAuth != "Bearer show-token" {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Bearer show-token")
+	}
+}

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -108,6 +108,14 @@ func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) ([]
 		return nil, fmt.Errorf("failed to create /api/show request for %q: %w", modelName, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	headers, err := o.resolveHeaders(ctx, HeaderParams{
+		ServerAddress: o.ServerAddress,
+		Model:         &ModelDefinition{Name: modelName},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve request headers: %w", err)
+	}
+	applyHeaders(req, headers)
 	client := o.client
 	if client == nil {
 		client = http.DefaultClient
@@ -173,6 +181,11 @@ func (o *Ollama) listLocalModels(ctx context.Context) ([]ollamaLocalModel, error
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	headers, err := o.resolveHeaders(ctx, HeaderParams{ServerAddress: o.ServerAddress})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve request headers: %w", err)
+	}
+	applyHeaders(req, headers)
 	resp, err := o.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch local models from Ollama: %w", err)
@@ -226,7 +239,13 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		Versions:     []string{},
 		ConfigSchema: core.InferSchemaMap(GenerateContentConfig{}),
 	}
-	gen := &generator{model: model, serverAddress: o.ServerAddress, timeout: o.Timeout}
+	gen := &generator{
+		model:             model,
+		serverAddress:     o.ServerAddress,
+		timeout:           o.Timeout,
+		requestHeaders:    o.RequestHeaders,
+		requestHeaderFunc: o.RequestHeaderFunc,
+	}
 	return genkit.DefineModel(g, api.NewName(provider, model.Name), meta, gen.generate)
 }
 
@@ -248,9 +267,11 @@ type ModelDefinition struct {
 }
 
 type generator struct {
-	model         ModelDefinition
-	serverAddress string
-	timeout       int
+	model             ModelDefinition
+	serverAddress     string
+	timeout           int
+	requestHeaders    map[string]string
+	requestHeaderFunc RequestHeaderFunc
 }
 
 type ollamaMessage struct {
@@ -404,6 +425,14 @@ type Ollama struct {
 	ServerAddress string // Server address of oLLama.
 	Timeout       int    // Response timeout in seconds (defaulted to 30 seconds)
 
+	// RequestHeaders are static headers applied to every Ollama HTTP request
+	// (model generate, embed, /api/tags, and /api/show). Useful for authenticating
+	// against hosted or proxied Ollama deployments.
+	RequestHeaders map[string]string
+	// RequestHeaderFunc, when set, is called per request to produce headers and
+	// takes precedence over RequestHeaders (matching the JS static-or-function API).
+	RequestHeaderFunc RequestHeaderFunc
+
 	mu      sync.Mutex   // Guards the plugin's own state below.
 	initted bool         // Whether the plugin has been initialized.
 	client  *http.Client // Shared HTTP client for API calls (e.g., /api/tags).
@@ -509,9 +538,11 @@ func (o *Ollama) newModel(name string, opts ai.ModelOptions) ai.Model {
 		ConfigSchema: core.InferSchemaMap(GenerateContentConfig{}),
 	}
 	gen := &generator{
-		model:         ModelDefinition{Name: name, Type: "chat"},
-		serverAddress: o.ServerAddress,
-		timeout:       o.Timeout,
+		model:             ModelDefinition{Name: name, Type: "chat"},
+		serverAddress:     o.ServerAddress,
+		timeout:           o.Timeout,
+		requestHeaders:    o.RequestHeaders,
+		requestHeaderFunc: o.RequestHeaderFunc,
 	}
 	return ai.NewModel(api.NewName(provider, name), meta, gen.generate)
 }
@@ -677,6 +708,15 @@ func (g *generator) generate(ctx context.Context, input *ai.ModelRequest, cb fun
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	headers, err := g.resolveHeaders(ctx, HeaderParams{
+		ServerAddress: g.serverAddress,
+		Model:         &g.model,
+		ModelRequest:  input,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve request headers: %w", err)
+	}
+	applyHeaders(req, headers)
 	req = req.WithContext(ctx)
 
 	resp, err := client.Do(req)

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -708,9 +708,10 @@ func (g *generator) generate(ctx context.Context, input *ai.ModelRequest, cb fun
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	modelCopy := g.model
 	headers, err := g.resolveHeaders(ctx, HeaderParams{
 		ServerAddress: g.serverAddress,
-		Model:         &g.model,
+		Model:         &modelCopy,
 		ModelRequest:  input,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `RequestHeaders` and `RequestHeaderFunc` on the Ollama plugin, matching the JS static-map-or-function union (`RequestHeaderFunc` wins when set).
- Apply resolved headers to generate (`/api/chat`, `/api/generate`), embed, `/api/tags`, and `/api/show` so hosted or proxied Ollama servers can authenticate.
- `HeaderParams` documents that `Model` / `ModelRequest` / `EmbedRequest` may be nil depending on the call site.
- README snippet for static and dynamic headers.

Fixes #5468

Reopened after this was closed on Aug 4. Rebased onto current `main`. Also covers `/api/show`, which landed after the original PR.

## Test plan
- [x] Static headers on `/api/tags`, embed, and `/api/show`
- [x] Dynamic headers on generate, with Content-Type preserved
- [x] `RequestHeaderFunc` takes precedence over static headers
- [ ] `go test ./go/plugins/ollama/`
- [ ] CLA check