### PR TITLE
feat(py): accept ModelRef on generate, prompt, and agent surfaces

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -19,8 +19,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator, Callable, Sequence
-from typing import Generic
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from typing import Any, Generic
 
 from opentelemetry import trace as trace_api
 
@@ -69,7 +69,7 @@ from genkit._ai._tools import Tool
 from genkit._core._action import Action, ActionKind, ActionRunContext, BidiAction, BidiFn, get_current_context
 from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware
-from genkit._core._model import ModelConfig
+from genkit._core._model import ModelConfig, ModelRef, ModelRefConfigT
 from genkit._core._registry import Registry
 from genkit._core._trace._attrs import metadata_key
 from genkit._core._typing import (
@@ -322,11 +322,11 @@ def define_agent(
     registry: Registry,
     name: str,
     *,
-    model: str | None = None,
+    model: ModelRef[ModelRefConfigT] | str | None = None,
     system: str | list[Part] | None = None,
     tools: Sequence[str | Tool] | None = None,
     use: Sequence[BaseMiddleware | MiddlewareRef] | None = None,
-    config: dict[str, object] | ModelConfig | None = None,
+    config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
     max_turns: int | None = None,
     description: str | None = None,
     metadata: dict[str, object] | None = None,

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -67,9 +67,7 @@ from genkit._ai._model import (
     ModelResponse,
     ModelResponseChunk,
     define_model,
-    normalize_config,
-    resolve_model_name,
-    resolve_model_ref,
+    resolve_call_model,
 )
 from genkit._ai._prompt import (
     ExecutablePrompt,
@@ -164,25 +162,6 @@ def _model_supports_long_running(model_action: Action) -> bool:
         supports = model_dict.get('supports')
         return bool(supports.get('longRunning', False)) if isinstance(supports, dict) else False
     return False
-
-
-def resolve_call_model(
-    *,
-    model: str | ModelRef[BaseModel] | None,
-    config: Mapping[str, Any] | BaseModel | None,
-    registry: Registry,
-    message: str = 'No model configured.',
-) -> tuple[str, Mapping[str, Any] | BaseModel | None]:
-    """Return the wire name and the config to send with this call.
-
-    A ModelRef carries defaults, so those get dumped and overlaid with
-    call-time config. A string name has nothing to merge — the caller's
-    config object is left alone so the plugin still sees that instance.
-    """
-    if isinstance(model, ModelRef):
-        resolved = resolve_model_ref(model=model, config=normalize_config(config=config))
-        return resolved.name, resolved.config
-    return resolve_model_name(model=model, registry=registry, message=message), config
 
 
 class Genkit:

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -66,7 +66,6 @@ from genkit._ai._model import (
     ModelFn,
     ModelResponse,
     ModelResponseChunk,
-    ResolvedModel,
     define_model,
     normalize_config,
     resolve_model_name,
@@ -165,6 +164,25 @@ def _model_supports_long_running(model_action: Action) -> bool:
         supports = model_dict.get('supports')
         return bool(supports.get('longRunning', False)) if isinstance(supports, dict) else False
     return False
+
+
+def resolve_call_model(
+    *,
+    model: str | ModelRef[BaseModel] | None,
+    config: Mapping[str, Any] | BaseModel | None,
+    registry: Registry,
+    message: str = 'No model configured.',
+) -> tuple[str, Mapping[str, Any] | BaseModel | None]:
+    """Return the wire name and the config to send with this call.
+
+    A ModelRef carries defaults, so those get dumped and overlaid with
+    call-time config. A string name has nothing to merge — the caller's
+    config object is left alone so the plugin still sees that instance.
+    """
+    if isinstance(model, ModelRef):
+        resolved = resolve_model_ref(model=model, config=normalize_config(config=config))
+        return resolved.name, resolved.config
+    return resolve_model_name(model=model, registry=registry, message=message), config
 
 
 class Genkit:
@@ -584,7 +602,7 @@ class Genkit:
         *,
         variant: str | None = None,
         model: str | ModelRef[BaseModel] | None = None,
-        config: BaseModel | Mapping[str, Any] | None = None,
+        config: Mapping[str, Any] | BaseModel | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -1051,7 +1069,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: BaseModel | Mapping[str, Any] | None = None,
+        config: Mapping[str, Any] | BaseModel | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1073,16 +1091,9 @@ class Genkit:
         child_registry = self.registry.new_child()
         await register_tools(child_registry, tools)
         refs = register_middleware(child_registry, use)
-        normalized_config = normalize_config(config=config)
-        if isinstance(model, ModelRef):
-            resolved = resolve_model_ref(model=model, config=normalized_config)
-        else:
-            resolved = ResolvedModel(
-                name=resolve_model_name(model=model, registry=child_registry),
-                config=normalized_config,
-            )
+        model_name, model_config = resolve_call_model(model=model, config=config, registry=child_registry)
         prompt_config = PromptConfig(
-            model=resolved.name,
+            model=model_name,
             prompt=prompt,
             system=system,
             messages=messages,
@@ -1092,7 +1103,7 @@ class Genkit:
             resume_respond=resume_respond,
             resume_restart=resume_restart,
             resume_metadata=resume_metadata,
-            config=resolved.config,
+            config=model_config,
             max_turns=max_turns,
             output_format=output_format,
             output_content_type=output_content_type,
@@ -1178,7 +1189,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: BaseModel | Mapping[str, Any] | None = None,
+        config: Mapping[str, Any] | BaseModel | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1199,16 +1210,9 @@ class Genkit:
             child_registry = self.registry.new_child()
             await register_tools(child_registry, tools)
             refs = register_middleware(child_registry, use)
-            normalized_config = normalize_config(config=config)
-            if isinstance(model, ModelRef):
-                resolved = resolve_model_ref(model=model, config=normalized_config)
-            else:
-                resolved = ResolvedModel(
-                    name=resolve_model_name(model=model, registry=child_registry),
-                    config=normalized_config,
-                )
+            model_name, model_config = resolve_call_model(model=model, config=config, registry=child_registry)
             prompt_config = PromptConfig(
-                model=resolved.name,
+                model=model_name,
                 prompt=prompt,
                 system=system,
                 messages=messages,
@@ -1218,7 +1222,7 @@ class Genkit:
                 resume_respond=resume_respond,
                 resume_restart=resume_restart,
                 resume_metadata=resume_metadata,
-                config=resolved.config,
+                config=model_config,
                 max_turns=max_turns,
                 output_format=output_format,
                 output_content_type=output_content_type,
@@ -1425,25 +1429,18 @@ class Genkit:
         docs: list[Document] | None = None,
     ) -> Operation:
         """Generate content using a long-running model, returning an Operation to poll."""
-        # Normalize at the veneer, then check long_running on the wire name.
-        normalized_config = normalize_config(config=config)
-        if isinstance(model, ModelRef):
-            resolved = resolve_model_ref(model=model, config=normalized_config)
-        else:
-            resolved = ResolvedModel(
-                name=resolve_model_name(
-                    model=model,
-                    registry=self.registry,
-                    message='No model specified for generate_operation.',
-                ),
-                config=normalized_config,
-            )
+        model_name, model_config = resolve_call_model(
+            model=model,
+            config=config,
+            registry=self.registry,
+            message='No model specified for generate_operation.',
+        )
 
-        model_action = await self.registry.resolve_model(resolved.name)
+        model_action = await self.registry.resolve_model(model_name)
         if not model_action:
             raise GenkitError(
                 status='NOT_FOUND',
-                message=f"Model '{resolved.name}' not found.",
+                message=f"Model '{model_name}' not found.",
             )
 
         # Check if model supports long-running operations
@@ -1455,14 +1452,14 @@ class Genkit:
 
         # Call generate with already-resolved wire name + config.
         response = await self.generate(
-            model=resolved.name,
+            model=model_name,
             prompt=prompt,
             system=system,
             messages=messages,
             tools=tools,
             return_tool_requests=return_tool_requests,
             tool_choice=tool_choice,
-            config=resolved.config,
+            config=model_config,
             max_turns=max_turns,
             context=context,
             output_schema=output_schema,

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -1439,7 +1439,7 @@ class Genkit:
                 config=normalized_config,
             )
 
-        model_action = await self.registry.resolve_action(ActionKind.MODEL, resolved.name)
+        model_action = await self.registry.resolve_model(resolved.name)
         if not model_action:
             raise GenkitError(
                 status='NOT_FOUND',

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -27,7 +27,7 @@ import signal
 import socket
 import threading
 import uuid
-from collections.abc import Awaitable, Callable, Coroutine, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
 from pathlib import Path
 from typing import Any, TypeVar, cast, overload
 
@@ -66,7 +66,11 @@ from genkit._ai._model import (
     ModelFn,
     ModelResponse,
     ModelResponseChunk,
+    ResolvedModel,
     define_model,
+    normalize_config,
+    resolve_model_name,
+    resolve_model_ref,
 )
 from genkit._ai._prompt import (
     ExecutablePrompt,
@@ -109,7 +113,7 @@ from genkit._core._middleware import (
     GenerateMiddleware,
     _validate_middleware_key_segment,
 )
-from genkit._core._model import Document
+from genkit._core._model import Document, ModelRef, ModelRefConfigT
 from genkit._core._plugin import Plugin
 from genkit._core._protocols import SessionLike
 from genkit._core._reflection import ReflectionServer, ServerSpec, create_reflection_asgi_app
@@ -469,8 +473,8 @@ class Genkit:
         name: str | None = None,
         *,
         variant: str | None = None,
-        model: str | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -497,8 +501,8 @@ class Genkit:
         name: str | None = None,
         *,
         variant: str | None = None,
-        model: str | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -525,8 +529,8 @@ class Genkit:
         name: str | None = None,
         *,
         variant: str | None = None,
-        model: str | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -553,8 +557,8 @@ class Genkit:
         name: str | None = None,
         *,
         variant: str | None = None,
-        model: str | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -579,8 +583,8 @@ class Genkit:
         name: str | None = None,
         *,
         variant: str | None = None,
-        model: str | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        model: str | ModelRef[BaseModel] | None = None,
+        config: BaseModel | Mapping[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -741,11 +745,11 @@ class Genkit:
         self,
         name: str,
         *,
-        model: str | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
         system: str | list[Part] | None = None,
         tools: Sequence[str | Tool] | None = None,
         use: Sequence[BaseMiddleware | MiddlewareRef] | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         max_turns: int | None = None,
         description: str | None = None,
         metadata: dict[str, object] | None = None,
@@ -985,7 +989,7 @@ class Genkit:
     async def generate(
         self,
         *,
-        model: str | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
         prompt: str | list[Part] | None = None,
         system: str | list[Part] | None = None,
         messages: list[Message] | None = None,
@@ -995,7 +999,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type[OutputT],
@@ -1012,7 +1016,7 @@ class Genkit:
     async def generate(
         self,
         *,
-        model: str | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
         prompt: str | list[Part] | None = None,
         system: str | list[Part] | None = None,
         messages: list[Message] | None = None,
@@ -1022,7 +1026,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1037,7 +1041,7 @@ class Genkit:
     async def generate(
         self,
         *,
-        model: str | None = None,
+        model: str | ModelRef[BaseModel] | None = None,
         prompt: str | list[Part] | None = None,
         system: str | list[Part] | None = None,
         messages: list[Message] | None = None,
@@ -1047,7 +1051,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        config: BaseModel | Mapping[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1069,8 +1073,16 @@ class Genkit:
         child_registry = self.registry.new_child()
         await register_tools(child_registry, tools)
         refs = register_middleware(child_registry, use)
+        normalized_config = normalize_config(config=config)
+        if isinstance(model, ModelRef):
+            resolved = resolve_model_ref(model=model, config=normalized_config)
+        else:
+            resolved = ResolvedModel(
+                name=resolve_model_name(model=model, registry=child_registry),
+                config=normalized_config,
+            )
         prompt_config = PromptConfig(
-            model=model,
+            model=resolved.name,
             prompt=prompt,
             system=system,
             messages=messages,
@@ -1080,7 +1092,7 @@ class Genkit:
             resume_respond=resume_respond,
             resume_restart=resume_restart,
             resume_metadata=resume_metadata,
-            config=config,
+            config=resolved.config,
             max_turns=max_turns,
             output_format=output_format,
             output_content_type=output_content_type,
@@ -1102,7 +1114,7 @@ class Genkit:
     def generate_stream(
         self,
         *,
-        model: str | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
         prompt: str | list[Part] | None = None,
         system: str | list[Part] | None = None,
         messages: list[Message] | None = None,
@@ -1112,7 +1124,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type[OutputT],
@@ -1130,7 +1142,7 @@ class Genkit:
     def generate_stream(
         self,
         *,
-        model: str | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
         prompt: str | list[Part] | None = None,
         system: str | list[Part] | None = None,
         messages: list[Message] | None = None,
@@ -1140,7 +1152,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1156,7 +1168,7 @@ class Genkit:
     def generate_stream(
         self,
         *,
-        model: str | None = None,
+        model: str | ModelRef[BaseModel] | None = None,
         prompt: str | list[Part] | None = None,
         system: str | list[Part] | None = None,
         messages: list[Message] | None = None,
@@ -1166,7 +1178,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        config: BaseModel | Mapping[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1187,8 +1199,16 @@ class Genkit:
             child_registry = self.registry.new_child()
             await register_tools(child_registry, tools)
             refs = register_middleware(child_registry, use)
+            normalized_config = normalize_config(config=config)
+            if isinstance(model, ModelRef):
+                resolved = resolve_model_ref(model=model, config=normalized_config)
+            else:
+                resolved = ResolvedModel(
+                    name=resolve_model_name(model=model, registry=child_registry),
+                    config=normalized_config,
+                )
             prompt_config = PromptConfig(
-                model=model,
+                model=resolved.name,
                 prompt=prompt,
                 system=system,
                 messages=messages,
@@ -1198,7 +1218,7 @@ class Genkit:
                 resume_respond=resume_respond,
                 resume_restart=resume_restart,
                 resume_metadata=resume_metadata,
-                config=config,
+                config=resolved.config,
                 max_turns=max_turns,
                 output_format=output_format,
                 output_content_type=output_content_type,
@@ -1386,14 +1406,14 @@ class Genkit:
     async def generate_operation(
         self,
         *,
-        model: str | None = None,
+        model: ModelRef[ModelRefConfigT] | str | None = None,
         prompt: str | list[Part] | None = None,
         system: str | list[Part] | None = None,
         messages: list[Message] | None = None,
         tools: Sequence[str | Tool] | None = None,
         return_tool_requests: bool | None = None,
         tool_choice: ToolChoice | None = None,
-        config: dict[str, object] | ModelConfig | None = None,
+        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1405,19 +1425,25 @@ class Genkit:
         docs: list[Document] | None = None,
     ) -> Operation:
         """Generate content using a long-running model, returning an Operation to poll."""
-        # Resolve the model and check for long_running support
-        resolved_model = model or cast(str | None, self.registry.lookup_value('defaultModel', 'defaultModel'))
-        if not resolved_model:
-            raise GenkitError(
-                status='INVALID_ARGUMENT',
-                message='No model specified for generate_operation.',
+        # Normalize at the veneer, then check long_running on the wire name.
+        normalized_config = normalize_config(config=config)
+        if isinstance(model, ModelRef):
+            resolved = resolve_model_ref(model=model, config=normalized_config)
+        else:
+            resolved = ResolvedModel(
+                name=resolve_model_name(
+                    model=model,
+                    registry=self.registry,
+                    message='No model specified for generate_operation.',
+                ),
+                config=normalized_config,
             )
 
-        model_action = await self.registry.resolve_action(ActionKind.MODEL, resolved_model)
+        model_action = await self.registry.resolve_action(ActionKind.MODEL, resolved.name)
         if not model_action:
             raise GenkitError(
                 status='NOT_FOUND',
-                message=f"Model '{resolved_model}' not found.",
+                message=f"Model '{resolved.name}' not found.",
             )
 
         # Check if model supports long-running operations
@@ -1427,16 +1453,16 @@ class Genkit:
                 message=f"Model '{model_action.name}' does not support long running operations.",
             )
 
-        # Call generate
+        # Call generate with already-resolved wire name + config.
         response = await self.generate(
-            model=model,
+            model=resolved.name,
             prompt=prompt,
             system=system,
             messages=messages,
             tools=tools,
             return_tool_requests=return_tool_requests,
             tool_choice=tool_choice,
-            config=config,
+            config=resolved.config,
             max_turns=max_turns,
             context=context,
             output_schema=output_schema,

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -53,7 +53,7 @@ ModelFn = Callable[[ModelRequest, ActionRunContext], Awaitable[ModelResponse[Any
 
 # Veneer-facing argument shapes. Internals resolve these into ResolvedModel.
 ModelArg: TypeAlias = str | ModelRef[BaseModel]
-ConfigArg: TypeAlias = BaseModel | Mapping[str, Any]
+ConfigArg: TypeAlias = Mapping[str, Any] | BaseModel
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -91,6 +91,14 @@ def normalize_config(*, config: object) -> dict[str, Any]:
     raise TypeError(f'Unsupported config type: {type(config).__name__}')
 
 
+def concrete_config_schema(*candidates: object) -> type[BaseModel] | None:
+    """Return the first concrete BaseModel subclass among candidates."""
+    for candidate in candidates:
+        if isinstance(candidate, type) and issubclass(candidate, BaseModel) and candidate is not BaseModel:
+            return candidate
+    return None
+
+
 def resolve_model_name(
     *,
     model: str | None,
@@ -105,19 +113,10 @@ def resolve_model_name(
 
 
 def resolve_model_ref(*, model: ModelRef[Any], config: dict[str, Any]) -> ResolvedModel:
-    """Merge a ModelRef's defaults with per-call config for the plugin request.
+    """Merge call-time config over a ModelRef's defaults into a wire ResolvedModel.
 
-    Precedence (lowest to highest): ``ref.version``, ``ref.config``, then
-    call-time ``config``. Each layer overwrites keys from the layers below.
-
-    The merged dict is forwarded to the plugin as-is — no schema validation or
-    key stripping at this layer. ``ModelRef`` typing catches config mistakes at
-    construction; at call time we still pass unknown keys through so plugins can
-    accept new provider options before the SDK schema is updated.
-
-    An explicitly set ``None`` clears a value inherited from a lower layer.
-    After merge, ``None`` values are removed so plugins see a missing key rather
-    than ``null``.
+    Call-time keys win; ref-only keys are kept. Matches generate()'s model-ref
+    config merge: version and ref defaults first, then the call-time override.
     """
     merged: dict[str, Any] = {}
     if model.version is not None:
@@ -125,7 +124,16 @@ def resolve_model_ref(*, model: ModelRef[Any], config: dict[str, Any]) -> Resolv
     if model.config is not None:
         merged.update(normalize_config(config=model.config))
     merged.update(config)
-    merged = {k: v for k, v in merged.items() if v is not None}
+
+    schema = concrete_config_schema(
+        model.config_schema,
+        type(model.config) if model.config is not None else None,
+    )
+    if schema is not None and merged:
+        return ResolvedModel(
+            name=model.name,
+            config=schema.model_validate(merged).model_dump(exclude_unset=True),
+        )
     return ResolvedModel(name=model.name, config=merged)
 
 

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -91,14 +91,6 @@ def normalize_config(*, config: object) -> dict[str, Any]:
     raise TypeError(f'Unsupported config type: {type(config).__name__}')
 
 
-def concrete_config_schema(*candidates: object) -> type[BaseModel] | None:
-    """Return the first concrete BaseModel subclass among candidates."""
-    for candidate in candidates:
-        if isinstance(candidate, type) and issubclass(candidate, BaseModel) and candidate is not BaseModel:
-            return candidate
-    return None
-
-
 def resolve_model_name(
     *,
     model: str | None,
@@ -113,30 +105,27 @@ def resolve_model_name(
 
 
 def resolve_model_ref(*, model: ModelRef[Any], config: dict[str, Any]) -> ResolvedModel:
-    """Merge call-time config over a ModelRef's default config into a wire ResolvedModel."""
-    merged: dict[str, Any] = {}
+    """Merge a ModelRef's defaults with per-call config for the plugin request.
 
-    # 1. Start with defaults defined on the ModelRef (e.g. temperature=0.7)
+    Precedence (lowest to highest): ``ref.version``, ``ref.config``, then
+    call-time ``config``. Each layer overwrites keys from the layers below.
+
+    The merged dict is forwarded to the plugin as-is — no schema validation or
+    key stripping at this layer. ``ModelRef`` typing catches config mistakes at
+    construction; at call time we still pass unknown keys through so plugins can
+    accept new provider options before the SDK schema is updated.
+
+    An explicitly set ``None`` clears a value inherited from a lower layer.
+    After merge, ``None`` values are removed so plugins see a missing key rather
+    than ``null``.
+    """
+    merged: dict[str, Any] = {}
+    if model.version is not None:
+        merged['version'] = model.version
     if model.config is not None:
         merged.update(normalize_config(config=model.config))
-
-    # 2. Call-time config overrides defaults (e.g. temperature=0.2, top_k=0.9)
     merged.update(config)
-
-    # 3. Find concrete Pydantic schema (e.g. GeminiConfig or ModelConfig)
-    schema = concrete_config_schema(
-        model.config_schema,
-        type(model.config) if model.config is not None else None,
-    )
-
-    # 4. Validate types against Pydantic schema & omit unset None fields
-    if schema is not None and merged:
-        return ResolvedModel(
-            name=model.name,
-            config=schema.model_validate(merged).model_dump(exclude_unset=True),
-        )
-
-    # 5. Fallback for untyped/raw models
+    merged = {k: v for k, v in merged.items() if v is not None}
     return ResolvedModel(name=model.name, config=merged)
 
 

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -129,6 +129,25 @@ def resolve_model_ref(*, model: ModelRef[Any], config: dict[str, Any]) -> Resolv
     return ResolvedModel(name=model.name, config=merged)
 
 
+def resolve_call_model(
+    *,
+    model: str | ModelRef[BaseModel] | None,
+    config: ConfigArg | None,
+    registry: Registry,
+    message: str = 'No model configured.',
+) -> tuple[str, ConfigArg | None]:
+    """Return the wire name and the config to send with this call.
+
+    A ModelRef carries defaults, so those get dumped and overlaid with
+    call-time config. A string name has nothing to merge — the caller's
+    config object is left alone so the plugin still sees that instance.
+    """
+    if isinstance(model, ModelRef):
+        resolved = resolve_model_ref(model=model, config=normalize_config(config=config))
+        return resolved.name, resolved.config
+    return resolve_model_name(model=model, registry=registry, message=message), config
+
+
 def model_action_metadata(
     name: str,
     info: dict[str, object] | None = None,

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -113,27 +113,30 @@ def resolve_model_name(
 
 
 def resolve_model_ref(*, model: ModelRef[Any], config: dict[str, Any]) -> ResolvedModel:
-    """Merge call-time config over a ModelRef's defaults into a wire ResolvedModel.
-
-    Call-time keys win; ref-only keys are kept. Matches generate()'s model-ref
-    config merge: version and ref defaults first, then the call-time override.
-    """
+    """Merge call-time config over a ModelRef's default config into a wire ResolvedModel."""
     merged: dict[str, Any] = {}
-    if model.version is not None:
-        merged['version'] = model.version
+
+    # 1. Start with defaults defined on the ModelRef (e.g. temperature=0.7)
     if model.config is not None:
         merged.update(normalize_config(config=model.config))
+
+    # 2. Call-time config overrides defaults (e.g. temperature=0.2, top_k=0.9)
     merged.update(config)
 
+    # 3. Find concrete Pydantic schema (e.g. GeminiConfig or ModelConfig)
     schema = concrete_config_schema(
         model.config_schema,
         type(model.config) if model.config is not None else None,
     )
+
+    # 4. Validate types against Pydantic schema & omit unset None fields
     if schema is not None and merged:
         return ResolvedModel(
             name=model.name,
             config=schema.model_validate(merged).model_dump(exclude_unset=True),
         )
+
+    # 5. Fallback for untyped/raw models
     return ResolvedModel(name=model.name, config=merged)
 
 

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -43,9 +43,15 @@ from genkit._ai._generate import (
     tools_to_action_names,
 )
 from genkit._ai._model import (
+    ConfigArg,
+    ModelArg,
     ModelRequest,
     ModelResponse,
     ModelResponseChunk,
+    ResolvedModel,
+    normalize_config,
+    resolve_model_name,
+    resolve_model_ref,
 )
 from genkit._ai._tools import Tool
 from genkit._core._action import (
@@ -59,7 +65,7 @@ from genkit._core._channel import Channel
 from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger
 from genkit._core._middleware import BaseMiddleware, middleware_class_index
-from genkit._core._model import Document, GenerateActionOptions, Message, ModelConfig
+from genkit._core._model import Document, GenerateActionOptions, Message, ModelConfig, ModelRef
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
@@ -128,8 +134,8 @@ def resume_options_to_resume(
 class PromptGenerateOptions(TypedDict, total=False):
     """Runtime options for prompt execution (config, tools, messages, etc.)."""
 
-    model: str | None
-    config: dict[str, Any] | ModelConfig | None
+    model: ModelArg | None
+    config: ConfigArg | None
     messages: list[Message] | None
     docs: list[Document] | None
     tools: Sequence[str | Tool] | None
@@ -242,8 +248,8 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         self,
         registry: Registry,
         variant: str | None = None,
-        model: str | None = None,
-        config: dict[str, Any] | ModelConfig | None = None,
+        model: ModelArg | None = None,
+        config: ConfigArg | None = None,
         description: str | None = None,
         input_schema: type | dict[str, Any] | str | None = None,
         system: str | list[Part] | None = None,
@@ -370,7 +376,7 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
     def _prompt_config_for_call(self, opts: PromptGenerateOptions) -> PromptConfig:
         """Merge this prompt's definition with per-call ``opts`` into a :class:`PromptConfig`."""
         output_opts = opts.get('output') or {}
-        merged_config: dict[str, Any] | ModelConfig | None
+        merged_config: ConfigArg | None
         if opts.get('config') is not None:
             base = (
                 self._config.model_dump(exclude_none=True)
@@ -385,6 +391,17 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         else:
             merged_config = self._config
 
+        # Normalize at the veneer, then resolve into concrete wire shapes.
+        model_arg = opts.get('model') or self._model
+        normalized_config = normalize_config(config=merged_config)
+        if isinstance(model_arg, ModelRef):
+            resolved = resolve_model_ref(model=model_arg, config=normalized_config)
+        else:
+            resolved = ResolvedModel(
+                name=resolve_model_name(model=model_arg, registry=self._registry),
+                config=normalized_config,
+            )
+
         merged_metadata = (
             {**(self._metadata or {}), **(opts.get('metadata') or {})} if opts.get('metadata') else self._metadata
         )
@@ -393,14 +410,14 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
             return opt_val if opt_val is not None else default
 
         return PromptConfig(
-            model=opts.get('model') or self._model,
+            model=resolved.name,
             prompt=self._prompt,
             system=self._system,
             messages=self._messages,
             tools=opts.get('tools') or self._tools,
             return_tool_requests=_or(opts.get('return_tool_requests'), self._return_tool_requests),
             tool_choice=opts.get('tool_choice') or self._tool_choice,
-            config=merged_config,
+            config=resolved.config,
             max_turns=_or(opts.get('max_turns'), self._max_turns),
             output_format=output_opts.get('format') or self._output_format,
             output_content_type=output_opts.get('content_type') or self._output_content_type,

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -49,8 +49,7 @@ from genkit._ai._model import (
     ModelResponse,
     ModelResponseChunk,
     normalize_config,
-    resolve_model_name,
-    resolve_model_ref,
+    resolve_call_model,
 )
 from genkit._ai._tools import Tool
 from genkit._core._action import (
@@ -64,7 +63,7 @@ from genkit._core._channel import Channel
 from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger
 from genkit._core._middleware import BaseMiddleware, middleware_class_index
-from genkit._core._model import Document, GenerateActionOptions, Message, ModelRef
+from genkit._core._model import Document, GenerateActionOptions, Message
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
@@ -386,16 +385,11 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         else:
             merged_config = self._config
 
-        model_arg = opts.get('model') or self._model
-        if isinstance(model_arg, ModelRef):
-            resolved = resolve_model_ref(
-                model=model_arg,
-                config=normalize_config(config=merged_config),
-            )
-            model_name, model_config = resolved.name, resolved.config
-        else:
-            model_name = resolve_model_name(model=model_arg, registry=self._registry)
-            model_config = merged_config
+        model_name, model_config = resolve_call_model(
+            model=opts.get('model') or self._model,
+            config=merged_config,
+            registry=self._registry,
+        )
 
         merged_metadata = (
             {**(self._metadata or {}), **(opts.get('metadata') or {})} if opts.get('metadata') else self._metadata

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -378,15 +378,11 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         output_opts = opts.get('output') or {}
         merged_config: ConfigArg | None
         if opts.get('config') is not None:
-            base = (
-                self._config.model_dump(exclude_none=True)
-                if isinstance(self._config, BaseModel)
-                else (self._config or {})
-            )
-            opt_config = opts.get('config')
-            override = (
-                opt_config.model_dump(exclude_none=True) if isinstance(opt_config, BaseModel) else (opt_config or {})
-            )
+            # exclude_unset semantics via normalize_config: untouched fields are
+            # absent (cannot clobber defaults); an explicitly-set None survives
+            # the merge and clears the lower-precedence value downstream.
+            base = normalize_config(config=self._config)
+            override = normalize_config(config=opts.get('config'))
             merged_config = {**base, **override} if base or override else None
         else:
             merged_config = self._config

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -20,7 +20,7 @@
 import asyncio
 import os
 import weakref
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Generic, TypedDict, TypeVar, cast
@@ -48,7 +48,6 @@ from genkit._ai._model import (
     ModelRequest,
     ModelResponse,
     ModelResponseChunk,
-    ResolvedModel,
     normalize_config,
     resolve_model_name,
     resolve_model_ref,
@@ -65,7 +64,7 @@ from genkit._core._channel import Channel
 from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger
 from genkit._core._middleware import BaseMiddleware, middleware_class_index
-from genkit._core._model import Document, GenerateActionOptions, Message, ModelConfig, ModelRef
+from genkit._core._model import Document, GenerateActionOptions, Message, ModelRef
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
@@ -217,7 +216,7 @@ class PromptConfig(BaseModel):
 
     variant: str | None = None
     model: str | None = None
-    config: dict[str, Any] | ModelConfig | None = None
+    config: Mapping[str, Any] | BaseModel | None = None
     description: str | None = None
     input_schema: type | dict[str, Any] | str | None = None
     system: str | list[Part] | None = None
@@ -387,16 +386,16 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         else:
             merged_config = self._config
 
-        # Normalize at the veneer, then resolve into concrete wire shapes.
         model_arg = opts.get('model') or self._model
-        normalized_config = normalize_config(config=merged_config)
         if isinstance(model_arg, ModelRef):
-            resolved = resolve_model_ref(model=model_arg, config=normalized_config)
-        else:
-            resolved = ResolvedModel(
-                name=resolve_model_name(model=model_arg, registry=self._registry),
-                config=normalized_config,
+            resolved = resolve_model_ref(
+                model=model_arg,
+                config=normalize_config(config=merged_config),
             )
+            model_name, model_config = resolved.name, resolved.config
+        else:
+            model_name = resolve_model_name(model=model_arg, registry=self._registry)
+            model_config = merged_config
 
         merged_metadata = (
             {**(self._metadata or {}), **(opts.get('metadata') or {})} if opts.get('metadata') else self._metadata
@@ -406,14 +405,14 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
             return opt_val if opt_val is not None else default
 
         return PromptConfig(
-            model=resolved.name,
+            model=model_name,
             prompt=self._prompt,
             system=self._system,
             messages=self._messages,
             tools=opts.get('tools') or self._tools,
             return_tool_requests=_or(opts.get('return_tool_requests'), self._return_tool_requests),
             tool_choice=opts.get('tool_choice') or self._tool_choice,
-            config=resolved.config,
+            config=model_config,
             max_turns=_or(opts.get('max_turns'), self._max_turns),
             output_format=output_opts.get('format') or self._output_format,
             output_content_type=output_opts.get('content_type') or self._output_content_type,
@@ -962,14 +961,17 @@ async def render_prompt_config_for_executable_call(
         merged_docs = [*merged_docs, *extra_docs] if merged_docs else list(extra_docs)
 
     resume = resume_from_prompt_call_opts(opts)
-    return PromptConfig.model_validate({
-        **prompt_config.model_dump(),
-        'system': None,
-        'prompt': None,
-        'messages': resolved_msgs,
-        'docs': merged_docs,
-        'resume': resume,
-    })
+    # Copy instead of dump/revalidate so a typed config object the caller
+    # passed through (no merge) is still that object when the plugin runs.
+    return prompt_config.model_copy(
+        update={
+            'system': None,
+            'prompt': None,
+            'messages': resolved_msgs,
+            'docs': merged_docs,
+            'resume': resume,
+        }
+    )
 
 
 async def executable_prompt_call_to_generate_options(

--- a/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for generate/prompt/agent/operation with ModelRef."""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit
+from genkit._ai._model import ModelConfig, normalize_config, resolve_model_ref
+from genkit._ai._testing import EchoModel, define_echo_model
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._model import Message, ModelRequest, ModelResponse
+from genkit._core._typing import ModelInfo, Operation, Part, Role, Supports, TextPart
+from genkit.model import model_ref
+
+
+class CustomConfig(BaseModel):
+    """Plugin-style config used for merge tests."""
+
+    temperature: float | None = None
+    top_k: float | None = None
+    safety_settings: dict[str, str] | None = None
+
+
+def _config_value(config: Any, key: str) -> Any:
+    if isinstance(config, dict):
+        return config.get(key)
+    return getattr(config, key, None)
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    return Genkit()
+
+
+@pytest.fixture
+def ai_with_echo() -> tuple[Genkit, EchoModel]:
+    ai = Genkit()
+    echo, _ = define_echo_model(ai, name='testEcho')
+    return ai, echo
+
+
+@pytest.mark.asyncio
+async def test_generate_with_model_ref(ai_with_echo: tuple[Genkit, EchoModel]) -> None:
+    """generate accepts a ModelRef and resolves its wire name."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ModelConfig)
+
+    response = await ai.generate(model=ref, prompt='Hello')
+
+    assert '[ECHO]' in response.text
+    assert echo.last_request is not None
+
+
+@pytest.mark.asyncio
+async def test_generate_model_ref_default_config(ai_with_echo: tuple[Genkit, EchoModel]) -> None:
+    """Default config on the ref is used when the call omits config."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ModelConfig, config=ModelConfig(temperature=0.1))
+
+    await ai.generate(model=ref, prompt='Hello')
+
+    assert echo.last_request is not None
+    assert echo.last_request.config is not None
+    assert _config_value(echo.last_request.config, 'temperature') == 0.1
+
+
+@pytest.mark.asyncio
+async def test_generate_model_ref_merges_call_time_dict(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Call-time dict config merges over ModelRef defaults (JS parity)."""
+    ai, echo = ai_with_echo
+    ref = model_ref(
+        'testEcho',
+        config_schema=ModelConfig,
+        config=ModelConfig(temperature=0.2),
+    )
+
+    await ai.generate(model=ref, config={'top_k': 0.9}, prompt='Hello')
+
+    assert echo.last_request is not None
+    assert echo.last_request.config is not None
+    assert _config_value(echo.last_request.config, 'temperature') == 0.2
+    assert _config_value(echo.last_request.config, 'top_k') == 0.9
+
+
+@pytest.mark.asyncio
+async def test_generate_model_ref_same_key_override(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Call-time config wins when the same key exists on the ModelRef default."""
+    ai, echo = ai_with_echo
+    ref = model_ref(
+        'testEcho',
+        config_schema=ModelConfig,
+        config=ModelConfig(temperature=0.2),
+    )
+
+    await ai.generate(model=ref, config={'temperature': 0.9}, prompt='Hello')
+
+    assert echo.last_request is not None
+    assert echo.last_request.config is not None
+    assert _config_value(echo.last_request.config, 'temperature') == 0.9
+
+
+@pytest.mark.asyncio
+async def test_generate_string_model_config_dict_unchanged(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Bare string model path still accepts dict config."""
+    ai, echo = ai_with_echo
+
+    response = await ai.generate(model='testEcho', prompt='Hello', config={'temperature': 0.1})
+
+    assert '0.1' in response.text
+    assert echo.last_request is not None
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_with_model_ref(ai_with_echo: tuple[Genkit, EchoModel]) -> None:
+    """generate_stream accepts a ModelRef."""
+    ai, _ = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ModelConfig)
+
+    stream = ai.generate_stream(model=ref, prompt='Hello')
+    response = await stream.response
+
+    assert '[ECHO]' in response.text
+
+
+@pytest.mark.asyncio
+async def test_define_prompt_with_model_ref(ai_with_echo: tuple[Genkit, EchoModel]) -> None:
+    """define_prompt stores a ModelRef and unwraps it at execution time."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ModelConfig, config=ModelConfig(temperature=0.2))
+
+    prompt = ai.define_prompt(
+        name='echoPrompt',
+        model=ref,
+        prompt='Hello',
+    )
+    response = await prompt()
+
+    assert '0.2' in response.text
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'temperature') == 0.2
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_with_model_ref(ai: Genkit) -> None:
+    """generate_operation accepts a ModelRef and uses its wire name."""
+    expected_operation = Operation(
+        id='ref-op-123',
+        done=False,
+        action='/background-model/lro-model',
+    )
+
+    async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        return ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Started'))],
+            ),
+            operation=expected_operation,
+        )
+
+    ai.define_model(
+        name='lro-model',
+        fn=model_fn,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+    ref = model_ref('lro-model', config_schema=ModelConfig, config=ModelConfig(temperature=0.4))
+
+    operation = await ai.generate_operation(model=ref, prompt='Generate video')
+
+    assert operation.id == 'ref-op-123'
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_model_ref_rejects_non_lro(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """generate_operation still rejects ModelRefs whose model lacks LRO support."""
+    ai, _ = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ModelConfig)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model=ref, prompt='Hi')
+
+    assert 'does not support long running' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_define_agent_with_model_ref(ai_with_echo: tuple[Genkit, EchoModel]) -> None:
+    """define_agent accepts a ModelRef and uses resolved name/config on turns."""
+    ai, echo = ai_with_echo
+    ref = model_ref(
+        'testEcho',
+        config_schema=ModelConfig,
+        config=ModelConfig(temperature=0.3),
+    )
+
+    agent = ai.define_agent(name='echoAgent', model=ref, system='Reply briefly.')
+    chat = agent.chat()
+    out = await chat.send('Hello')
+
+    assert '[ECHO]' in out.text
+    assert echo.last_request is not None
+    assert echo.last_request.config is not None
+    assert _config_value(echo.last_request.config, 'temperature') == 0.3
+
+
+def test_resolve_model_ref_merges_without_overwrite() -> None:
+    """resolve_model_ref keeps ref-only keys and lets call-time keys win."""
+    ref = model_ref(
+        'gemini-pro-latest',
+        namespace='googleai',
+        config_schema=CustomConfig,
+        config=CustomConfig(temperature=0.7, safety_settings={'HARM': 'BLOCK'}),
+    )
+
+    resolved = resolve_model_ref(model=ref, config={'temperature': 0.2})
+
+    assert resolved.name == 'googleai/gemini-pro-latest'
+    assert resolved.config['temperature'] == 0.2
+    assert resolved.config['safety_settings'] == {'HARM': 'BLOCK'}
+
+
+def test_normalize_config_dumps_pydantic() -> None:
+    """normalize_config turns configs into plain dicts, using {} for None."""
+    assert normalize_config(config=ModelConfig(temperature=0.5)) == {'temperature': 0.5}
+    assert normalize_config(config=None) == {}

--- a/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
@@ -8,7 +8,7 @@
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from genkit import Genkit
 from genkit._ai._model import ModelConfig
@@ -26,6 +26,12 @@ class CustomConfig(BaseModel):
     temperature: float | None = None
     top_k: float | None = None
     safety_settings: dict[str, str] | None = None
+
+
+class ExcludedKeyConfig(ModelConfig):
+    """ModelConfig whose api_key is omitted from model_dump."""
+
+    api_key: str | None = Field(default=None, exclude=True)
 
 
 def _config_value(config: Any, key: str) -> Any:
@@ -305,3 +311,50 @@ async def test_unset_fields_do_not_clobber_ref_defaults(
     assert echo.last_request is not None
     assert _config_value(echo.last_request.config, 'temperature') == 0.7
     assert _config_value(echo.last_request.config, 'top_k') == 40
+
+
+@pytest.mark.asyncio
+async def test_model_config_none_clears_ref_default_via_generate(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """ModelConfig(temperature=None) clears a ref default on the generate path."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ModelConfig, config=ModelConfig(temperature=0.7))
+
+    await ai.generate(model=ref, config=ModelConfig(temperature=None), prompt='Hello')
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'temperature') is None
+
+
+@pytest.mark.asyncio
+async def test_model_config_aliased_field_same_key_override(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Call-time max_output_tokens replaces the ref default instead of adding maxOutputTokens."""
+    ai, echo = ai_with_echo
+    ref = model_ref(
+        'testEcho',
+        config_schema=ModelConfig,
+        config=ModelConfig(max_output_tokens=100),
+    )
+
+    await ai.generate(model=ref, config={'max_output_tokens': 200}, prompt='Hello')
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'max_output_tokens') == 200
+    assert _config_value(echo.last_request.config, 'maxOutputTokens') is None
+
+
+@pytest.mark.asyncio
+async def test_excluded_api_key_reaches_plugin(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Per-request api_key still lands on the plugin request after veneer dump."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ExcludedKeyConfig)
+
+    await ai.generate(model=ref, config=ExcludedKeyConfig(api_key='secret'), prompt='Hello')
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'api_key') == 'secret'

--- a/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
@@ -34,6 +34,12 @@ class ExcludedKeyConfig(ModelConfig):
     api_key: str | None = Field(default=None, exclude=True)
 
 
+class PluginOnlyConfig(ModelConfig):
+    """Plugin-owned fields that aren't on GenerationCommonConfig."""
+
+    duration_seconds: int | None = None
+
+
 def _config_value(config: Any, key: str) -> Any:
     if isinstance(config, dict):
         return config.get(key)
@@ -127,6 +133,37 @@ async def test_generate_string_model_config_dict_unchanged(
 
     assert '0.1' in response.text
     assert echo.last_request is not None
+
+
+@pytest.mark.asyncio
+async def test_generate_string_model_keeps_typed_config_instance(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """String model + typed config is not dumped; the plugin sees that class."""
+    ai, echo = ai_with_echo
+    cfg = PluginOnlyConfig(duration_seconds=8)
+
+    await ai.generate(model='testEcho', prompt='Hello', config=cfg)
+
+    assert echo.last_request is not None
+    assert type(echo.last_request.config) is PluginOnlyConfig
+    assert echo.last_request.config.duration_seconds == 8
+
+
+@pytest.mark.asyncio
+async def test_define_prompt_string_model_keeps_typed_config_instance(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """define_prompt with a string model keeps the typed config when nothing merges."""
+    ai, echo = ai_with_echo
+    cfg = PluginOnlyConfig(duration_seconds=8)
+
+    prompt = ai.define_prompt(name='typedCfgPrompt', model='testEcho', prompt='Hello', config=cfg)
+    await prompt()
+
+    assert echo.last_request is not None
+    assert type(echo.last_request.config) is PluginOnlyConfig
+    assert echo.last_request.config.duration_seconds == 8
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
@@ -11,7 +11,7 @@ import pytest
 from pydantic import BaseModel
 
 from genkit import Genkit
-from genkit._ai._model import ModelConfig, normalize_config, resolve_model_ref
+from genkit._ai._model import ModelConfig
 from genkit._ai._testing import EchoModel, define_echo_model
 from genkit._core._action import ActionRunContext
 from genkit._core._error import GenkitError
@@ -217,28 +217,6 @@ async def test_define_agent_with_model_ref(ai_with_echo: tuple[Genkit, EchoModel
     assert _config_value(echo.last_request.config, 'temperature') == 0.3
 
 
-def test_resolve_model_ref_merges_without_overwrite() -> None:
-    """resolve_model_ref keeps ref-only keys and lets call-time keys win."""
-    ref = model_ref(
-        'gemini-pro-latest',
-        namespace='googleai',
-        config_schema=CustomConfig,
-        config=CustomConfig(temperature=0.7, safety_settings={'HARM': 'BLOCK'}),
-    )
-
-    resolved = resolve_model_ref(model=ref, config={'temperature': 0.2})
-
-    assert resolved.name == 'googleai/gemini-pro-latest'
-    assert resolved.config['temperature'] == 0.2
-    assert resolved.config['safety_settings'] == {'HARM': 'BLOCK'}
-
-
-def test_normalize_config_dumps_pydantic() -> None:
-    """normalize_config turns configs into plain dicts, using {} for None."""
-    assert normalize_config(config=ModelConfig(temperature=0.5)) == {'temperature': 0.5}
-    assert normalize_config(config=None) == {}
-
-
 @pytest.mark.asyncio
 async def test_model_ref_version_seeds_config(ai_with_echo: tuple[Genkit, EchoModel]) -> None:
     """ref.version flows into config at lowest precedence (JS generate.ts parity)."""
@@ -327,18 +305,3 @@ async def test_unset_fields_do_not_clobber_ref_defaults(
     assert echo.last_request is not None
     assert _config_value(echo.last_request.config, 'temperature') == 0.7
     assert _config_value(echo.last_request.config, 'top_k') == 40
-
-
-def test_resolve_model_ref_strips_explicit_none() -> None:
-    """Post-merge None-strip: cleared keys are absent from the resolved config."""
-    ref = model_ref(
-        'gemini-pro-latest',
-        namespace='googleai',
-        config_schema=CustomConfig,
-        config=CustomConfig(temperature=0.7, top_k=40),
-    )
-
-    resolved = resolve_model_ref(model=ref, config={'temperature': None})
-
-    assert 'temperature' not in resolved.config
-    assert resolved.config['top_k'] == 40

--- a/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_generate_test.py
@@ -237,3 +237,108 @@ def test_normalize_config_dumps_pydantic() -> None:
     """normalize_config turns configs into plain dicts, using {} for None."""
     assert normalize_config(config=ModelConfig(temperature=0.5)) == {'temperature': 0.5}
     assert normalize_config(config=None) == {}
+
+
+@pytest.mark.asyncio
+async def test_model_ref_version_seeds_config(ai_with_echo: tuple[Genkit, EchoModel]) -> None:
+    """ref.version flows into config at lowest precedence (JS generate.ts parity)."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ModelConfig, version='001')
+
+    await ai.generate(model=ref, prompt='Hello')
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'version') == '001'
+
+
+@pytest.mark.asyncio
+async def test_model_ref_version_overridden_by_call_config(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Call-time config version beats ref.version."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=ModelConfig, version='001')
+
+    await ai.generate(model=ref, config={'version': '002'}, prompt='Hello')
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'version') == '002'
+
+
+@pytest.mark.asyncio
+async def test_unknown_config_keys_pass_through_to_plugin(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Escape hatch: keys outside the ref schema reach the plugin untouched."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=CustomConfig, config=CustomConfig(temperature=0.7))
+
+    await ai.generate(model=ref, config={'thinking_config': {'budget': 8192}}, prompt='Hello')
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'temperature') == 0.7
+    assert _config_value(echo.last_request.config, 'thinking_config') == {'budget': 8192}
+
+
+@pytest.mark.asyncio
+async def test_explicit_none_clears_ref_default_via_generate(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Explicitly-set None clears the ref default; plugin sees absence."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=CustomConfig, config=CustomConfig(temperature=0.7))
+
+    await ai.generate(model=ref, config=CustomConfig(temperature=None), prompt='Hello')
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'temperature') is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_none_clears_default_via_prompt(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """The prompt path honors the same clearing rule as generate."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=CustomConfig)
+
+    prompt = ai.define_prompt(
+        name='clearingPrompt',
+        model=ref,
+        prompt='Hello',
+        config=CustomConfig(temperature=0.7),
+    )
+    await prompt(config=CustomConfig(temperature=None))
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'temperature') is None
+
+
+@pytest.mark.asyncio
+async def test_unset_fields_do_not_clobber_ref_defaults(
+    ai_with_echo: tuple[Genkit, EchoModel],
+) -> None:
+    """Unset != None: untouched fields on a typed config cannot clear defaults."""
+    ai, echo = ai_with_echo
+    ref = model_ref('testEcho', config_schema=CustomConfig, config=CustomConfig(temperature=0.7))
+
+    await ai.generate(model=ref, config=CustomConfig(top_k=40), prompt='Hello')
+
+    assert echo.last_request is not None
+    assert _config_value(echo.last_request.config, 'temperature') == 0.7
+    assert _config_value(echo.last_request.config, 'top_k') == 40
+
+
+def test_resolve_model_ref_strips_explicit_none() -> None:
+    """Post-merge None-strip: cleared keys are absent from the resolved config."""
+    ref = model_ref(
+        'gemini-pro-latest',
+        namespace='googleai',
+        config_schema=CustomConfig,
+        config=CustomConfig(temperature=0.7, top_k=40),
+    )
+
+    resolved = resolve_model_ref(model=ref, config={'temperature': None})
+
+    assert 'temperature' not in resolved.config
+    assert resolved.config['top_k'] == 40

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -89,6 +89,16 @@ def test_model_ref_dataclass_value_equality() -> None:
     assert ref1 != 'm1'
 
 
+def test_model_ref_version_equality() -> None:
+    """ModelRef instances with different versions compare as not equal."""
+    v1 = model_ref('m1', config_schema=CustomConfig, version='001')
+    v2 = model_ref('m1', config_schema=CustomConfig, version='001')
+    v3 = model_ref('m1', config_schema=CustomConfig, version='002')
+
+    assert v1 == v2
+    assert v1 != v3
+
+
 def test_model_ref_is_unhashable() -> None:
     """ModelRef opts out of hashing so set/dict use doesn't fail only when config is set."""
     ref = model_ref('m1', config_schema=CustomConfig, config=CustomConfig(temperature=0.5))

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -41,6 +41,13 @@ def test_model_ref_with_custom_pydantic_schema() -> None:
     assert ref.config.top_p == 0.9
 
 
+def test_typed_ref_assignable_to_model_ref_base_model() -> None:
+    """A ref built with a plugin config class is still usable as ModelRef[BaseModel]."""
+    ref = model_ref('echo', config_schema=CustomConfig)
+    as_base: ModelRef[BaseModel] = ref
+    assert as_base is ref
+
+
 def test_model_ref_with_bare_base_model_schema() -> None:
     """model_ref() accepts arbitrary BaseModel schemas, including bare BaseModel itself."""
     ref = model_ref('generic-model', config_schema=BaseModel)

--- a/py/packages/genkit/tests/genkit/ai/model_resolution_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_resolution_test.py
@@ -37,7 +37,7 @@ class CustomConfig(BaseModel):
 class ExcludedKeyConfig(ModelConfig):
     """ModelConfig whose api_key is omitted from model_dump."""
 
-    api_key: str | None = Field(None, exclude=True)
+    api_key: str | None = Field(default=None, exclude=True)
 
 
 def test_resolve_model_ref_merges_without_overwrite() -> None:

--- a/py/packages/genkit/tests/genkit/ai/model_resolution_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_resolution_test.py
@@ -5,8 +5,8 @@
 
 """Unit tests for veneer model resolution helpers.
 
-Covers normalize_config, resolve_model_name, and resolve_model_ref as pure
-functions, independent of generate()/prompt wiring.
+Covers normalize_config, resolve_model_name, resolve_model_ref, and
+resolve_call_model as pure functions, independent of generate()/prompt wiring.
 """
 
 from dataclasses import FrozenInstanceError
@@ -18,6 +18,7 @@ from genkit._ai._model import (
     ModelConfig,
     ResolvedModel,
     normalize_config,
+    resolve_call_model,
     resolve_model_name,
     resolve_model_ref,
 )
@@ -169,3 +170,25 @@ def test_resolve_model_ref_same_key_override_on_aliased_field() -> None:
 def test_normalize_config_restores_excluded_fields() -> None:
     """Fields marked exclude=True still reach the plugin (per-request api_key)."""
     assert normalize_config(config=ExcludedKeyConfig(api_key='secret')) == {'api_key': 'secret'}
+
+
+def test_resolve_call_model_string_keeps_config_instance() -> None:
+    """A string model has nothing to merge, so the caller's config is unchanged."""
+    registry = Registry()
+    cfg = CustomConfig(temperature=0.2)
+    name, config = resolve_call_model(model='echo', config=cfg, registry=registry)
+    assert name == 'echo'
+    assert config is cfg
+
+
+def test_resolve_call_model_ref_dumps_and_merges() -> None:
+    """A ModelRef dumps defaults and overlays call-time config."""
+    registry = Registry()
+    ref = model_ref(
+        'echo',
+        config_schema=CustomConfig,
+        config=CustomConfig(temperature=0.7),
+    )
+    name, config = resolve_call_model(model=ref, config={'top_k': 40}, registry=registry)
+    assert name == 'echo'
+    assert config == {'temperature': 0.7, 'top_k': 40}


### PR DESCRIPTION
### What this does
You can now pass a ModelRef — not just a string — anywhere the SDK takes a model: ai.generate(), ai.generate_stream(), ai.generate_operation(), ai.define_prompt(), and agent definitions. The ref's defaults (version, config) merge with your call-time config under one documented precedence rule, matching the JS SDK.

### For SDK users
```python
flash = model_ref(
    'gemini-2.5-flash',
    namespace='googleai',
    config_schema=GeminiConfig,
    config=GeminiConfig(temperature=0.7),
)

# Ref defaults apply:
await ai.generate(model=flash, prompt='hi')
# temperature=0.7

# Call-time config wins per key:
await ai.generate(model=flash, prompt='hi', config={'temperature': 0.2})
# temperature=0.2

# Explicitly passing None clears a ref default:
await ai.generate(model=flash, prompt='hi', config={'temperature': None})
# temperature not sent
```
Merge precedence, lowest to highest: ref.version → ref.config → call-time config. Unknown config keys pass through to the plugin untouched (no stripping or validation at this layer). After merging, keys whose value is None are removed, so plugins see an absent key rather than null. Plain string model names behave exactly as before.

generate_operation() gets the same treatment, so background models can be invoked via a typed ref too.

### Behavior change to prompt config merging
ExecutablePrompt previously merged its defined config with per-call config using exclude_none dumps. It now uses exclude_unset semantics, aligning prompts with generate():

Fields you never set on a Pydantic config no longer participate in the merge (they can't clobber lower-precedence values with implicit Nones).
A field you explicitly set to None now survives the merge and clears the inherited default (previously it was dropped).
If you relied on explicit Nones being ignored in prompt config overrides, this changes your behavior.

### Stacked on
#5969 — typed ModelRef (the type this PR wires in).
#6015 — normalize_config / resolve_model_name / resolve_model_ref / ResolvedModel, the pure functions that implement the merge rule above, with direct unit tests. This PR contains only the surface signatures, the dispatch into those helpers, and end-to-end tests.

### Test plan
model_ref_generate_test.py (e2e): refs through generate / stream / prompt / agents / generate_operation, default-and-override merging, same-key override, explicit-None clearing via both generate and prompt, unknown-key pass-through, version seeding and override, string-model paths unchanged, and rejection of refs to non-long-running models in generate_operation.