### PR TITLE
fix(py): serialize ModelInfo with camelCase aliases for Dev UI capability compatibility

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -94,7 +94,7 @@ def define_model(
 
     # Start with info if provided
     if info:
-        model_options.update(info.model_dump())
+        model_options.update(info.model_dump(by_alias=True, exclude_none=True))
 
     # Check if metadata has model info
     if metadata and 'model' in metadata:

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -221,7 +221,7 @@ def define_background_model(
         start: Function to start the background operation.
         check: Function to check operation status.
         cancel: Optional function to cancel operations.
-        label: Human-readable label (defaults to name).
+        label: Human-readable label (defaults to info.label, then model name).
         info: Model capability information.
         config_schema: Schema for model configuration options.
         metadata: Additional metadata for the model.
@@ -252,9 +252,8 @@ def define_background_model(
         model_options.update(info.model_dump(by_alias=True, exclude_none=True))
 
     # Precedence: explicit label argument > info.label > fallback to model name
-    effective_label = label or model_options.get('label') or name
-    model_options['label'] = effective_label
-    label = effective_label
+    label = label or model_options.get('label') or name
+    model_options['label'] = label
 
     if config_schema:
         model_options['customOptions'] = to_json_schema(config_schema)
@@ -292,7 +291,7 @@ def define_background_model(
         kind=ActionKind.BACKGROUND_MODEL,
         fn=wrapped_start,
         metadata=model_meta,
-        description=description or f'Background model: {effective_label}',
+        description=description or f'Background model: {label}',
     )
 
     # Register the check action
@@ -303,7 +302,7 @@ def define_background_model(
         kind=ActionKind.CHECK_OPERATION,
         fn=wrapped_check,
         metadata={'outputSchema': output_schema_meta},
-        description=f'Check operation status for {effective_label}',
+        description=f'Check operation status for {label}',
     )
 
     # Register the cancel action if provided

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -254,6 +254,7 @@ def define_background_model(
     # Precedence: explicit label argument > info.label > fallback to model name
     effective_label = label or model_options.get('label') or name
     model_options['label'] = effective_label
+    label = effective_label
 
     if config_schema:
         model_options['customOptions'] = to_json_schema(config_schema)

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -250,7 +250,7 @@ def define_background_model(
     model_options: dict[str, Any] = {}
 
     if info:
-        model_options.update(info.model_dump())
+        model_options.update(info.model_dump(by_alias=True, exclude_none=True))
 
     model_options['label'] = label
     if config_schema:

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -242,7 +242,6 @@ def define_background_model(
         ...     await asyncio.sleep(5)
         ...     op = await action.check(op)
     """
-    label = label or name
     action_key = _make_action_key(ActionKind.BACKGROUND_MODEL, name)
 
     # Build model metadata matching JS structure
@@ -252,7 +251,10 @@ def define_background_model(
     if info:
         model_options.update(info.model_dump(by_alias=True, exclude_none=True))
 
-    model_options['label'] = label
+    # Precedence: explicit label argument > info.label > fallback to model name
+    effective_label = label or model_options.get('label') or name
+    model_options['label'] = effective_label
+
     if config_schema:
         model_options['customOptions'] = to_json_schema(config_schema)
 
@@ -289,7 +291,7 @@ def define_background_model(
         kind=ActionKind.BACKGROUND_MODEL,
         fn=wrapped_start,
         metadata=model_meta,
-        description=description or f'Background model: {label}',
+        description=description or f'Background model: {effective_label}',
     )
 
     # Register the check action
@@ -300,7 +302,7 @@ def define_background_model(
         kind=ActionKind.CHECK_OPERATION,
         fn=wrapped_check,
         metadata={'outputSchema': output_schema_meta},
-        description=f'Check operation status for {label}',
+        description=f'Check operation status for {effective_label}',
     )
 
     # Register the cancel action if provided

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -41,6 +41,7 @@ from genkit._core._typing import (
     EvalResponse,
     FinishReason,
     ModelInfo,
+    Operation,
     Part,
     Role,
     Score,
@@ -1570,13 +1571,18 @@ def test_define_model_with_info(setup_test: SetupFixture) -> None:
     action = ai.define_model(
         name='foo',
         fn=foo_model_fn,
-        info=ModelInfo(label='Foo Bar', supports=Supports(multiturn=True, tools=True)),
+        info=ModelInfo(
+            label='Foo Bar',
+            supports=Supports(multiturn=True, tools=True, system_role=True, long_running=True),
+        ),
     )
     assert action.metadata['model'] == {
         'label': 'Foo Bar',
         'supports': {
             'multiturn': True,
             'tools': True,
+            'systemRole': True,
+            'longRunning': True,
         },
     }
 
@@ -1767,3 +1773,32 @@ async def test_evaluate(setup_test: SetupFixture) -> None:
     assert response.root[1].test_case_id == 'case2'
     assert isinstance(response.root[1].evaluation, Score)
     assert response.root[1].evaluation.score is True
+
+
+def test_define_background_model_with_info(setup_test: SetupFixture) -> None:
+    """Test that define_background_model correctly serializes info by alias and excludes None."""
+    ai, _, _, *_ = setup_test
+
+    async def start_fn(request: ModelRequest, ctx: ActionRunContext) -> Operation:
+        return Operation(id='123', done=False)
+
+    async def check_fn(op: Operation) -> Operation:
+        return op
+
+    action = ai.define_background_model(
+        name='bg_model',
+        label='Background Model',
+        start=start_fn,
+        check=check_fn,
+        info=ModelInfo(
+            label='Background Model',
+            supports=Supports(multiturn=True, system_role=True),
+        ),
+    )
+    assert action.start_action.metadata['model'] == {
+        'label': 'Background Model',
+        'supports': {
+            'multiturn': True,
+            'systemRole': True,
+        },
+    }

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -1787,7 +1787,6 @@ def test_define_background_model_with_info(setup_test: SetupFixture) -> None:
 
     action = ai.define_background_model(
         name='bg_model',
-        label='Background Model',
         start=start_fn,
         check=check_fn,
         info=ModelInfo(

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -1801,3 +1801,26 @@ def test_define_background_model_with_info(setup_test: SetupFixture) -> None:
             'systemRole': True,
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_with_model_info_long_running(
+    setup_test: SetupFixture,
+) -> None:
+    """Verify generate_operation succeeds for a model defined with ModelInfo(supports=Supports(long_running=True))."""
+    ai, _, _, *_ = setup_test
+
+    async def my_model(request: ModelRequest) -> ModelResponse:
+        return ModelResponse(
+            message=Message(role='model', content=[TextPart(text='done')]),
+            operation=Operation(id='op123', done=False),
+        )
+
+    ai.define_model(
+        name='lr_model',
+        fn=my_model,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    op = await ai.generate_operation(model='lr_model', prompt='test')
+    assert op is not None


### PR DESCRIPTION
## Description

When defining custom models or background models in Python (`define_model` and `define_background_model`), dumping `ModelInfo` without parameters serialized snake_case names (e.g. `system_role`, `long_running`, `content_type`, `config_schema`) and included `None` values.

This PR passes `by_alias=True` and `exclude_none=True` to `info.model_dump(...)` in `_model.py` and `_background.py` so field names are properly formatted as camelCase JSON aliases matching JS schema expectations and `None` fields are omitted.

This fixes an issue with Genkit Python on Dev UI. When the Dev UI evaluates `metadata.model.supports?.systemRole in JavaScript, "system_role" is not recognized, returning undefined. The UI interprets this as false and hides capability controls (such as the System Prompt input card). All the model info metadata is broken in the same way.

(I noticed this bug while testing with Ollama. Gemini/Vertex models have some magic on Dev UI side that hides this wire format inconsistency.)

## Checklist

- [x] Unit tests updated and passing
- [x] Preflight lint and license checks passing

## Manual inspection in Dev UI

I tested before/after using an Ollama sample. 

BEFORE: System prompt is missing.
<img width="1695" height="363" alt="Screenshot 2026-08-05 at 7 31 37 PM" src="https://github.com/user-attachments/assets/1b9cd236-6242-43d8-a64f-3cb279d54780" />

AFTER: system prompt renders correctly.
<img width="1708" height="339" alt="Screenshot 2026-08-05 at 7 31 20 PM" src="https://github.com/user-attachments/assets/b255f81f-cea8-407f-b3c9-6101f3c34e57" />

