### PR TITLE
feat(py): support Veo image-to-video via GenerateVideosSource

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -16,10 +16,12 @@
 
 """Veo video generation model for Google GenAI plugin.
 
-Veo is Google's video generation model that creates videos from text prompts.
+Veo is Google's video generation model that creates videos from text prompts
+and supports image-to-video when an image media part is provided.
 """
 
 import asyncio
+import base64
 import sys
 from typing import Any, cast
 
@@ -42,7 +44,6 @@ from genkit import (
     Part,
     Role,
     Supports,
-    TextPart,
 )
 from genkit.model import Error, Operation
 from genkit.plugin_api import ActionRunContext, tracer
@@ -140,6 +141,69 @@ def _extract_text(request: ModelRequest) -> str:
         if hasattr(part.root, 'text') and part.root.text
     ]
     return ' '.join(prompt_parts)
+
+
+def _media_content_type(media: Media) -> str:
+    """Resolve a media content type from the part or a data: URL prefix."""
+    if media.content_type:
+        return media.content_type
+    url = media.url or ''
+    if url.startswith('data:') and ';' in url:
+        return url[len('data:') : url.index(';')]
+    if url.startswith('data:') and ',' in url:
+        return url[len('data:') : url.index(',')]
+    return ''
+
+
+def _extract_veo_image(request: ModelRequest) -> genai_types.Image | None:
+    """Extract an image from the last message for Veo image-to-video.
+
+    Matches JS ``extractVeoImage``: looks at the last message for an image/*
+    media part. Supports ``data:`` URLs (base64) and ``gs://`` URIs.
+
+    Args:
+        request: The generation request.
+
+    Returns:
+        A google-genai ``Image``, or None if no suitable image is present.
+    """
+    messages = request.messages or []
+    if not messages:
+        return None
+
+    for part in messages[-1].content or []:
+        if not isinstance(part.root, MediaPart):
+            continue
+        media = part.root.media
+        content_type = _media_content_type(media)
+        if not content_type.startswith('image/'):
+            continue
+
+        url = media.url or ''
+        if url.startswith('gs://'):
+            return genai_types.Image(gcs_uri=url, mime_type=content_type)
+
+        if url.startswith('data:'):
+            _, _, payload = url.partition(',')
+            if not payload:
+                return None
+            try:
+                image_bytes = base64.b64decode(payload, validate=False)
+            except (ValueError, TypeError):
+                return None
+            return genai_types.Image(image_bytes=image_bytes, mime_type=content_type)
+
+        # http(s) and other URL schemes are not inlined here (JS only accepts data: URLs).
+        return None
+
+    return None
+
+
+def _build_veo_source(request: ModelRequest) -> genai_types.GenerateVideosSource:
+    """Build a GenerateVideosSource from text and optional image parts."""
+    prompt = _extract_text(request) or None
+    image = _extract_veo_image(request)
+    return genai_types.GenerateVideosSource(prompt=prompt, image=image)
 
 
 def _to_veo_parameters(config: Any) -> dict[str, Any]:  # noqa: ANN401
@@ -242,19 +306,6 @@ class VeoModel:
         self._version = version
         self._client = client
 
-    def _build_prompt(self, request: ModelRequest) -> str:
-        """Build prompt request from Genkit request."""
-        prompt = []
-        for message in request.messages:
-            for part in message.content:
-                if isinstance(part.root, TextPart):
-                    prompt.append(part.root.text)
-                else:
-                    # TODO(#4363): Support image input if Veo supports it (e.g. for image-to-video)
-                    # For now, strict text text-to-video
-                    pass
-        return ' '.join(prompt)
-
     async def generate(self, request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         """Handle a generation request (synchronous/blocking mode for Vertex AI).
 
@@ -268,11 +319,14 @@ class VeoModel:
         if request.tools:
             raise ValueError('Tools are not supported for this model.')
 
-        prompt = self._build_prompt(request)
+        source = _build_veo_source(request)
+        if not source.prompt and not source.image:
+            raise ValueError('Veo requires a text prompt or an image for image-to-video')
+
         config = self._get_config(request)
 
         with tracer.start_as_current_span('generate_videos'):
-            operation = await self._client.aio.models.generate_videos(model=self._version, prompt=prompt, config=config)
+            operation = await self._client.aio.models.generate_videos(model=self._version, source=source, config=config)
 
             # Handling LRO. Using cast(Any) to avoid strict type definition issues for operation.result()
             op = cast(Any, operation)
@@ -308,14 +362,14 @@ class VeoModel:
         if request.tools:
             raise ValueError('Tools are not supported for this model.')
 
-        prompt = _extract_text(request)
-        if not prompt:
-            raise ValueError('Veo requires a text prompt')
+        source = _build_veo_source(request)
+        if not source.prompt and not source.image:
+            raise ValueError('Veo requires a text prompt or an image for image-to-video')
 
-        # Call the generateVideos API
+        # Call the generateVideos API via GenerateVideosSource (text and/or image).
         response = await self._client.aio.models.generate_videos(
             model=self._version,
-            prompt=prompt,
+            source=source,
             # pyrefly: ignore[bad-argument-type] - config dict matches GenerateVideosConfigDict
             config=request.config if isinstance(request.config, dict) else None,  # pyright: ignore[reportArgumentType]
         )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -143,8 +143,10 @@ def _extract_text(request: ModelRequest) -> str:
     return ' '.join(prompt_parts)
 
 
-def _media_content_type(media: Media) -> str:
+def _media_content_type(media: Media | None) -> str:
     """Resolve a media content type from the part or a data: URL prefix."""
+    if not media:
+        return ''
     if media.content_type:
         return media.content_type
     url = media.url or ''
@@ -175,6 +177,8 @@ def _extract_veo_image(request: ModelRequest) -> genai_types.Image | None:
         if not isinstance(part.root, MediaPart):
             continue
         media = part.root.media
+        if not media:
+            continue
         content_type = _media_content_type(media)
         if not content_type.startswith('image/'):
             continue
@@ -186,15 +190,16 @@ def _extract_veo_image(request: ModelRequest) -> genai_types.Image | None:
         if url.startswith('data:'):
             _, _, payload = url.partition(',')
             if not payload:
-                return None
+                continue
             try:
                 image_bytes = base64.b64decode(payload, validate=False)
             except (ValueError, TypeError):
-                return None
+                continue
             return genai_types.Image(image_bytes=image_bytes, mime_type=content_type)
 
         # http(s) and other URL schemes are not inlined here (JS only accepts data: URLs).
-        return None
+        # Keep scanning later parts for a supported image.
+        continue
 
     return None
 

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -18,18 +18,25 @@
 
 Verifies _from_veo_operation handles both dict-based responses (from the
 start path) and Pydantic GenerateVideosResponse objects (from the check
-path where the SDK returns a model instance).
+path where the SDK returns a model instance). Also covers image-to-video
+extraction into GenerateVideosSource.
 """
+
+import base64
 
 import pytest
 from genkit_google_genai.models.veo import (
     VeoConfigSchema,
     VeoVersion,
+    _build_veo_source,
+    _extract_veo_image,
     _from_veo_operation,
     _to_veo_parameters,
     is_veo_model,
 )
 from google.genai import types as genai_types
+
+from genkit import Media, MediaPart, Message, ModelRequest, Part, Role, TextPart
 
 
 class TestIsVeoModel:
@@ -216,3 +223,96 @@ class TestFromVeoOperation:
         })
         assert op.done is True
         assert op.output is None
+
+
+class TestExtractVeoImage:
+    """Tests for _extract_veo_image / _build_veo_source (image-to-video)."""
+
+    def test_extracts_data_url_image(self) -> None:
+        """Base64 data: URL image becomes Image with image_bytes."""
+        raw = b'\x89PNG\r\n\x1a\n'
+        data_url = f'data:image/png;base64,{base64.b64encode(raw).decode()}'
+        request = ModelRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(root=TextPart(text='Animate this')),
+                        Part(root=MediaPart(media=Media(url=data_url, content_type='image/png'))),
+                    ],
+                )
+            ]
+        )
+        image = _extract_veo_image(request)
+        assert image is not None
+        assert image.mime_type == 'image/png'
+        assert image.image_bytes == raw
+
+        source = _build_veo_source(request)
+        assert source.prompt == 'Animate this'
+        assert source.image is not None
+        assert source.image.image_bytes == raw
+
+    def test_extracts_gcs_image(self) -> None:
+        """gs:// image URIs map to Image.gcs_uri."""
+        request = ModelRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=MediaPart(media=Media(url='gs://bucket/frame.png', content_type='image/png')))],
+                )
+            ]
+        )
+        image = _extract_veo_image(request)
+        assert image is not None
+        assert image.gcs_uri == 'gs://bucket/frame.png'
+        assert image.mime_type == 'image/png'
+
+    def test_ignores_video_media(self) -> None:
+        """Video media parts are not treated as image-to-video input."""
+        request = ModelRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(root=MediaPart(media=Media(url='data:video/mp4;base64,AAAA', content_type='video/mp4')))
+                    ],
+                )
+            ]
+        )
+        assert _extract_veo_image(request) is None
+
+    def test_uses_last_message_only(self) -> None:
+        """Only the last message is scanned for an image, matching JS."""
+        raw = b'img'
+        data_url = f'data:image/jpeg;base64,{base64.b64encode(raw).decode()}'
+        request = ModelRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=MediaPart(media=Media(url=data_url, content_type='image/jpeg')))],
+                ),
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='no image here'))],
+                ),
+            ]
+        )
+        assert _extract_veo_image(request) is None
+
+    def test_image_only_source(self) -> None:
+        """Image without text prompt is a valid source."""
+        raw = b'frame'
+        data_url = f'data:image/jpeg;base64,{base64.b64encode(raw).decode()}'
+        request = ModelRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=MediaPart(media=Media(url=data_url, content_type='image/jpeg')))],
+                )
+            ]
+        )
+        source = _build_veo_source(request)
+        assert source.prompt is None
+        assert source.image is not None
+        assert source.image.image_bytes == raw

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -316,3 +316,22 @@ class TestExtractVeoImage:
         assert source.prompt is None
         assert source.image is not None
         assert source.image.image_bytes == raw
+
+    def test_skips_unsupported_url_and_uses_later_image(self) -> None:
+        """Unsupported http(s) image parts do not block a later supported image."""
+        request = ModelRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(
+                            root=MediaPart(media=Media(url='https://example.com/frame.png', content_type='image/png'))
+                        ),
+                        Part(root=MediaPart(media=Media(url='gs://bucket/frame.png', content_type='image/png'))),
+                    ],
+                )
+            ]
+        )
+        image = _extract_veo_image(request)
+        assert image is not None
+        assert image.gcs_uri == 'gs://bucket/frame.png'


### PR DESCRIPTION
## Summary
- Veo API supports image-to-video; wire Genkit `image/*` media parts into `google.genai.types.GenerateVideosSource`
- Extract images from the last message (`data:` base64 and `gs://`), matching JS `extractVeoImage`
- Both background `start` and blocking Vertex `generate` paths now pass `source=` (prompt and/or image)
- Unit tests cover extraction edge cases (video ignored, last-message-only, image-only)

Fixes #4363

## Test plan
- [x] `pytest packages/genkit-google-genai/tests/veo_test.py --no-cov`
- [x] Unit coverage for image extraction (`data:` / `gs://`), last-message selection, video parts ignored, `source=` wiring for start/generate
- [ ] CI green on this PR
- [ ] Manual (optional): Vertex Veo image-to-video with a real image part

