### PR TITLE
feat(py): make ModelRef generic over ModelRefConfigT

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -33,6 +33,7 @@ from genkit._core._model import (
     Message,
     ModelConfig,
     ModelRef,
+    ModelRefConfigT,
     ModelRequest,
     ModelResponse,
     ModelResponseChunk,
@@ -67,16 +68,23 @@ def model_action_metadata(
 
 def model_ref(
     name: str,
+    *,
+    config_schema: type[ModelRefConfigT],
     namespace: str | None = None,
     info: ModelInfo | None = None,
     version: str | None = None,
-    config: dict[str, object] | None = None,
-) -> ModelRef:
+    config: ModelRefConfigT | None = None,
+) -> ModelRef[ModelRefConfigT]:
     """Create a ModelRef, optionally prefixing name with namespace."""
-    # Logic: if (options.namespace && !name.startsWith(options.namespace + '/'))
     final_name = f'{namespace}/{name}' if namespace and not name.startswith(f'{namespace}/') else name
 
-    return ModelRef(name=final_name, info=info, version=version, config=config)
+    return ModelRef[ModelRefConfigT](
+        name=final_name,
+        config_schema=config_schema,
+        info=info,
+        version=version,
+        config=config,
+    )
 
 
 def define_model(

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -78,7 +78,7 @@ def model_ref(
     """Create a ModelRef, optionally prefixing name with namespace."""
     final_name = f'{namespace}/{name}' if namespace and not name.startswith(f'{namespace}/') else name
 
-    return ModelRef[ModelRefConfigT](
+    return ModelRef(
         name=final_name,
         config_schema=config_schema,
         info=info,

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -74,13 +74,26 @@ ModelRefConfigT = TypeVar('ModelRefConfigT', bound=BaseModel, covariant=True)
 
 @dataclass(frozen=True, kw_only=True)
 class ModelRef(Generic[ModelRefConfigT]):
-    """Frozen reference to a model, optionally tied to a config schema."""
+    """Frozen reference to a model tied to a config schema."""
 
     name: str
     config_schema: type[ModelRefConfigT]
     info: ModelInfo | None = None
     version: str | None = None
     config: ModelRefConfigT | None = None
+
+    # Config schemas are Pydantic models and usually aren't hashable, so a
+    # generated __hash__ would work when config is None and blow up once one is
+    # set — a nasty footgun if someone keys a cache or set by ModelRef.
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        # Catch dicts / wrong types at construction so plugins don't discover
+        # the mismatch later when they touch typed config fields.
+        if self.config is not None and not isinstance(self.config, self.config_schema):
+            raise TypeError(
+                f'config must be an instance of {self.config_schema.__name__}, got {type(self.config).__name__}'
+            )
 
 
 class Message(MessageData):

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -75,7 +75,12 @@ ModelRefConfigT = TypeVar('ModelRefConfigT', bound=BaseModel, covariant=True)
 
 @dataclass(frozen=True, kw_only=True)
 class ModelRef(Generic[ModelRefConfigT]):
-    """Frozen reference to a model tied to a config schema."""
+    """Handle for a model tied to a config schema.
+
+    Fields cannot be rebound. config and info are copied at construction so later
+    mutations of the caller's objects don't change the ref; the copies themselves
+    stay ordinary mutable Pydantic models.
+    """
 
     name: str
     config_schema: type[ModelRefConfigT]
@@ -114,6 +119,12 @@ class ModelRef(Generic[ModelRefConfigT]):
                 status='INVALID_ARGUMENT',
                 message=(f'{self.name}: info must be an instance of {ModelInfo.__module__}.ModelInfo, got {actual}'),
             )
+        # Callers often keep the config/info they passed in. Copy so later
+        # mutations of those objects don't change the ref's defaults.
+        if self.config is not None:
+            object.__setattr__(self, 'config', self.config.model_copy(deep=True))
+        if self.info is not None:
+            object.__setattr__(self, 'info', self.info.model_copy(deep=True))
 
 
 class Message(MessageData):

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -82,9 +82,8 @@ class ModelRef(Generic[ModelRefConfigT]):
     version: str | None = None
     config: ModelRefConfigT | None = None
 
-    # Config schemas are Pydantic models and usually aren't hashable, so a
-    # generated __hash__ would work when config is None and blow up once one is
-    # set — a nasty footgun if someone keys a cache or set by ModelRef.
+    # Explicitly opt out of hashing: Pydantic configs are unhashable, so an
+    # auto-generated __hash__ would fail once set.
     __hash__ = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -88,10 +88,22 @@ class ModelRef(Generic[ModelRefConfigT]):
     __hash__ = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
-        # Catch dicts / wrong types at construction so plugins don't discover
-        # the mismatch later when they touch typed config fields.
-        if self.config is not None and not isinstance(self.config, self.config_schema):
-            expected = f'{self.config_schema.__module__}.{self.config_schema.__name__}'
+        # Schema first: isinstance(config, schema) raises TypeError if schema
+        # isn't a class — the JSON-schema dict a plugin would paste in from
+        # action metadata.
+        schema = self.config_schema
+        if not isinstance(schema, type) or not issubclass(schema, BaseModel):
+            got = (
+                f'{schema.__module__}.{schema.__name__}'
+                if isinstance(schema, type)
+                else f'{type(schema).__module__}.{type(schema).__name__}'
+            )
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=f'{self.name}: config_schema must be a BaseModel subclass, got {got}',
+            )
+        if self.config is not None and not isinstance(self.config, schema):
+            expected = f'{schema.__module__}.{schema.__name__}'
             actual = f'{type(self.config).__module__}.{type(self.config).__name__}'
             raise GenkitError(
                 status='INVALID_ARGUMENT',

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -91,10 +91,11 @@ class ModelRef(Generic[ModelRefConfigT]):
         # Catch dicts / wrong types at construction so plugins don't discover
         # the mismatch later when they touch typed config fields.
         if self.config is not None and not isinstance(self.config, self.config_schema):
-            config_type = type(self.config).__name__
+            expected = f'{self.config_schema.__module__}.{self.config_schema.__name__}'
+            actual = f'{type(self.config).__module__}.{type(self.config).__name__}'
             raise GenkitError(
                 status='INVALID_ARGUMENT',
-                message=f'config must be an instance of {self.config_schema.__name__}, got {config_type}',
+                message=f'{self.name}: config must be an instance of {expected}, got {actual}',
             )
 
 

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from copy import deepcopy
+from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, ClassVar, Generic, cast
 
@@ -47,6 +48,7 @@ from genkit._core._typing import (
     MediaPart,
     MessageData,
     MiddlewareRef,
+    ModelInfo,
     ModelResponseChunk as ModelResponseChunkSchema,
     Operation,
     Part,
@@ -65,16 +67,20 @@ ModelUsage = GenerationUsage  # public name for GenerationUsage
 # TypeVars for generic types
 OutputT = TypeVar('OutputT', default=object)
 ConfigT = TypeVar('ConfigT', bound=ModelConfig, default=ModelConfig)
+# Bound to BaseModel so ModelRef is always parameterized with a concrete Pydantic config schema.
+# Covariant so ModelRef[GeminiConfig] is assignable to ModelRef[BaseModel] or ModelRef[Any].
+ModelRefConfigT = TypeVar('ModelRefConfigT', bound=BaseModel, covariant=True)
 
 
-class ModelRef(BaseModel):
-    """Reference to a model with configuration."""
+@dataclass(frozen=True, kw_only=True)
+class ModelRef(Generic[ModelRefConfigT]):
+    """Frozen reference to a model, optionally tied to a config schema."""
 
     name: str
-    config_schema: object | None = None
-    info: object | None = None
+    config_schema: type[ModelRefConfigT]
+    info: ModelInfo | None = None
     version: str | None = None
-    config: dict[str, object] | None = None
+    config: ModelRefConfigT | None = None
 
 
 class Message(MessageData):

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -88,9 +88,7 @@ class ModelRef(Generic[ModelRefConfigT]):
     __hash__ = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
-        # Schema first: isinstance(config, schema) raises TypeError if schema
-        # isn't a class — the JSON-schema dict a plugin would paste in from
-        # action metadata.
+        # If config_schema is not a BaseModel subclass, raise an error.
         schema = self.config_schema
         if not isinstance(schema, type) or not issubclass(schema, BaseModel):
             got = (
@@ -108,6 +106,13 @@ class ModelRef(Generic[ModelRefConfigT]):
             raise GenkitError(
                 status='INVALID_ARGUMENT',
                 message=f'{self.name}: config must be an instance of {expected}, got {actual}',
+            )
+        # If info is present, validate that it is a ModelInfo and raise an error if not.
+        if self.info is not None and not isinstance(self.info, ModelInfo):
+            actual = f'{type(self.info).__module__}.{type(self.info).__name__}'
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=(f'{self.name}: info must be an instance of {ModelInfo.__module__}.ModelInfo, got {actual}'),
             )
 
 

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -33,6 +33,7 @@ from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
 from genkit._core._base import GenkitModel
+from genkit._core._error import GenkitError
 from genkit._core._extract_json import extract_json
 from genkit._core._typing import (
     Candidate,
@@ -90,8 +91,10 @@ class ModelRef(Generic[ModelRefConfigT]):
         # Catch dicts / wrong types at construction so plugins don't discover
         # the mismatch later when they touch typed config fields.
         if self.config is not None and not isinstance(self.config, self.config_schema):
-            raise TypeError(
-                f'config must be an instance of {self.config_schema.__name__}, got {type(self.config).__name__}'
+            config_type = type(self.config).__name__
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=f'config must be an instance of {self.config_schema.__name__}, got {config_type}',
             )
 
 

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -98,7 +98,8 @@ def test_model_ref_is_unhashable() -> None:
 
 def test_model_ref_invalid_config_type_raises() -> None:
     """ModelRef raises GenkitError(INVALID_ARGUMENT) when config is not an instance of config_schema."""
-    with pytest.raises(GenkitError, match='config must be an instance of CustomConfig'):
+    expected = f'm1: config must be an instance of {CustomConfig.__module__}.CustomConfig, got builtins.dict'
+    with pytest.raises(GenkitError, match=expected):
         model_ref('m1', config_schema=CustomConfig, config={'temperature': 0.7})  # type: ignore[arg-type]
 
 

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -120,6 +120,13 @@ def test_model_ref_invalid_config_schema_does_not_leak_isinstance() -> None:
         )
 
 
+def test_model_ref_invalid_info_type_raises() -> None:
+    """ModelRef raises GenkitError when info is a dict instead of ModelInfo."""
+    expected = f'm1: info must be an instance of {ModelInfo.__module__}.ModelInfo, got builtins.dict'
+    with pytest.raises(GenkitError, match=expected):
+        model_ref('m1', config_schema=CustomConfig, info={'not': 'a ModelInfo'})  # type: ignore[arg-type]
+
+
 def test_model_ref_preserves_version_and_info_metadata() -> None:
     """model_ref() stamps version and ModelInfo metadata on the ModelRef instance."""
     info = ModelInfo(supports=Supports(multiturn=True, media=True))

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -103,6 +103,23 @@ def test_model_ref_invalid_config_type_raises() -> None:
         model_ref('m1', config_schema=CustomConfig, config={'temperature': 0.7})  # type: ignore[arg-type]
 
 
+def test_model_ref_invalid_config_schema_raises() -> None:
+    """ModelRef raises GenkitError when config_schema is not a BaseModel subclass."""
+    expected = 'm1: config_schema must be a BaseModel subclass, got builtins.dict'
+    with pytest.raises(GenkitError, match=expected):
+        model_ref('m1', config_schema={'type': 'object'})  # type: ignore[arg-type]
+
+
+def test_model_ref_invalid_config_schema_does_not_leak_isinstance() -> None:
+    """A dict schema fails as config_schema, not as isinstance() arg 2."""
+    with pytest.raises(GenkitError, match='config_schema must be a BaseModel subclass'):
+        model_ref(
+            'm1',
+            config_schema={'type': 'object'},  # type: ignore[arg-type]
+            config=CustomConfig(temperature=0.7),
+        )
+
+
 def test_model_ref_preserves_version_and_info_metadata() -> None:
     """model_ref() stamps version and ModelInfo metadata on the ModelRef instance."""
     info = ModelInfo(supports=Supports(multiturn=True, media=True))

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -35,7 +35,8 @@ def test_model_ref_with_custom_pydantic_schema() -> None:
     assert isinstance(ref, ModelRef)
     assert ref.name == 'googleai/gemini-pro-latest'
     assert ref.config_schema is CustomConfig
-    assert ref.config is config
+    assert ref.config is not config
+    assert ref.config == config
     assert ref.config is not None
     assert ref.config.temperature == 0.7
     assert ref.config.top_p == 0.9
@@ -140,7 +141,30 @@ def test_model_ref_preserves_version_and_info_metadata() -> None:
 
     assert ref.name == 'googleai/veo-2'
     assert ref.version == '001'
-    assert ref.info is info
+    assert ref.info is not info
+    assert ref.info == info
     assert ref.info is not None
+    assert ref.info.supports is not None
+    assert ref.info.supports.multiturn is True
+
+
+def test_model_ref_isolates_caller_config_and_info() -> None:
+    """Mutating the caller's config or info after construction does not change the ref."""
+    config = CustomConfig(temperature=0.5, safety_settings={'HARM': 'BLOCK_NONE'})
+    info = ModelInfo(label='before', supports=Supports(multiturn=True))
+    ref = model_ref('m1', config_schema=CustomConfig, config=config, info=info)
+
+    config.temperature = 0.9
+    assert config.safety_settings is not None
+    config.safety_settings['HARM'] = 'BLOCK_ALL'
+    info.label = 'after'
+    assert info.supports is not None
+    info.supports.multiturn = False
+
+    assert ref.config is not None
+    assert ref.config.temperature == 0.5
+    assert ref.config.safety_settings == {'HARM': 'BLOCK_NONE'}
+    assert ref.info is not None
+    assert ref.info.label == 'before'
     assert ref.info.supports is not None
     assert ref.info.supports.multiturn is True

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -10,8 +10,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 from pydantic import BaseModel
 
-from genkit._core._typing import ModelInfo, Supports
-from genkit.model import ModelConfig, ModelRef, model_ref
+from genkit.model import ModelConfig, ModelInfo, ModelRef, Supports, model_ref
 
 
 class CustomConfig(BaseModel):
@@ -89,6 +88,19 @@ def test_model_ref_dataclass_value_equality() -> None:
     assert ref1 != 'm1'
 
 
+def test_model_ref_is_unhashable() -> None:
+    """ModelRef opts out of hashing so set/dict use doesn't fail only when config is set."""
+    ref = model_ref('m1', config_schema=CustomConfig, config=CustomConfig(temperature=0.5))
+    with pytest.raises(TypeError, match='unhashable type'):
+        hash(ref)
+
+
+def test_model_ref_invalid_config_type_raises() -> None:
+    """ModelRef raises TypeError when config is not an instance of config_schema."""
+    with pytest.raises(TypeError, match='config must be an instance of CustomConfig'):
+        model_ref('m1', config_schema=CustomConfig, config={'temperature': 0.7})  # type: ignore[arg-type]
+
+
 def test_model_ref_preserves_version_and_info_metadata() -> None:
     """model_ref() stamps version and ModelInfo metadata on the ModelRef instance."""
     info = ModelInfo(supports=Supports(multiturn=True, media=True))
@@ -103,5 +115,6 @@ def test_model_ref_preserves_version_and_info_metadata() -> None:
     assert ref.name == 'googleai/veo-2'
     assert ref.version == '001'
     assert ref.info is info
+    assert ref.info is not None
     assert ref.info.supports is not None
     assert ref.info.supports.multiturn is True

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ModelRef and model_ref()."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from pydantic import BaseModel
+
+from genkit._core._typing import ModelInfo, Supports
+from genkit.model import ModelConfig, ModelRef, model_ref
+
+
+class CustomConfig(BaseModel):
+    """Plugin-specific configuration schema for testing typed ModelRef parameterization."""
+
+    temperature: float | None = None
+    top_p: float | None = None
+    safety_settings: dict[str, str] | None = None
+
+
+def test_model_ref_with_custom_pydantic_schema() -> None:
+    """ModelRef parameterized with a custom Pydantic schema retains typed config_schema and config."""
+    config = CustomConfig(temperature=0.7, top_p=0.9, safety_settings={'HARM': 'BLOCK_NONE'})
+    ref = model_ref(
+        'gemini-pro-latest',
+        namespace='googleai',
+        config_schema=CustomConfig,
+        config=config,
+    )
+
+    assert isinstance(ref, ModelRef)
+    assert ref.name == 'googleai/gemini-pro-latest'
+    assert ref.config_schema is CustomConfig
+    assert ref.config is config
+    assert ref.config is not None
+    assert ref.config.temperature == 0.7
+    assert ref.config.top_p == 0.9
+
+
+def test_model_ref_with_bare_base_model_schema() -> None:
+    """model_ref() accepts arbitrary BaseModel schemas, including bare BaseModel itself."""
+    ref = model_ref('generic-model', config_schema=BaseModel)
+
+    assert isinstance(ref, ModelRef)
+    assert ref.name == 'generic-model'
+    assert ref.config_schema is BaseModel
+    assert ref.config is None
+
+
+def test_model_ref_namespace_prefixing() -> None:
+    """model_ref() prefixes namespace on names and is idempotent for already-prefixed names."""
+    ref1 = model_ref('gemini-pro-latest', namespace='googleai', config_schema=ModelConfig)
+    assert ref1.name == 'googleai/gemini-pro-latest'
+
+    # Already prefixed: should not duplicate namespace
+    ref2 = model_ref('googleai/gemini-pro-latest', namespace='googleai', config_schema=ModelConfig)
+    assert ref2.name == 'googleai/gemini-pro-latest'
+
+
+def test_model_ref_requires_explicit_config_schema() -> None:
+    """model_ref() raises TypeError if config_schema keyword argument is missing."""
+    with pytest.raises(TypeError):
+        model_ref('gemini-pro-latest', namespace='googleai')  # type: ignore[call-arg]
+
+
+def test_model_ref_immutability() -> None:
+    """ModelRef is a frozen dataclass and disallows mutating attributes after creation."""
+    ref = model_ref('custom-model', config_schema=CustomConfig)
+
+    with pytest.raises(FrozenInstanceError):
+        ref.name = 'changed'  # type: ignore[misc]
+
+    with pytest.raises(FrozenInstanceError):
+        ref.config = CustomConfig(temperature=0.1)  # type: ignore[misc]
+
+
+def test_model_ref_dataclass_value_equality() -> None:
+    """ModelRef instances support value-based equality comparison."""
+    ref1 = model_ref('m1', config_schema=CustomConfig, config=CustomConfig(temperature=0.5))
+    ref2 = model_ref('m1', config_schema=CustomConfig, config=CustomConfig(temperature=0.5))
+    ref3 = model_ref('m1', config_schema=CustomConfig, config=CustomConfig(temperature=0.9))
+
+    assert ref1 == ref2
+    assert ref1 != ref3
+    assert ref1 != 'm1'
+
+
+def test_model_ref_preserves_version_and_info_metadata() -> None:
+    """model_ref() stamps version and ModelInfo metadata on the ModelRef instance."""
+    info = ModelInfo(supports=Supports(multiturn=True, media=True))
+    ref = model_ref(
+        'veo-2',
+        config_schema=BaseModel,
+        namespace='googleai',
+        version='001',
+        info=info,
+    )
+
+    assert ref.name == 'googleai/veo-2'
+    assert ref.version == '001'
+    assert ref.info is info
+    assert ref.info.supports is not None
+    assert ref.info.supports.multiturn is True

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -10,6 +10,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 from pydantic import BaseModel
 
+from genkit._core._error import GenkitError
 from genkit.model import ModelConfig, ModelInfo, ModelRef, Supports, model_ref
 
 
@@ -96,8 +97,8 @@ def test_model_ref_is_unhashable() -> None:
 
 
 def test_model_ref_invalid_config_type_raises() -> None:
-    """ModelRef raises TypeError when config is not an instance of config_schema."""
-    with pytest.raises(TypeError, match='config must be an instance of CustomConfig'):
+    """ModelRef raises GenkitError(INVALID_ARGUMENT) when config is not an instance of config_schema."""
+    with pytest.raises(GenkitError, match='config must be an instance of CustomConfig'):
         model_ref('m1', config_schema=CustomConfig, config={'temperature': 0.7})  # type: ignore[arg-type]
 
 


### PR DESCRIPTION
### What this does
Makes ModelRef a typed, immutable reference to a model, generic over its config schema. A plugin can now export refs like gemini_25_flash: ModelRef[GeminiConfig], and users who pass a config of the wrong shape find out immediately — at construction, with a clear error — instead of deep inside a request, or worse, silently.

### For SDK users
```python
from genkit.model import model_ref

ref = model_ref(
    'gemini-2.5-flash',
    namespace='googleai',
    config_schema=GeminiConfig,
    config=GeminiConfig(temperature=0.7),
)
```
Your editor autocompletes `ref.config` when the ref is ModelRef[GeminiConfig], and rejects a dict passed in as config.
Passing a config that isn't an instance of config_schema raises GenkitError with status INVALID_ARGUMENT at construction time, naming the expected and actual types.

Refs are frozen: mutating a field raises FrozenInstanceError, so a ref shared across your codebase can't be changed out from under you. Two refs with the same fields compare equal.

### For plugin authors
Export typed refs alongside your models. ModelRefConfigT is covariant and bound to pydantic.BaseModel, so a ModelRef[GeminiConfig] is assignable wherever a ModelRef[BaseModel] is accepted.

### Breaking changes
model_ref() now requires a config_schema keyword argument, and all arguments after name are keyword-only. Before → after: model_ref('m', namespace='ns') → model_ref('m', namespace='ns', config_schema=MyConfig).
config must be an instance of that schema (previously a plain dict).
ModelRef is now an unhashable frozen dataclass rather than a mutable Pydantic model; use its fields, not .model_dump().

### Notes
This is the foundation PR of a stack extracted from #5854 / the original #5965: it deliberately changes no call sites. Accepting ModelRef at generate(), define_prompt(), and agent surfaces lands separately (#5977), on top of a small helpers PR that carries the config-merge semantics.

### Test plan
py/packages/genkit/tests/genkit/ai/model_ref_test.py covers construction, namespace prefixing, typed-config validation (including the INVALID_ARGUMENT path), frozen-ness, equality, and the missing-kwarg TypeError.