### PR TITLE
fix(go/plugins/anthropic): map multipart tool response content to tool_result blocks

### DIFF
--- a/go/plugins/anthropic/anthropic_live_test.go
+++ b/go/plugins/anthropic/anthropic_live_test.go
@@ -254,6 +254,40 @@ func TestAnthropicLive(t *testing.T) {
 			t.Fatal("expected a response but nothing was returned")
 		}
 	})
+	t.Run("multipart tool", func(t *testing.T) {
+		m := anthropicPlugin.Model(g, "claude-sonnet-4-5-20250929")
+		img64, err := fetchImgAsBase64()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tool := genkit.DefineMultipartTool(g, "getImage", "returns a misterious image",
+			func(ctx *ai.ToolContext, input any) (*ai.MultipartToolResponse, error) {
+				return &ai.MultipartToolResponse{
+					Output: map[string]any{"status": "success"},
+					Content: []*ai.Part{
+						ai.NewMediaPart("image/jpeg", "data:image/jpeg;base64,"+img64),
+					},
+				}, nil
+			},
+		)
+
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithConfig(&anthropic.MessageNewParams{
+				MaxTokens: 1024,
+			}),
+			ai.WithTools(tool),
+			ai.WithPrompt("get an image and tell me what is in it"),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(strings.ToLower(resp.Text()), "cat") {
+			t.Errorf("expected response to contain 'cat', got: %s", resp.Text())
+		}
+	})
 	t.Run("streaming", func(t *testing.T) {
 		m := anthropicPlugin.Model(g, "claude-sonnet-4-5-20250929")
 		out := ""

--- a/go/plugins/anthropic/anthropic_live_test.go
+++ b/go/plugins/anthropic/anthropic_live_test.go
@@ -261,7 +261,7 @@ func TestAnthropicLive(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		tool := genkit.DefineMultipartTool(g, "getImage", "returns a misterious image",
+		tool := genkit.DefineMultipartTool(g, "getImage", "returns a mysterious image",
 			func(ctx *ai.ToolContext, input any) (*ai.MultipartToolResponse, error) {
 				return &ai.MultipartToolResponse{
 					Output: map[string]any{"status": "success"},

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -469,12 +469,11 @@ func toAnthropicParts(parts []*ai.Part) ([]anthropic.ContentBlockParamUnion, err
 			toolReq := p.ToolRequest
 			blocks = append(blocks, anthropic.NewToolUseBlock(toolReq.Ref, toolReq.Input, toolReq.Name))
 		case p.IsToolResponse():
-			toolResp := p.ToolResponse
-			output, err := json.Marshal(toolResp.Output)
+			block, err := toAnthropicToolResultBlock(p.ToolResponse)
 			if err != nil {
-				return nil, fmt.Errorf("unable to parse tool response, err: %w", err)
+				return nil, err
 			}
-			blocks = append(blocks, anthropic.NewToolResultBlock(toolResp.Ref, string(output), false))
+			blocks = append(blocks, block)
 		case p.IsReasoning():
 			blocks = append(blocks, anthropic.NewThinkingBlock(string(metadataSignature(p.Metadata)), p.Text))
 		default:
@@ -483,6 +482,77 @@ func toAnthropicParts(parts []*ai.Part) ([]anthropic.ContentBlockParamUnion, err
 	}
 
 	return blocks, nil
+}
+
+// toAnthropicToolResultBlock translates an [ai.ToolResponse] to an Anthropic
+// tool_result block.
+//
+// Multipart tools return rich content parts alongside their structured output.
+// Anthropic exposes a single content array per tool_result rather than separate
+// fields, so the structured output is emitted as a leading text block and the
+// content parts follow as text, image, or document blocks.
+func toAnthropicToolResultBlock(toolResp *ai.ToolResponse) (anthropic.ContentBlockParamUnion, error) {
+	content := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(toolResp.Content)+1)
+
+	// Only send the structured output when the tool produced one. A multipart
+	// tool may return content parts alone, and a literal "null" text block
+	// would be noise to the model. Tool responses with neither output nor
+	// content still send "null" so the block is never empty, which the API
+	// rejects.
+	if toolResp.Output != nil || len(toolResp.Content) == 0 {
+		output, err := json.Marshal(toolResp.Output)
+		if err != nil {
+			return anthropic.ContentBlockParamUnion{}, fmt.Errorf("unable to parse tool response, err: %w", err)
+		}
+		content = append(content, anthropic.ToolResultBlockParamContentUnion{
+			OfText: &anthropic.TextBlockParam{Text: string(output)},
+		})
+	}
+
+	for _, p := range toolResp.Content {
+		c, err := toAnthropicToolResultContent(p)
+		if err != nil {
+			return anthropic.ContentBlockParamUnion{}, err
+		}
+		content = append(content, c)
+	}
+
+	return anthropic.ContentBlockParamUnion{
+		OfToolResult: &anthropic.ToolResultBlockParam{
+			ToolUseID: toolResp.Ref,
+			Content:   content,
+			IsError:   anthropic.Bool(false),
+		},
+	}, nil
+}
+
+// toAnthropicToolResultContent translates a part of a multipart tool response
+// to a block accepted inside an Anthropic tool_result.
+func toAnthropicToolResultContent(p *ai.Part) (anthropic.ToolResultBlockParamContentUnion, error) {
+	switch {
+	case p.IsText():
+		return anthropic.ToolResultBlockParamContentUnion{
+			OfText: &anthropic.TextBlockParam{Text: p.Text},
+		}, nil
+	case p.IsMedia(), p.IsData():
+		kind := "media"
+		if p.IsData() {
+			kind = "data"
+		}
+		block, err := toAnthropicMediaBlock(p, kind)
+		if err != nil {
+			return anthropic.ToolResultBlockParamContentUnion{}, err
+		}
+		switch {
+		case block.OfImage != nil:
+			return anthropic.ToolResultBlockParamContentUnion{OfImage: block.OfImage}, nil
+		case block.OfDocument != nil:
+			return anthropic.ToolResultBlockParamContentUnion{OfDocument: block.OfDocument}, nil
+		}
+	}
+
+	return anthropic.ToolResultBlockParamContentUnion{}, status.Errorf(ai.ErrInvalidPart,
+		"unsupported part in tool response content: Anthropic tool results accept text, image, and document parts")
 }
 
 // toGenkitResponse translates an Anthropic Message to [ai.ModelResponse]

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -492,6 +492,10 @@ func toAnthropicParts(parts []*ai.Part) ([]anthropic.ContentBlockParamUnion, err
 // fields, so the structured output is emitted as a leading text block and the
 // content parts follow as text, image, or document blocks.
 func toAnthropicToolResultBlock(toolResp *ai.ToolResponse) (anthropic.ContentBlockParamUnion, error) {
+	if toolResp == nil {
+		return anthropic.ContentBlockParamUnion{}, status.Errorf(ai.ErrInvalidPart, "tool response part carries no tool response")
+	}
+
 	content := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(toolResp.Content)+1)
 
 	// Only send the structured output when the tool produced one. A multipart

--- a/go/plugins/internal/anthropic/anthropic_test.go
+++ b/go/plugins/internal/anthropic/anthropic_test.go
@@ -410,6 +410,70 @@ func TestToAnthropicParts(t *testing.T) {
 				anthropic.NewToolResultBlock("ref1", `{"result":"ok"}`, false),
 			},
 		},
+		{
+			name: "multipart tool response keeps output and content parts",
+			parts: []*ai.Part{
+				ai.NewToolResponsePart(&ai.ToolResponse{
+					Ref:    "ref1",
+					Output: map[string]any{"result": "ok"},
+					Content: []*ai.Part{
+						ai.NewTextPart("here is the chart"),
+						ai.NewMediaPart("image/png", "data:image/png;base64,iVBORw0KGgo="),
+					},
+				}),
+			},
+			expected: []anthropic.ContentBlockParamUnion{
+				{OfToolResult: &anthropic.ToolResultBlockParam{
+					ToolUseID: "ref1",
+					IsError:   anthropic.Bool(false),
+					Content: []anthropic.ToolResultBlockParamContentUnion{
+						{OfText: &anthropic.TextBlockParam{Text: `{"result":"ok"}`}},
+						{OfText: &anthropic.TextBlockParam{Text: "here is the chart"}},
+						{OfImage: anthropic.NewImageBlockBase64("image/png", "iVBORw0KGgo=").OfImage},
+					},
+				}},
+			},
+		},
+		{
+			name: "multipart tool response without output omits the null text block",
+			parts: []*ai.Part{
+				ai.NewToolResponsePart(&ai.ToolResponse{
+					Ref: "ref1",
+					Content: []*ai.Part{
+						ai.NewMediaPart("application/pdf", "data:application/pdf;base64,JVBERi0xLjQK"),
+					},
+				}),
+			},
+			expected: []anthropic.ContentBlockParamUnion{
+				{OfToolResult: &anthropic.ToolResultBlockParam{
+					ToolUseID: "ref1",
+					IsError:   anthropic.Bool(false),
+					Content: []anthropic.ToolResultBlockParamContentUnion{
+						{OfDocument: anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: "JVBERi0xLjQK"}).OfDocument},
+					},
+				}},
+			},
+		},
+		{
+			name: "tool response content with unsupported media type is rejected",
+			parts: []*ai.Part{
+				ai.NewToolResponsePart(&ai.ToolResponse{
+					Ref:     "ref1",
+					Content: []*ai.Part{ai.NewMediaPart("audio/mpeg", "data:audio/mpeg;base64,SUQzAw==")},
+				}),
+			},
+			expectedErr: `unsupported media content type "audio/mpeg"`,
+		},
+		{
+			name: "tool response content with unsupported part kind is rejected",
+			parts: []*ai.Part{
+				ai.NewToolResponsePart(&ai.ToolResponse{
+					Ref:     "ref1",
+					Content: []*ai.Part{ai.NewReasoningPart("thinking", nil)},
+				}),
+			},
+			expectedErr: "unsupported part in tool response content",
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/plugins/internal/anthropic/anthropic_test.go
+++ b/go/plugins/internal/anthropic/anthropic_test.go
@@ -474,6 +474,23 @@ func TestToAnthropicParts(t *testing.T) {
 			},
 			expectedErr: "unsupported part in tool response content",
 		},
+		{
+			// Only reachable by hand-constructing the part: unmarshaling never
+			// sets the kind without the payload.
+			name:        "tool response part without a tool response is rejected",
+			parts:       []*ai.Part{{Kind: ai.PartToolResponse}},
+			expectedErr: "tool response part carries no tool response",
+		},
+		{
+			name: "nil part in tool response content is rejected",
+			parts: []*ai.Part{
+				ai.NewToolResponsePart(&ai.ToolResponse{
+					Ref:     "ref1",
+					Content: []*ai.Part{nil},
+				}),
+			},
+			expectedErr: "unsupported part in tool response content",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Multipart tool responses were dropped in the Anthropic request path. `toAnthropicParts` marshaled `ToolResponse.Output` into a single text block and never read `ToolResponse.Content`, so the parts a multipart tool attaches through `DefineMultipartTool` or `tool.AttachParts` never reached the model. A tool that returned an image and no structured output sent Claude a lone `"null"` text block. `vertexai/modelgarden` shares this conversion and had the same behavior.

Anthropic's `tool_result` carries one `content` array rather than Gemini's separate `response` and `parts` fields, so the structured output leads as a text block and the content parts follow as `text`, `image`, or `document` blocks, reusing the plugin's existing content-type mapping (`image/*`, `application/pdf`, `text/plain`):

```json
{"type":"tool_result","tool_use_id":"toolu_1","is_error":false,"content":[
  {"type":"text","text":"{\"result\":\"ok\"}"},
  {"type":"text","text":"here is the chart"},
  {"type":"image","source":{"type":"base64","media_type":"image/png","data":"..."}}]}
```

Parts Anthropic cannot carry inside a `tool_result` (reasoning, nested tool requests, audio or video media) now fail with `ErrInvalidPart` or `ErrUnsupportedByModel` rather than being silently dropped. Plain tool responses serialize byte-identically to before.

## Verification

Six cases added to `TestToAnthropicParts`: output plus content, content with no output, an unsupported media type, an unsupported part kind, a tool response part with no tool response, and a nil part inside the content. Each fails on main. Go 1.26.3, full `go test ./...` in `go/`: 41 packages pass, no failures.
