### PR TITLE
fix(py): action input validation for generic Pydantic model payloads

### DIFF
--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -465,22 +465,26 @@ class Action(Generic[InputT, OutputT, ChunkT]):
         """
         # Validate input if we have a schema
         if self._input_type is not None:
-            try:
-                input = self._input_type.validate_python(input)
-            except ValidationError as e:
-                if input is None:
-                    raise GenkitError(
-                        message=(
-                            f"Action '{self.name}' requires input but none was provided. "
-                            'Please supply a valid input payload.'
-                        ),
-                        status='INVALID_ARGUMENT',
-                    ) from e
-                raise GenkitError(
-                    message=f"Invalid input for action '{self.name}': {e}",
-                    status='INVALID_ARGUMENT',
-                    cause=e,
-                ) from e
+            payload: object = input
+            # If input is a BaseModel of a different type (e.g. ModelRequest[dict] vs ModelRequest[PluginConfig]),
+            # Pydantic rejects direct class validation. We dump it to a plain dict so Pydantic can re-parse
+            # the raw fields into the action's schema.
+            if isinstance(input, BaseModel):
+                try:
+                    input = self._input_type.validate_python(input)
+                except ValidationError:
+                    payload = input.model_dump(mode='python')
+
+            if payload is not input or not isinstance(input, BaseModel):
+                try:
+                    input = self._input_type.validate_python(payload)
+                except ValidationError as e:
+                    msg = (
+                        f"Action '{self.name}' requires input but none was provided. Please supply a valid input payload."
+                        if input is None
+                        else f"Invalid input for action '{self.name}': {e}"
+                    )
+                    raise GenkitError(message=msg, status='INVALID_ARGUMENT', cause=e) from e
 
         if context:
             _ = _action_context.set(context)

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -282,7 +282,13 @@ async def test_run_no_input_type_allows_none() -> None:
 
 @pytest.mark.asyncio
 async def test_validate_input_reparses_generic_pydantic_mismatch() -> None:
-    """Action input validation dumps and re-parses Pydantic instances when direct class validation fails."""
+    """Verify Action._validate_input plain-dict re-parsing for generic Pydantic model mismatches.
+
+    Why this test exists: When a caller passes a generic BaseModel instance (e.g. ModelRequest[dict])
+    to an action expecting a parameterized schema (e.g. ModelRequest[SubConfig]), Pydantic's direct
+    validate_python(input) fails because the Python class types do not match. Dumping to a plain dict
+    and re-parsing forces Pydantic to validate the raw payload into the action's target schema.
+    """
 
     class SubConfig(BaseModel):
         foo: str
@@ -302,7 +308,12 @@ async def test_validate_input_reparses_generic_pydantic_mismatch() -> None:
 
 @pytest.mark.asyncio
 async def test_validate_input_reparses_model_request_plugin_config() -> None:
-    """Action input validation dumps and re-parses ModelRequest[dict] to ModelRequest[PluginConfig]."""
+    """Verify ModelRequest[dict] payload re-parsing into ModelRequest[PluginConfig].
+
+    Why this test exists: Real-world Model actions registered with custom PluginConfig schemas
+    receive raw dict configs from ai.generate() wrapped in ModelRequest[dict]. This verifies that
+    Action._validate_input successfully coerces the raw dict config into the model's PluginConfig instance.
+    """
 
     class PluginConfig(BaseModel):
         thinking_summaries: str

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -282,20 +282,29 @@ async def test_run_no_input_type_allows_none() -> None:
 
 @pytest.mark.asyncio
 async def test_validate_input_reparses_generic_pydantic_mismatch() -> None:
-    """Action input validation dumps and re-parses Pydantic instances when direct class validation fails."""
+    """Action input validation dumps and re-parses ModelRequest[dict] to ModelRequest[PluginConfig]."""
 
-    class SubConfig(BaseModel):
-        foo: str
+    class PluginConfig(BaseModel):
+        thinking_summaries: str
+        google_search: bool
 
-    async def fn(request: ModelRequest[SubConfig]) -> str:
-        assert isinstance(request.config, SubConfig)
-        return request.config.foo
+    async def fn(request: ModelRequest[PluginConfig]) -> str:
+        assert isinstance(request.config, PluginConfig)
+        assert request.config.thinking_summaries == 'auto'
+        assert request.config.google_search is True
+        return f'summaries={request.config.thinking_summaries}'
 
-    action = Action(name='genericAction', kind=ActionKind.CUSTOM, fn=fn)
-    action._override_input_schema(ModelRequest[SubConfig])  # ty: ignore[invalid-type-form]
+    action = Action(name='genericAction', kind=ActionKind.MODEL, fn=fn)
+    action._override_input_schema(ModelRequest[PluginConfig])  # ty: ignore[invalid-type-form]
 
-    input_req = ModelRequest(messages=[], config={'foo': 'bar'})
+    # Caller passes bare ModelRequest (ModelRequest[dict]) with raw dict config
+    raw_req = ModelRequest(
+        messages=[],
+        config={'thinking_summaries': 'auto', 'google_search': True},
+    )
+    assert not isinstance(raw_req.config, PluginConfig)
 
-    result = await action.run(input=input_req)
-    assert result.response == 'bar'
+    # Action._validate_input dumps raw_req to dict and re-parses into ModelRequest[PluginConfig]
+    result = await action.run(input=raw_req)
+    assert result.response == 'summaries=auto'
 

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -282,6 +282,26 @@ async def test_run_no_input_type_allows_none() -> None:
 
 @pytest.mark.asyncio
 async def test_validate_input_reparses_generic_pydantic_mismatch() -> None:
+    """Action input validation dumps and re-parses Pydantic instances when direct class validation fails."""
+
+    class SubConfig(BaseModel):
+        foo: str
+
+    async def fn(request: ModelRequest[SubConfig]) -> str:
+        assert isinstance(request.config, SubConfig)
+        return request.config.foo
+
+    action = Action(name='genericAction', kind=ActionKind.CUSTOM, fn=fn)
+    action._override_input_schema(ModelRequest[SubConfig])  # ty: ignore[invalid-type-form]
+
+    input_req = ModelRequest(messages=[], config={'foo': 'bar'})
+
+    result = await action.run(input=input_req)
+    assert result.response == 'bar'
+
+
+@pytest.mark.asyncio
+async def test_validate_input_reparses_model_request_plugin_config() -> None:
     """Action input validation dumps and re-parses ModelRequest[dict] to ModelRequest[PluginConfig]."""
 
     class PluginConfig(BaseModel):
@@ -294,7 +314,7 @@ async def test_validate_input_reparses_generic_pydantic_mismatch() -> None:
         assert request.config.google_search is True
         return f'summaries={request.config.thinking_summaries}'
 
-    action = Action(name='genericAction', kind=ActionKind.MODEL, fn=fn)
+    action = Action(name='modelAction', kind=ActionKind.MODEL, fn=fn)
     action._override_input_schema(ModelRequest[PluginConfig])  # ty: ignore[invalid-type-form]
 
     # Caller passes bare ModelRequest (ModelRequest[dict]) with raw dict config

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -10,6 +10,8 @@ from typing import cast
 
 import pytest
 
+from pydantic import BaseModel
+
 from genkit._core._action import (
     Action,
     ActionKind,
@@ -21,6 +23,7 @@ from genkit._core._action import (
     parse_plugin_name_from_action_name,
 )
 from genkit._core._error import GenkitError
+from genkit._core._model import ModelRequest
 
 
 def test_action_enum_behaves_like_str() -> None:
@@ -275,3 +278,24 @@ async def test_run_no_input_type_allows_none() -> None:
 
     result = await action.run(input=None)
     assert result.response == 'no input needed'
+
+
+@pytest.mark.asyncio
+async def test_validate_input_reparses_generic_pydantic_mismatch() -> None:
+    """Action input validation dumps and re-parses Pydantic instances when direct class validation fails."""
+
+    class SubConfig(BaseModel):
+        foo: str
+
+    async def fn(request: ModelRequest[SubConfig]) -> str:
+        assert isinstance(request.config, SubConfig)
+        return request.config.foo
+
+    action = Action(name='genericAction', kind=ActionKind.CUSTOM, fn=fn)
+    action._override_input_schema(ModelRequest[SubConfig])  # ty: ignore[invalid-type-form]
+
+    input_req = ModelRequest(messages=[], config={'foo': 'bar'})
+
+    result = await action.run(input=input_req)
+    assert result.response == 'bar'
+

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -282,13 +282,7 @@ async def test_run_no_input_type_allows_none() -> None:
 
 @pytest.mark.asyncio
 async def test_validate_input_reparses_generic_pydantic_mismatch() -> None:
-    """Verify Action._validate_input plain-dict re-parsing for generic Pydantic model mismatches.
-
-    Why this test exists: When a caller passes a generic BaseModel instance (e.g. ModelRequest[dict])
-    to an action expecting a parameterized schema (e.g. ModelRequest[SubConfig]), Pydantic's direct
-    validate_python(input) fails because the Python class types do not match. Dumping to a plain dict
-    and re-parsing forces Pydantic to validate the raw payload into the action's target schema.
-    """
+    """Action input validation dumps and re-parses Pydantic instances when direct class validation fails."""
 
     class SubConfig(BaseModel):
         foo: str
@@ -308,11 +302,11 @@ async def test_validate_input_reparses_generic_pydantic_mismatch() -> None:
 
 @pytest.mark.asyncio
 async def test_validate_input_reparses_model_request_plugin_config() -> None:
-    """Verify ModelRequest[dict] payload re-parsing into ModelRequest[PluginConfig].
+    """Validate that ModelRequest[dict] re-parses into ModelRequest[PluginConfig].
 
-    Why this test exists: Real-world Model actions registered with custom PluginConfig schemas
-    receive raw dict configs from ai.generate() wrapped in ModelRequest[dict]. This verifies that
-    Action._validate_input successfully coerces the raw dict config into the model's PluginConfig instance.
+    ai.generate() constructs a bare ModelRequest(config={...}) with a raw dict. When passed
+    to a model action typed as ModelRequest[PluginConfig], Action._validate_input converts
+    the raw dict config into the model's PluginConfig instance.
     """
 
     class PluginConfig(BaseModel):


### PR DESCRIPTION
# PR Description

## Summary
Refactors `Action._validate_input` in `_action.py` to support automatic plain-dict re-parsing when a Pydantic `BaseModel` payload fails direct class identity validation due to generic parameter mismatches (such as `ModelRequest[dict]` vs `ModelRequest[PluginConfig]`).

---

## The Problem
When callers (or `ai.generate()`) pass a generic `BaseModel` instance (like `ModelRequest(config={'foo': 'bar'})`) to an Action whose input schema is parameterized with a concrete subtype (like `ModelRequest[PluginConfig]`):
1. Pydantic compares class identity during direct `validate_python(input)`.
2. Because `ModelRequest[dict]` is not the exact same class object as `ModelRequest[PluginConfig]`, direct class validation raises a `ValidationError`.

---

## The Fix
1. **Direct Validation First**: Tries direct class validation on the incoming instance (`self._input_type.validate_python(input)`).
2. **Fallback Re-parsing**: If direct validation raises a `ValidationError` on a `BaseModel` instance, dumps the instance to a plain Python dictionary (`input.model_dump(mode='python')`).
3. **Target Schema Coercion**: Pydantic parses the plain dictionary into the Action's target schema, successfully coercing nested raw fields (like `payload['config']`) into the expected model type (`PluginConfig`).

---

## File Changes
* **`py/packages/genkit/src/genkit/_core/_action.py`**: Refactored `_validate_input` with fallback plain-dict re-parsing.
* **`py/packages/genkit/tests/genkit/core/action_test.py`**: Added `test_validate_input_reparses_generic_pydantic_mismatch` unit test.

---

## Verification
* All 18 unit tests in `action_test.py` pass 100%.
* Tested with `ModelRequest[dict]` input validating into `ModelRequest[SubConfig]` action.