### PR TITLE
fix(py/core): stop debug logs dumping model responses by default

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -173,6 +173,8 @@ class Genkit:
         prompt_dir: str | Path | None = None,
         reflection_server_spec: ServerSpec | None = None,
     ) -> None:
+        # Before anything that logs, so plugin initialization is covered too.
+        configure_logging()
         self.registry: Registry = Registry()
         self._reflection_server_spec: ServerSpec | None = reflection_server_spec
         self._reflection_ready = threading.Event()
@@ -180,7 +182,6 @@ class Genkit:
         # Ensure the default generate action is registered for async usage.
         define_generate_action(self.registry)
         self._register_plugin_middleware(plugins)
-        configure_logging()
         # In dev mode, start the reflection server immediately in a background
         # daemon thread so it's available regardless of which web framework (or
         # none) the user chooses.

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -47,7 +47,7 @@ from genkit._core._action import (
     ActionRunContext,
 )
 from genkit._core._error import GenkitError
-from genkit._core._logger import get_logger
+from genkit._core._logger import get_logger, is_debug_enabled
 from genkit._core._middleware import (
     BaseMiddleware,
     GenerateHookParams,
@@ -391,24 +391,57 @@ def _augment_with_context(
 # parameters (e.g. "data:audio/L16;codec=pcm;rate=24000;base64,").
 _DATA_URI_RE = re.compile(r'data:[^,]{0,200},(?=.{100})', re.ASCII)
 
+# Longest string kept intact when serializing a response for debug logs.
+_MAX_LOGGED_STR_LEN = 8192
 
-def _redact_data_uris(obj: Any) -> Any:  # noqa: ANN401
-    """Recursively truncate long ``data:`` URIs in a serialized dict/list.
+# Tighter limit inside subtrees carrying the provider's own payload.
+_PROVIDER_STR_LEN = 1024
+_PROVIDER_FIELDS = frozenset({'custom', 'raw'})
 
-    Replaces values like ``data:image/png;base64,iVBORw0KGgo...`` with
-    ``data:image/png;base64,...<12345 bytes>`` so debug logs stay readable
-    when requests contain inline images or other binary media.
+# Most list items kept when serializing a response for debug logs.
+_MAX_LOGGED_LIST_LEN = 100
+
+
+def _redact_large_values(obj: Any, limit: int = _MAX_LOGGED_STR_LEN) -> Any:  # noqa: ANN401
+    """Recursively shrink oversized values in a serialized dict/list.
+
+    Data URIs keep their media type and drop the payload
+    (``data:image/png;base64,...<12345 chars>``); other over-long strings keep
+    their leading characters; binary values collapse to their size; over-long
+    lists keep their leading items. ``custom`` and ``raw`` subtrees use
+    ``_PROVIDER_STR_LEN`` so a provider blob costs less than model output.
+
+    Args:
+        obj: Value from a ``model_dump()``, walked recursively.
+        limit: Longest string kept intact within this subtree.
+
+    Returns:
+        The value with oversized leaves replaced by a truncated form that
+        reports how much was dropped.
     """
     if isinstance(obj, str):
         m = _DATA_URI_RE.match(obj)
         if m:
-            return f'{m.group()}...<{len(obj) - m.end()} bytes>'
+            return f'{m.group()}...<{len(obj) - m.end()} chars>'
+        if len(obj) > limit:
+            return f'{obj[:limit]}...<{len(obj) - limit} chars>'
         return obj
+    if isinstance(obj, (bytes, bytearray, memoryview)):
+        return f'<{len(obj)} bytes>'
     if isinstance(obj, dict):
-        return {k: _redact_data_uris(v) for k, v in obj.items()}
+        return {
+            k: _redact_large_values(v, _PROVIDER_STR_LEN if k in _PROVIDER_FIELDS else limit) for k, v in obj.items()
+        }
     if isinstance(obj, list):
-        return [_redact_data_uris(v) for v in obj]
+        head = [_redact_large_values(v, limit) for v in obj[:_MAX_LOGGED_LIST_LEN]]
+        dropped = len(obj) - len(head)
+        return [*head, f'...<{dropped} more items>'] if dropped else head
     return obj
+
+
+def _loggable_response(response: ModelResponse) -> dict[str, Any]:
+    """Serialize a response for debug logging with oversized values shrunk."""
+    return _redact_large_values(response.model_dump())
 
 
 def raise_if_aborted(abort_signal: asyncio.Event) -> None:
@@ -764,10 +797,8 @@ async def _generate_action_turn(
         if schema_type:
             response._schema_type = schema_type
 
-        logger.debug(
-            'generate response',
-            response=_redact_data_uris(response.model_dump()),
-        )
+        if is_debug_enabled(logger):
+            logger.debug('generate response', response=_loggable_response(response))
 
         response.assert_valid()
         generated_msg = response.message

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -13,6 +13,21 @@ from structlog.typing import FilteringBoundLogger
 
 from genkit._core._environment import is_dev_environment
 
+# Environment variable name
+GENKIT_LOG = 'GENKIT_LOG'
+
+DEFAULT_LOG_LEVEL = logging.INFO
+
+_LOG_LEVELS = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warn': logging.WARNING,
+    'warning': logging.WARNING,
+    'error': logging.ERROR,
+    'critical': logging.CRITICAL,
+    'fatal': logging.CRITICAL,
+}
+
 # Libraries that log every HTTP request or poll. Under Dev UI, health checks
 # and span exports generate noise unless GENKIT_LOG=debug is explicitly set.
 QUIET_LOGGERS = (
@@ -25,16 +40,53 @@ QUIET_LOGGERS = (
 
 def resolve_level() -> int:
     """Resolve logging level from GENKIT_LOG environment variable."""
-    raw = os.environ.get('GENKIT_LOG', 'info').strip().lower()
-    return {
-        'debug': logging.DEBUG,
-        'info': logging.INFO,
-        'warn': logging.WARNING,
-        'warning': logging.WARNING,
-        'error': logging.ERROR,
-        'critical': logging.CRITICAL,
-        'fatal': logging.CRITICAL,
-    }.get(raw, logging.INFO)
+    raw = os.environ.get(GENKIT_LOG, 'info').strip().lower()
+    return _LOG_LEVELS.get(raw, DEFAULT_LOG_LEVEL)
+
+
+def unrecognized_level() -> str | None:
+    """Return the raw ``GENKIT_LOG`` value when it names no known level.
+
+    Returns:
+        The value as set, or ``None`` when it is absent, empty, or recognized.
+    """
+    raw = os.environ.get(GENKIT_LOG, '')
+    if not raw.strip() or raw.strip().lower() in _LOG_LEVELS:
+        return None
+    return raw
+
+
+def _app_chose_level() -> bool:
+    """Report whether the application configured structlog with a level of its own."""
+    if not structlog.is_configured():
+        return False
+    unfiltered = structlog.make_filtering_bound_logger(logging.NOTSET)
+    return structlog.get_config().get('wrapper_class') is not unfiltered
+
+
+def configure_structlog_level() -> bool:
+    """Apply ``GENKIT_LOG`` to structlog unless the application chose a level.
+
+    structlog is unconfigured by default, and its defaults emit DEBUG to stdout
+    through ``PrintLoggerFactory``, bypassing :mod:`logging` entirely. Muting the
+    stdlib loggers therefore cannot quiet genkit's own events.
+
+    Returns:
+        ``True`` when the level was applied, ``False`` when an
+        application-configured level was left untouched.
+    """
+    if _app_chose_level():
+        return False
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(resolve_level()))
+    ignored = unrecognized_level()
+    if ignored is not None:
+        get_logger(__name__).warning(
+            'ignoring unrecognized log level',
+            variable=GENKIT_LOG,
+            value=ignored,
+            using=logging.getLevelName(resolve_level()),
+        )
+    return True
 
 
 def configure_logging(*, shared_tty: bool | None = None) -> None:
@@ -43,6 +95,8 @@ def configure_logging(*, shared_tty: bool | None = None) -> None:
     Safe to call more than once. Default level is ``info``; override with
     ``GENKIT_LOG=debug|info|warn|error``.
     """
+    configure_structlog_level()
+
     if shared_tty is None:
         shared_tty = is_dev_environment()
 
@@ -61,3 +115,24 @@ def configure_logging(*, shared_tty: bool | None = None) -> None:
 def get_logger(name: str | None = None) -> FilteringBoundLogger:
     """Return a structlog bound logger with a concrete return type for checkers."""
     return structlog.get_logger(name)
+
+
+def is_debug_enabled(logger: FilteringBoundLogger) -> bool:
+    """Report whether ``logger`` emits DEBUG events.
+
+    Args:
+        logger: Logger to inspect.
+
+    Returns:
+        ``True`` when DEBUG events are emitted, including when ``logger``
+        exposes no usable level check.
+    """
+    for attr in ('is_enabled_for', 'isEnabledFor'):
+        check = getattr(logger, attr, None)
+        if not callable(check):
+            continue
+        try:
+            return bool(check(logging.DEBUG))
+        except Exception:
+            return True
+    return True

--- a/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
@@ -1,0 +1,208 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the debug-log payload built by genkit._ai._generate."""
+
+from collections.abc import Iterator
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from genkit import Genkit, Message, ModelResponse
+from genkit._ai._generate import (
+    _MAX_LOGGED_LIST_LEN,
+    _MAX_LOGGED_STR_LEN,
+    _PROVIDER_STR_LEN,
+    _loggable_response,
+    _redact_large_values,
+)
+from genkit._ai._testing import define_programmable_model
+from genkit._core._environment import GENKIT_ENV
+from genkit._core._logger import GENKIT_LOG
+from genkit._core._typing import CustomPart, GenerationUsage, Media, MediaPart, Role, TextPart
+
+BLOB = 'A' * 1_000_000
+
+
+@pytest.fixture(autouse=True)
+def _restore_structlog() -> Iterator[None]:
+    """Restore structlog's global configuration around each test."""
+    saved = structlog.get_config().copy()
+    was_configured = structlog.is_configured()
+    yield
+    structlog.reset_defaults()
+    if was_configured:
+        structlog.configure(**saved)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run each test with the Genkit env vars unset unless it sets them."""
+    monkeypatch.delenv(GENKIT_LOG, raising=False)
+    monkeypatch.delenv(GENKIT_ENV, raising=False)
+
+
+def test_short_values_pass_through() -> None:
+    """Values under the limits are untouched."""
+    payload = {'text': 'hello', 'items': [1, None, True, 'short'], 'nested': {'k': 'v'}}
+
+    assert _redact_large_values(payload) == payload
+
+
+def test_data_uris_keep_their_media_type() -> None:
+    """Data URIs report the dropped payload size and keep the media type."""
+    uri = 'data:audio/L16;codec=pcm;rate=24000;base64,' + 'B' * 500
+
+    assert _redact_large_values(uri) == 'data:audio/L16;codec=pcm;rate=24000;base64,...<500 chars>'
+
+
+def test_bare_long_strings_are_truncated() -> None:
+    """A long string with no data URI prefix keeps its leading characters."""
+    blob = 'C' * (_MAX_LOGGED_STR_LEN + 4096)
+
+    redacted = _redact_large_values(blob)
+
+    assert redacted.startswith('C' * _MAX_LOGGED_STR_LEN)
+    assert redacted.endswith('...<4096 chars>')
+
+
+def test_binary_values_collapse_to_their_size() -> None:
+    """bytes survive model_dump in python mode, so they are reported by length."""
+    assert _redact_large_values(b'\x00' * 200_000) == '<200000 bytes>'
+    assert _redact_large_values(bytearray(b'ab')) == '<2 bytes>'
+    assert _redact_large_values(memoryview(b'abc')) == '<3 bytes>'
+
+
+def test_long_lists_are_truncated() -> None:
+    """An over-long list keeps its leading items and reports the remainder."""
+    redacted = _redact_large_values(list(range(_MAX_LOGGED_LIST_LEN + 250)))
+
+    assert len(redacted) == _MAX_LOGGED_LIST_LEN + 1
+    assert redacted[:3] == [0, 1, 2]
+    assert redacted[-1] == '...<250 more items>'
+
+
+def test_redaction_recurses_into_containers() -> None:
+    """Oversized values nested in dicts and lists are shrunk too."""
+    blob = 'D' * (_MAX_LOGGED_STR_LEN + 1)
+
+    redacted = _redact_large_values({'a': [{'b': blob, 'c': b'xy'}]})
+
+    assert redacted == {'a': [{'b': 'D' * _MAX_LOGGED_STR_LEN + '...<1 chars>', 'c': '<2 bytes>'}]}
+
+
+def test_loggable_response_keeps_provider_payloads_bounded() -> None:
+    """raw and custom stay in the log for provider debugging, but bounded in size."""
+    response = ModelResponse(
+        message=Message(role=Role.MODEL, content=[TextPart(text='hi')]),
+        custom={'audio': BLOB},
+        raw={'audio': BLOB},
+        usage=GenerationUsage(input_tokens=1, output_tokens=2),
+    )
+
+    logged = _loggable_response(response)
+
+    assert logged['message']['content'][0]['text'] == 'hi'
+    assert logged['usage']['inputTokens'] == 1
+    assert logged['raw']['audio'].endswith(f'...<{1_000_000 - _PROVIDER_STR_LEN} chars>')
+    assert logged['custom']['audio'] == logged['raw']['audio']
+    assert len(str(logged)) < len(str(response.model_dump())) / 100
+
+
+def test_loggable_response_truncates_nested_part_payloads() -> None:
+    """Oversized values on a part, not just on the response, are shrunk."""
+    response = ModelResponse(
+        message=Message(role=Role.MODEL, content=[CustomPart(custom={'blob': BLOB})]),
+    )
+
+    logged = _loggable_response(response)
+
+    assert logged['message']['content'][0]['custom']['blob'].endswith(f'...<{1_000_000 - _PROVIDER_STR_LEN} chars>')
+
+
+def test_model_output_gets_a_longer_limit_than_provider_payloads() -> None:
+    """Model text survives to _MAX_LOGGED_STR_LEN while raw is held to _PROVIDER_STR_LEN."""
+    prose = 'W' * (_MAX_LOGGED_STR_LEN * 2)
+    response = ModelResponse(
+        message=Message(role=Role.MODEL, content=[TextPart(text=prose)]),
+        raw={'echo': prose},
+    )
+
+    logged = _loggable_response(response)
+
+    assert logged['message']['content'][0]['text'].endswith(f'...<{_MAX_LOGGED_STR_LEN} chars>')
+    assert logged['raw']['echo'].endswith(f'...<{_MAX_LOGGED_STR_LEN * 2 - _PROVIDER_STR_LEN} chars>')
+
+
+def test_loggable_response_truncates_media_in_message() -> None:
+    """Inline media that survives into the message is truncated rather than dumped."""
+    response = ModelResponse(
+        message=Message(
+            role=Role.MODEL,
+            content=[MediaPart(media=Media(content_type='image/png', url='data:image/png;base64,' + 'E' * 900))],
+        ),
+    )
+
+    logged = _loggable_response(response)
+
+    assert logged['message']['content'][0]['media']['url'] == 'data:image/png;base64,...<900 chars>'
+
+
+async def _generate_once() -> None:
+    """Run one generate call against a model returning a blob in raw and custom."""
+    ai = Genkit(model='programmableModel')
+    pm, _ = define_programmable_model(ai)
+    pm.responses = [
+        ModelResponse(
+            message=Message(role=Role.MODEL, content=[TextPart(text='hello there')]),
+            custom={'audio': BLOB},
+            raw={'audio': BLOB},
+        )
+    ]
+    _ = await ai.generate(prompt='hi')
+
+
+@pytest.mark.asyncio
+async def test_generate_logs_nothing_at_default_level() -> None:
+    """A generate call under the default configuration emits no response dump."""
+    structlog.reset_defaults()
+
+    with capture_logs() as entries:
+        await _generate_once()
+
+    events = [entry['event'] for entry in entries]
+    assert events, 'capture_logs saw nothing, so the assertion below would be vacuous'
+    assert 'generate response' not in events
+
+
+@pytest.mark.asyncio
+async def test_generate_logs_bounded_response_when_debug_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With debug on, the response is logged but the blob is truncated."""
+    structlog.reset_defaults()
+    monkeypatch.setenv(GENKIT_LOG, 'debug')
+
+    with capture_logs() as entries:
+        await _generate_once()
+
+    logged = [entry for entry in entries if entry['event'] == 'generate response']
+    assert len(logged) == 1
+    assert len(str(logged[0]['response'])) < 3 * _MAX_LOGGED_STR_LEN
+
+
+@pytest.mark.asyncio
+async def test_response_is_not_serialized_when_debug_is_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The payload is not built at all when the event would be dropped."""
+    structlog.reset_defaults()
+    calls: list[int] = []
+    original = ModelResponse.model_dump
+
+    def counting_model_dump(self: ModelResponse, **kwargs: object) -> dict[str, object]:
+        calls.append(1)
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(ModelResponse, 'model_dump', counting_model_dump)
+
+    await _generate_once()
+
+    assert calls == []

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -5,9 +5,25 @@
 
 import logging
 import os
+from collections.abc import Iterator
+from typing import Any
 from unittest import mock
 
-from genkit._core._logger import QUIET_LOGGERS, configure_logging, resolve_level
+import pytest
+import structlog
+from structlog.processors import JSONRenderer
+from structlog.testing import capture_logs
+
+from genkit._core._logger import (
+    GENKIT_LOG,
+    QUIET_LOGGERS,
+    configure_logging,
+    configure_structlog_level,
+    get_logger,
+    is_debug_enabled,
+    resolve_level,
+    unrecognized_level,
+)
 
 
 def test_resolve_level() -> None:
@@ -95,3 +111,189 @@ def test_configure_logging_respects_user_configured_levels() -> None:
         mock_get_logger.return_value.level = logging.DEBUG
         configure_logging(shared_tty=True)
         mock_get_logger.return_value.setLevel.assert_not_called()
+
+
+@pytest.fixture
+def _restore_structlog() -> Iterator[None]:
+    """Restore structlog's global configuration around a test."""
+    saved = structlog.get_config().copy()
+    was_configured = structlog.is_configured()
+    yield
+    structlog.reset_defaults()
+    if was_configured:
+        structlog.configure(**saved)
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_unrecognized_level() -> None:
+    """Only a set, non-empty, unrecognized GENKIT_LOG value is reported, verbatim."""
+    with mock.patch.dict(os.environ, clear=True):
+        assert unrecognized_level() is None
+
+    for value in ['', '   ', 'debug', '  WARN  ']:
+        with mock.patch.dict(os.environ, {GENKIT_LOG: value}):
+            assert unrecognized_level() is None
+
+    with mock.patch.dict(os.environ, {GENKIT_LOG: 'dbug'}):
+        assert unrecognized_level() == 'dbug'
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_configure_structlog_level_drops_debug_events() -> None:
+    """The applied level filters DEBUG events out while keeping INFO and above."""
+    structlog.reset_defaults()
+    with mock.patch.dict(os.environ, clear=True):
+        assert configure_structlog_level() is True
+
+        logger = get_logger('test')
+        assert is_debug_enabled(logger) is False
+        with capture_logs() as entries:
+            logger.debug('noisy', response={'blob': 'x' * 1000})
+            logger.info('kept')
+        assert [entry['event'] for entry in entries] == ['kept']
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_configure_structlog_level_honours_debug_opt_in() -> None:
+    """GENKIT_LOG=debug turns the genkit debug logs back on."""
+    structlog.reset_defaults()
+    with mock.patch.dict(os.environ, {GENKIT_LOG: 'debug'}):
+        assert configure_structlog_level() is True
+
+        logger = get_logger('test')
+        assert is_debug_enabled(logger) is True
+        with capture_logs() as entries:
+            logger.debug('noisy')
+        assert 'noisy' in [entry['event'] for entry in entries]
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_configure_structlog_level_applies_when_app_configured_processors_only() -> None:
+    """An app that configured only processors has not chosen a level."""
+    structlog.reset_defaults()
+    structlog.configure(processors=[JSONRenderer()])
+    with mock.patch.dict(os.environ, clear=True):
+        assert configure_structlog_level() is True
+        assert is_debug_enabled(get_logger('test')) is False
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_configure_structlog_level_leaves_an_app_chosen_level_alone() -> None:
+    """An app that configured its own wrapper_class keeps its level."""
+    structlog.reset_defaults()
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG))
+    with mock.patch.dict(os.environ, clear=True):
+        assert configure_structlog_level() is False
+        assert is_debug_enabled(get_logger('test')) is True
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_configure_structlog_level_is_idempotent() -> None:
+    """A second call reports that nothing was applied."""
+    structlog.reset_defaults()
+    with mock.patch.dict(os.environ, clear=True):
+        assert configure_structlog_level() is True
+        assert configure_structlog_level() is False
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_unrecognized_level_warns_and_falls_back() -> None:
+    """A misspelled GENKIT_LOG logs a warning instead of failing silently."""
+    structlog.reset_defaults()
+    with mock.patch.dict(os.environ, {GENKIT_LOG: 'dbug'}), capture_logs() as entries:
+        assert configure_structlog_level() is True
+
+    warnings = [e for e in entries if e['event'] == 'ignoring unrecognized log level']
+    assert len(warnings) == 1
+    assert warnings[0]['value'] == 'dbug'
+    assert warnings[0]['using'] == 'INFO'
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_import_time_loggers_pick_up_late_configuration() -> None:
+    """Loggers bound at import time honour a level configured afterwards."""
+    structlog.reset_defaults()
+    logger = get_logger('bound.early')
+    assert is_debug_enabled(logger) is True
+
+    with mock.patch.dict(os.environ, clear=True):
+        configure_structlog_level()
+
+    assert is_debug_enabled(logger) is False
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_level_survives_a_later_processors_only_configure() -> None:
+    """A plugin appending processors after genkit set the level keeps the filter."""
+    structlog.reset_defaults()
+    with mock.patch.dict(os.environ, clear=True):
+        configure_structlog_level()
+
+    processors = list(structlog.get_config()['processors'])
+    structlog.configure(processors=[*processors, JSONRenderer()])
+
+    assert is_debug_enabled(get_logger('test')) is False
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_configure_logging_sets_the_structlog_level_outside_dev() -> None:
+    """Muting is dev-only, but the structlog level applies in every environment."""
+    structlog.reset_defaults()
+    with mock.patch.dict(os.environ, clear=True):
+        configure_logging(shared_tty=False)
+
+    assert is_debug_enabled(get_logger('test')) is False
+
+
+@pytest.mark.parametrize(
+    ('wrapper', 'expected'),
+    [
+        (None, True),
+        (structlog.make_filtering_bound_logger(logging.NOTSET), True),
+        (structlog.make_filtering_bound_logger(logging.DEBUG), True),
+        (structlog.make_filtering_bound_logger(logging.INFO), False),
+        (structlog.make_filtering_bound_logger(logging.CRITICAL), False),
+        (structlog.BoundLogger, True),
+    ],
+)
+@pytest.mark.usefixtures('_restore_structlog')
+def test_is_debug_enabled_against_real_wrapper_classes(wrapper: Any, expected: bool) -> None:
+    """Every structlog wrapper class answers without raising.
+
+    ``structlog.BoundLogger`` proxies unknown attributes to the wrapped logger, so a
+    level check looks callable and then fails; that must not escape.
+    """
+    structlog.reset_defaults()
+    if wrapper is not None:
+        structlog.configure(wrapper_class=wrapper)
+
+    assert is_debug_enabled(get_logger('test')) is expected
+
+
+@pytest.mark.parametrize(
+    ('root_level', 'expected'),
+    [(logging.DEBUG, True), (logging.WARNING, False)],
+)
+@pytest.mark.usefixtures('_restore_structlog')
+def test_is_debug_enabled_against_stdlib_wrapper(root_level: int, expected: bool) -> None:
+    """The stdlib wrapper exposes isEnabledFor and is consulted through it."""
+    structlog.reset_defaults()
+    structlog.configure(
+        wrapper_class=structlog.stdlib.BoundLogger,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+    )
+    previous = logging.getLogger().level
+    logging.getLogger().setLevel(root_level)
+    try:
+        assert is_debug_enabled(get_logger('test')) is expected
+    finally:
+        logging.getLogger().setLevel(previous)
+
+
+@pytest.mark.usefixtures('_restore_structlog')
+def test_is_debug_enabled_when_the_level_check_cannot_run() -> None:
+    """A wrapper whose level check proxies to a logger lacking it falls back to enabled."""
+    structlog.reset_defaults()
+    structlog.configure(wrapper_class=structlog.stdlib.BoundLogger)
+
+    assert is_debug_enabled(get_logger('test')) is True


### PR DESCRIPTION
## Why

Every `generate()` call printed the full model response to stdout, base64 included. A response carrying 1MB of audio dumped ~2MB per call. Two causes:

1. `_core/_logger.py` never configured structlog, and structlog's defaults emit DEBUG to stdout via `PrintLoggerFactory`.
2. `_redact_data_uris` only truncated `data:<mime>;base64,...` strings, so plain base64 in `response.custom` and `response.raw` printed in full.

#5867 doesn't cover this. It mutes stdlib loggers with `logging.getLogger(name).setLevel(...)`, but genkit's own events never go through `logging`. structlog writes straight to stdout and filters in `wrapper_class`, so even `logging.disable(logging.CRITICAL)` leaves the dump intact, and `GENKIT_LOG=warn` has no effect on it.

## Changes

`configure_structlog_level()` applies `GENKIT_LOG` to structlog's `wrapper_class`, reusing #5867's env var and level names instead of adding a second knob. It's called from `configure_logging()`, which I moved to the top of `Genkit.__init__` so plugin init is covered, and it runs before the `shared_tty` early return since this dump happens in every environment, not just dev.

It skips when the app picked its own level. `structlog.is_configured()` alone isn't enough: it's True when an app configures only `processors`, which leaves the DEBUG-emitting default `wrapper_class` in place, so the guard also checks that `wrapper_class` is still structlog's unfiltered default.

`_redact_large_values` replaces `_redact_data_uris`. It truncates long strings, collapses `bytes` to `<N bytes>`, and caps lists. Two limits: 8192 chars for model output, 1024 inside `custom`/`raw`, so a provider blob costs less than real output. `raw` is kept rather than dropped, since debug is opt-in now and that's the field you want when debugging a provider.

The call site is guarded by `is_debug_enabled()` so `model_dump()` no longer runs when the event gets dropped anyway.

## Verification

One `generate()` against a model returning 1MB base64 in both `raw` and `custom`:

| | stdout |
|---|---|
| before | 2,000,532 bytes |
| after, default | 87 bytes |
| after, `GENKIT_LOG=debug` | 2,615 bytes |

`GENKIT_LOG=warn` now gives 87 bytes too.