### PR TITLE
docs: align Python and main README taglines to highlight agentic workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Genkit logo](docs/resources/genkit-logo-dark.png#gh-dark-mode-only 'Genkit')
 ![Genkit logo](docs/resources/genkit-logo.png#gh-light-mode-only 'Genkit')
 
-[Genkit](https://genkit.dev) is an open-source framework for building full-stack AI-powered applications, built and used in production by Google's Firebase. It provides SDKs for multiple programming languages with varying levels of stability:
+[Genkit](https://genkit.dev) is an open-source framework for building AI-powered applications and agentic workflows, built and used in production by Google's Firebase. It provides SDKs for multiple programming languages with varying levels of stability:
 
 - **JavaScript/TypeScript**: Production-ready with full feature support
 - **Go**: Production-ready with full feature support

--- a/py/README.md
+++ b/py/README.md
@@ -1,6 +1,6 @@
 # Genkit Python SDK
 
-Build production-ready AI applications in Python with type-safe flows, structured outputs, and integrated observability.
+Build production-ready AI applications and agentic workflows in Python with type-safe flows, structured outputs, and integrated observability.
 
 ## Quick Start
 

--- a/py/packages/genkit/README.md
+++ b/py/packages/genkit/README.md
@@ -1,6 +1,6 @@
 # genkit
 
-Genkit is a framework designed to help you build AI-powered applications and features.
+Genkit is an open-source framework designed to help you build AI-powered applications and agentic workflows.
 It provides open source libraries for Python, Node.js and Go, plus developer tools for testing
 and debugging.
 


### PR DESCRIPTION
## Description
Updates the intro taglines in `README.md`, `py/README.md`, and `py/packages/genkit/README.md` to align with the genkit.dev messaging and highlight building **AI-powered applications and agentic workflows**.

This addresses feedback from @ashaban (GopherCon update) to explicitly mention agentic apps/workflows in the intro.

## Changes
- **`py/README.md`**: "Build production-ready AI applications and agentic workflows in Python..."
- **`py/packages/genkit/README.md`**: "Genkit is an open-source framework designed to help you build AI-powered applications and agentic workflows."
- **`README.md`**: "[Genkit](https://genkit.dev) is an open-source framework for building AI-powered applications and agentic workflows..."