### PR TITLE
feat(js/plugins/pinecone): attribute Pinecone usage with Genkit sourceTag

### DIFF
--- a/js/plugins/pinecone/package.json
+++ b/js/plugins/pinecone/package.json
@@ -20,7 +20,8 @@
     "compile": "tsup-node",
     "build:clean": "rimraf ./lib",
     "build": "npm-run-all build:clean check compile",
-    "build:watch": "tsup-node --watch"
+    "build:watch": "tsup-node --watch",
+    "test": "node --import tsx --test tests/*_test.ts"
   },
   "repository": {
     "type": "git",
@@ -30,7 +31,7 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@pinecone-database/pinecone": "^2.0.1",
+    "@pinecone-database/pinecone": "^2.2.0",
     "ts-md5": "^1.3.1"
   },
   "peerDependencies": {

--- a/js/plugins/pinecone/src/index.ts
+++ b/js/plugins/pinecone/src/index.ts
@@ -63,6 +63,13 @@ const CONTENT_KEY = '_content';
 const CONTENT_TYPE = '_contentType';
 
 /**
+ * Source tag applied to Pinecone clients created by this plugin so usage is
+ * attributed to the Genkit integration.
+ * @see https://docs.pinecone.io/integrations/build-integration/attribute-usage-to-your-integration
+ */
+export const GENKIT_PINECONE_SOURCE_TAG = 'genkit';
+
+/**
  * pineconeRetrieverRef function creates a retriever for Pinecone.
  * @param params The params for the new Pinecone retriever
  * @param params.indexId The indexId for the Pinecone retriever
@@ -166,7 +173,7 @@ export function configurePineconeRetriever<
   const { indexId, embedder, embedderOptions } = {
     ...params,
   };
-  const pineconeConfig = params.clientParams ?? getDefaultConfig();
+  const pineconeConfig = resolvePineconeConfig(params.clientParams);
   const contentKey = params.contentKey ?? params.textKey ?? CONTENT_KEY;
   const pinecone = new Pinecone(pineconeConfig);
   const index = pinecone.index(indexId);
@@ -247,7 +254,7 @@ export function configurePineconeIndexer<
   const { indexId, embedder, embedderOptions } = {
     ...params,
   };
-  const pineconeConfig = params.clientParams ?? getDefaultConfig();
+  const pineconeConfig = resolvePineconeConfig(params.clientParams);
   const contentKey = params.contentKey ?? params.textKey ?? CONTENT_KEY;
   const pinecone = new Pinecone(pineconeConfig);
   const index = pinecone.index(indexId);
@@ -316,7 +323,7 @@ export async function createPineconeIndex(params: {
   clientParams?: PineconeConfiguration;
   options: CreateIndexOptions;
 }) {
-  const pineconeConfig = params.clientParams ?? getDefaultConfig();
+  const pineconeConfig = resolvePineconeConfig(params.clientParams);
   const pinecone = new Pinecone(pineconeConfig);
   return await pinecone.createIndex(params.options);
 }
@@ -332,7 +339,7 @@ export async function describePineconeIndex(params: {
   clientParams?: PineconeConfiguration;
   name: string;
 }) {
-  const pineconeConfig = params.clientParams ?? getDefaultConfig();
+  const pineconeConfig = resolvePineconeConfig(params.clientParams);
   const pinecone = new Pinecone(pineconeConfig);
   return await pinecone.describeIndex(params.name);
 }
@@ -348,9 +355,23 @@ export async function deletePineconeIndex(params: {
   clientParams?: PineconeConfiguration;
   name: string;
 }) {
-  const pineconeConfig = params.clientParams ?? getDefaultConfig();
+  const pineconeConfig = resolvePineconeConfig(params.clientParams);
   const pinecone = new Pinecone(pineconeConfig);
   return await pinecone.deleteIndex(params.name);
+}
+
+/**
+ * Resolves Pinecone client configuration, always attributing requests to Genkit.
+ * Explicit `clientParams.sourceTag` values are preserved when provided.
+ */
+export function resolvePineconeConfig(
+  clientParams?: PineconeConfiguration
+): PineconeConfiguration {
+  const base = clientParams ?? getDefaultConfig();
+  return {
+    ...base,
+    sourceTag: base.sourceTag ?? GENKIT_PINECONE_SOURCE_TAG,
+  };
 }
 
 function getDefaultConfig() {

--- a/js/plugins/pinecone/tests/config_test.ts
+++ b/js/plugins/pinecone/tests/config_test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { afterEach, describe, it } from 'node:test';
+import {
+  GENKIT_PINECONE_SOURCE_TAG,
+  resolvePineconeConfig,
+} from '../src/index.js';
+
+describe('resolvePineconeConfig', () => {
+  const originalApiKey = process.env.PINECONE_API_KEY;
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env.PINECONE_API_KEY;
+    } else {
+      process.env.PINECONE_API_KEY = originalApiKey;
+    }
+  });
+
+  it('defaults sourceTag to genkit when using env API key', () => {
+    process.env.PINECONE_API_KEY = 'test-key';
+    const config = resolvePineconeConfig();
+    assert.strictEqual(config.apiKey, 'test-key');
+    assert.strictEqual(config.sourceTag, GENKIT_PINECONE_SOURCE_TAG);
+    assert.strictEqual(config.sourceTag, 'genkit');
+  });
+
+  it('defaults sourceTag when clientParams omit it', () => {
+    const config = resolvePineconeConfig({ apiKey: 'explicit-key' });
+    assert.strictEqual(config.apiKey, 'explicit-key');
+    assert.strictEqual(config.sourceTag, GENKIT_PINECONE_SOURCE_TAG);
+  });
+
+  it('preserves an explicit sourceTag from clientParams', () => {
+    const config = resolvePineconeConfig({
+      apiKey: 'explicit-key',
+      sourceTag: 'custom_integration',
+    });
+    assert.strictEqual(config.sourceTag, 'custom_integration');
+  });
+
+  it('preserves other clientParams fields', () => {
+    const config = resolvePineconeConfig({
+      apiKey: 'explicit-key',
+      controllerHostUrl: 'https://example.pinecone.io',
+      additionalHeaders: { 'X-Custom': '1' },
+    });
+    assert.strictEqual(config.controllerHostUrl, 'https://example.pinecone.io');
+    assert.deepStrictEqual(config.additionalHeaders, { 'X-Custom': '1' });
+    assert.strictEqual(config.sourceTag, GENKIT_PINECONE_SOURCE_TAG);
+  });
+
+  it('throws when neither clientParams nor env API key is set', () => {
+    delete process.env.PINECONE_API_KEY;
+    assert.throws(
+      () => resolvePineconeConfig(),
+      /PINECONE_API_KEY/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Set `sourceTag: 'genkit'` on every Pinecone client constructed by the plugin (retriever, indexer, and index helpers) so Pinecone can attribute traffic to the Genkit integration.
- Route all client construction through `resolvePineconeConfig()`, which defaults the tag while preserving an explicit `clientParams.sourceTag` when provided.
- Bump `@pinecone-database/pinecone` to `^2.2.0` (minimum SDK version that supports `sourceTag`) and add unit tests for config resolution.

Fixes #2289

cc @huangjeff5

## Test plan
- [x] `node --import tsx --test tests/*_test.ts` in `js/plugins/pinecone` (5/5 pass)
- [x] `tsc --noEmit` in `js/plugins/pinecone`
- [ ] Confirm Pinecone User-Agent includes `source_tag=genkit` for a live query/upsert via the plugin
