### PR TITLE
fix(py): raise GenkitError for generate model resolution failures

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1079,11 +1079,17 @@ async def resolve_parameters(
         else cast(str | None, registry.lookup_value('defaultModel', 'defaultModel'))
     )
     if not model:
-        raise Exception('No model configured.')
+        raise GenkitError(status='INVALID_ARGUMENT', message='No model configured.')
 
     model_action = await registry.resolve_model(model)
     if model_action is None:
-        raise Exception(f'Failed to to resolve model {model}')
+        message = f"Failed to resolve model '{model}'."
+        if isinstance(model, str) and '/' not in model:
+            message += ' Ensure the model name includes the plugin namespace.'
+        raise GenkitError(
+            status='NOT_FOUND',
+            message=message,
+        )
 
     # Resolve tools up front to fail fast on invalid caller-supplied tool names or
     # duplicate short names before running side effects or middleware.

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1085,7 +1085,7 @@ async def resolve_parameters(
     if model_action is None:
         message = f"Failed to resolve model '{model}'."
         if isinstance(model, str) and '/' not in model:
-            message += ' Ensure the model name includes the plugin namespace.'
+            message += " Ensure the model name includes the plugin namespace (e.g., 'plugin/model')."
         raise GenkitError(
             status='NOT_FOUND',
             message=message,

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for generate-path model resolution errors."""
+
+import pytest
+
+from genkit import GenkitError
+from genkit._ai._generate import resolve_parameters
+from genkit._core._model import GenerateActionOptions
+from genkit._core._registry import Registry
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> None:
+    registry = Registry()
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(
+            registry,
+            GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
+        )
+    assert exc_info.value.status == 'NOT_FOUND'
+    assert "Failed to resolve model 'lyria-3-clip-preview'." in str(exc_info.value)
+    assert 'Ensure the model name includes the plugin namespace' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_no_model_is_invalid_argument() -> None:
+    registry = Registry()
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(registry, GenerateActionOptions(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'No model configured' in str(exc_info.value)


### PR DESCRIPTION
## Summary
- When `generate` has no model configured, callers get a clear invalid-argument error instead of a bare exception.
- When a model name can't be resolved, the error says so explicitly and, if the name has no plugin prefix, hints that it should look like `plugin/model`.
- Adds tests for both failure paths.
