### PR TITLE
feat(py): Make ModelRequest generic

### DIFF
--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -47,6 +47,7 @@ from genkit import (
     ToolDefinition,
     ToolRequestPart,
 )
+from genkit._core._model import OutputConfig
 
 
 def _create_sample_request() -> ModelRequest:
@@ -442,8 +443,7 @@ class TestMaybeStripFences:
         """Strips markdown fences when JSON output is requested."""
         request = ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
-            output_format='json',
-            output_schema={'type': 'object'},
+            output=OutputConfig(format='json', json_schema={'type': 'object'}),
         )
         parts = [Part(root=TextPart(text='```json\n{"a": 1}\n```'))]
         result = maybe_strip_fences(request, parts)
@@ -453,7 +453,7 @@ class TestMaybeStripFences:
         """Does not modify responses when output format is not json."""
         request = ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
-            output_format='text',
+            output=OutputConfig(format='text'),
         )
         fenced = '```json\n{"a": 1}\n```'
         parts = [Part(root=TextPart(text=fenced))]
@@ -474,8 +474,7 @@ class TestMaybeStripFences:
         """Does not modify clean JSON responses."""
         request = ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
-            output_format='json',
-            output_schema={'type': 'object'},
+            output=OutputConfig(format='json', json_schema={'type': 'object'}),
         )
         text = '{"name": "John"}'
         parts = [Part(root=TextPart(text=text))]
@@ -699,9 +698,11 @@ def test_structured_output_uses_native_output_config(model_name: str) -> None:
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
-        output_format='json',
-        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
-        output_constrained=True,
+        output=OutputConfig(
+            format='json',
+            json_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+            constrained=True,
+        ),
     )
 
     params = model._build_params(request)
@@ -718,9 +719,7 @@ def test_structured_output_uses_native_output_config_for_empty_schema() -> None:
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate JSON'))])],
-        output_format='json',
-        output_schema={},
-        output_constrained=True,
+        output=OutputConfig(format='json', json_schema={}, constrained=True),
     )
 
     params = model._build_params(request)
@@ -735,8 +734,7 @@ def test_structured_output_falls_back_to_system_prompt() -> None:
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate JSON'))])],
-        output_format='json',
-        output_constrained=True,
+        output=OutputConfig(format='json', constrained=True),
     )
 
     params = model._build_params(request)
@@ -754,9 +752,11 @@ def test_structured_output_falls_back_when_unconstrained(output_constrained: boo
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
-        output_format='json',
-        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
-        output_constrained=output_constrained,
+        output=OutputConfig(
+            format='json',
+            json_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+            constrained=output_constrained,
+        ),
     )
 
     params = model._build_params(request)
@@ -776,9 +776,11 @@ def test_structured_output_falls_back_for_unsupported_models() -> None:
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
-        output_format='json',
-        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
-        output_constrained=True,
+        output=OutputConfig(
+            format='json',
+            json_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+            constrained=True,
+        ),
     )
 
     params = model._build_params(request)
@@ -798,9 +800,11 @@ def test_structured_output_falls_back_when_model_disallows_constraints() -> None
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
-        output_format='json',
-        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
-        output_constrained=True,
+        output=OutputConfig(
+            format='json',
+            json_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+            constrained=True,
+        ),
     )
 
     params = model._build_params(request)
@@ -817,9 +821,11 @@ def test_structured_output_with_no_tools_capability() -> None:
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
-        output_format='json',
-        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
-        output_constrained=True,
+        output=OutputConfig(
+            format='json',
+            json_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+            constrained=True,
+        ),
     )
     params_without_tools = model._build_params(request)
 
@@ -1317,10 +1323,12 @@ def test_structured_output_merges_existing_output_config() -> None:
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
-        output_format='json',
-        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+        output=OutputConfig(
+            format='json',
+            json_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+            constrained=True,
+        ),
         config=config,
-        output_constrained=True,
     )
 
     params = model._build_params(request)

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -35,6 +35,7 @@ from genkit import (
     Role,
     TextPart,
 )
+from genkit._core._model import OutputConfig
 from genkit.plugin_api import ActionRunContext
 
 
@@ -209,25 +210,31 @@ class TestNeedsSchemaInPrompt:
     def test_true_for_deepseek_with_json_and_schema(self) -> None:
         """Returns True for DeepSeek model with json format and schema."""
         model = OpenAIModel(model='deepseek-chat', client=MagicMock())
-        request = ModelRequest(messages=[], output_format='json', output_schema=_SAMPLE_SCHEMA)
+        request = ModelRequest(
+            messages=[],
+            output=OutputConfig(format='json', json_schema=_SAMPLE_SCHEMA),
+        )
         assert model._needs_schema_in_prompt(request) is True
 
     def test_false_for_gpt_with_json_and_schema(self) -> None:
         """Returns False for GPT models even with json format and schema."""
         model = OpenAIModel(model='gpt-4o', client=MagicMock())
-        request = ModelRequest(messages=[], output_format='json', output_schema=_SAMPLE_SCHEMA)
+        request = ModelRequest(
+            messages=[],
+            output=OutputConfig(format='json', json_schema=_SAMPLE_SCHEMA),
+        )
         assert model._needs_schema_in_prompt(request) is False
 
     def test_false_for_deepseek_without_schema(self) -> None:
         """Returns False for DeepSeek when no schema is provided."""
         model = OpenAIModel(model='deepseek-chat', client=MagicMock())
-        request = ModelRequest(messages=[], output_format='json')
+        request = ModelRequest(messages=[], output=OutputConfig(format='json'))
         assert model._needs_schema_in_prompt(request) is False
 
     def test_false_for_deepseek_with_text_format(self) -> None:
         """Returns False for DeepSeek when format is text."""
         model = OpenAIModel(model='deepseek-chat', client=MagicMock())
-        request = ModelRequest(messages=[], output_format='text')
+        request = ModelRequest(messages=[], output=OutputConfig(format='text'))
         assert model._needs_schema_in_prompt(request) is False
 
     def test_false_for_no_format(self) -> None:
@@ -270,8 +277,7 @@ class TestSchemaInjectionInConfig:
             messages=[
                 Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a character'))]),
             ],
-            output_format='json',
-            output_schema=_SAMPLE_SCHEMA,
+            output=OutputConfig(format='json', json_schema=_SAMPLE_SCHEMA),
         )
         config = await model._get_openai_request_config(request)
 
@@ -291,8 +297,7 @@ class TestSchemaInjectionInConfig:
             messages=[
                 Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a character'))]),
             ],
-            output_format='json',
-            output_schema=_SAMPLE_SCHEMA,
+            output=OutputConfig(format='json', json_schema=_SAMPLE_SCHEMA),
         )
         config = await model._get_openai_request_config(request)
 
@@ -309,7 +314,7 @@ class TestSchemaInjectionInConfig:
             messages=[
                 Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))]),
             ],
-            output_format='json',
+            output=OutputConfig(format='json'),
         )
         config = await model._get_openai_request_config(request)
 
@@ -326,8 +331,7 @@ class TestSchemaInjectionInConfig:
                 Message(role=Role.SYSTEM, content=[Part(root=TextPart(text='You are helpful'))]),
                 Message(role=Role.USER, content=[Part(root=TextPart(text='Generate'))]),
             ],
-            output_format='json',
-            output_schema=_SAMPLE_SCHEMA,
+            output=OutputConfig(format='json', json_schema=_SAMPLE_SCHEMA),
         )
         config = await model._get_openai_request_config(request)
 
@@ -384,8 +388,7 @@ class TestCleanJsonResponse:
         model = OpenAIModel(model='deepseek-chat', client=MagicMock())
         request = ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
-            output_format='json',
-            output_schema=_SAMPLE_SCHEMA,
+            output=OutputConfig(format='json', json_schema=_SAMPLE_SCHEMA),
         )
         response = ModelResponse(
             request=request,
@@ -403,8 +406,7 @@ class TestCleanJsonResponse:
         model = OpenAIModel(model='gpt-4o', client=MagicMock())
         request = ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
-            output_format='json',
-            output_schema=_SAMPLE_SCHEMA,
+            output=OutputConfig(format='json', json_schema=_SAMPLE_SCHEMA),
         )
         fenced_text = '```json\n{"name": "John", "level": 5}\n```'
         response = ModelResponse(
@@ -423,7 +425,7 @@ class TestCleanJsonResponse:
         model = OpenAIModel(model='deepseek-chat', client=MagicMock())
         request = ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
-            output_format='text',
+            output=OutputConfig(format='text'),
         )
         text = '```json\n{"a": 1}\n```'
         response = ModelResponse(
@@ -454,8 +456,7 @@ class TestCleanJsonResponse:
         model = OpenAIModel(model='deepseek-chat', client=MagicMock())
         request = ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
-            output_format='json',
-            output_schema=_SAMPLE_SCHEMA,
+            output=OutputConfig(format='json', json_schema=_SAMPLE_SCHEMA),
         )
         text = '{"name": "John", "level": 5}'
         response = ModelResponse(

--- a/py/packages/genkit/src/genkit/_ai/_formats/_array.py
+++ b/py/packages/genkit/src/genkit/_ai/_formats/_array.py
@@ -44,16 +44,14 @@ class ArrayFormat(FormatDef):
 
     Usage:
         ai.generate(
-            output=OutputConfig(
-                format='array',
-                schema={
-                    'type': 'array',
-                    'items': {
-                        'type': 'object',
-                        'properties': {'name': {'type': 'string'}}
-                    }
+            output_format='array',
+            output_schema={
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {'name': {'type': 'string'}}
                 }
-            )
+            }
         )
     """
 

--- a/py/packages/genkit/src/genkit/_ai/_formats/_enum.py
+++ b/py/packages/genkit/src/genkit/_ai/_formats/_enum.py
@@ -41,13 +41,11 @@ class EnumFormat(FormatDef):
 
     Usage:
         ai.generate(
-            output=OutputConfig(
-                format='enum',
-                schema={
-                    'type': 'string',
-                    'enum': ['positive', 'negative', 'neutral']
-                }
-            )
+            output_format='enum',
+            output_schema={
+                'type': 'string',
+                'enum': ['positive', 'negative', 'neutral']
+            }
         )
     """
 

--- a/py/packages/genkit/src/genkit/_ai/_formats/_json.py
+++ b/py/packages/genkit/src/genkit/_ai/_formats/_json.py
@@ -40,10 +40,8 @@ class JsonFormat(FormatDef):
 
     Usage:
         ai.generate(
-            output=OutputConfig(
-                format='json',
-                schema={'type': 'object', 'properties': {'foo': {'type': 'string'}}}
-            )
+            output_format='json',
+            output_schema={'type': 'object', 'properties': {'foo': {'type': 'string'}}}
         )
     """
 

--- a/py/packages/genkit/src/genkit/_ai/_formats/_jsonl.py
+++ b/py/packages/genkit/src/genkit/_ai/_formats/_jsonl.py
@@ -46,13 +46,11 @@ class JsonlFormat(FormatDef):
 
     Usage:
         ai.generate(
-            output=OutputConfig(
-                format='jsonl',
-                schema={
-                    'type': 'array',
-                    'items': {'type': 'object', 'properties': ...}
-                }
-            )
+            output_format='jsonl',
+            output_schema={
+                'type': 'array',
+                'items': {'type': 'object', 'properties': ...}
+            }
         )
     """
 

--- a/py/packages/genkit/src/genkit/_ai/_formats/_text.py
+++ b/py/packages/genkit/src/genkit/_ai/_formats/_text.py
@@ -34,7 +34,7 @@ class TextFormat(FormatDef):
 
     Usage:
         ai.generate(
-            output=OutputConfig(format='text')
+            output_format='text'
         )
     """
 

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -25,7 +25,7 @@ from collections.abc import Awaitable, Callable, Generator, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typing_extensions import Never
 
 from genkit._ai._agents._session import get_current_session
@@ -62,6 +62,7 @@ from genkit._core._middleware import (
 from genkit._core._model import (
     Document,
     GenerateActionOptions,
+    OutputConfig,
 )
 from genkit._core._protocols import RegistryLike, SessionLike
 from genkit._core._registry import Registry
@@ -1137,7 +1138,7 @@ async def resolve_parameters(
 
 
 async def action_to_generate_request(
-    options: GenerateActionOptions, resolved_tools: list[Action], _model: Action
+    options: GenerateActionOptions, resolved_tools: list[Action], model: Action
 ) -> ModelRequest[Any]:
     """Convert GenerateActionOptions to a ModelRequest with tool definitions."""
     # TODO(#4340): add warning when tools are not supported in ModelInfo
@@ -1148,18 +1149,34 @@ async def action_to_generate_request(
     out_schema = output.json_schema if output else None
     if out_schema is not None and hasattr(out_schema, 'model_dump'):
         out_schema = out_schema.model_dump()
-    return ModelRequest(
+    request_kwargs: dict[str, Any] = dict(
         # Field validators auto-wrap MessageData -> Message and DocumentData -> Document
-        messages=options.messages,  # type: ignore[arg-type]
-        config=options.config if options.config is not None else {},  # type: ignore[arg-type]
-        docs=options.docs if options.docs else None,  # type: ignore[arg-type]
+        messages=options.messages,
+        config=options.config if options.config is not None else {},
+        docs=options.docs if options.docs else None,
         tools=tool_defs,
         tool_choice=options.tool_choice,
-        output_format=output.format if output else None,
-        output_schema=out_schema,
-        output_constrained=output.constrained if output else None,
-        output_content_type=output.content_type if output else None,
+        output=OutputConfig(
+            format=output.format if output else None,
+            # pyrefly: ignore[unexpected-keyword] - populate_by_name accepts the field name
+            json_schema=out_schema,
+            constrained=output.constrained if output else None,
+            content_type=output.content_type if output else None,
+        ),
     )
+    input_class = model.input_class
+    if input_class is not None and issubclass(input_class, ModelRequest) and input_class is not ModelRequest:
+        try:
+            # Fast path: construct the action's exact input class so validation
+            # happens once, here; _validate_input then passes it through as-is.
+            return input_class(**request_kwargs)
+        except ValidationError:
+            # Invalid input for the typed class. Fall through to the bare
+            # carrier so Action._validate_input re-discovers the failure and
+            # raises the proper GenkitError(INVALID_ARGUMENT) with the action
+            # name — the pre-fast-path error contract, preserved exactly.
+            pass
+    return ModelRequest(**request_kwargs)
 
 
 def to_tool_definition(tool: Action) -> ToolDefinition:

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -18,8 +18,9 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any, cast
+from typing import Annotated, Any, cast, get_args, get_origin, get_type_hints
 
 from pydantic import BaseModel
 
@@ -29,6 +30,7 @@ from genkit._core._action import (
     ActionRunContext,
     get_func_description,
 )
+from genkit._core._error import GenkitError
 from genkit._core._model import (
     Message,
     ModelConfig,
@@ -87,6 +89,42 @@ def model_ref(
     )
 
 
+def _check_request_annotation(name: str, fn: ModelFn) -> None:
+    """Reject model fns whose request annotation is not a ModelRequest class.
+
+    Unions like ``ModelRequest[X] | None`` are an antipattern: generate() never
+    passes None, and a non-class annotation silently disables typed-request
+    construction (the request falls back to the untyped carrier + rebuild).
+    Fail fast at definition time with an actionable message instead.
+    """
+    try:
+        hints = get_type_hints(fn, include_extras=True)
+        params = list(inspect.signature(fn).parameters)
+    except Exception:  # noqa: BLE001 - unresolvable annotations: let Action handle it
+        return
+    if not params:
+        return
+    ann = hints.get(params[0])
+    if ann is None:
+        return  # unannotated stays allowed
+    if get_origin(ann) is Annotated:
+        ann = get_args(ann)[0]
+    # Hand-written ModelRequest subclasses also pass this check. That is
+    # incidental — generate() only builds bare ModelRequest and
+    # ModelRequest[Config], so subclassing is not a supported surface.
+    if isinstance(ann, type) and issubclass(ann, ModelRequest):
+        return
+    raise GenkitError(
+        status='INVALID_ARGUMENT',
+        message=(
+            f"Model '{name}': the request parameter must be annotated as ModelRequest "
+            f'or ModelRequest[YourConfig], got {ann!r}. Unions such as '
+            f"'ModelRequest[X] | None' are not allowed: generate() never passes None, "
+            f'and non-class annotations disable typed-request construction.'
+        ),
+    )
+
+
 def define_model(
     registry: Registry,
     name: str,
@@ -97,6 +135,7 @@ def define_model(
     description: str | None = None,
 ) -> Action:
     """Register a custom model action."""
+    _check_request_annotation(name, fn)
     # Build model options dict
     model_options: dict[str, object] = {}
 

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -59,13 +59,12 @@ from genkit._core._channel import Channel
 from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger
 from genkit._core._middleware import BaseMiddleware, middleware_class_index
-from genkit._core._model import Document, GenerateActionOptions, Message, ModelConfig
+from genkit._core._model import Document, GenerateActionOptions, Message, ModelConfig, OutputConfig
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
     GenerateActionOutputConfig,
     MiddlewareRef,
-    OutputConfig,
     Part,
     Resume,
     Role,
@@ -720,7 +719,7 @@ async def to_generate_request(registry: Registry, options: GenerateActionOptions
         content_type=options.output.content_type if options.output else None,
         format=options.output.format if options.output else None,
         # pyrefly: ignore[unexpected-keyword] - populate_by_name accepts the field name
-        json_schema=options.output.json_schema if options.output else None,  # pyright: ignore[reportCallIssue]
+        json_schema=options.output.json_schema if options.output else None,
         constrained=options.output.constrained if options.output else None,
     )
     return ModelRequest(
@@ -730,10 +729,7 @@ async def to_generate_request(registry: Registry, options: GenerateActionOptions
         docs=options.docs if options.docs else None,  # type: ignore[arg-type]
         tools=tool_defs,
         tool_choice=options.tool_choice,
-        output_format=output_config.format,
-        output_schema=output_config.json_schema,
-        output_constrained=output_config.constrained,
-        output_content_type=output_config.content_type,
+        output=output_config,
     )
 
 

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -33,6 +33,7 @@ from typing_extensions import TypeVar
 from genkit._core._channel import Channel, CloseableQueue
 from genkit._core._compat import StrEnum
 from genkit._core._error import GenkitError
+from genkit._core._model import config_type_path, declared_config_type
 from genkit._core._schema import to_json_schema
 from genkit._core._trace._suppress import suppress_telemetry
 from genkit._core._tracing import SpanMetadata, run_in_new_span
@@ -703,13 +704,25 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         if input is None and self._first_arg_optional:
             return input
         payload: object = input
-        # If input is a BaseModel of a different type (e.g. ModelRequest[dict] vs
-        # ModelRequest[PluginConfig]), Pydantic rejects direct class validation.
-        # Dump to a plain dict so we can re-parse into the action's schema.
+        # A differently-typed ModelRequest with a mapping config is dumped and
+        # re-parsed into the plugin class. A Pydantic config instance of the
+        # wrong class is a caller mistake — dump would silently coerce it.
         if isinstance(input, BaseModel):
             try:
                 return self._input_type.validate_python(input)
             except ValidationError:
+                config = getattr(input, 'config', None)
+                if isinstance(config, BaseModel):
+                    expected = declared_config_type(self._input_class) if self._input_class is not None else None
+                    want = config_type_path(expected) if isinstance(expected, type) else 'the plugin config class'
+                    raise GenkitError(
+                        message=(
+                            f"Invalid input for action '{self.name}': "
+                            f'config must be {want} or a mapping, '
+                            f'got {config_type_path(type(config))}'
+                        ),
+                        status='INVALID_ARGUMENT',
+                    ) from None
                 payload = input.model_dump(mode='python')
 
         try:

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -472,6 +472,11 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         return self._input_type
 
     @property
+    def input_class(self) -> type | None:
+        """The action's input annotation as a concrete class, when it is one."""
+        return getattr(self, '_input_class', None)
+
+    @property
     def input_schema(self) -> dict[str, object]:
         return self._input_schema
 
@@ -626,10 +631,12 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
             type_adapter = TypeAdapter(arg_types[0])
             self._input_schema: dict[str, object] = type_adapter.json_schema()
             self._input_type: TypeAdapter[InputT] | None = cast(TypeAdapter[InputT], type_adapter)
+            self._input_class: type | None = arg_types[0] if isinstance(arg_types[0], type) else None
             self._metadata[ActionMetadataKey.INPUT_KEY] = self._input_schema
         else:
             self._input_schema = TypeAdapter(object).json_schema()
             self._input_type = None
+            self._input_class = None
             self._metadata[ActionMetadataKey.INPUT_KEY] = self._input_schema
 
         if ActionMetadataKey.RETURN in annotations:
@@ -695,22 +702,25 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         # signal that "no input" is a legitimate way to invoke this action.
         if input is None and self._first_arg_optional:
             return input
+        payload: object = input
+        # If input is a BaseModel of a different type (e.g. ModelRequest[dict] vs
+        # ModelRequest[PluginConfig]), Pydantic rejects direct class validation.
+        # Dump to a plain dict so we can re-parse into the action's schema.
+        if isinstance(input, BaseModel):
+            try:
+                return self._input_type.validate_python(input)
+            except ValidationError:
+                payload = input.model_dump(mode='python')
+
         try:
-            return self._input_type.validate_python(input)
+            return self._input_type.validate_python(payload)
         except ValidationError as e:
-            if input is None:
-                raise GenkitError(
-                    message=(
-                        f"Action '{self.name}' requires input but none was provided. "
-                        'Please supply a valid input payload.'
-                    ),
-                    status='INVALID_ARGUMENT',
-                ) from e
-            raise GenkitError(
-                message=f"Invalid input for action '{self.name}': {e}",
-                status='INVALID_ARGUMENT',
-                cause=e,
-            ) from e
+            msg = (
+                f"Action '{self.name}' requires input but none was provided. Please supply a valid input payload."
+                if input is None
+                else f"Invalid input for action '{self.name}': {e}"
+            )
+            raise GenkitError(message=msg, status='INVALID_ARGUMENT', cause=e) from e
 
     async def _run_with_telemetry(
         self,

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -75,7 +75,9 @@ ConfigT = TypeVar('ConfigT', bound=ModelConfig, default=ModelConfig)
 ModelRefConfigT = TypeVar('ModelRefConfigT', bound=BaseModel, covariant=True)
 # Unbounded so ModelRequest can carry plugin config schemas, plain dicts, or
 # ModelConfig subclasses without forcing everything through GenerationCommonConfig.
-ModelRequestConfigT = TypeVar('ModelRequestConfigT', covariant=True)
+# Invariant: config is writable, so ModelRequest[GeminiConfig] is not a
+# ModelRequest[ModelConfig] you can assign a ModelConfig into.
+ModelRequestConfigT = TypeVar('ModelRequestConfigT')
 
 
 def declared_config_type(cls: type) -> type | None:
@@ -398,11 +400,23 @@ class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
     @field_validator('docs', mode='before')
     @classmethod
     def _wrap_docs(cls, v: list[DocumentData] | None) -> list[Document] | None:
-        """Wrap DocumentData in Document veneer for convenience methods."""
+        """Wrap DocumentData in Document veneer for convenience methods.
+
+        A dumped request sends docs as dicts. Messages already take a mapping;
+        this wrap has to as well or a bad config plus docs= never reaches the
+        GenkitError for the config.
+        """
         if v is None:
             return None
-        # pyrefly: ignore[bad-return]
-        return [d if isinstance(d, Document) else Document(d.content, d.metadata) for d in v]
+        wrapped: list[Document] = []
+        for d in v:
+            if isinstance(d, Document):
+                wrapped.append(d)
+            elif isinstance(d, dict):
+                wrapped.append(Document(d.get('content') or [], d.get('metadata')))
+            else:
+                wrapped.append(Document(d.content, d.metadata))
+        return wrapped
 
     # Flat accessors: the plugin-author convenience surface over nested output.
 

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -22,10 +22,11 @@ properties and methods on top of the generated wire types.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import cached_property
+from importlib import import_module
 from typing import Any, ClassVar, Generic, cast
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
@@ -75,6 +76,48 @@ ModelRefConfigT = TypeVar('ModelRefConfigT', bound=BaseModel, covariant=True)
 # Unbounded so ModelRequest can carry plugin config schemas, plain dicts, or
 # ModelConfig subclasses without forcing everything through GenerationCommonConfig.
 ModelRequestConfigT = TypeVar('ModelRequestConfigT', covariant=True)
+
+
+def declared_config_type(cls: type) -> type | None:
+    """The config class on ``ModelRequest[ThatClass]``, or None if unparametrized."""
+    meta = getattr(cls, '__pydantic_generic_metadata__', None)
+    if not meta:
+        return None
+    args = meta.get('args') or ()
+    if not args:
+        return None
+    arg = args[0]
+    if isinstance(arg, TypeVar) or arg is Any:
+        return None
+    return arg
+
+
+def config_type_path(cls: type) -> str:
+    """The public import a plugin author would use, else the defining module.
+
+    Walks parent packages from the top and uses the first one that re-exports
+    this class under the same name (``genkit_openai.OpenAIConfig``, not
+    ``genkit_openai.typing.OpenAIConfig``). Nested / test-local classes keep
+    the defining path.
+    """
+    impl = f'{cls.__module__}.{cls.__qualname__}'
+    if '<locals>' in cls.__qualname__ or '.' in cls.__qualname__:
+        return impl
+    parts = cls.__module__.split('.')
+    name = cls.__name__
+    for i in range(1, len(parts) + 1):
+        mod_name = '.'.join(parts[:i])
+        try:
+            mod = import_module(mod_name)
+        except ImportError:
+            continue
+        if getattr(mod, name, None) is not cls:
+            continue
+        public = getattr(mod, '__all__', None)
+        if public is not None and name not in public:
+            continue
+        return f'{mod_name}.{name}'
+    return impl
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -325,14 +368,25 @@ class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
     @field_validator('config', mode='before')
     @classmethod
     def _check_config_type(cls, v: object) -> object:
-        """Ensure config is None, a dict, or a BaseModel instance.
+        """A mapping is the bag the plugin schema coerces.
 
-        Raises ValueError (not TypeError) so pydantic wraps it in a
-        ValidationError and the veneer's error contract holds.
+        A Pydantic instance is only legal if it is that schema. OpenAIConfig
+        on a Gemini request is a caller mistake — pass a mapping instead.
         """
-        if v is not None and not isinstance(v, (BaseModel, dict)):
-            raise ValueError(f'config must be a BaseModel or dict, got {type(v).__name__}')
-        return v
+        if v is None:
+            return v
+        if isinstance(v, Mapping) and not isinstance(v, BaseModel):
+            return v
+        if isinstance(v, BaseModel):
+            expected = declared_config_type(cls)
+            if isinstance(expected, type) and issubclass(expected, BaseModel) and not isinstance(v, expected):
+                raise ValueError(
+                    f'config must be {config_type_path(expected)} or a mapping, got {config_type_path(type(v))}'
+                )
+            if expected is dict:
+                raise ValueError(f'config must be a mapping, got {type(v).__name__}')
+            return v
+        raise ValueError(f'config must be a BaseModel or mapping, got {type(v).__name__}')
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, ClassVar, Generic, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
@@ -52,6 +52,7 @@ from genkit._core._typing import (
     ModelInfo,
     ModelResponseChunk as ModelResponseChunkSchema,
     Operation,
+    OutputConfig as OutputConfigData,
     Part,
     Resume,
     Role,
@@ -71,6 +72,9 @@ ConfigT = TypeVar('ConfigT', bound=ModelConfig, default=ModelConfig)
 # Bound to BaseModel so ModelRef is always parameterized with a concrete Pydantic config schema.
 # Covariant so ModelRef[GeminiConfig] is assignable to ModelRef[BaseModel] or ModelRef[Any].
 ModelRefConfigT = TypeVar('ModelRefConfigT', bound=BaseModel, covariant=True)
+# Unbounded so ModelRequest can carry plugin config schemas, plain dicts, or
+# ModelConfig subclasses without forcing everything through GenerationCommonConfig.
+ModelRequestConfigT = TypeVar('ModelRequestConfigT', covariant=True)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -273,12 +277,22 @@ class Document(DocumentData):
         return None
 
 
-class ModelRequest(GenkitModel, Generic[ConfigT]):
-    """Hand-written model request with flat output fields and veneer types.
+class OutputConfig(OutputConfigData):
+    """Output settings for a model request.
 
-    Output config is inlined as flat fields (output_format, output_schema, etc.)
-    instead of a nested OutputConfig object. Messages and docs use veneer types
-    (Message, Document) for convenience methods like .text.
+    Construct with ``json_schema=``; the serialized key on the wire is
+    ``schema``. This is the class to import and construct from hand-written
+    code.
+    """
+
+
+class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
+    """Hand-written model request with veneer types and flat output accessors.
+
+    Output settings live nested as ``output: OutputConfig`` so dump/validate
+    round-trips the wire shape, while flat properties (``output_format`` etc.)
+    stay the plugin-author convenience surface. Messages and docs use veneer
+    types (Message, Document) for helpers like ``.text``.
 
     Example:
         class GeminiConfig(ModelConfig):
@@ -290,20 +304,35 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
                 print(msg.text)  # Message veneer property
             if request.output_format == 'json':
                 schema = request.output_schema
+
+    Note:
+        Pass output settings as ``output=OutputConfig(...)``. The flat
+        names (``output_format`` etc.) are convenience properties you read
+        and write after construction — they are not constructor arguments,
+        so passing them there leaves output unset.
     """
 
     model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='allow', populate_by_name=True)
     # Veneer types for IDE/typing (validators wrap MessageData->Message, DocumentData->Document)
     messages: list[Message]  # pyright: ignore[reportIncompatibleVariableOverride]
     docs: list[Document] | None = None  # pyright: ignore[reportIncompatibleVariableOverride]
-    config: ConfigT | None = None
+    config: ModelRequestConfigT | None = None
     tools: list[ToolDefinition] | None = None
     tool_choice: ToolChoice | None = Field(default=None)
-    # Flat output fields (no nested OutputConfig)
-    output_format: str | None = None
-    output_schema: dict[str, Any] | None = None
-    output_constrained: bool | None = None
-    output_content_type: str | None = None
+    # Wire-shaped output storage; flat access via the properties below.
+    output: OutputConfig = Field(default_factory=OutputConfig)
+
+    @field_validator('config', mode='before')
+    @classmethod
+    def _check_config_type(cls, v: object) -> object:
+        """Ensure config is None, a dict, or a BaseModel instance.
+
+        Raises ValueError (not TypeError) so pydantic wraps it in a
+        ValidationError and the veneer's error contract holds.
+        """
+        if v is not None and not isinstance(v, (BaseModel, dict)):
+            raise ValueError(f'config must be a BaseModel or dict, got {type(v).__name__}')
+        return v
 
     @field_validator('messages', mode='before')
     @classmethod
@@ -321,27 +350,43 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
         # pyrefly: ignore[bad-return]
         return [d if isinstance(d, Document) else Document(d.content, d.metadata) for d in v]
 
-    @model_serializer(mode='wrap')
-    def _serialize_for_spec(self, serializer: Callable[..., dict[str, Any]]) -> dict[str, Any]:
-        """Serialize to spec wire format with nested output (matches JS/Go)."""
-        data = serializer(self)
-        # Build nested output from flat fields - spec expects output key always present
-        output: dict[str, Any] = {}
-        if self.output_format is not None:
-            output['format'] = self.output_format
-        if self.output_schema is not None:
-            output['schema'] = self.output_schema
-        if self.output_constrained is not None:
-            output['constrained'] = self.output_constrained
-        if self.output_content_type is not None:
-            output['contentType'] = self.output_content_type
-        # Remove flat fields, add nested output
-        data.pop('outputFormat', None)
-        data.pop('outputSchema', None)
-        data.pop('outputConstrained', None)
-        data.pop('outputContentType', None)
-        data['output'] = output
-        return data
+    # Flat accessors: the plugin-author convenience surface over nested output.
+
+    @property
+    def output_format(self) -> str | None:
+        """Output format (e.g. 'json'); reads ``output.format``."""
+        return self.output.format
+
+    @output_format.setter
+    def output_format(self, v: str | None) -> None:
+        self.output.format = v
+
+    @property
+    def output_schema(self) -> dict[str, Any] | None:
+        """Output JSON schema; reads ``output.json_schema``."""
+        return self.output.json_schema
+
+    @output_schema.setter
+    def output_schema(self, v: dict[str, Any] | None) -> None:
+        self.output.json_schema = v
+
+    @property
+    def output_constrained(self) -> bool | None:
+        """Whether constrained decoding is requested; reads ``output.constrained``."""
+        return self.output.constrained
+
+    @output_constrained.setter
+    def output_constrained(self, v: bool | None) -> None:
+        self.output.constrained = v
+
+    @property
+    def output_content_type(self) -> str | None:
+        """Output content type; reads ``output.content_type``."""
+        return self.output.content_type
+
+    @output_content_type.setter
+    def output_content_type(self, v: str | None) -> None:
+        self.output.content_type = v
 
 
 class ModelResponse(GenkitModel, Generic[OutputT]):

--- a/py/packages/genkit/src/genkit/_core/_typing.py
+++ b/py/packages/genkit/src/genkit/_core/_typing.py
@@ -583,7 +583,7 @@ class OutputConfig(GenkitModel):
         alias_generator=to_camel, extra='forbid', populate_by_name=True, protected_namespaces=()
     )
     format: str | None = None
-    json_schema: dict[str, Any] | None = Field(default=None, alias='schema')
+    json_schema: dict[str, Any] | None = Field(default=None, validation_alias='schema', serialization_alias='schema')
     constrained: bool | None = None
     content_type: str | None = None
 

--- a/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
@@ -19,7 +19,7 @@ from genkit._ai._generate import (
 )
 from genkit._ai._testing import define_programmable_model
 from genkit._core._environment import GENKIT_ENV
-from genkit._core._logger import GENKIT_LOG
+from genkit._core._logger import GENKIT_LOG, get_logger
 from genkit._core._typing import CustomPart, GenerationUsage, Media, MediaPart, Role, TextPart
 
 BLOB = 'A' * 1_000_000
@@ -169,10 +169,12 @@ async def test_generate_logs_nothing_at_default_level() -> None:
     structlog.reset_defaults()
 
     with capture_logs() as entries:
+        get_logger('genkit.test').info('capture probe')
         await _generate_once()
 
     events = [entry['event'] for entry in entries]
-    assert events == []
+    assert 'capture probe' in events
+    assert 'generate response' not in events
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/generate_request_construction_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_request_construction_test.py
@@ -3,7 +3,7 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed-request fast path through generate: happy path, error contract, escape hatch."""
+"""What a plugin handler sees after ai.generate: typed config, extras, errors, output."""
 
 import pytest
 from pydantic import BaseModel
@@ -16,21 +16,21 @@ from genkit._core._typing import Part, Role, TextPart
 
 
 class ConformingCfg(BaseModel):
-    """Follows the extra='allow' convention: the escape hatch stays open."""
+    """Unknown keys are kept."""
 
     model_config = {'extra': 'allow'}
     temperature: float | None = None
 
 
 class StrictCfg(BaseModel):
-    """Deliberately closes the hatch — a legitimate plugin choice."""
+    """Unknown keys are rejected."""
 
     model_config = {'extra': 'forbid'}
     temperature: float | None = None
 
 
 class PluginOnlyCfg(ModelConfig):
-    """A field the common config does not have. The plugin schema owns it."""
+    """A knob the common config does not have."""
 
     duration_seconds: int | None = None
 
@@ -45,6 +45,7 @@ def ai_and_seen() -> tuple[Genkit, dict]:
 
     async def conforming(request: ModelRequest[ConformingCfg], ctx: ActionRunContext) -> ModelResponse:
         seen['config'] = request.config
+        seen['request'] = request
         return OK
 
     async def strict(request: ModelRequest[StrictCfg], ctx: ActionRunContext) -> ModelResponse:
@@ -68,7 +69,7 @@ def ai_and_seen() -> tuple[Genkit, dict]:
 
 @pytest.mark.asyncio
 async def test_typed_plugin_receives_typed_config(ai_and_seen: tuple[Genkit, dict]) -> None:
-    """Fast path: the dict config arrives parsed into the plugin's class."""
+    """ai.generate(config={'temperature': 0.7}) arrives as MyConfig.temperature."""
     ai, seen = ai_and_seen
     await ai.generate(model='conforming', prompt='hi', config={'temperature': 0.7})
     assert isinstance(seen['config'], ConformingCfg)
@@ -79,12 +80,7 @@ async def test_typed_plugin_receives_typed_config(ai_and_seen: tuple[Genkit, dic
 async def test_typed_plugin_receives_plugin_only_fields_from_instance(
     ai_and_seen: tuple[Genkit, dict],
 ) -> None:
-    """Plugin-only knobs are legal because the action parses its schema.
-
-    ``duration_seconds`` is not on the common config. Passing the object or a
-    dict both land as ``PluginOnlyCfg.duration_seconds`` — not because generate
-    kept the instance, because ``ModelRequest[PluginOnlyCfg]`` rehydrated it.
-    """
+    """A field only the plugin schema owns still arrives, from an instance or a dict."""
     ai, seen = ai_and_seen
     cfg = PluginOnlyCfg(duration_seconds=8)
 
@@ -99,7 +95,7 @@ async def test_typed_plugin_receives_plugin_only_fields_from_instance(
 
 @pytest.mark.asyncio
 async def test_bare_plugin_receives_raw_dict(ai_and_seen: tuple[Genkit, dict]) -> None:
-    """Pass-through carrier: bare ModelRequest never transforms config."""
+    """A handler annotated ModelRequest (no type param) still sees the raw dict."""
     ai, seen = ai_and_seen
     await ai.generate(model='bare', prompt='hi', config={'temperature': 0.7, 'anything': 1})
     assert seen['config'] == {'temperature': 0.7, 'anything': 1}
@@ -108,7 +104,7 @@ async def test_bare_plugin_receives_raw_dict(ai_and_seen: tuple[Genkit, dict]) -
 
 @pytest.mark.asyncio
 async def test_omitted_config_yields_empty_typed_config(ai_and_seen: tuple[Genkit, dict]) -> None:
-    """The request is never None; absent config means an empty typed config."""
+    """Omitting config still gives the plugin an empty MyConfig, not None."""
     ai, seen = ai_and_seen
     await ai.generate(model='conforming', prompt='hi')
     assert isinstance(seen['config'], ConformingCfg)
@@ -117,7 +113,7 @@ async def test_omitted_config_yields_empty_typed_config(ai_and_seen: tuple[Genki
 
 @pytest.mark.asyncio
 async def test_unknown_keys_reach_plugin_via_model_extra(ai_and_seen: tuple[Genkit, dict]) -> None:
-    """D1 escape hatch, end to end: unknown keys survive to model_extra."""
+    """A key the plugin schema does not declare still reaches model_extra."""
     ai, seen = ai_and_seen
     await ai.generate(model='conforming', prompt='hi', config={'thinking': {'budget': 8192}})
     assert seen['config'].model_extra == {'thinking': {'budget': 8192}}
@@ -125,7 +121,7 @@ async def test_unknown_keys_reach_plugin_via_model_extra(ai_and_seen: tuple[Genk
 
 @pytest.mark.asyncio
 async def test_invalid_value_raises_genkit_error(ai_and_seen: tuple[Genkit, dict]) -> None:
-    """Error contract: bad values in declared fields surface as GenkitError, never raw ValidationError."""
+    """A bad value on a declared field is GenkitError, not a raw ValidationError."""
     ai, _ = ai_and_seen
     with pytest.raises(GenkitError, match="Invalid input for action 'conforming'"):
         await ai.generate(model='conforming', prompt='hi', config={'temperature': 'high'})
@@ -133,7 +129,22 @@ async def test_invalid_value_raises_genkit_error(ai_and_seen: tuple[Genkit, dict
 
 @pytest.mark.asyncio
 async def test_strict_config_rejects_unknown_keys_as_genkit_error(ai_and_seen: tuple[Genkit, dict]) -> None:
-    """A plugin that closes the hatch (extra='forbid') gets a loud, wrapped error — its choice."""
+    """extra='forbid' rejects unknown keys as GenkitError — the plugin opted in."""
     ai, _ = ai_and_seen
     with pytest.raises(GenkitError, match="Invalid input for action 'strict'"):
         await ai.generate(model='strict', prompt='hi', config={'thinking': True})
+
+
+@pytest.mark.asyncio
+async def test_output_format_reaches_the_plugin(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """ai.generate(output_format='json') is what the plugin reads as request.output_format."""
+    ai, seen = ai_and_seen
+    await ai.generate(
+        model='conforming',
+        prompt='hi',
+        output_format='json',
+        output_schema={'type': 'object'},
+    )
+    assert seen['request'].output_format == 'json'
+    assert seen['request'].output_schema == {'type': 'object'}
+    assert seen['request'].output.format == 'json'

--- a/py/packages/genkit/tests/genkit/ai/generate_request_construction_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_request_construction_test.py
@@ -136,6 +136,17 @@ async def test_strict_config_rejects_unknown_keys_as_genkit_error(ai_and_seen: t
 
 
 @pytest.mark.asyncio
+async def test_foreign_config_class_raises_genkit_error(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """ModelConfig on a plugin that wants ConformingCfg is a raise. Pass a mapping."""
+    ai, _ = ai_and_seen
+    with pytest.raises(
+        GenkitError,
+        match=r'config must be .+\.ConformingCfg or a mapping, got .+\.GenerationCommonConfig',
+    ):
+        await ai.generate(model='conforming', prompt='hi', config=ModelConfig(temperature=0.7))
+
+
+@pytest.mark.asyncio
 async def test_output_format_reaches_the_plugin(ai_and_seen: tuple[Genkit, dict]) -> None:
     """ai.generate(output_format='json') is what the plugin reads as request.output_format."""
     ai, seen = ai_and_seen

--- a/py/packages/genkit/tests/genkit/ai/generate_request_construction_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_request_construction_test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed-request fast path through generate: happy path, error contract, escape hatch."""
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._model import Message, ModelConfig, ModelRequest, ModelResponse
+from genkit._core._typing import Part, Role, TextPart
+
+
+class ConformingCfg(BaseModel):
+    """Follows the extra='allow' convention: the escape hatch stays open."""
+
+    model_config = {'extra': 'allow'}
+    temperature: float | None = None
+
+
+class StrictCfg(BaseModel):
+    """Deliberately closes the hatch — a legitimate plugin choice."""
+
+    model_config = {'extra': 'forbid'}
+    temperature: float | None = None
+
+
+class PluginOnlyCfg(ModelConfig):
+    """A field the common config does not have. The plugin schema owns it."""
+
+    duration_seconds: int | None = None
+
+
+OK = ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='ok'))]))
+
+
+@pytest.fixture
+def ai_and_seen() -> tuple[Genkit, dict]:
+    ai = Genkit()
+    seen: dict = {}
+
+    async def conforming(request: ModelRequest[ConformingCfg], ctx: ActionRunContext) -> ModelResponse:
+        seen['config'] = request.config
+        return OK
+
+    async def strict(request: ModelRequest[StrictCfg], ctx: ActionRunContext) -> ModelResponse:
+        seen['config'] = request.config
+        return OK
+
+    async def bare(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        seen['config'] = request.config
+        return OK
+
+    async def plugin_only(request: ModelRequest[PluginOnlyCfg], ctx: ActionRunContext) -> ModelResponse:
+        seen['config'] = request.config
+        return OK
+
+    ai.define_model(name='conforming', fn=conforming)
+    ai.define_model(name='strict', fn=strict)
+    ai.define_model(name='bare', fn=bare)
+    ai.define_model(name='plugin_only', fn=plugin_only)
+    return ai, seen
+
+
+@pytest.mark.asyncio
+async def test_typed_plugin_receives_typed_config(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """Fast path: the dict config arrives parsed into the plugin's class."""
+    ai, seen = ai_and_seen
+    await ai.generate(model='conforming', prompt='hi', config={'temperature': 0.7})
+    assert isinstance(seen['config'], ConformingCfg)
+    assert seen['config'].temperature == 0.7
+
+
+@pytest.mark.asyncio
+async def test_typed_plugin_receives_plugin_only_fields_from_instance(
+    ai_and_seen: tuple[Genkit, dict],
+) -> None:
+    """Plugin-only knobs are legal because the action parses its schema.
+
+    ``duration_seconds`` is not on the common config. Passing the object or a
+    dict both land as ``PluginOnlyCfg.duration_seconds`` — not because generate
+    kept the instance, because ``ModelRequest[PluginOnlyCfg]`` rehydrated it.
+    """
+    ai, seen = ai_and_seen
+    cfg = PluginOnlyCfg(duration_seconds=8)
+
+    await ai.generate(model='plugin_only', prompt='hi', config=cfg)
+    assert type(seen['config']) is PluginOnlyCfg
+    assert seen['config'].duration_seconds == 8
+
+    await ai.generate(model='plugin_only', prompt='hi', config={'duration_seconds': 8})
+    assert type(seen['config']) is PluginOnlyCfg
+    assert seen['config'].duration_seconds == 8
+
+
+@pytest.mark.asyncio
+async def test_bare_plugin_receives_raw_dict(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """Pass-through carrier: bare ModelRequest never transforms config."""
+    ai, seen = ai_and_seen
+    await ai.generate(model='bare', prompt='hi', config={'temperature': 0.7, 'anything': 1})
+    assert seen['config'] == {'temperature': 0.7, 'anything': 1}
+    assert type(seen['config']) is dict
+
+
+@pytest.mark.asyncio
+async def test_omitted_config_yields_empty_typed_config(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """The request is never None; absent config means an empty typed config."""
+    ai, seen = ai_and_seen
+    await ai.generate(model='conforming', prompt='hi')
+    assert isinstance(seen['config'], ConformingCfg)
+    assert seen['config'].temperature is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_keys_reach_plugin_via_model_extra(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """D1 escape hatch, end to end: unknown keys survive to model_extra."""
+    ai, seen = ai_and_seen
+    await ai.generate(model='conforming', prompt='hi', config={'thinking': {'budget': 8192}})
+    assert seen['config'].model_extra == {'thinking': {'budget': 8192}}
+
+
+@pytest.mark.asyncio
+async def test_invalid_value_raises_genkit_error(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """Error contract: bad values in declared fields surface as GenkitError, never raw ValidationError."""
+    ai, _ = ai_and_seen
+    with pytest.raises(GenkitError, match="Invalid input for action 'conforming'"):
+        await ai.generate(model='conforming', prompt='hi', config={'temperature': 'high'})
+
+
+@pytest.mark.asyncio
+async def test_strict_config_rejects_unknown_keys_as_genkit_error(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """A plugin that closes the hatch (extra='forbid') gets a loud, wrapped error — its choice."""
+    ai, _ = ai_and_seen
+    with pytest.raises(GenkitError, match="Invalid input for action 'strict'"):
+        await ai.generate(model='strict', prompt='hi', config={'thinking': True})

--- a/py/packages/genkit/tests/genkit/ai/generate_request_construction_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_request_construction_test.py
@@ -6,9 +6,10 @@
 """What a plugin handler sees after ai.generate: typed config, extras, errors, output."""
 
 import pytest
-from pydantic import BaseModel
+from genkit_openai import OpenAIConfig
+from pydantic import BaseModel, ValidationError
 
-from genkit import Genkit
+from genkit import Document, Genkit
 from genkit._core._action import ActionRunContext
 from genkit._core._error import GenkitError
 from genkit._core._model import Message, ModelConfig, ModelRequest, ModelResponse
@@ -77,6 +78,23 @@ async def test_typed_plugin_receives_typed_config(ai_and_seen: tuple[Genkit, dic
 
 
 @pytest.mark.asyncio
+async def test_matching_config_instance_passes_through(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """ai.generate(config=MyConfig(...)) arrives as that same class. MyConfig subclasses ModelConfig."""
+    ai, seen = ai_and_seen
+    await ai.generate(model='plugin_only', prompt='hi', config=PluginOnlyCfg(duration_seconds=8))
+    assert type(seen['config']) is PluginOnlyCfg
+    assert seen['config'].duration_seconds == 8
+
+
+@pytest.mark.asyncio
+async def test_plain_basemodel_config_rejected_at_generate(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """ai.generate(config=) accepts a dict or a ModelConfig. A plain BaseModel is a ValidationError here."""
+    ai, _ = ai_and_seen
+    with pytest.raises(ValidationError):
+        await ai.generate(model='conforming', prompt='hi', config=ConformingCfg(temperature=0.7))
+
+
+@pytest.mark.asyncio
 async def test_typed_plugin_receives_plugin_only_fields_from_instance(
     ai_and_seen: tuple[Genkit, dict],
 ) -> None:
@@ -128,6 +146,19 @@ async def test_invalid_value_raises_genkit_error(ai_and_seen: tuple[Genkit, dict
 
 
 @pytest.mark.asyncio
+async def test_invalid_config_with_docs_is_still_genkit_error(ai_and_seen: tuple[Genkit, dict]) -> None:
+    """ai.generate(docs=..., config={'temperature': 'high'}) is GenkitError, not AttributeError."""
+    ai, _ = ai_and_seen
+    with pytest.raises(GenkitError, match="Invalid input for action 'conforming'"):
+        await ai.generate(
+            model='conforming',
+            prompt='hi',
+            docs=[Document.from_text('ctx')],
+            config={'temperature': 'high'},
+        )
+
+
+@pytest.mark.asyncio
 async def test_strict_config_rejects_unknown_keys_as_genkit_error(ai_and_seen: tuple[Genkit, dict]) -> None:
     """extra='forbid' rejects unknown keys as GenkitError — the plugin opted in."""
     ai, _ = ai_and_seen
@@ -137,13 +168,13 @@ async def test_strict_config_rejects_unknown_keys_as_genkit_error(ai_and_seen: t
 
 @pytest.mark.asyncio
 async def test_foreign_config_class_raises_genkit_error(ai_and_seen: tuple[Genkit, dict]) -> None:
-    """ModelConfig on a plugin that wants ConformingCfg is a raise. Pass a mapping."""
+    """ai.generate(config=OpenAIConfig(...)) on a ConformingCfg plugin is GenkitError. Pass a dict."""
     ai, _ = ai_and_seen
     with pytest.raises(
         GenkitError,
-        match=r'config must be .+\.ConformingCfg or a mapping, got .+\.GenerationCommonConfig',
+        match=r'config must be .+\.ConformingCfg or a mapping, got genkit_openai\.OpenAIConfig',
     ):
-        await ai.generate(model='conforming', prompt='hi', config=ModelConfig(temperature=0.7))
+        await ai.generate(model='conforming', prompt='hi', config=OpenAIConfig(temperature=0.7))
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/model_definition_contract_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_definition_contract_test.py
@@ -3,7 +3,7 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""define_model request-annotation contract: allowed shapes vs rejected antipatterns."""
+"""define_model accepts ModelRequest / ModelRequest[Cfg] and rejects the rest."""
 
 from typing import Annotated, Any, Optional
 
@@ -63,7 +63,7 @@ def test_annotated_wrapper_unwrapped_and_allowed(ai: Genkit) -> None:
 
 
 def test_dict_and_any_parametrizations_allowed_unblessed(ai: Genkit) -> None:
-    """ModelRequest[dict] / ModelRequest[Any] are real classes; permitted, not recommended."""
+    """ModelRequest[dict] and ModelRequest[Any] still register; they do not validate a schema."""
 
     async def fn_d(request: ModelRequest[dict], ctx: ActionRunContext) -> ModelResponse:
         return OK
@@ -79,7 +79,7 @@ def test_dict_and_any_parametrizations_allowed_unblessed(ai: Genkit) -> None:
 
 
 def test_union_with_none_rejected(ai: Genkit) -> None:
-    """generate() never passes None; the union silently disables typed construction."""
+    """ModelRequest[Cfg] | None is rejected — generate never passes None."""
 
     async def fn(request: ModelRequest[Cfg] | None, ctx: ActionRunContext) -> ModelResponse:
         return OK
@@ -97,7 +97,7 @@ def test_optional_spelling_rejected(ai: Genkit) -> None:
 
 
 def test_dict_annotation_rejected(ai: Genkit) -> None:
-    """The model contract is ModelRequest; raw-dict handlers only worked by accident."""
+    """A handler annotated dict is rejected. The request is a ModelRequest."""
 
     async def fn(request: dict, ctx: ActionRunContext) -> ModelResponse:
         return OK

--- a/py/packages/genkit/tests/genkit/ai/model_definition_contract_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_definition_contract_test.py
@@ -35,6 +35,8 @@ def ai() -> Genkit:
 
 
 def test_typed_annotation_allowed(ai: Genkit) -> None:
+    """define_model(fn with ModelRequest[Cfg]) registers."""
+
     async def fn(request: ModelRequest[Cfg], ctx: ActionRunContext) -> ModelResponse:
         return OK
 
@@ -42,6 +44,8 @@ def test_typed_annotation_allowed(ai: Genkit) -> None:
 
 
 def test_bare_annotation_allowed(ai: Genkit) -> None:
+    """define_model(fn with ModelRequest) registers. Config stays a dict."""
+
     async def fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
         return OK
 
@@ -49,6 +53,8 @@ def test_bare_annotation_allowed(ai: Genkit) -> None:
 
 
 def test_unannotated_allowed(ai: Genkit) -> None:
+    """define_model(fn with no request annotation) still registers."""
+
     async def fn(request, ctx: ActionRunContext) -> ModelResponse:  # noqa: ANN001
         return OK
 
@@ -56,6 +62,8 @@ def test_unannotated_allowed(ai: Genkit) -> None:
 
 
 def test_annotated_wrapper_unwrapped_and_allowed(ai: Genkit) -> None:
+    """Annotated[ModelRequest[Cfg], ...] is treated as ModelRequest[Cfg]."""
+
     async def fn(request: Annotated[ModelRequest[Cfg], 'doc'], ctx: ActionRunContext) -> ModelResponse:
         return OK
 
@@ -89,6 +97,8 @@ def test_union_with_none_rejected(ai: Genkit) -> None:
 
 
 def test_optional_spelling_rejected(ai: Genkit) -> None:
+    """Optional[ModelRequest[Cfg]] is the same reject as ModelRequest[Cfg] | None."""
+
     async def fn(request: Optional[ModelRequest[Cfg]], ctx: ActionRunContext) -> ModelResponse:  # noqa: UP045
         return OK
 
@@ -107,6 +117,8 @@ def test_dict_annotation_rejected(ai: Genkit) -> None:
 
 
 def test_arbitrary_class_rejected(ai: Genkit) -> None:
+    """A handler annotated with some other class is rejected. The request is a ModelRequest."""
+
     class NotARequest(BaseModel):
         pass
 

--- a/py/packages/genkit/tests/genkit/ai/model_definition_contract_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_definition_contract_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""define_model request-annotation contract: allowed shapes vs rejected antipatterns."""
+
+from typing import Annotated, Any, Optional
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._model import Message, ModelRequest, ModelResponse
+from genkit._core._typing import Part, Role, TextPart
+
+
+class Cfg(BaseModel):
+    """Sample typed plugin config."""
+
+    temperature: float | None = None
+
+
+OK = ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='ok'))]))
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    return Genkit()
+
+
+# --- allowed shapes -----------------------------------------------------------
+
+
+def test_typed_annotation_allowed(ai: Genkit) -> None:
+    async def fn(request: ModelRequest[Cfg], ctx: ActionRunContext) -> ModelResponse:
+        return OK
+
+    ai.define_model(name='typed', fn=fn)
+
+
+def test_bare_annotation_allowed(ai: Genkit) -> None:
+    async def fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        return OK
+
+    ai.define_model(name='bare', fn=fn)
+
+
+def test_unannotated_allowed(ai: Genkit) -> None:
+    async def fn(request, ctx: ActionRunContext) -> ModelResponse:  # noqa: ANN001
+        return OK
+
+    ai.define_model(name='unannotated', fn=fn)
+
+
+def test_annotated_wrapper_unwrapped_and_allowed(ai: Genkit) -> None:
+    async def fn(request: Annotated[ModelRequest[Cfg], 'doc'], ctx: ActionRunContext) -> ModelResponse:
+        return OK
+
+    ai.define_model(name='annotated', fn=fn)
+
+
+def test_dict_and_any_parametrizations_allowed_unblessed(ai: Genkit) -> None:
+    """ModelRequest[dict] / ModelRequest[Any] are real classes; permitted, not recommended."""
+
+    async def fn_d(request: ModelRequest[dict], ctx: ActionRunContext) -> ModelResponse:
+        return OK
+
+    async def fn_a(request: ModelRequest[Any], ctx: ActionRunContext) -> ModelResponse:
+        return OK
+
+    ai.define_model(name='param_dict', fn=fn_d)
+    ai.define_model(name='param_any', fn=fn_a)
+
+
+# --- rejected antipatterns ----------------------------------------------------
+
+
+def test_union_with_none_rejected(ai: Genkit) -> None:
+    """generate() never passes None; the union silently disables typed construction."""
+
+    async def fn(request: ModelRequest[Cfg] | None, ctx: ActionRunContext) -> ModelResponse:
+        return OK
+
+    with pytest.raises(GenkitError, match='must be annotated as ModelRequest'):
+        ai.define_model(name='union', fn=fn)
+
+
+def test_optional_spelling_rejected(ai: Genkit) -> None:
+    async def fn(request: Optional[ModelRequest[Cfg]], ctx: ActionRunContext) -> ModelResponse:  # noqa: UP045
+        return OK
+
+    with pytest.raises(GenkitError, match='must be annotated as ModelRequest'):
+        ai.define_model(name='optional', fn=fn)
+
+
+def test_dict_annotation_rejected(ai: Genkit) -> None:
+    """The model contract is ModelRequest; raw-dict handlers only worked by accident."""
+
+    async def fn(request: dict, ctx: ActionRunContext) -> ModelResponse:
+        return OK
+
+    with pytest.raises(GenkitError, match='must be annotated as ModelRequest'):
+        ai.define_model(name='rawdict', fn=fn)
+
+
+def test_arbitrary_class_rejected(ai: Genkit) -> None:
+    class NotARequest(BaseModel):
+        pass
+
+    async def fn(request: NotARequest, ctx: ActionRunContext) -> ModelResponse:
+        return OK
+
+    with pytest.raises(GenkitError, match='must be annotated as ModelRequest'):
+        ai.define_model(name='arbitrary', fn=fn)

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -431,7 +431,7 @@ def test_parameterized_model_request_rejects_mismatched_config_instance() -> Non
 
 
 def test_model_request_rejects_non_model_non_dict_config() -> None:
-    with pytest.raises(ValidationError, match='config must be a BaseModel or dict'):
+    with pytest.raises(ValidationError, match='config must be a BaseModel or mapping'):
         ModelRequest(
             messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
             config='not-a-config',  # pyright: ignore[reportArgumentType]

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -411,6 +411,7 @@ def test_bare_model_request_keeps_dict_config() -> None:
 
 
 def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
+    """ModelRequest[PluginConfig](config={'api_key': 'k'}) builds a PluginConfig."""
     request = ModelRequest[PluginConfig](
         messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
         config={'api_key': 'k'},
@@ -420,6 +421,8 @@ def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
 
 
 def test_parameterized_model_request_rejects_mismatched_config_instance() -> None:
+    """ModelRequest[PluginConfig](config=OtherConfig()) is a ValidationError."""
+
     class OtherConfig(BaseModel):
         top_k: int | None = None
 
@@ -431,6 +434,7 @@ def test_parameterized_model_request_rejects_mismatched_config_instance() -> Non
 
 
 def test_model_request_rejects_non_model_non_dict_config() -> None:
+    """ModelRequest(config='not-a-config') is a ValidationError."""
     with pytest.raises(ValidationError, match='config must be a BaseModel or mapping'):
         ModelRequest(
             messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -5,10 +5,14 @@
 
 """Tests for the action module."""
 
+import warnings
+
 import pytest
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from genkit import Message, ModelRequest, ModelResponse, ModelResponseChunk, ModelUsage
 from genkit._ai._model import text_from_content
+from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
     ActionMetadata,
     DocumentPart,
@@ -20,6 +24,14 @@ from genkit._core._typing import (
     ToolRequestPart,
 )
 from genkit.model import get_basic_usage_stats, model_action_metadata
+
+
+class PluginConfig(BaseModel):
+    """Stand-in for a plugin-specific config schema (e.g. LyriaConfig)."""
+
+    model_config = ConfigDict(extra='allow')
+    api_key: str | None = None
+    response_modalities: list[str] | None = None
 
 
 def test_message_wrapper_text() -> None:
@@ -376,3 +388,71 @@ def test_text_from_content_with_none_text() -> None:
         Part(root=TextPart(text=' world')),
     ]
     assert text_from_content(content) == 'hello world'
+
+
+def test_bare_model_request_accepts_plugin_config_instance() -> None:
+    """Bare ModelRequest(config=PluginConfig) keeps the plugin schema instance."""
+    plugin_config = PluginConfig(api_key='k', response_modalities=['audio'])
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config=plugin_config,
+    )
+    assert request.config is plugin_config
+    assert isinstance(request.config, PluginConfig)
+
+
+def test_bare_model_request_keeps_dict_config() -> None:
+    """Dict configs stay dicts on bare ModelRequest; Action coerces to the plugin schema."""
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'temperature': 0.5, 'api_key': 'k'},
+    )
+    assert request.config == {'temperature': 0.5, 'api_key': 'k'}
+
+
+def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
+    request = ModelRequest[PluginConfig](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    assert isinstance(request.config, PluginConfig)
+    assert request.config.api_key == 'k'
+
+
+def test_parameterized_model_request_rejects_mismatched_config_instance() -> None:
+    class OtherConfig(BaseModel):
+        top_k: int | None = None
+
+    with pytest.raises(ValidationError):
+        ModelRequest[PluginConfig](
+            messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+            config=OtherConfig(top_k=3),  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_model_request_rejects_non_model_non_dict_config() -> None:
+    with pytest.raises(ValidationError, match='config must be a BaseModel or dict'):
+        ModelRequest(
+            messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+            config='not-a-config',  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_parameterized_model_request_config_json_schema_refs_plugin_schema() -> None:
+    """Verify JSON schema for ModelRequest[PluginConfig] includes a $ref to PluginConfig for Reflection API / Dev UI."""
+    schema = to_json_schema(ModelRequest[PluginConfig])
+    config_prop = schema['properties']['config']
+    assert any('$ref' in arm for arm in config_prop.get('anyOf', [])), config_prop
+
+
+def test_model_request_dump_emits_no_serializer_warnings() -> None:
+    """Verify model_dump() and model_dump_json() execute without triggering Pydantic serialization warnings."""
+    request = ModelRequest[PluginConfig](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    # Convert all Python/Pydantic warnings into hard errors so silent serialization warnings fail the test.
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        request.model_dump(mode='python')
+        request.model_dump_json()

--- a/py/packages/genkit/tests/genkit/ai/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/ai/prompt_test.py
@@ -100,7 +100,7 @@ async def test_simple_prompt() -> None:
     """Test simple prompt rendering."""
     ai, *_ = setup_test()
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     my_prompt = ai.define_prompt(prompt='hi', config={'temperature': 11})
 
@@ -123,7 +123,7 @@ async def test_simple_prompt_with_override_config() -> None:
     ai, *_ = setup_test()
 
     # Config is MERGED: prompt config (banana: true) + opts config (temperature: 12)
-    want_txt = '[ECHO] user: "hi" {"temperature":12.0,"banana":true}'
+    want_txt = '[ECHO] user: "hi" {"banana":true,"temperature":12}'
 
     my_prompt = ai.define_prompt(prompt='hi', config={'banana': True})
 
@@ -221,7 +221,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] system: "hello foo (bar)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] system: "hello foo (bar)" {"banana":"ripe","temperature":11.0}""",
     ),
     (
         'renders user prompt',
@@ -241,7 +241,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] user: "hello foo (bar_system)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] user: "hello foo (bar_system)" {"banana":"ripe","temperature":11.0}""",
     ),
     (
         'renders user prompt with context',
@@ -261,7 +261,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {'auth': {'email': 'a@b.c'}},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] user: "hello foo (bar, a@b.c)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] user: "hello foo (bar, a@b.c)" {"banana":"ripe","temperature":11.0}""",
     ),
 ]
 

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -388,16 +388,31 @@ async def test_action_revalidates_bare_model_request_into_plugin_config() -> Non
 
 
 @pytest.mark.asyncio
-async def test_action_revalidates_cross_typed_model_request() -> None:
-    """The plugin handler sees its own config class, not the caller's.
+async def test_action_rejects_foreign_config_class() -> None:
+    """OpenAIConfig on a Gemini plugin is a raise. Pass a mapping to coerce."""
 
-    generate and wrap_model may build the request with a different config
-    type. The plugin still gets PluginCfg and the JSON-mode settings, not a
-    type miss or unconstrained text.
-    """
-
-    class CarrierCfg(BaseModel):
+    class OpenAICfg(BaseModel):
         temperature: float | None = None
+
+    class GeminiCfg(BaseModel):
+        temperature: float | None = None
+
+    async def model_fn(request: ModelRequest[GeminiCfg]) -> str:
+        return 'ok'
+
+    action = Action(name='gemini', kind=ActionKind.MODEL, fn=model_fn)
+    request = ModelRequest[OpenAICfg](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config=OpenAICfg(temperature=0.5),
+    )
+
+    with pytest.raises(GenkitError, match=r'config must be .+\.GeminiCfg or a mapping, got .+\.OpenAICfg'):
+        await action.run(input=request)
+
+
+@pytest.mark.asyncio
+async def test_action_coerces_dict_config_from_other_request_type() -> None:
+    """A mapping on ModelRequest[dict] still becomes the plugin class."""
 
     class PluginCfg(BaseModel):
         temperature: float | None = None
@@ -405,20 +420,18 @@ async def test_action_revalidates_cross_typed_model_request() -> None:
     seen: dict[str, Any] = {}
 
     async def model_fn(request: ModelRequest[PluginCfg]) -> str:
-        seen['request'] = request
+        seen['config'] = request.config
         return 'ok'
 
     action = Action(name='pluginModel', kind=ActionKind.MODEL, fn=model_fn)
-    request = ModelRequest[CarrierCfg](
+    request = ModelRequest[dict](
         messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
-        config=CarrierCfg(temperature=0.5),
+        config={'temperature': 0.5},
         output=OutputConfig(format='json', constrained=True),
     )
-    assert isinstance(request.config, CarrierCfg)
+    assert type(request.config) is dict
 
     result = await action.run(input=request)
     assert result.response == 'ok'
-    assert isinstance(seen['request'].config, PluginCfg)
-    assert seen['request'].config.temperature == 0.5
-    assert seen['request'].output_format == 'json'
-    assert seen['request'].output_constrained is True
+    assert isinstance(seen['config'], PluginCfg)
+    assert seen['config'].temperature == 0.5

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -6,10 +6,12 @@
 """Tests for the action module."""
 
 import json
-from typing import cast
+from typing import Any, cast
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
+from genkit import Message, ModelRequest, Part, TextPart
 from genkit._core._action import (
     Action,
     ActionKind,
@@ -354,3 +356,31 @@ async def test_run_defaulted_input_arg_allows_none_with_ctx() -> None:
     assert (await action.run(input='Bob')).response == 'hi Bob'
     assert (await action.run(input=None)).response == 'hi world'
     assert (await action.run()).response == 'hi world'
+
+
+@pytest.mark.asyncio
+async def test_action_revalidates_bare_model_request_into_plugin_config() -> None:
+    """Bare ModelRequest with a dict config is re-parsed as ModelRequest[PluginConfig]."""
+
+    class PluginConfig(BaseModel):
+        model_config = ConfigDict(extra='allow')
+        api_key: str | None = None
+
+    seen: dict[str, Any] = {}
+
+    async def model_fn(request: ModelRequest[PluginConfig]) -> str:
+        seen['config'] = request.config
+        return 'ok'
+
+    action = Action(name='pluginModel', kind=ActionKind.MODEL, fn=model_fn)
+    # Mimic generate constructing a bare request that keeps the dict until Action runs.
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    assert request.config == {'api_key': 'k'}
+
+    result = await action.run(input=request)
+    assert result.response == 'ok'
+    assert isinstance(seen['config'], PluginConfig)
+    assert seen['config'].api_key == 'k'

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -24,6 +24,7 @@ from genkit._core._action import (
     parse_plugin_name_from_action_name,
 )
 from genkit._core._error import GenkitError
+from genkit._core._model import OutputConfig
 
 
 def test_action_enum_behaves_like_str() -> None:
@@ -384,3 +385,40 @@ async def test_action_revalidates_bare_model_request_into_plugin_config() -> Non
     assert result.response == 'ok'
     assert isinstance(seen['config'], PluginConfig)
     assert seen['config'].api_key == 'k'
+
+
+@pytest.mark.asyncio
+async def test_action_revalidates_cross_typed_model_request() -> None:
+    """The plugin handler sees its own config class, not the caller's.
+
+    generate and wrap_model may build the request with a different config
+    type. The plugin still gets PluginCfg and the JSON-mode settings, not a
+    type miss or unconstrained text.
+    """
+
+    class CarrierCfg(BaseModel):
+        temperature: float | None = None
+
+    class PluginCfg(BaseModel):
+        temperature: float | None = None
+
+    seen: dict[str, Any] = {}
+
+    async def model_fn(request: ModelRequest[PluginCfg]) -> str:
+        seen['request'] = request
+        return 'ok'
+
+    action = Action(name='pluginModel', kind=ActionKind.MODEL, fn=model_fn)
+    request = ModelRequest[CarrierCfg](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config=CarrierCfg(temperature=0.5),
+        output=OutputConfig(format='json', constrained=True),
+    )
+    assert isinstance(request.config, CarrierCfg)
+
+    result = await action.run(input=request)
+    assert result.response == 'ok'
+    assert isinstance(seen['request'].config, PluginCfg)
+    assert seen['request'].config.temperature == 0.5
+    assert seen['request'].output_format == 'json'
+    assert seen['request'].output_constrained is True

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -361,7 +361,7 @@ async def test_run_defaulted_input_arg_allows_none_with_ctx() -> None:
 
 @pytest.mark.asyncio
 async def test_action_revalidates_bare_model_request_into_plugin_config() -> None:
-    """A bare ModelRequest with a dict config arrives as the plugin's config class."""
+    """Action.run: a bare ModelRequest with a dict config arrives as the plugin class."""
 
     class PluginConfig(BaseModel):
         model_config = ConfigDict(extra='allow')
@@ -389,7 +389,7 @@ async def test_action_revalidates_bare_model_request_into_plugin_config() -> Non
 
 @pytest.mark.asyncio
 async def test_action_rejects_foreign_config_class() -> None:
-    """OpenAIConfig on a Gemini plugin is a raise. Pass a mapping to coerce."""
+    """Action.run: a request already carrying OpenAICfg is not dumped into GeminiCfg."""
 
     class OpenAICfg(BaseModel):
         temperature: float | None = None
@@ -412,7 +412,7 @@ async def test_action_rejects_foreign_config_class() -> None:
 
 @pytest.mark.asyncio
 async def test_action_coerces_dict_config_from_other_request_type() -> None:
-    """A mapping on ModelRequest[dict] still becomes the plugin class."""
+    """Action.run: a mapping on ModelRequest[dict] still becomes the plugin class."""
 
     class PluginCfg(BaseModel):
         temperature: float | None = None

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -361,7 +361,7 @@ async def test_run_defaulted_input_arg_allows_none_with_ctx() -> None:
 
 @pytest.mark.asyncio
 async def test_action_revalidates_bare_model_request_into_plugin_config() -> None:
-    """Bare ModelRequest with a dict config is re-parsed as ModelRequest[PluginConfig]."""
+    """A bare ModelRequest with a dict config arrives as the plugin's config class."""
 
     class PluginConfig(BaseModel):
         model_config = ConfigDict(extra='allow')
@@ -374,7 +374,7 @@ async def test_action_revalidates_bare_model_request_into_plugin_config() -> Non
         return 'ok'
 
     action = Action(name='pluginModel', kind=ActionKind.MODEL, fn=model_fn)
-    # Mimic generate constructing a bare request that keeps the dict until Action runs.
+    # generate may hand the action a bare request that still has a dict config.
     request = ModelRequest(
         messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
         config={'api_key': 'k'},

--- a/py/packages/genkit/tests/genkit/core/model_request_wire_roundtrip_test.py
+++ b/py/packages/genkit/tests/genkit/core/model_request_wire_roundtrip_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""ModelRequest wire-format round-trip and config type-contract tests."""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from genkit._core._model import ModelRequest, OutputConfig
+
+
+class CarrierCfg(BaseModel):
+    """Permissive stand-in for the sending side of a cross-typed handoff."""
+
+    model_config = {'extra': 'allow'}
+
+
+class PluginCfg(BaseModel):
+    """Stand-in for a plugin config schema."""
+
+    temperature: float | None = None
+
+
+def test_wire_roundtrip_preserves_output_fields() -> None:
+    """dump -> validate must be an identity for the output settings."""
+    req = ModelRequest[CarrierCfg](
+        messages=[],
+        config={'temperature': 0.5},
+        output=OutputConfig(
+            format='json',
+            constrained=True,
+            content_type='application/json',
+            json_schema={'type': 'object'},
+        ),
+    )
+    dumped = req.model_dump(mode='python')
+    assert dumped['output'] == {
+        'format': 'json',
+        'constrained': True,
+        'contentType': 'application/json',
+        'schema': {'type': 'object'},
+    }
+    reparsed = ModelRequest[CarrierCfg].model_validate(dumped)
+    assert reparsed.output_format == 'json'
+    assert reparsed.output_constrained is True
+    assert reparsed.output_content_type == 'application/json'
+    assert reparsed.output_schema == {'type': 'object'}
+
+
+def test_output_always_present_on_wire() -> None:
+    """A built request always includes an output object, even when empty.
+
+    This matches how the JS SDK's generate path builds requests: an output
+    object is always present (empty when no output options are set), even
+    though the wire schema marks the field optional for hand-built requests.
+    """
+    req = ModelRequest[CarrierCfg](messages=[])
+    assert req.model_dump(mode='python')['output'] == {}
+
+
+def test_cross_config_revalidation_preserves_output() -> None:
+    """The _validate_input fallback scenario: ModelRequest[CarrierCfg] -> ModelRequest[PluginCfg]."""
+    req = ModelRequest[CarrierCfg](
+        messages=[],
+        config={'temperature': 0.5},
+        output=OutputConfig(format='json', constrained=True),
+    )
+    dumped = req.model_dump(mode='python')
+    reparsed = ModelRequest[PluginCfg].model_validate(dumped)
+    assert isinstance(reparsed.config, PluginCfg)
+    assert reparsed.config.temperature == 0.5
+    assert reparsed.output_format == 'json'
+    assert reparsed.output_constrained is True
+
+
+def test_flat_properties_read_and_write_nested_storage() -> None:
+    """The flat accessors are a live view over output (plugin tests mutate them)."""
+    req = ModelRequest[CarrierCfg](messages=[])
+    req.output_format = 'json'
+    req.output_schema = {'type': 'integer'}
+    assert req.output.format == 'json'
+    assert req.output.json_schema == {'type': 'integer'}
+    assert req.model_dump(mode='python')['output']['schema'] == {'type': 'integer'}
+
+
+def test_bad_config_type_raises_validation_error() -> None:
+    """Wrong config type must surface as ValidationError, never bare TypeError."""
+    with pytest.raises(ValidationError):
+        ModelRequest[CarrierCfg](messages=[], config=5)  # type: ignore[arg-type]

--- a/py/packages/genkit/tests/genkit/core/model_request_wire_roundtrip_test.py
+++ b/py/packages/genkit/tests/genkit/core/model_request_wire_roundtrip_test.py
@@ -8,7 +8,7 @@
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from genkit._core._model import ModelRequest, OutputConfig
+from genkit._core._model import ModelRequest, OutputConfig, config_type_path
 
 
 class CarrierCfg(BaseModel):
@@ -84,3 +84,18 @@ def test_bad_config_type_raises_validation_error() -> None:
     """config=5 on the constructor is a ValidationError."""
     with pytest.raises(ValidationError):
         ModelRequest[CarrierCfg](messages=[], config=5)  # type: ignore[arg-type]
+
+
+def test_foreign_config_class_raises_validation_error() -> None:
+    """OpenAIConfig on ModelRequest[GeminiCfg] is a ValidationError. Pass a mapping."""
+    with pytest.raises(ValidationError, match=r'config must be .+\.PluginCfg or a mapping, got .+\.CarrierCfg'):
+        ModelRequest[PluginCfg](messages=[], config=CarrierCfg())
+
+
+def test_config_type_path_uses_plugin_package_export() -> None:
+    """Error strings use the package import, not the defining submodule."""
+    from genkit_google_genai import GeminiConfigSchema
+    from genkit_openai import OpenAIConfig
+
+    assert config_type_path(GeminiConfigSchema) == 'genkit_google_genai.GeminiConfigSchema'
+    assert config_type_path(OpenAIConfig) == 'genkit_openai.OpenAIConfig'

--- a/py/packages/genkit/tests/genkit/core/model_request_wire_roundtrip_test.py
+++ b/py/packages/genkit/tests/genkit/core/model_request_wire_roundtrip_test.py
@@ -12,7 +12,7 @@ from genkit._core._model import ModelRequest, OutputConfig, config_type_path
 
 
 class CarrierCfg(BaseModel):
-    """Permissive stand-in for the sending side of a cross-typed handoff."""
+    """Stand-in for a different plugin's config class."""
 
     model_config = {'extra': 'allow'}
 
@@ -56,7 +56,7 @@ def test_output_always_present_on_wire() -> None:
 
 
 def test_cross_config_revalidation_preserves_output() -> None:
-    """Re-reading a request built with one config class yields the plugin's config class."""
+    """model_validate of a dumped request rebuilds config as the target plugin class."""
     req = ModelRequest[CarrierCfg](
         messages=[],
         config={'temperature': 0.5},
@@ -87,13 +87,13 @@ def test_bad_config_type_raises_validation_error() -> None:
 
 
 def test_foreign_config_class_raises_validation_error() -> None:
-    """OpenAIConfig on ModelRequest[GeminiCfg] is a ValidationError. Pass a mapping."""
+    """ModelRequest[PluginCfg](config=CarrierCfg()) is a ValidationError. Pass a dict."""
     with pytest.raises(ValidationError, match=r'config must be .+\.PluginCfg or a mapping, got .+\.CarrierCfg'):
         ModelRequest[PluginCfg](messages=[], config=CarrierCfg())
 
 
 def test_config_type_path_uses_plugin_package_export() -> None:
-    """Error strings use the package import, not the defining submodule."""
+    """Error strings say genkit_openai.OpenAIConfig, not genkit_openai.typing.OpenAIConfig."""
     from genkit_google_genai import GeminiConfigSchema
     from genkit_openai import OpenAIConfig
 

--- a/py/packages/genkit/tests/genkit/core/model_request_wire_roundtrip_test.py
+++ b/py/packages/genkit/tests/genkit/core/model_request_wire_roundtrip_test.py
@@ -3,7 +3,7 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""ModelRequest wire-format round-trip and config type-contract tests."""
+"""Dumping a ModelRequest and reading it back keeps output settings and config."""
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -24,7 +24,7 @@ class PluginCfg(BaseModel):
 
 
 def test_wire_roundtrip_preserves_output_fields() -> None:
-    """dump -> validate must be an identity for the output settings."""
+    """JSON mode written as OutputConfig comes back as output_format / schema on the wire."""
     req = ModelRequest[CarrierCfg](
         messages=[],
         config={'temperature': 0.5},
@@ -50,18 +50,13 @@ def test_wire_roundtrip_preserves_output_fields() -> None:
 
 
 def test_output_always_present_on_wire() -> None:
-    """A built request always includes an output object, even when empty.
-
-    This matches how the JS SDK's generate path builds requests: an output
-    object is always present (empty when no output options are set), even
-    though the wire schema marks the field optional for hand-built requests.
-    """
+    """A built request always has an output object, even when nobody asked for JSON."""
     req = ModelRequest[CarrierCfg](messages=[])
     assert req.model_dump(mode='python')['output'] == {}
 
 
 def test_cross_config_revalidation_preserves_output() -> None:
-    """The _validate_input fallback scenario: ModelRequest[CarrierCfg] -> ModelRequest[PluginCfg]."""
+    """Re-reading a request built with one config class yields the plugin's config class."""
     req = ModelRequest[CarrierCfg](
         messages=[],
         config={'temperature': 0.5},
@@ -76,7 +71,7 @@ def test_cross_config_revalidation_preserves_output() -> None:
 
 
 def test_flat_properties_read_and_write_nested_storage() -> None:
-    """The flat accessors are a live view over output (plugin tests mutate them)."""
+    """Assigning request.output_format writes the nested output object."""
     req = ModelRequest[CarrierCfg](messages=[])
     req.output_format = 'json'
     req.output_schema = {'type': 'integer'}
@@ -86,6 +81,6 @@ def test_flat_properties_read_and_write_nested_storage() -> None:
 
 
 def test_bad_config_type_raises_validation_error() -> None:
-    """Wrong config type must surface as ValidationError, never bare TypeError."""
+    """config=5 on the constructor is a ValidationError."""
     with pytest.raises(ValidationError):
         ModelRequest[CarrierCfg](messages=[], config=5)  # type: ignore[arg-type]

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -31,7 +31,7 @@ from genkit._ai._testing import (
     define_programmable_model,
 )
 from genkit._core._action import ActionKind, ActionRunContext
-from genkit._core._model import ModelRequest
+from genkit._core._model import ModelRequest, OutputConfig
 from genkit._core._typing import (
     BaseDataPoint,
     Details,
@@ -76,7 +76,7 @@ async def test_generate_uses_default_model(setup_test: SetupFixture) -> None:
     """Test that the generate function uses the default model."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
 
@@ -126,11 +126,11 @@ async def test_generate_with_explicit_model(setup_test: SetupFixture) -> None:
 
     response = await ai.generate(model='echoModel', prompt='hi', config={'temperature': 11})
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
     stream_result = ai.generate_stream(model='echoModel', prompt='hi', config={'temperature': 11})
 
-    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -140,7 +140,7 @@ async def test_generate_with_str_prompt(setup_test: SetupFixture) -> None:
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -148,7 +148,7 @@ async def test_generate_with_part_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a part prompt works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     response = await ai.generate(prompt=[Part(root=TextPart(text='hi'))], config={'temperature': 11})
 
@@ -164,7 +164,7 @@ async def test_generate_with_part_list_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of parts prompt works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hello","world" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hello","world" {"temperature":11}'
 
     response = await ai.generate(
         prompt=[Part(root=TextPart(text='hello')), Part(root=TextPart(text='world'))],
@@ -186,7 +186,7 @@ async def test_generate_with_str_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a string system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(system='talk like pirate', prompt='hi', config={'temperature': 11})
 
@@ -202,7 +202,7 @@ async def test_generate_with_part_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a part system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(
         system=[Part(root=TextPart(text='talk like pirate'))],
@@ -226,7 +226,7 @@ async def test_generate_with_part_list_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of parts system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(
         system=[Part(root=TextPart(text='talk')), Part(root=TextPart(text='like pirate'))],
@@ -260,7 +260,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
         config={'temperature': 11},
     )
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
     stream_result = ai.generate_stream(
         messages=[
@@ -272,7 +272,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
         config={'temperature': 11},
     )
 
-    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -854,10 +854,12 @@ async def test_generate_with_output(setup_test: SetupFixture) -> None:
         ],
         config={},  # type: ignore[arg-type]
         tools=[],
-        output_format='json',
-        output_schema=_schema,
-        output_constrained=True,
-        output_content_type='application/json',
+        output=OutputConfig(
+            format='json',
+            json_schema=_schema,
+            constrained=True,
+            content_type='application/json',
+        ),
     )
 
     response = await ai.generate(
@@ -920,11 +922,13 @@ async def test_generate_defaults_to_json_format(
         ],
         config={},  # type: ignore[arg-type]
         tools=[],
-        output_format='json',
-        output_schema=_schema,
-        # these get populated by the format
-        output_constrained=True,
-        output_content_type='application/json',
+        output=OutputConfig(
+            format='json',
+            json_schema=_schema,
+            # these get populated by the format
+            constrained=True,
+            content_type='application/json',
+        ),
     )
 
     response = await ai.generate(
@@ -961,27 +965,29 @@ async def test_generate_json_format_unconstrained(
         ],
         config={},  # type: ignore[arg-type]
         tools=[],
-        output_format='json',
-        output_schema={
-            'properties': {
-                'foo': {
-                    'anyOf': [{'type': 'integer'}, {'type': 'null'}],
-                    'default': None,
-                    'description': 'foo field',
-                    'title': 'Foo',
+        output=OutputConfig(
+            format='json',
+            json_schema={
+                'properties': {
+                    'foo': {
+                        'anyOf': [{'type': 'integer'}, {'type': 'null'}],
+                        'default': None,
+                        'description': 'foo field',
+                        'title': 'Foo',
+                    },
+                    'bar': {
+                        'anyOf': [{'type': 'string'}, {'type': 'null'}],
+                        'default': None,
+                        'description': 'bar field',
+                        'title': 'Bar',
+                    },
                 },
-                'bar': {
-                    'anyOf': [{'type': 'string'}, {'type': 'null'}],
-                    'default': None,
-                    'description': 'bar field',
-                    'title': 'Bar',
-                },
+                'title': 'TestSchema',
+                'type': 'object',
             },
-            'title': 'TestSchema',
-            'type': 'object',
-        },
-        output_constrained=False,
-        output_content_type='application/json',
+            constrained=False,
+            content_type='application/json',
+        ),
     )
 
     response = await ai.generate(
@@ -1239,27 +1245,29 @@ async def test_generate_json_format_unconstrained_with_instructions(
         ],
         config={},  # type: ignore[arg-type]
         tools=[],
-        output_format='json',
-        output_schema={
-            'properties': {
-                'foo': {
-                    'anyOf': [{'type': 'integer'}, {'type': 'null'}],
-                    'default': None,
-                    'description': 'foo field',
-                    'title': 'Foo',
+        output=OutputConfig(
+            format='json',
+            json_schema={
+                'properties': {
+                    'foo': {
+                        'anyOf': [{'type': 'integer'}, {'type': 'null'}],
+                        'default': None,
+                        'description': 'foo field',
+                        'title': 'Foo',
+                    },
+                    'bar': {
+                        'anyOf': [{'type': 'string'}, {'type': 'null'}],
+                        'default': None,
+                        'description': 'bar field',
+                        'title': 'Bar',
+                    },
                 },
-                'bar': {
-                    'anyOf': [{'type': 'string'}, {'type': 'null'}],
-                    'default': None,
-                    'description': 'bar field',
-                    'title': 'Bar',
-                },
+                'title': 'TestSchema',
+                'type': 'object',
             },
-            'title': 'TestSchema',
-            'type': 'object',
-        },
-        output_constrained=False,
-        output_content_type='application/json',
+            constrained=False,
+            content_type='application/json',
+        ),
     )
 
     response = await ai.generate(
@@ -1479,27 +1487,29 @@ async def test_define_format(setup_test: SetupFixture) -> None:
         ],
         config={},  # type: ignore[arg-type]
         tools=[],
-        output_format='json',
-        output_schema={
-            'properties': {
-                'foo': {
-                    'anyOf': [{'type': 'integer'}, {'type': 'null'}],
-                    'default': None,
-                    'description': 'foo field',
-                    'title': 'Foo',
+        output=OutputConfig(
+            format='json',
+            json_schema={
+                'properties': {
+                    'foo': {
+                        'anyOf': [{'type': 'integer'}, {'type': 'null'}],
+                        'default': None,
+                        'description': 'foo field',
+                        'title': 'Foo',
+                    },
+                    'bar': {
+                        'anyOf': [{'type': 'string'}, {'type': 'null'}],
+                        'default': None,
+                        'description': 'bar field',
+                        'title': 'Bar',
+                    },
                 },
-                'bar': {
-                    'anyOf': [{'type': 'string'}, {'type': 'null'}],
-                    'default': None,
-                    'description': 'bar field',
-                    'title': 'Bar',
-                },
+                'title': 'TestSchema',
+                'type': 'object',
             },
-            'title': 'TestSchema',
-            'type': 'object',
-        },
-        output_constrained=True,
-        output_content_type='application/banana',
+            constrained=True,
+            content_type='application/banana',
+        ),
     )
 
 

--- a/py/scripts/schema_to_typing.py
+++ b/py/scripts/schema_to_typing.py
@@ -288,7 +288,7 @@ def _emit_model(
         force_field = False
         if name == 'OutputConfig' and snake == 'schema':
             field_name = 'json_schema'
-            alias_extra = ", alias='schema'"
+            alias_extra = ", validation_alias='schema', serialization_alias='schema'"
             force_field = True
         elif snake in ('schema_', 'schema'):
             field_name = 'schema'


### PR DESCRIPTION
## Summary
- Plugin authors can annotate `request: ModelRequest[MyConfig]`. `ai.generate(config={'temperature': 0.7})` arrives as a `MyConfig` instance. Bare `ModelRequest` still gets a raw dict. Unknown keys land on `model_extra`; a plugin that sets `extra='forbid'` rejects them.
- Output settings live on the request as `output: { format, schema, constrained, contentType }`. `ai.generate(output_format='json', ...)` is unchanged. Plugins still read `request.output_format` (properties over that object). Construct a request with `output=OutputConfig(...)`; passing `output_format=` into the constructor does not set output.
- A Pydantic config instance is only legal if it is the plugin's schema (or a subclass). `ai.generate(config=OpenAIConfig(...))` on a Gemini-typed plugin is `GenkitError(INVALID_ARGUMENT)`. A mapping still coerces. `generate()` accepts a dict or a `ModelConfig`; a plain `BaseModel` is a `ValidationError` at `generate()`. The error names the public import (`genkit_openai.OpenAIConfig`, not `genkit_openai.typing.OpenAIConfig`).
- `ai.generate(docs=..., config={'temperature': 'high'})` is still that `GenkitError`, not an `AttributeError`. Dumped docs rebuild from dicts the same way messages already do.
- `define_model` rejects `ModelRequest | None` / a raw `dict` at startup so typed construction cannot silently turn off. A bad declared field (`temperature='high'`) is `GenkitError(INVALID_ARGUMENT)`.

```python
async def my_model(request: ModelRequest[MyConfig], ctx):
    request.config.temperature
    if request.output_format == 'json':
        ...
```