### PR TITLE
feat(py/plugins/amazon-bedrock): add ConverseStream streaming path

### DIFF
--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -2,11 +2,10 @@
 
 Amazon Bedrock plugin for Genkit Python. Provides text generation with
 Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama, Mistral,
-Cohere, and others) through the Bedrock Converse API.
+Cohere, and others) through the Bedrock Converse and ConverseStream APIs.
 
-> Status: in progress. Only non-streaming text generation (Converse) is
-> available so far. Streaming, embedders, image generation, and reranking are
-> still to come.
+> Status: in progress. Text generation is available, streaming and
+> non-streaming. Embedders, image generation, and reranking are still to come.
 
 ## Installation
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -584,7 +584,8 @@ def _coerce_map(value: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]
     return {key: _coerce_value(item, properties.get(key)) for key, item in value.items()}
 
 
-def _coerce_tool_input(name: str, value: Any, tools: list[ToolDefinition] | None) -> Any:  # noqa: ANN401
+def coerce_tool_input(name: str, value: Any, tools: list[ToolDefinition] | None) -> Any:  # noqa: ANN401
+    """Coerces a decoded tool input toward the named tool's declared schema."""
     if not isinstance(value, dict):
         return value
     for tool in tools or []:
@@ -601,19 +602,30 @@ def _reasoning_block_to_part(block: dict[str, Any]) -> Part | None:  # noqa: ANN
         signature = reasoning_text.get('signature')
         if not text and not signature:
             return None
-        return _bedrock_reasoning_part(text, signature, None)
+        return bedrock_reasoning_part(text, signature, None)
     redacted = block.get('redactedContent')
     if redacted is not None:
         if not redacted:
             return None
-        return _bedrock_reasoning_part('', None, redacted)
+        return bedrock_reasoning_part('', None, redacted)
     raise GenkitError(
         message=f'bedrock: unhandled reasoning content variant {sorted(block.keys())!r}',
         status='INTERNAL',
     )
 
 
-def _bedrock_reasoning_part(text: str, signature: str | None, redacted: bytes | None) -> Part:
+def bedrock_reasoning_part(text: str, signature: str | None, redacted: bytes | None) -> Part:
+    """Builds a reasoning part carrying the Bedrock replay metadata.
+
+    Args:
+        text: Reasoning text; empty for a redacted-only part.
+        signature: Signature string, replayed verbatim (it is a string on the
+            Converse wire, never bytes).
+        redacted: Redacted reasoning blob, stored base64-encoded.
+
+    Returns:
+        A Part wrapping a ReasoningPart.
+    """
     metadata: dict[str, Any] = {}
     if signature:
         # Also stored under the generic key so framework-level consumers see it.
@@ -649,7 +661,7 @@ def content_blocks_to_parts(
                         tool_request=ToolRequest(
                             ref=tool_use.get('toolUseId'),
                             name=tool_use.get('name') or '',
-                            input=_coerce_tool_input(tool_use.get('name') or '', tool_input, tools),
+                            input=coerce_tool_input(tool_use.get('name') or '', tool_input, tools),
                         )
                     )
                 )

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
@@ -14,10 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Bedrock model action implementation (Converse API)."""
+"""Bedrock model action implementation (Converse and ConverseStream APIs)."""
 
 import math
 import time
+from collections.abc import AsyncGenerator
+from contextlib import aclosing
 from email.utils import parsedate_to_datetime
 from typing import Any, Protocol
 
@@ -33,9 +35,10 @@ from botocore.exceptions import (
     ReadTimeoutError,
 )
 
-from genkit import ErrorResponseMetadata, ModelRequest, ModelResponse, ModelResponseChunk, Role
+from genkit import ErrorResponseMetadata, ModelRequest, ModelResponse
 from genkit.plugin_api import ActionRunContext, GenkitError, StatusName
 from genkit_amazon_bedrock.converters import build_converse_request, to_model_response
+from genkit_amazon_bedrock.stream import consume_converse_stream
 
 
 class ConverseTransport(Protocol):
@@ -43,6 +46,10 @@ class ConverseTransport(Protocol):
 
     async def converse(self, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
         """Calls the Converse API and returns the raw response dict."""
+        ...
+
+    def converse_stream(self, **kwargs: Any) -> AsyncGenerator[dict[str, Any], None]:  # noqa: ANN401
+        """Calls the ConverseStream API and yields raw event dicts."""
         ...
 
 
@@ -60,6 +67,9 @@ _ERROR_CODE_STATUS: dict[str, StatusName] = {
     'ModelNotReadyException': 'UNAVAILABLE',
     'ServiceUnavailableException': 'UNAVAILABLE',
     'ModelErrorException': 'INTERNAL',
+    'InternalServerException': 'INTERNAL',
+    # Stream-only; botocore surfaces it as an EventStreamError mid-stream.
+    'ModelStreamErrorException': 'INTERNAL',
 }
 
 
@@ -113,28 +123,39 @@ def _retry_after_ms(error: ClientError) -> float | None:
     return None
 
 
-def _from_client_error(error: ClientError) -> GenkitError:
+def _from_client_error(error: ClientError, operation: str = 'converse') -> GenkitError:
     error_info: dict[str, Any] = error.response.get('Error') or {}
     code = error_info.get('Code') or ''
     message = error_info.get('Message') or str(error)
+    prefix = f'bedrock {operation} failed'
     retry_after_ms = _retry_after_ms(error)
     response_metadata: ErrorResponseMetadata | None = None
     if retry_after_ms is not None:
         response_metadata = {'retry_after_ms': retry_after_ms}
     return GenkitError(
-        message=f'bedrock converse failed: {code}: {message}' if code else f'bedrock converse failed: {message}',
-        status=_ERROR_CODE_STATUS.get(code, 'UNKNOWN'),
+        message=f'{prefix}: {code}: {message}' if code else f'{prefix}: {message}',
+        status=_ERROR_CODE_STATUS.get(_normalize_error_code(code), 'UNKNOWN'),
         response_metadata=response_metadata,
     )
 
 
-def _from_botocore_error(error: BotoCoreError) -> GenkitError:
+def _normalize_error_code(code: str) -> str:
+    """Upper-cases the leading letter of an AWS error code.
+
+    Mid-stream failures are named by the event stream's ``:exception-type``
+    header, which is lowerCamelCase (``throttlingException``) where the
+    modelled exception names are UpperCamel.
+    """
+    return code[:1].upper() + code[1:] if code else code
+
+
+def _from_botocore_error(error: BotoCoreError, operation: str = 'converse') -> GenkitError:
     status: StatusName = 'UNKNOWN'
     for error_type, mapped in _BOTOCORE_ERROR_STATUS:
         if isinstance(error, error_type):
             status = mapped
             break
-    return GenkitError(message=f'bedrock converse failed: {error}', status=status)
+    return GenkitError(message=f'bedrock {operation} failed: {error}', status=status)
 
 
 class BedrockModel:
@@ -152,25 +173,44 @@ class BedrockModel:
         self._transport = transport
 
     async def generate(self, request: ModelRequest[Any], ctx: ActionRunContext | None = None) -> ModelResponse:
-        """Runs a non-streaming Converse call.
+        """Runs a Converse or ConverseStream call.
 
         Args:
             request: The Genkit model request.
-            ctx: Action run context; when a streaming callback is attached the
-                full response is emitted as a single chunk until
-                ConverseStream lands in a later slice.
+            ctx: Action run context; a streaming callback routes the call to
+                ConverseStream. Both paths build the same request.
 
         Returns:
             The converted model response.
         """
         converse_kwargs = build_converse_request(self._model_id, request)
+        if ctx is not None and ctx.is_streaming:
+            return await self._generate_stream(converse_kwargs, request, ctx)
         try:
             response = await self._transport.converse(**converse_kwargs)
         except ClientError as e:
             raise _from_client_error(e) from e
         except BotoCoreError as e:
             raise _from_botocore_error(e) from e
-        model_response = to_model_response(response, request)
-        if ctx is not None and ctx.is_streaming and model_response.message is not None:
-            ctx.send_chunk(ModelResponseChunk(role=Role.MODEL, index=0, content=model_response.message.content))
-        return model_response
+        return to_model_response(response, request)
+
+    async def _generate_stream(
+        self,
+        converse_kwargs: dict[str, Any],
+        request: ModelRequest[Any],
+        ctx: ActionRunContext,
+    ) -> ModelResponse:
+        """Streams a ConverseStream call, accumulating the final response.
+
+        The pump runs inside the try so mid-stream failures map like any other
+        AWS error: botocore raises them as EventStreamError, a ClientError
+        subclass. ``aclosing`` guarantees the event stream is closed even when
+        a chunk callback raises.
+        """
+        try:
+            async with aclosing(self._transport.converse_stream(**converse_kwargs)) as events:
+                return await consume_converse_stream(events, request, ctx)
+        except ClientError as e:
+            raise _from_client_error(e, 'converse stream') from e
+        except BotoCoreError as e:
+            raise _from_botocore_error(e, 'converse stream') from e

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -18,8 +18,8 @@
 
 Registers Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama,
 Mistral, Cohere, and others) as Genkit model actions. Text generation uses the
-Bedrock Converse API, non-streaming; streaming, embedders, image generation,
-and reranking are not supported yet.
+Bedrock Converse and ConverseStream APIs; embedders, image generation, and
+reranking are not supported yet.
 """
 
 from typing import TYPE_CHECKING

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
@@ -1,0 +1,237 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ConverseStream event reassembly.
+
+Ported from the Go plugin's ``stream.go``. Bedrock streams a message as
+deltas tagged with a ``contentBlockIndex``; this module accumulates them per
+block, emits Genkit chunks as they arrive, and assembles the final message in
+block order. Request conversion is shared with the non-streaming path.
+"""
+
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from genkit import (
+    FinishReason,
+    Message,
+    ModelRequest,
+    ModelResponse,
+    ModelResponseChunk,
+    Part,
+    Role,
+    TextPart,
+    ToolDefinition,
+    ToolRequest,
+    ToolRequestPart,
+)
+from genkit.plugin_api import ActionRunContext, GenkitError
+from genkit_amazon_bedrock.converters import (
+    bedrock_reasoning_part,
+    coerce_tool_input,
+    map_finish_reason,
+    usage_from_response,
+)
+
+
+@dataclass
+class _StreamBlock:
+    """Accumulated state of one content block across its delta events."""
+
+    text: list[str] = field(default_factory=list)
+    reasoning: list[str] = field(default_factory=list)
+    signature: str | None = None
+    redacted: bytearray = field(default_factory=bytearray)
+    tool_id: str | None = None
+    tool_name: str = ''
+    tool_input: list[str] = field(default_factory=list)
+    is_tool: bool = False
+
+
+async def consume_converse_stream(
+    events: AsyncIterator[dict[str, Any]],
+    request: ModelRequest[Any],
+    ctx: ActionRunContext | None = None,
+) -> ModelResponse:
+    """Reassembles a ConverseStream into a ModelResponse, streaming chunks.
+
+    Chunks are deltas, not snapshots: text and reasoning text are forwarded as
+    they arrive, while a tool call is held back until its block closes because
+    its input arrives as JSON fragments. The framework assigns each chunk's
+    index when it re-wraps them, so the block index is not propagated.
+
+    Args:
+        events: Raw ConverseStream event dicts, in wire order.
+        request: The originating Genkit request; supplies tool schemas and is
+            echoed on the response.
+        ctx: Action run context; chunks are sent only when it is streaming.
+
+    Returns:
+        The assembled model response.
+    """
+    blocks: dict[int, _StreamBlock] = {}
+    stop_reason: str | None = None
+    usage: dict[str, Any] | None = None
+    streaming = ctx is not None and ctx.is_streaming
+
+    async for event in events:
+        if (block_start := event.get('contentBlockStart')) is not None:
+            block = _get_or_init(blocks, _block_index(block_start))
+            # Only a toolUse start carries state; other variants are ignored.
+            tool_use = (block_start.get('start') or {}).get('toolUse')
+            if tool_use is not None:
+                block.is_tool = True
+                block.tool_id = tool_use.get('toolUseId')
+                block.tool_name = tool_use.get('name') or ''
+        elif (block_delta := event.get('contentBlockDelta')) is not None:
+            delta = block_delta.get('delta')
+            if delta is None:
+                continue
+            block = _get_or_init(blocks, _block_index(block_delta))
+            part = _append_delta(block, delta)
+            if part is not None and streaming and ctx is not None:
+                ctx.send_chunk(ModelResponseChunk(role=Role.MODEL, index=0, content=[part]))
+        elif (block_stop := event.get('contentBlockStop')) is not None:
+            index = _block_index(block_stop)
+            block = blocks.get(index)
+            # A tool call is only complete now, so this is its one chunk.
+            if streaming and ctx is not None and block is not None and block.is_tool:
+                ctx.send_chunk(
+                    ModelResponseChunk(
+                        role=Role.MODEL,
+                        index=0,
+                        content=[_tool_block_to_part(index, block, request.tools)],
+                    )
+                )
+        elif (message_stop := event.get('messageStop')) is not None:
+            stop_reason = message_stop.get('stopReason')
+        elif (metadata := event.get('metadata')) is not None:
+            usage = metadata.get('usage')
+        # messageStart and unrecognized events are ignored so new Bedrock
+        # event types don't break streaming.
+
+    parts = _blocks_to_parts(blocks, request.tools)
+    if not parts:
+        parts = [Part(root=TextPart(text=''))]
+    # A stream that ends without messageStop stopped normally; the sync path's
+    # mapping would call that OTHER.
+    finish_reason = map_finish_reason(stop_reason) if stop_reason else FinishReason.STOP
+    return ModelResponse(
+        message=Message(role=Role.MODEL, content=parts),
+        finish_reason=finish_reason,
+        usage=usage_from_response(usage),
+        request=request,
+    )
+
+
+def _block_index(event: dict[str, Any]) -> int:
+    """Reads contentBlockIndex; an absent index means block 0."""
+    index = event.get('contentBlockIndex')
+    return int(index) if index is not None else 0
+
+
+def _get_or_init(blocks: dict[int, _StreamBlock], index: int) -> _StreamBlock:
+    block = blocks.get(index)
+    if block is None:
+        block = _StreamBlock()
+        blocks[index] = block
+    return block
+
+
+def _append_delta(block: _StreamBlock, delta: dict[str, Any]) -> Part | None:
+    """Accumulates one content delta; returns the part to stream, if any."""
+    if (text := delta.get('text')) is not None:
+        block.text.append(text)
+        return Part(root=TextPart(text=text))
+    if (tool_use := delta.get('toolUse')) is not None:
+        block.is_tool = True
+        block.tool_input.append(tool_use.get('input') or '')
+        return None
+    if (reasoning := delta.get('reasoningContent')) is not None:
+        return _append_reasoning_delta(block, reasoning)
+    # Unhandled variants (citation today) are dropped rather than raised on:
+    # Bedrock adds delta variants without notice, and Go's fail-loud default
+    # would kill any stream that used one. The sync path fails loud instead,
+    # because dropping a whole content block would lose model output.
+    return None
+
+
+def _append_reasoning_delta(block: _StreamBlock, delta: dict[str, Any]) -> Part | None:
+    """Accumulates a reasoning delta; only text is streamed as a chunk.
+
+    The signature and redacted blob are needed whole to replay the reasoning
+    on the next turn, so they accumulate silently.
+    """
+    if (text := delta.get('text')) is not None:
+        block.reasoning.append(text)
+        return bedrock_reasoning_part(text, None, None)
+    if (signature := delta.get('signature')) is not None:
+        block.signature = signature
+        return None
+    if (redacted := delta.get('redactedContent')) is not None:
+        block.redacted.extend(redacted)
+    # Unhandled reasoning variants are dropped, as above.
+    return None
+
+
+def _blocks_to_parts(blocks: dict[int, _StreamBlock], tools: list[ToolDefinition] | None) -> list[Part]:
+    """Assembles accumulated blocks into parts in contentBlockIndex order."""
+    parts: list[Part] = []
+    for index in sorted(blocks):
+        block = blocks[index]
+        if block.is_tool:
+            parts.append(_tool_block_to_part(index, block, tools))
+            continue
+        # One block can carry both reasoning and text; reasoning comes first.
+        reasoning = ''.join(block.reasoning)
+        if reasoning or block.redacted:
+            parts.append(bedrock_reasoning_part(reasoning, block.signature, bytes(block.redacted) or None))
+        text = ''.join(block.text)
+        if text:
+            parts.append(Part(root=TextPart(text=text)))
+    return parts
+
+
+def _tool_block_to_part(index: int, block: _StreamBlock, tools: list[ToolDefinition] | None) -> Part:
+    tool_input = _decode_tool_input(index, ''.join(block.tool_input))
+    if tool_input is None:
+        # {} rather than None, matching the sync path: a tool declared with an
+        # input model rejects None, so the two paths would dispatch differently.
+        tool_input = {}
+    if isinstance(tool_input, dict):
+        tool_input = coerce_tool_input(block.tool_name, tool_input, tools)
+    return Part(
+        root=ToolRequestPart(tool_request=ToolRequest(ref=block.tool_id, name=block.tool_name, input=tool_input))
+    )
+
+
+def _decode_tool_input(index: int, raw: str) -> Any:  # noqa: ANN401
+    """Decodes accumulated tool-input fragments; None when none were sent.
+
+    ``json.loads`` rejects trailing data after the JSON value, which is the
+    check Go spells out by hand.
+    """
+    if not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError as e:
+        raise GenkitError(
+            message=f'bedrock: stream tool block {index}: decode tool input: {e}',
+            status='INTERNAL',
+        ) from e

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
@@ -26,6 +26,7 @@ matures without touching converters or models.
 import asyncio
 import os
 import threading
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 from genkit.plugin_api import GenkitError
@@ -44,6 +45,22 @@ NO_REGION_MESSAGE = (
     'bedrock: no AWS region resolved; set Bedrock(region=...), AWS_REGION, '
     'AWS_DEFAULT_REGION, or a region in ~/.aws/config'
 )
+
+# Distinguishes stream exhaustion from a legitimately falsy event.
+_STREAM_DONE = object()
+
+
+def _close_abandoned_stream(call: 'asyncio.Future[dict[str, Any]]') -> None:
+    """Closes an event stream nobody is left to consume.
+
+    A worker thread cannot be interrupted, so a call cancelled in flight still
+    opens a stream; without this it stays open until garbage collection.
+    """
+    if call.cancelled() or call.exception() is not None:
+        return
+    stream = call.result().get('stream')
+    if stream is not None:
+        stream.close()
 
 
 def _botocore_session(session: Any) -> Any:  # noqa: ANN401
@@ -175,6 +192,51 @@ class BedrockTransport:
 
     def _converse_sync(self, kwargs: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
         return self.client().converse(**kwargs)
+
+    async def converse_stream(self, **kwargs: Any) -> AsyncGenerator[dict[str, Any], None]:  # noqa: ANN401
+        """Calls ConverseStream and yields raw event dicts.
+
+        botocore hands back a blocking ``EventStream``, so both the initial
+        call and every ``next()`` cross the thread bridge — a stream idles for
+        seconds between events and must not hold the event loop.
+
+        Args:
+            kwargs: Keyword arguments passed verbatim to ``converse_stream``.
+
+        Yields:
+            One raw event dict per event, e.g. ``{'contentBlockDelta': {...}}``.
+
+        Raises:
+            GenkitError: INTERNAL when the response carries no event stream.
+            botocore.exceptions.EventStreamError: For mid-stream failures; it
+                subclasses ``ClientError``, so callers map it like any other
+                AWS error.
+        """
+        # Shielded so a cancellation here can still close the stream the
+        # uninterruptible worker goes on to open.
+        call = asyncio.ensure_future(asyncio.to_thread(self._converse_stream_sync, kwargs))
+        try:
+            response = await asyncio.shield(call)
+        except asyncio.CancelledError:
+            call.add_done_callback(_close_abandoned_stream)
+            raise
+        stream = response.get('stream')
+        if stream is None:
+            raise GenkitError(message='bedrock: converse stream response has no stream', status='INTERNAL')
+        events = iter(stream)
+        try:
+            while True:
+                event: Any = await asyncio.to_thread(next, events, _STREAM_DONE)
+                if event is _STREAM_DONE:
+                    return
+                yield event
+        finally:
+            # Called inline rather than through the bridge: it is a socket
+            # teardown, and awaiting here would be re-cancelled on cancellation.
+            stream.close()
+
+    def _converse_stream_sync(self, kwargs: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
+        return self.client().converse_stream(**kwargs)
 
     def _resolve_region(self, session: Any) -> str:  # noqa: ANN401
         # botocore only began reading AWS_REGION in 1.41, above this package's

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -33,6 +33,7 @@ from genkit_amazon_bedrock.models import BedrockModel
 from genkit_amazon_bedrock.transport import BedrockTransport
 
 from genkit import FinishReason, Message, ModelRequest, Part, Role, TextPart, ToolDefinition
+from genkit.plugin_api import ActionRunContext
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -65,6 +66,11 @@ def text_request(text: str, **kwargs) -> ModelRequest:
     )
 
 
+def streaming_ctx() -> tuple[ActionRunContext, list]:
+    chunks: list = []
+    return ActionRunContext(streaming_callback=chunks.append), chunks
+
+
 def undocumented_weather_tool() -> ToolDefinition:
     # No description on purpose: Bedrock rejects an empty one, and a Genkit
     # tool declared without a docstring arrives that way.
@@ -86,6 +92,20 @@ async def test_nova_sync() -> None:
     assert response.message.content[0].root.text
     assert response.usage is not None
     assert response.usage.input_tokens is not None and response.usage.input_tokens > 0
+
+
+async def test_nova_stream() -> None:
+    ctx, chunks = streaming_ctx()
+    response = await make_model(NOVA).generate(text_request('Count from 1 to 5, one number per line.'), ctx)
+
+    assert len(chunks) > 1, 'expected the response to arrive as multiple deltas'
+    streamed = ''.join(chunk.content[0].root.text or '' for chunk in chunks)
+    assert response.message is not None
+    # Deltas, not snapshots: concatenating them must reproduce the final text.
+    assert streamed == response.message.content[0].root.text
+    assert response.finish_reason == FinishReason.STOP
+    assert response.usage is not None
+    assert response.usage.output_tokens is not None and response.usage.output_tokens > 0
 
 
 async def test_undocumented_tool_round_trip() -> None:
@@ -124,6 +144,32 @@ async def test_undocumented_tool_round_trip() -> None:
         tools=[weather],
     )
     assert (await make_model(NOVA).generate(follow_up)).message is not None
+
+
+async def test_undocumented_tool_stream() -> None:
+    weather = undocumented_weather_tool()
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='What is the weather in Lagos?'))])],
+        tools=[weather],
+        config=BedrockConfig(tool_choice='get_weather'),
+    )
+    ctx, chunks = streaming_ctx()
+    response = await make_model(NOVA).generate(request, ctx)
+
+    # Tool input arrives as JSON fragments, so it is held back and emitted
+    # once, whole, when the content block closes.
+    tool_chunks = [
+        chunk.content[0].root.tool_request for chunk in chunks if chunk.content[0].root.tool_request is not None
+    ]
+    assert len(tool_chunks) == 1
+    assert tool_chunks[0].name == 'get_weather'
+    assert tool_chunks[0].ref
+    assert isinstance(tool_chunks[0].input, dict) and tool_chunks[0].input.get('city')
+
+    assert response.message is not None
+    final = [part.root.tool_request for part in response.message.content if part.root.tool_request is not None]
+    assert len(final) == 1
+    assert final[0].input == tool_chunks[0].input
 
 
 async def test_claude_sync_without_config() -> None:
@@ -166,6 +212,45 @@ async def test_claude_reasoning_signature_round_trip() -> None:
     )
     follow_up_response = await model.generate(follow_up)
     assert follow_up_response.finish_reason == FinishReason.STOP
+
+
+async def test_claude_thinking_stream() -> None:
+    config = BedrockConfig(
+        max_tokens=4096,
+        additional_model_request_fields={'thinking': {'type': 'enabled', 'budget_tokens': 1024}},
+    )
+    ctx, chunks = streaming_ctx()
+    response = await make_model(CLAUDE).generate(text_request('What is 17 * 23? Think it through.', config=config), ctx)
+
+    assert any(getattr(chunk.content[0].root, 'reasoning', None) for chunk in chunks), (
+        'expected reasoning deltas on a thinking-enabled stream'
+    )
+    assert response.message is not None
+    reasoning_parts = [
+        part.root for part in response.message.content if getattr(part.root, 'reasoning', None) is not None
+    ]
+    assert reasoning_parts
+    assert reasoning_parts[0].metadata is not None
+    # The signature arrives in its own delta, which streams nothing, so this
+    # only passes if reassembly kept it.
+    assert reasoning_parts[0].metadata.get(REASONING_SIGNATURE_METADATA_KEY)
+
+
+async def test_deepseek_reasoning_stream() -> None:
+    ctx, chunks = streaming_ctx()
+    response = await make_model(DEEPSEEK).generate(
+        text_request('What is 17 * 23? Think it through.', config=BedrockConfig(max_tokens=2048)), ctx
+    )
+
+    assert any(getattr(chunk.content[0].root, 'reasoning', None) for chunk in chunks)
+    assert response.message is not None
+    reasoning_parts = [
+        part.root for part in response.message.content if getattr(part.root, 'reasoning', None) is not None
+    ]
+    assert reasoning_parts
+    # Unsigned reasoning: this model sends no signature delta at all.
+    metadata = reasoning_parts[0].metadata
+    assert metadata is None or not metadata.get(REASONING_SIGNATURE_METADATA_KEY)
 
 
 async def test_deepseek_reasoning_sync_and_round_trip() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -216,7 +216,7 @@ async def test_claude_reasoning_signature_round_trip() -> None:
 
 async def test_claude_thinking_stream() -> None:
     config = BedrockConfig(
-        max_tokens=4096,
+        max_output_tokens=4096,
         additional_model_request_fields={'thinking': {'type': 'enabled', 'budget_tokens': 1024}},
     )
     ctx, chunks = streaming_ctx()
@@ -239,7 +239,7 @@ async def test_claude_thinking_stream() -> None:
 async def test_deepseek_reasoning_stream() -> None:
     ctx, chunks = streaming_ctx()
     response = await make_model(DEEPSEEK).generate(
-        text_request('What is 17 * 23? Think it through.', config=BedrockConfig(max_tokens=2048)), ctx
+        text_request('What is 17 * 23? Think it through.', config=BedrockConfig(max_output_tokens=2048)), ctx
     )
 
     assert any(getattr(chunk.content[0].root, 'reasoning', None) for chunk in chunks)

--- a/py/packages/genkit-amazon-bedrock/tests/models_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/models_test.py
@@ -16,6 +16,7 @@
 
 """Tests for the BedrockModel generate orchestration (no AWS involved)."""
 
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
@@ -24,6 +25,7 @@ from botocore.exceptions import (
     ClientError,
     ConnectTimeoutError,
     EndpointConnectionError,
+    EventStreamError,
     NoCredentialsError,
     NoRegionError,
     ParamValidationError,
@@ -39,16 +41,34 @@ from genkit.plugin_api import ActionRunContext, GenkitError
 class FakeTransport:
     """Stands in for BedrockTransport; records the Converse kwargs."""
 
-    def __init__(self, response: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        response: dict[str, Any] | None = None,
+        error: Exception | None = None,
+        stream_events: list[dict[str, Any]] | None = None,
+    ) -> None:
         self.response = response
         self.error = error
+        self.stream_events = stream_events or []
         self.kwargs: dict[str, Any] | None = None
+        self.stream_kwargs: dict[str, Any] | None = None
+        self.stream_closed = False
 
     async def converse(self, **kwargs: Any) -> dict[str, Any]:
         self.kwargs = kwargs
         if self.error is not None:
             raise self.error
         return self.response or {}
+
+    async def converse_stream(self, **kwargs: Any) -> AsyncGenerator[dict[str, Any], None]:
+        self.stream_kwargs = kwargs
+        try:
+            for event in self.stream_events:
+                yield event
+            if self.error is not None:
+                raise self.error
+        finally:
+            self.stream_closed = True
 
 
 def text_request(text: str = 'hello') -> ModelRequest:
@@ -81,22 +101,32 @@ async def test_generate_round_trip() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_context_receives_single_bridge_chunk() -> None:
-    transport = FakeTransport(response=text_response('streamed'))
+async def test_streaming_context_routes_to_converse_stream() -> None:
+    transport = FakeTransport(
+        stream_events=[
+            {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'strea'}}},
+            {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'med'}}},
+            {'messageStop': {'stopReason': 'end_turn'}},
+        ]
+    )
     model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
     chunks = []
-    ctx = ActionRunContext(streaming_callback=chunks.append)
 
-    response = await model.generate(text_request(), ctx)
+    response = await model.generate(text_request(), ActionRunContext(streaming_callback=chunks.append))
 
-    assert len(chunks) == 1
-    assert chunks[0].content[0].root.text == 'streamed'
+    # The streaming path builds the same request as the sync one.
+    assert transport.stream_kwargs is not None
+    assert transport.stream_kwargs['modelId'] == 'amazon.nova-lite-v1:0'
+    assert transport.stream_kwargs['messages'] == [{'role': 'user', 'content': [{'text': 'hello'}]}]
+    assert transport.kwargs is None
+    assert [chunk.content[0].root.text for chunk in chunks] == ['strea', 'med']
     assert response.message is not None
     assert response.message.content[0].root.text == 'streamed'
+    assert transport.stream_closed
 
 
 @pytest.mark.asyncio
-async def test_non_streaming_context_sends_no_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_non_streaming_context_uses_converse_and_sends_no_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
     transport = FakeTransport(response=text_response())
     model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
     ctx = ActionRunContext()
@@ -108,6 +138,8 @@ async def test_non_streaming_context_sends_no_chunks(monkeypatch: pytest.MonkeyP
     await model.generate(text_request(), ctx)
 
     assert sent == []
+    assert transport.kwargs is not None
+    assert transport.stream_kwargs is None
 
 
 ENDPOINT = 'https://bedrock-runtime.us-east-1.amazonaws.com'
@@ -224,3 +256,70 @@ async def test_missing_or_unparseable_retry_after_is_omitted(headers: dict[str, 
 
     assert genkit_error.status == 'RESOURCE_EXHAUSTED'
     assert genkit_error.response_metadata is None
+
+
+# Mid-stream failures are named by the event stream's ``:exception-type``
+# header, which is lowerCamelCase where the modelled exception names are not.
+@pytest.mark.parametrize(
+    'code,expected_status',
+    [
+        ('throttlingException', 'RESOURCE_EXHAUSTED'),
+        ('validationException', 'INVALID_ARGUMENT'),
+        ('internalServerException', 'INTERNAL'),
+        ('serviceUnavailableException', 'UNAVAILABLE'),
+        ('modelStreamErrorException', 'INTERNAL'),
+        ('someFutureException', 'UNKNOWN'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_mid_stream_errors_map_to_genkit_statuses(code: str, expected_status: str) -> None:
+    error = EventStreamError({'Error': {'Code': code, 'Message': 'nope'}}, 'ConverseStream')
+    transport = FakeTransport(
+        error=error,
+        stream_events=[{'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'partial'}}}],
+    )
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
+    chunks = []
+
+    with pytest.raises(GenkitError) as excinfo:
+        await model.generate(text_request(), ActionRunContext(streaming_callback=chunks.append))
+
+    assert excinfo.value.status == expected_status
+    assert 'bedrock converse stream failed' in excinfo.value.original_message
+    assert excinfo.value.__cause__ is error
+    # Chunks already delivered stand; the stream is closed on the way out.
+    assert len(chunks) == 1
+    assert transport.stream_closed
+
+
+@pytest.mark.asyncio
+async def test_stream_botocore_errors_map_to_genkit_statuses() -> None:
+    error = ReadTimeoutError(endpoint_url='https://bedrock-runtime.us-east-1.amazonaws.com')
+    transport = FakeTransport(error=error)
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
+
+    with pytest.raises(GenkitError) as excinfo:
+        await model.generate(text_request(), ActionRunContext(streaming_callback=lambda _chunk: None))
+
+    assert excinfo.value.status == 'DEADLINE_EXCEEDED'
+    assert 'bedrock converse stream failed' in excinfo.value.original_message
+    assert transport.stream_closed
+
+
+@pytest.mark.asyncio
+async def test_stream_is_closed_when_a_chunk_callback_raises() -> None:
+    def explode(_chunk: Any) -> None:  # noqa: ANN401
+        raise RuntimeError('callback failed')
+
+    transport = FakeTransport(
+        stream_events=[
+            {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'hi'}}},
+            {'messageStop': {'stopReason': 'end_turn'}},
+        ]
+    )
+    model = BedrockModel(model_id='amazon.nova-lite-v1:0', transport=transport)
+
+    with pytest.raises(RuntimeError, match='callback failed'):
+        await model.generate(text_request(), ActionRunContext(streaming_callback=explode))
+
+    assert transport.stream_closed

--- a/py/packages/genkit-amazon-bedrock/tests/request_validation_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/request_validation_test.py
@@ -20,6 +20,10 @@ Several Converse fields are ``NonEmptyString`` (``min: 1``) and botocore
 enforces that client-side, so an empty value fails the call before it reaches
 AWS. These tests run the real validator over the request builder's output, which
 catches that whole class of defect without credentials or network access.
+
+Every request is validated against both Converse and ConverseStream: one
+builder feeds both operations, so a field that only one of them models would
+otherwise fail client-side on the streaming path alone.
 """
 
 import base64
@@ -40,18 +44,25 @@ from genkit import (
     ToolDefinition,
 )
 
-CONVERSE_INPUT_SHAPE = (
-    botocore.session.get_session().get_service_model('bedrock-runtime').operation_model('Converse').input_shape
-)
+_SERVICE_MODEL = botocore.session.get_session().get_service_model('bedrock-runtime')
+CONVERSE_INPUT_SHAPES = {
+    operation: _SERVICE_MODEL.operation_model(operation).input_shape for operation in ('Converse', 'ConverseStream')
+}
 
 PNG_B64 = base64.b64encode(b'\x89PNG\r\n\x1a\nfakeimagedata').decode()
+
+
+def assert_valid_request(kwargs: dict) -> None:
+    """Asserts botocore accepts every parameter, for both operations."""
+    for operation, shape in CONVERSE_INPUT_SHAPES.items():
+        report = ParamValidator().validate(kwargs, shape)
+        assert not report.has_errors(), f'{operation}: {report.generate_report()}'
 
 
 def assert_valid_converse_request(request: ModelRequest) -> dict:
     """Builds the request and asserts botocore accepts every parameter."""
     kwargs = build_converse_request('amazon.nova-lite-v1:0', request)
-    report = ParamValidator().validate(kwargs, CONVERSE_INPUT_SHAPE)
-    assert not report.has_errors(), report.generate_report()
+    assert_valid_request(kwargs)
     return kwargs
 
 
@@ -165,6 +176,4 @@ def test_inference_config_passes_validation(model_id: str) -> None:
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
         config=BedrockConfig(temperature=0.0, top_p=0.9, max_output_tokens=256, stop_sequences=['STOP']),
     )
-    kwargs = build_converse_request(model_id, request)
-    report = ParamValidator().validate(kwargs, CONVERSE_INPUT_SHAPE)
-    assert not report.has_errors(), report.generate_report()
+    assert_valid_request(build_converse_request(model_id, request))

--- a/py/packages/genkit-amazon-bedrock/tests/stream_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/stream_test.py
@@ -1,0 +1,353 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ConverseStream event reassembly (no AWS involved)."""
+
+import base64
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from genkit_amazon_bedrock.converters import (
+    REASONING_SIGNATURE_METADATA_KEY,
+    REDACTED_CONTENT_METADATA_KEY,
+    to_model_response,
+)
+from genkit_amazon_bedrock.stream import consume_converse_stream
+
+from genkit import FinishReason, Message, ModelRequest, Part, Role, TextPart, ToolDefinition
+from genkit.plugin_api import ActionRunContext, GenkitError
+
+pytestmark = pytest.mark.asyncio
+
+
+async def events(*items: dict[str, Any]) -> AsyncIterator[dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+def text_request(text: str = 'hello', **kwargs: Any) -> ModelRequest:
+    return ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=text))])],
+        **kwargs,
+    )
+
+
+def text_delta(index: int, text: str) -> dict[str, Any]:
+    return {'contentBlockDelta': {'contentBlockIndex': index, 'delta': {'text': text}}}
+
+
+def reasoning_delta(index: int, delta: dict[str, Any]) -> dict[str, Any]:
+    return {'contentBlockDelta': {'contentBlockIndex': index, 'delta': {'reasoningContent': delta}}}
+
+
+def tool_start(index: int, tool_use_id: str, name: str) -> dict[str, Any]:
+    return {
+        'contentBlockStart': {
+            'contentBlockIndex': index,
+            'start': {'toolUse': {'toolUseId': tool_use_id, 'name': name}},
+        }
+    }
+
+
+def tool_delta(index: int, fragment: str) -> dict[str, Any]:
+    return {'contentBlockDelta': {'contentBlockIndex': index, 'delta': {'toolUse': {'input': fragment}}}}
+
+
+def tool_stop(index: int) -> dict[str, Any]:
+    return {'contentBlockStop': {'contentBlockIndex': index}}
+
+
+def message_stop(stop_reason: str) -> dict[str, Any]:
+    return {'messageStop': {'stopReason': stop_reason}}
+
+
+def metadata(usage: dict[str, Any]) -> dict[str, Any]:
+    return {'metadata': {'usage': usage}}
+
+
+def streaming_ctx() -> tuple[ActionRunContext, list[Any]]:
+    chunks: list[Any] = []
+    return ActionRunContext(streaming_callback=chunks.append), chunks
+
+
+async def test_text_deltas_stream_and_accumulate() -> None:
+    ctx, chunks = streaming_ctx()
+    request = text_request()
+
+    response = await consume_converse_stream(
+        events(
+            {'messageStart': {'role': 'assistant'}},
+            text_delta(0, 'hel'),
+            text_delta(0, 'lo'),
+            metadata({'inputTokens': 3, 'outputTokens': 2, 'totalTokens': 5}),
+            message_stop('end_turn'),
+        ),
+        request,
+        ctx,
+    )
+
+    assert [chunk.content[0].root.text for chunk in chunks] == ['hel', 'lo']
+    assert all(chunk.role == Role.MODEL for chunk in chunks)
+    assert response.message is not None
+    assert [part.root.text for part in response.message.content] == ['hello']
+    assert response.finish_reason == FinishReason.STOP
+    assert response.usage is not None
+    assert response.usage.total_tokens == 5
+    assert response.request is request
+
+
+async def test_missing_message_stop_finishes_as_stop() -> None:
+    response = await consume_converse_stream(events(text_delta(0, 'hi')), text_request())
+
+    # The sync path maps an empty stop reason to OTHER; a truncated stream did
+    # not tell us anything went wrong.
+    assert response.finish_reason == FinishReason.STOP
+
+
+async def test_max_tokens_stop_reason_maps_to_length() -> None:
+    response = await consume_converse_stream(
+        events(text_delta(0, 'hi'), message_stop('max_tokens')),
+        text_request(),
+    )
+
+    assert response.finish_reason == FinishReason.LENGTH
+
+
+async def test_absent_block_index_defaults_to_zero() -> None:
+    response = await consume_converse_stream(
+        events(
+            {'contentBlockDelta': {'delta': {'text': 'a'}}},
+            text_delta(0, 'b'),
+        ),
+        text_request(),
+    )
+
+    assert response.message is not None
+    assert [part.root.text for part in response.message.content] == ['ab']
+
+
+async def test_blocks_assemble_in_index_order() -> None:
+    response = await consume_converse_stream(
+        events(
+            text_delta(1, 'second'),
+            text_delta(0, 'first'),
+            message_stop('end_turn'),
+        ),
+        text_request(),
+    )
+
+    assert response.message is not None
+    assert [part.root.text for part in response.message.content] == ['first', 'second']
+
+
+async def test_empty_stream_returns_empty_text_placeholder() -> None:
+    response = await consume_converse_stream(events(), text_request())
+
+    assert response.message is not None
+    assert len(response.message.content) == 1
+    assert response.message.content[0].root.text == ''
+
+
+async def test_unknown_events_and_deltas_are_ignored() -> None:
+    ctx, chunks = streaming_ctx()
+
+    response = await consume_converse_stream(
+        events(
+            {'someFutureEvent': {'whatever': True}},
+            {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'citation': {'title': 'a'}}}},
+            {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': None}},
+            text_delta(0, 'ok'),
+            message_stop('end_turn'),
+        ),
+        text_request(),
+        ctx,
+    )
+
+    assert [chunk.content[0].root.text for chunk in chunks] == ['ok']
+    assert response.message is not None
+    assert [part.root.text for part in response.message.content] == ['ok']
+
+
+async def test_tool_use_fragments_emit_one_chunk_on_block_stop() -> None:
+    ctx, chunks = streaming_ctx()
+    request = text_request(
+        tools=[
+            ToolDefinition(
+                name='get_weather',
+                description='Get the weather',
+                input_schema={
+                    'type': 'object',
+                    'properties': {'location': {'type': 'string'}, 'count': {'type': 'integer'}},
+                },
+            )
+        ]
+    )
+
+    response = await consume_converse_stream(
+        events(
+            tool_start(0, 'call_1', 'get_weather'),
+            tool_delta(0, '{"location":"NYC",'),
+            tool_delta(0, '"count":"42"}'),
+            tool_stop(0),
+            message_stop('tool_use'),
+        ),
+        request,
+        ctx,
+    )
+
+    assert len(chunks) == 1
+    streamed = chunks[0].content[0].root.tool_request
+    assert streamed.name == 'get_weather'
+    assert streamed.ref == 'call_1'
+    # Coerced against the declared schema, like the sync path.
+    assert streamed.input == {'location': 'NYC', 'count': 42}
+    assert response.finish_reason == FinishReason.STOP
+    assert response.message is not None
+    final = response.message.content[0].root.tool_request
+    assert final is not None
+    assert final.input == {'location': 'NYC', 'count': 42}
+
+
+async def test_tool_block_without_input_matches_the_sync_path() -> None:
+    stream_response = await consume_converse_stream(
+        events(tool_start(0, 'call_1', 'noop'), tool_stop(0), message_stop('tool_use')),
+        text_request(),
+    )
+    # The same response, unstreamed. Both paths must dispatch identically: a
+    # tool declared with an input model accepts {} and rejects None.
+    sync_response = to_model_response(
+        {
+            'output': {
+                'message': {'role': 'assistant', 'content': [{'toolUse': {'toolUseId': 'call_1', 'name': 'noop'}}]}
+            },
+            'stopReason': 'tool_use',
+        },
+        text_request(),
+    )
+
+    assert stream_response.message is not None
+    assert sync_response.message is not None
+    streamed = stream_response.message.content[0].root.tool_request
+    synced = sync_response.message.content[0].root.tool_request
+    assert streamed is not None and synced is not None
+    assert streamed.input == synced.input == {}
+
+
+async def test_malformed_tool_input_raises() -> None:
+    ctx, chunks = streaming_ctx()
+
+    with pytest.raises(GenkitError) as excinfo:
+        await consume_converse_stream(
+            events(tool_start(0, 'call_1', 'get_weather'), tool_delta(0, '{not valid'), tool_stop(0)),
+            text_request(),
+            ctx,
+        )
+
+    assert 'stream tool block 0' in excinfo.value.original_message
+    assert chunks == []
+
+
+async def test_trailing_data_after_tool_input_raises() -> None:
+    with pytest.raises(GenkitError) as excinfo:
+        await consume_converse_stream(
+            events(tool_start(0, 'call_1', 'get_weather'), tool_delta(0, '{"ok":true} {"extra":true}'), tool_stop(0)),
+            text_request(),
+        )
+
+    assert 'stream tool block 0' in excinfo.value.original_message
+
+
+async def test_content_block_stop_for_unknown_index_is_a_noop() -> None:
+    ctx, chunks = streaming_ctx()
+
+    response = await consume_converse_stream(events(tool_stop(7), message_stop('end_turn')), text_request(), ctx)
+
+    assert chunks == []
+    assert response.message is not None
+    assert response.message.content[0].root.text == ''
+
+
+async def test_reasoning_text_streams_and_signature_accumulates() -> None:
+    ctx, chunks = streaming_ctx()
+
+    response = await consume_converse_stream(
+        events(
+            reasoning_delta(0, {'text': 'think'}),
+            reasoning_delta(0, {'text': 'ing'}),
+            reasoning_delta(0, {'signature': 'sig-abc'}),
+            text_delta(0, 'answer'),
+            message_stop('end_turn'),
+        ),
+        text_request(),
+        ctx,
+    )
+
+    # Signature deltas are accumulated only; they carry no user-visible text.
+    assert [chunk.content[0].root.reasoning for chunk in chunks[:2]] == ['think', 'ing']
+    assert len(chunks) == 3
+    assert chunks[2].content[0].root.text == 'answer'
+
+    assert response.message is not None
+    reasoning_part, text_part = response.message.content
+    assert reasoning_part.root.reasoning == 'thinking'
+    assert reasoning_part.root.metadata is not None
+    assert reasoning_part.root.metadata[REASONING_SIGNATURE_METADATA_KEY] == 'sig-abc'
+    assert text_part.root.text == 'answer'
+
+
+async def test_redacted_reasoning_accumulates_as_base64_without_chunks() -> None:
+    ctx, chunks = streaming_ctx()
+
+    response = await consume_converse_stream(
+        events(
+            reasoning_delta(0, {'redactedContent': b'\x00\x01'}),
+            reasoning_delta(0, {'redactedContent': b'\x02'}),
+            message_stop('end_turn'),
+        ),
+        text_request(),
+        ctx,
+    )
+
+    assert chunks == []
+    assert response.message is not None
+    part = response.message.content[0].root
+    assert part.reasoning == ''
+    assert part.metadata is not None
+    assert base64.b64decode(part.metadata[REDACTED_CONTENT_METADATA_KEY]) == b'\x00\x01\x02'
+
+
+async def test_non_streaming_context_sends_no_chunks() -> None:
+    response = await consume_converse_stream(
+        events(text_delta(0, 'hi'), tool_start(1, 'call_1', 'noop'), tool_delta(1, '{}'), tool_stop(1)),
+        text_request(),
+        ActionRunContext(),
+    )
+
+    assert response.message is not None
+    assert len(response.message.content) == 2
+
+
+async def test_chunk_callback_error_aborts_the_stream() -> None:
+    def explode(_chunk: Any) -> None:
+        raise RuntimeError('callback failed')
+
+    with pytest.raises(RuntimeError, match='callback failed'):
+        await consume_converse_stream(
+            events(text_delta(0, 'hi')),
+            text_request(),
+            ActionRunContext(streaming_callback=explode),
+        )

--- a/py/packages/genkit-amazon-bedrock/tests/transport_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/transport_test.py
@@ -17,7 +17,8 @@
 """Transport tests: region resolution, client config, and the boto3 bridge.
 
 Client construction needs no credentials, and the bridge tests stand a fake
-client in for boto3 so the real ``converse`` path runs without AWS.
+client in for boto3 so the real ``converse`` and ``converse_stream`` paths run
+without AWS.
 """
 
 import asyncio
@@ -27,7 +28,7 @@ from typing import Any
 import boto3.session
 import pytest
 from botocore.config import Config
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, EventStreamError
 from genkit_amazon_bedrock.transport import BedrockTransport
 
 from genkit.plugin_api import GenkitError
@@ -294,3 +295,189 @@ async def test_ensure_client_builds_off_the_event_loop(monkeypatch: pytest.Monke
     await transport.ensure_client()
 
     assert idents and idents[0] != threading.get_ident()
+
+
+# --- The ConverseStream event pump ------------------------------------------
+
+
+class FakeEventStream:
+    """Stands in for botocore's blocking EventStream.
+
+    ``__iter__`` is a generator, as botocore's is, and each ``next()`` blocks
+    on an event so the test fails if the pump stops crossing the thread bridge.
+    """
+
+    def __init__(self, events: list[dict[str, Any]], error: Exception | None = None) -> None:
+        self._events = events
+        self._error = error
+        self.close_calls = 0
+        self.iter_threads: list[int] = []
+        self._resume = threading.Event()
+        self._resume.set()
+
+    def __iter__(self):  # noqa: ANN204
+        for event in self._events:
+            # Bounded so a transport that stops closing the stream fails the
+            # test instead of parking this worker for the whole run.
+            self._resume.wait(timeout=5)
+            self.iter_threads.append(threading.get_ident())
+            yield event
+        if self._error is not None:
+            raise self._error
+
+    def close(self) -> None:
+        self.close_calls += 1
+        # Releases a worker parked in next(), which is why the real close is
+        # called inline rather than through the bridge.
+        self._resume.set()
+
+    def block(self) -> None:
+        self._resume.clear()
+
+
+class FakeStreamClient:
+    """Minimal bedrock-runtime stand-in returning a FakeEventStream.
+
+    ``gate``, when given, holds the call open so a test can cancel while it is
+    still in flight on its worker thread.
+    """
+
+    def __init__(self, stream: FakeEventStream | None, gate: threading.Event | None = None) -> None:
+        self._stream = stream
+        self._gate = gate
+        self.calls: list[dict[str, Any]] = []
+
+    def converse_stream(self, **kwargs: Any) -> dict[str, Any]:
+        if self._gate is not None:
+            self._gate.wait(timeout=5)
+        self.calls.append(kwargs)
+        return {'stream': self._stream} if self._stream is not None else {}
+
+
+def streaming_transport(
+    events: list[dict[str, Any]] | None = None,
+    error: Exception | None = None,
+    with_stream: bool = True,
+    gate: threading.Event | None = None,
+) -> tuple[BedrockTransport, FakeStreamClient, FakeEventStream | None]:
+    fake_stream = FakeEventStream(events or [], error) if with_stream else None
+    client = FakeStreamClient(fake_stream, gate)
+    transport = make_transport(region='eu-west-1')
+    transport._client = client  # noqa: SLF001
+    return transport, client, fake_stream
+
+
+TEXT_EVENT = {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'hi'}}}
+STOP_EVENT = {'messageStop': {'stopReason': 'end_turn'}}
+
+
+@pytest.mark.asyncio
+async def test_converse_stream_yields_events_in_order_and_closes() -> None:
+    transport, client, stream = streaming_transport([TEXT_EVENT, STOP_EVENT])
+
+    received = [event async for event in transport.converse_stream(modelId='m', messages=[])]
+
+    assert received == [TEXT_EVENT, STOP_EVENT]
+    assert client.calls == [{'modelId': 'm', 'messages': []}]
+    assert stream is not None and stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_converse_stream_runs_the_iterator_off_the_event_loop() -> None:
+    transport, _client, stream = streaming_transport([TEXT_EVENT, STOP_EVENT])
+
+    async for _event in transport.converse_stream(modelId='m'):
+        pass
+
+    # One missed bridge freezes the loop for the minutes a generation can take.
+    assert stream is not None
+    assert stream.iter_threads and threading.get_ident() not in stream.iter_threads
+
+
+@pytest.mark.asyncio
+async def test_converse_stream_propagates_mid_stream_errors_and_closes() -> None:
+    error = EventStreamError({'Error': {'Code': 'modelStreamErrorException', 'Message': 'boom'}}, 'ConverseStream')
+    transport, _client, stream = streaming_transport([TEXT_EVENT], error=error)
+    received = []
+
+    with pytest.raises(EventStreamError) as excinfo:
+        async for event in transport.converse_stream(modelId='m'):
+            received.append(event)
+
+    assert excinfo.value is error
+    # Events delivered before the failure stand.
+    assert received == [TEXT_EVENT]
+    assert stream is not None and stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_converse_stream_closes_when_the_consumer_stops_early() -> None:
+    transport, _client, stream = streaming_transport([TEXT_EVENT, STOP_EVENT])
+
+    generator = transport.converse_stream(modelId='m')
+    async for _event in generator:
+        break
+    await generator.aclose()
+
+    assert stream is not None and stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_converse_stream_closes_when_cancelled_mid_pump() -> None:
+    transport, _client, stream = streaming_transport([TEXT_EVENT, STOP_EVENT])
+    assert stream is not None
+    first_event = asyncio.Event()
+
+    async def consume() -> None:
+        async for _event in transport.converse_stream(modelId='m'):
+            # Parks the next worker in next() so the cancel lands mid-pump.
+            stream.block()
+            first_event.set()
+
+    task = asyncio.ensure_future(consume())
+    await asyncio.wait_for(first_event.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_converse_stream_closes_when_cancelled_during_the_initial_call() -> None:
+    # A worker thread cannot be interrupted, so the call still opens a stream
+    # after the consumer is gone; it has to be closed on their behalf.
+    released = threading.Event()
+    transport, _client, stream = streaming_transport([TEXT_EVENT], gate=released)
+    assert stream is not None
+
+    async def consume() -> None:
+        async for _event in transport.converse_stream(modelId='m'):
+            pass
+
+    task = asyncio.ensure_future(consume())
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert stream.close_calls == 0, 'the call has not returned yet'
+
+    released.set()
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if stream.close_calls:
+            break
+
+    assert stream.close_calls == 1
+    assert stream.iter_threads == [], 'no events should be consumed after cancellation'
+
+
+@pytest.mark.asyncio
+async def test_converse_stream_without_a_stream_member_fails_loudly() -> None:
+    transport, _client, _stream = streaming_transport(with_stream=False)
+
+    with pytest.raises(GenkitError, match='no stream') as excinfo:
+        async for _event in transport.converse_stream(modelId='m'):
+            pass
+
+    assert excinfo.value.status == 'INTERNAL'

--- a/py/samples/amazon-bedrock-sample/README.md
+++ b/py/samples/amazon-bedrock-sample/README.md
@@ -1,7 +1,8 @@
 # Amazon Bedrock
 
-Run text generation, structured output, tool calling, and reasoning through
-Genkit with Amazon Bedrock's Converse API.
+Run text generation, streaming, structured output, tool calling, and
+reasoning through Genkit with Amazon Bedrock's Converse and ConverseStream
+APIs.
 
 You need an AWS account with Amazon Bedrock model access granted for the four
 models the sample uses:
@@ -41,10 +42,18 @@ genkit start -- uv run src/main.py
 Then open [http://localhost:4000](http://localhost:4000) and try:
 
 - `haiku`
+- `haiku_stream`
 - `cat_profile`
 - `weather_report`
+- `weather_report_stream`
 - `reasoning`
 - `thinking`
+- `thinking_stream`
+
+The `*_stream` flows go through ConverseStream. Chunks are deltas rather than
+snapshots, so the Dev UI's streamed output is the concatenation of them; a tool
+call is the exception, arriving whole in one chunk because its arguments come
+over the wire as JSON fragments.
 
 The plugin resolves any Bedrock model ID, inference profile, or ARN on demand,
 so the Dev UI model runner also works with models beyond the four declared

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -14,17 +14,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Amazon Bedrock samples for the non-streaming Converse path.
+"""Amazon Bedrock samples for the Converse and ConverseStream paths.
 
 Needs AWS credentials and a region (``AWS_REGION`` or ``~/.aws/config``) with
-model access granted for the four models below. Streaming is not wired up yet,
-so every flow here is a single Converse call.
+model access granted for the models below. The flows named ``*_stream`` go
+through ConverseStream; the rest are a single Converse call.
 """
 
 from genkit_amazon_bedrock import Bedrock, ModelDefinition
 from pydantic import BaseModel, Field
 
-from genkit import Genkit, ModelResponse, ReasoningPart
+from genkit import ActionRunContext, Genkit, ModelResponse, ReasoningPart
 
 NOVA = 'bedrock/us.amazon.nova-lite-v1:0'
 LLAMA = 'bedrock/us.meta.llama3-3-70b-instruct-v1:0'
@@ -86,6 +86,77 @@ async def haiku(data: TopicInput) -> str:
     """Plain-text generate through Converse."""
     response = await ai.generate(prompt=f'Write a haiku about {data.topic}.')
     return response.text
+
+
+@ai.flow()
+async def haiku_stream(data: TopicInput, ctx: ActionRunContext) -> str:
+    """Plain-text generate through ConverseStream.
+
+    Chunks are deltas, not snapshots, so the full text is the concatenation.
+    """
+    stream_response = ai.generate_stream(prompt=f'Write a haiku about {data.topic}.')
+    chunks: list[str] = []
+    async for chunk in stream_response.stream:
+        if chunk.text:
+            ctx.send_chunk(chunk.text)
+            chunks.append(chunk.text)
+
+    await stream_response.response
+    return ''.join(chunks)
+
+
+@ai.flow()
+async def weather_report_stream(data: CityInput, ctx: ActionRunContext) -> str:
+    """Tool calling over ConverseStream.
+
+    A tool call's arguments arrive as JSON fragments, so unlike text it cannot
+    be forwarded per delta: the whole tool request lands in one chunk when its
+    content block closes.
+    """
+    stream_response = ai.generate_stream(
+        prompt=f'What is the weather in {data.city}? Use the tool, then answer in one sentence.',
+        tools=['current_weather'],
+    )
+    tool_calls: list[str] = []
+    text: list[str] = []
+    async for chunk in stream_response.stream:
+        for part in chunk.content:
+            if part.root.tool_request is not None:
+                tool_calls.append(part.root.tool_request.name)
+        if chunk.text:
+            ctx.send_chunk(chunk.text)
+            text.append(chunk.text)
+
+    await stream_response.response
+    return f'tools called: {tool_calls}\n{"".join(text)}'
+
+
+@ai.flow()
+async def thinking_stream(data: TopicInput, ctx: ActionRunContext) -> dict[str, object]:
+    """Claude extended thinking over ConverseStream.
+
+    Reasoning text streams delta by delta; the signature arrives in its own
+    delta that streams nothing, and is attached to the final reasoning part so
+    it can be replayed on the next turn.
+    """
+    stream_response = ai.generate_stream(
+        model=CLAUDE,
+        prompt=f'What is 17 * 23? Think it through, then state the answer. Mention {data.topic} once.',
+        config={
+            'maxTokens': 4096,
+            'additionalModelRequestFields': {'thinking': {'type': 'enabled', 'budget_tokens': 1024}},
+        },
+    )
+    reasoning_chunks = 0
+    async for chunk in stream_response.stream:
+        for part in chunk.content:
+            if isinstance(part.root, ReasoningPart):
+                reasoning_chunks += 1
+        if chunk.text:
+            ctx.send_chunk(chunk.text)
+
+    summary = _reasoning_summary(await stream_response.response)
+    return {**summary, 'reasoning_chunks': reasoning_chunks}
 
 
 @ai.flow()
@@ -175,6 +246,7 @@ async def main() -> None:
     """Run the lightweight flows once from the CLI."""
     try:
         print(await haiku(TopicInput()))  # noqa: T201
+        print(await haiku_stream(TopicInput()))  # noqa: T201
         print(await weather_report(CityInput()))  # noqa: T201
     except Exception as error:
         # Printed, not raised: in dev mode the Dev UI stays up either way.


### PR DESCRIPTION
Slice 4 of #5820, stacked on #5876.

## Why

The plugin only spoke Converse, so `ai.generate_stream()` against a Bedrock model ran the non-streaming call and handed back the finished response as one chunk. ConverseStream is a separate API with a different shape: a blocking event stream of deltas tagged with `contentBlockIndex` rather than a message snapshot, so it needs its own reassembly.

## Changes

`stream.py` accumulates deltas per block index, emits chunks as they arrive, and assembles the final message in block order. Text and reasoning text forward immediately; a tool call is held back until its block closes, because its input arrives as JSON fragments. Request conversion is shared with the sync path verbatim.

`transport.py` gains `converse_stream`. botocore returns a blocking `EventStream`, so the initial call and every `next()` cross the thread bridge; a stream that idles between events must not hold the loop. The stream is closed on exhaustion, mid-stream error, early break, and cancellation. Also added streaming flows to the sample app.

Three points worth the reasoning:

- Unhandled delta variants are dropped, unlike Go's fail-loud default. Bedrock adds variants without notice and the pinned botocore already carries `citation`, which would kill any stream that used one. The sync path still fails loud there, since dropping a whole content block loses model output.
- A tool call with no arguments yields `{}`, not Go's `nil`, so streamed and non-streamed responses dispatch identically. A tool declared with an input model accepts `{}` and rejects `None`.
- Mid-stream failures arrive as `EventStreamError` carrying a lowerCamelCase code from the `:exception-type` header, where the modelled exception names are UpperCamel, so the code is normalized before the status lookup.

## Verification

Every built request is validated against botocore's own `ConverseStream` input shape, not just `Converse`, so the two stay interchangeable.

## Screenshots
<img width="569" height="438" alt="Screenshot 2026-08-06 at 16 07 23" src="https://github.com/user-attachments/assets/28cd7d92-b4f2-4061-8009-ee17c59ccae8" />
<img width="1010" height="769" alt="Screenshot 2026-08-06 at 16 07 55" src="https://github.com/user-attachments/assets/8f1829df-f662-4e74-8910-b06c3eac4d4b" />
<img width="1014" height="489" alt="Screenshot 2026-08-06 at 16 08 11" src="https://github.com/user-attachments/assets/68b11267-c764-4fc8-a074-c1abcd084719" />
