### PR TITLE
fix(py): demote Dev UI framework chatter on the shared terminal

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -846,7 +846,7 @@ class Genkit:
         async def _run_server() -> None:
             v2_url = os.environ.get('GENKIT_REFLECTION_V2_SERVER')
             if v2_url:
-                await logger.ainfo(f'Genkit Dev UI reflection v2 client connecting to {v2_url}')
+                await logger.adebug(f'Genkit Dev UI reflection v2 client connecting to {v2_url}')
                 server_v2 = ReflectionServerV2(self.registry, v2_url)
                 self._reflection_ready.set()
                 await server_v2.run_forever()
@@ -895,7 +895,7 @@ class Genkit:
                     return
 
                 runtime_manager.write_runtime_file()
-                await logger.ainfo(f'Genkit Dev UI reflection server running at {spec.url}')
+                await logger.adebug(f'Genkit Dev UI reflection server running at {spec.url}')
                 await server_task
 
         threading.Thread(
@@ -912,7 +912,7 @@ class Genkit:
             self.define_format(fmt)
 
         if not plugins:
-            logger.warning('No plugins provided to Genkit')
+            logger.debug('No plugins provided to Genkit')
         else:
             for plugin in plugins:
                 if isinstance(plugin, Plugin):  # pyright: ignore[reportUnnecessaryIsInstance]
@@ -931,22 +931,22 @@ class Genkit:
     def run_main(self, coro: Coroutine[Any, Any, T]) -> T | None:
         """Run the user's main coroutine, blocking in dev mode for the reflection server."""
         if not is_dev_environment():
-            logger.info('Running in production mode.')
             return run_loop(coro)
-
-        logger.info('Running in development mode.')
 
         async def dev_runner() -> T | None:
             user_result: T | None = None
             try:
                 user_result = await coro
                 logger.debug('User coroutine completed successfully.')
-            except Exception:
-                logger.exception('User coroutine failed')
+            except Exception as e:
+                # Script entrypoint failed — there's no Dev UI panel for this run,
+                # so keep a headline + a debug traceback.
+                logger.error('Startup failed: %s: %s', type(e).__name__, e)
+                logger.debug('Startup failure details', exc_info=True)
 
             # Block until Ctrl+C (SIGINT handled by anyio) or SIGTERM, keeping
             # the daemon reflection thread alive.
-            logger.info('Script done — Dev UI running. Press Ctrl+C to stop.')
+            logger.info('Dev UI ready. Press Ctrl+C to stop.')
             try:
                 async with anyio.create_task_group() as tg:
 
@@ -961,7 +961,7 @@ class Genkit:
             except anyio.get_cancelled_exc_class():
                 pass
 
-            logger.info('Dev UI server stopped.')
+            logger.debug('Dev UI server stopped.')
             return user_result
 
         return anyio.run(dev_runner)

--- a/py/packages/genkit/src/genkit/_ai/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_runtime.py
@@ -88,18 +88,13 @@ def _remove_file(file_path: Path | None) -> bool:
     Returns:
         True if cleanup was successful or file didn't exist, False on error.
     """
-    # NOTE: Neither print nor logger appears to work during atexit, so print is intentional here.
+    # Logger is unreliable during atexit; only print on failure.
     if not file_path:
         return True
     try:
         if file_path.exists():
-            print(f'Removing file: {file_path}')  # noqa: T201 - atexit handler, logger unavailable
             file_path.unlink()
-            # Consider success if unlink didn't raise error
-            return True
-        else:
-            # Consider success if file already gone
-            return True
+        return True
     except Exception as e:
         print(f'Error deleting {file_path}: {e}')  # noqa: T201 - atexit handler, logger unavailable
         return False
@@ -158,7 +153,7 @@ def _create_and_write_runtime_file(runtime_dir: Path, spec: ServerSpec) -> Path:
     with Path(runtime_file_path).open('w', encoding='utf-8') as f:
         _ = f.write(metadata)
 
-    logger.info(f'Initialized runtime file: {runtime_file_path}')
+    logger.debug(f'Initialized runtime file: {runtime_file_path}')
     _ = sys.stdout.flush()
     _ = sys.stderr.flush()
     return runtime_file_path

--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -163,7 +163,10 @@ class ActionRunner:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.exception('Error executing action')
+            # Dev UI already shows the error + stack from the reflection response.
+            # Dumping a full traceback here turns every playground failure into
+            # terminal noise.
+            logger.debug('Action failed: %s: %s', type(e).__name__, e, exc_info=True)
             self.queue.put_nowait(json.dumps({'error': get_reflection_json(e).model_dump(by_alias=True)}))
         finally:
             self.trace_ready.set()
@@ -204,7 +207,7 @@ def create_reflection_asgi_app(
         return JSONResponse({'status': 'OK'})
 
     async def terminate(_: Request) -> JSONResponse:
-        logger.info('Shutting down...')
+        logger.debug('Shutting down...')
         asyncio.get_running_loop().call_soon(os.kill, os.getpid(), signal.SIGTERM)
         return JSONResponse({'status': 'OK'})
 
@@ -248,10 +251,11 @@ def create_reflection_asgi_app(
                     serialized[key] = val.model_dump(by_alias=True, exclude_none=True, mode='json')
                 raw_values = serialized
             return JSONResponse(raw_values, headers={'x-genkit-version': version})
-        except Exception:
-            logger.exception('Reflection /api/values failed')
+        except Exception as e:
+            logger.error(f'Failed to list values: {type(e).__name__}: {e}')
+            logger.debug('Reflection /api/values failed', exc_info=e)
             return JSONResponse(
-                {'error': 'Failed to list values', 'detail': 'See Python process logs for the traceback.'},
+                {'error': 'Failed to list values', 'detail': str(e)},
                 status_code=500,
                 headers={'x-genkit-version': version},
             )

--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -251,11 +251,10 @@ def create_reflection_asgi_app(
                     serialized[key] = val.model_dump(by_alias=True, exclude_none=True, mode='json')
                 raw_values = serialized
             return JSONResponse(raw_values, headers={'x-genkit-version': version})
-        except Exception as e:
-            logger.error(f'Failed to list values: {type(e).__name__}: {e}')
-            logger.debug('Reflection /api/values failed', exc_info=e)
+        except Exception:
+            logger.exception('Reflection /api/values failed')
             return JSONResponse(
-                {'error': 'Failed to list values', 'detail': str(e)},
+                {'error': 'Failed to list values', 'detail': 'See Python process logs for the traceback.'},
                 status_code=500,
                 headers={'x-genkit-version': version},
             )

--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -363,8 +363,9 @@ class ReflectionServerV2:
                     )
                 else:
                     logger.debug('reflection V2: unknown notification', method=method)
-        except Exception:
-            logger.exception('reflection V2: handler error', method=method)
+        except Exception as e:
+            logger.error(f'Reflection error in {method}: {type(e).__name__}: {e}')
+            logger.debug('reflection V2: handler error', method=method, exc_info=e)
             if req_id is not None:
                 await self.send_error(str(req_id), JSON_RPC_SERVER_ERROR, 'internal error')
 
@@ -490,7 +491,8 @@ class ReflectionServerV2:
             await self.send_error(sid, JSON_RPC_SERVER_ERROR, 'Action was cancelled', err_data)
             return
 
-        logger.exception('reflection V2: runAction error')
+        # Dev UI already shows the error + stack from the JSON-RPC response.
+        logger.debug('Action failed: %s: %s', type(exc).__name__, exc, exc_info=True)
         # Wire contract requires ``details`` to carry only ``stack`` and ``traceId``
         # (see ``GenkitErrorSchema.data.genkitErrorDetails`` in genkit-tools); anything
         # else in ``GenkitError.details`` is runtime-internal and gets dropped.


### PR DESCRIPTION
## Summary
- Demote reflection/runtime/shutdown/"no plugins" logs to debug
- Playground action failures log at debug in reflection server & v2 (Dev UI already has error + stack)
- Retain full server-side exception logging on `/api/values` endpoint failures
- `run_main`: startup failures formatted as short `Error` + debug traceback; keep a single `Dev UI ready. Press Ctrl+C to stop.` readiness line
- `_runtime`: stop printing `"Removing file: …"` on atexit success

## Demo
`GENKIT_ENV=dev genkit start -- uv run main.py`
- Before: reflection URL, runtime file path, mode banners, exception walls on playground misses
- After: clean "Dev UI ready. Press Ctrl+C to stop." line unless `GENKIT_LOG=debug`

## Test plan
- [x] CI / preflight green across typecheckers & tests
- [x] Manual genkit start: terminal stays readable; failing a playground action does not dump a traceback wall