### PR TITLE
feat(py): add ModelConfigDict for config={...} autocomplete

### DIFF
--- a/py/packages/genkit-anthropic/tests/anthropic_live_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_live_test.py
@@ -104,10 +104,11 @@ async def test_thinking_enabled_budget_streaming(ai: Genkit) -> None:
 
 async def test_thinking_adaptive(ai: Genkit) -> None:
     """Adaptive thinking with display is accepted by Opus 4.7+ models."""
+    thinking_config: dict[str, Any] = {'thinking': {'adaptive': True, 'display': 'summarized'}}
     response = await ai.generate(
         model='anthropic/claude-opus-4-8',
         prompt='Write a one-sentence story about a robot.',
-        config={'thinking': {'adaptive': True, 'display': 'summarized'}},
+        config=thinking_config,
     )
 
     assert response.message is not None
@@ -116,10 +117,11 @@ async def test_thinking_adaptive(ai: Genkit) -> None:
 
 async def test_thinking_disabled(ai: Genkit) -> None:
     """Disabled thinking is accepted and yields no reasoning parts."""
+    thinking_config: dict[str, Any] = {'thinking': {'enabled': False}}
     response = await ai.generate(
         model='anthropic/claude-haiku-4-5',
         prompt='What is 2 + 2? Answer with just the number.',
-        config={'thinking': {'enabled': False}},
+        config=thinking_config,
     )
 
     assert response.message is not None

--- a/py/packages/genkit/src/genkit/__init__.py
+++ b/py/packages/genkit/src/genkit/__init__.py
@@ -68,6 +68,7 @@ from genkit.model import (
     FinishReason,
     Message,
     ModelConfig,
+    ModelConfigDict,
     ModelInfo,
     ModelRequest,
     ModelResponse,
@@ -93,6 +94,7 @@ __all__ = [
     'EmbedderOptions',
     'EmbedderRef',
     'ModelConfig',
+    'ModelConfigDict',
     'ModelInfo',
     'ModelStreamResponse',
     # Errors

--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -326,7 +326,7 @@ def define_agent(
     system: str | list[Part] | None = None,
     tools: Sequence[str | Tool] | None = None,
     use: Sequence[BaseMiddleware | MiddlewareRef] | None = None,
-    config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
+    config: ModelRefConfigT | ModelConfigDict | Mapping[str, Any] | None = None,
     max_turns: int | None = None,
     description: str | None = None,
     metadata: dict[str, object] | None = None,

--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from typing import Any, Generic
 
 from opentelemetry import trace as trace_api

--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
 from typing import Any, Generic
 
 from opentelemetry import trace as trace_api
@@ -69,7 +69,7 @@ from genkit._ai._tools import Tool
 from genkit._core._action import Action, ActionKind, ActionRunContext, BidiAction, BidiFn, get_current_context
 from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware
-from genkit._core._model import ModelConfig, ModelRef, ModelRefConfigT
+from genkit._core._model import ModelConfigDict, ModelRef, ModelRefConfigT
 from genkit._core._registry import Registry
 from genkit._core._trace._attrs import metadata_key
 from genkit._core._typing import (
@@ -326,7 +326,7 @@ def define_agent(
     system: str | list[Part] | None = None,
     tools: Sequence[str | Tool] | None = None,
     use: Sequence[BaseMiddleware | MiddlewareRef] | None = None,
-    config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+    config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
     max_turns: int | None = None,
     description: str | None = None,
     metadata: dict[str, object] | None = None,

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -27,7 +27,7 @@ import signal
 import socket
 import threading
 import uuid
-from collections.abc import Awaitable, Callable, Coroutine, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
 from pathlib import Path
 from typing import Any, TypeVar, cast, overload
 

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -472,7 +472,7 @@ class Genkit:
         *,
         variant: str | None = None,
         model: ModelRef[ModelRefConfigT] | str | None = None,
-        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | Mapping[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -27,7 +27,7 @@ import signal
 import socket
 import threading
 import uuid
-from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from pathlib import Path
 from typing import Any, TypeVar, cast, overload
 
@@ -62,7 +62,6 @@ from genkit._ai._generate import (
 )
 from genkit._ai._model import (
     Message,
-    ModelConfig,
     ModelFn,
     ModelResponse,
     ModelResponseChunk,
@@ -113,7 +112,7 @@ from genkit._core._middleware import (
     GenerateMiddleware,
     _validate_middleware_key_segment,
 )
-from genkit._core._model import Document, ModelRef, ModelRefConfigT
+from genkit._core._model import Document, ModelConfigDict, ModelRef, ModelRefConfigT
 from genkit._core._plugin import Plugin
 from genkit._core._protocols import SessionLike
 from genkit._core._reflection import ReflectionServer, ServerSpec, create_reflection_asgi_app
@@ -473,7 +472,7 @@ class Genkit:
         *,
         variant: str | None = None,
         model: ModelRef[ModelRefConfigT] | str | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -501,7 +500,7 @@ class Genkit:
         *,
         variant: str | None = None,
         model: ModelRef[ModelRefConfigT] | str | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -529,7 +528,7 @@ class Genkit:
         *,
         variant: str | None = None,
         model: ModelRef[ModelRefConfigT] | str | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -557,7 +556,7 @@ class Genkit:
         *,
         variant: str | None = None,
         model: ModelRef[ModelRefConfigT] | str | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -583,7 +582,7 @@ class Genkit:
         *,
         variant: str | None = None,
         model: str | ModelRef[BaseModel] | None = None,
-        config: BaseModel | Mapping[str, Any] | None = None,
+        config: BaseModel | ModelConfigDict | dict[str, Any] | None = None,
         description: str | None = None,
         system: str | list[Part] | None = None,
         prompt: str | list[Part] | None = None,
@@ -748,7 +747,7 @@ class Genkit:
         system: str | list[Part] | None = None,
         tools: Sequence[str | Tool] | None = None,
         use: Sequence[BaseMiddleware | MiddlewareRef] | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         max_turns: int | None = None,
         description: str | None = None,
         metadata: dict[str, object] | None = None,
@@ -998,7 +997,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type[OutputT],
@@ -1025,7 +1024,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1050,7 +1049,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: BaseModel | Mapping[str, Any] | None = None,
+        config: BaseModel | ModelConfigDict | dict[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1123,7 +1122,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type[OutputT],
@@ -1151,7 +1150,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1177,7 +1176,7 @@ class Genkit:
         resume_respond: ToolResponsePart | list[ToolResponsePart] | None = None,
         resume_restart: ToolRequestPart | list[ToolRequestPart] | None = None,
         resume_metadata: dict[str, Any] | None = None,
-        config: BaseModel | Mapping[str, Any] | None = None,
+        config: BaseModel | ModelConfigDict | dict[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,
@@ -1412,7 +1411,7 @@ class Genkit:
         tools: Sequence[str | Tool] | None = None,
         return_tool_requests: bool | None = None,
         tool_choice: ToolChoice | None = None,
-        config: ModelRefConfigT | ModelConfig | Mapping[str, Any] | None = None,
+        config: ModelRefConfigT | ModelConfigDict | dict[str, Any] | None = None,
         max_turns: int | None = None,
         context: dict[str, object] | None = None,
         output_schema: type | dict | None = None,

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -54,7 +54,7 @@ ModelFn = Callable[[ModelRequest, ActionRunContext], Awaitable[ModelResponse[Any
 
 # Veneer-facing argument shapes. Internals resolve these into ResolvedModel.
 ModelArg: TypeAlias = str | ModelRef[BaseModel]
-ConfigArg: TypeAlias = BaseModel | ModelConfigDict | dict[str, Any]
+ConfigArg: TypeAlias = BaseModel | ModelConfigDict | Mapping[str, Any]
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -34,6 +34,7 @@ from genkit._core._error import GenkitError
 from genkit._core._model import (
     Message,
     ModelConfig,
+    ModelConfigDict,
     ModelRef,
     ModelRefConfigT,
     ModelRequest,
@@ -53,7 +54,7 @@ ModelFn = Callable[[ModelRequest, ActionRunContext], Awaitable[ModelResponse[Any
 
 # Veneer-facing argument shapes. Internals resolve these into ResolvedModel.
 ModelArg: TypeAlias = str | ModelRef[BaseModel]
-ConfigArg: TypeAlias = BaseModel | Mapping[str, Any]
+ConfigArg: TypeAlias = BaseModel | ModelConfigDict | dict[str, Any]
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -77,7 +77,7 @@ class ModelConfigDict(TypedDict, total=False):
     max_output_tokens: int
     top_k: int
     top_p: float
-    stop_sequences: list[str]
+    stop_sequences: Sequence[str]
     api_key: str
 
 

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -26,7 +26,7 @@ from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, ClassVar, Generic, cast
+from typing import Any, ClassVar, Generic, TypedDict, cast
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer
 from pydantic.alias_generators import to_camel
@@ -63,6 +63,23 @@ from genkit._core._typing import (
 
 ModelConfig = GenerationCommonConfig  # public name for GenerationCommonConfig
 ModelUsage = GenerationUsage  # public name for GenerationUsage
+
+
+class ModelConfigDict(TypedDict, total=False):
+    """Common knobs for dict-literal autocomplete on config={...}.
+
+    Provider-specific keys still work at runtime; type them as Mapping[str, Any]
+    (or pass a Pydantic config) when the checker rejects the literal.
+    """
+
+    version: str
+    temperature: float
+    max_output_tokens: int
+    top_k: int
+    top_p: float
+    stop_sequences: list[str]
+    api_key: str
+
 
 # TypeVars for generic types
 OutputT = TypeVar('OutputT', default=object)

--- a/py/packages/genkit/src/genkit/model/__init__.py
+++ b/py/packages/genkit/src/genkit/model/__init__.py
@@ -18,6 +18,7 @@
 
 from genkit._ai._model import (
     ModelConfig,
+    ModelConfigDict,
     model_action_metadata,
     model_ref,
 )
@@ -76,6 +77,7 @@ __all__ = [
     'ModelRef',
     # Config
     'ModelConfig',
+    'ModelConfigDict',
     # Message
     'Message',
     # Usage

--- a/py/packages/genkit/tests/genkit/ai/model_ref_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_ref_test.py
@@ -10,7 +10,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 from pydantic import BaseModel
 
-from genkit.model import ModelConfig, ModelInfo, ModelRef, Supports, model_ref
+from genkit.model import ModelConfig, ModelConfigDict, ModelInfo, ModelRef, Supports, model_ref
 
 
 class CustomConfig(BaseModel):
@@ -128,3 +128,19 @@ def test_model_ref_preserves_version_and_info_metadata() -> None:
     assert ref.info is not None
     assert ref.info.supports is not None
     assert ref.info.supports.multiturn is True
+
+
+def test_model_config_dict_accepts_common_knobs() -> None:
+    """ModelConfigDict is the typed shape for config={...} literals."""
+    config: ModelConfigDict = {
+        'temperature': 0.5,
+        'max_output_tokens': 256,
+        'top_k': 40,
+        'top_p': 0.9,
+        'stop_sequences': ['END'],
+        'version': '001',
+        'api_key': 'test-key',
+    }
+
+    assert config['temperature'] == 0.5
+    assert config['max_output_tokens'] == 256

--- a/py/packages/genkit/tests/genkit/ai/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/ai/prompt_test.py
@@ -125,7 +125,9 @@ async def test_simple_prompt_with_override_config() -> None:
     # Config is MERGED: prompt config (banana: true) + opts config (temperature: 12)
     want_txt = '[ECHO] user: "hi" {"temperature":12.0,"banana":true}'
 
-    my_prompt = ai.define_prompt(prompt='hi', config={'banana': True})
+    # banana is a pass-through test key, not a ModelConfigDict field
+    prompt_config: dict[str, Any] = {'banana': True}
+    my_prompt = ai.define_prompt(prompt='hi', config=prompt_config)
 
     # Pass config via kwargs — this MERGES with prompt config
     response = await my_prompt(config={'temperature': 12})
@@ -522,9 +524,11 @@ async def test_config_merge_priority() -> None:
     """
     ai, *_ = setup_test()
 
+    # banana is a pass-through test key, not a ModelConfigDict field
+    prompt_config: dict[str, Any] = {'temperature': 0.5, 'banana': 'yellow'}
     my_prompt = ai.define_prompt(
         prompt='test',
-        config={'temperature': 0.5, 'banana': 'yellow'},
+        config=prompt_config,
     )
 
     # New API: runtime config is MERGED with prompt config

--- a/py/samples/anthropic-sample/src/main.py
+++ b/py/samples/anthropic-sample/src/main.py
@@ -16,6 +16,8 @@
 
 """Anthropic generation samples, including stable/beta API selection."""
 
+from typing import Any
+
 from genkit_anthropic import Anthropic
 from pydantic import BaseModel, Field
 
@@ -26,6 +28,11 @@ from genkit import ActionRunContext, Genkit, ModelResponse, ReasoningPart
 ai = Genkit(plugins=[Anthropic(api_version='beta')], model='anthropic/claude-opus-4-8')
 
 LIVE_TEST_MODEL = 'anthropic/claude-haiku-4-5'
+
+
+def _provider_config(**kwargs: Any) -> dict[str, Any]:
+    """Pass-through for Anthropic-only / camelCase knobs (not common ModelConfigDict keys)."""
+    return kwargs
 
 
 class TopicInput(BaseModel):
@@ -102,7 +109,7 @@ async def beta_plugin_default(data: TopicInput) -> str:
     response = await ai.generate(
         model=LIVE_TEST_MODEL,
         prompt=f'Write a one-line fact about {data.topic}.',
-        config={'maxOutputTokens': 64},
+        config=_provider_config(maxOutputTokens=64),
     )
     return response.text
 
@@ -113,7 +120,7 @@ async def stable_request_override(data: TopicInput) -> str:
     response = await ai.generate(
         model=LIVE_TEST_MODEL,
         prompt=f'Write a one-line fact about {data.topic}.',
-        config={'apiVersion': 'stable', 'maxOutputTokens': 64},
+        config=_provider_config(apiVersion='stable', maxOutputTokens=64),
     )
     return response.text
 
@@ -124,7 +131,7 @@ async def beta_without_default_headers(data: TopicInput) -> str:
     response = await ai.generate(
         model=LIVE_TEST_MODEL,
         prompt=f'Write a one-line fact about {data.topic}.',
-        config={'apiVersion': 'beta', 'betas': [], 'maxOutputTokens': 64},
+        config=_provider_config(apiVersion='beta', betas=[], maxOutputTokens=64),
     )
     return response.text
 
@@ -135,7 +142,7 @@ async def beta_plugin_default_stream(data: TopicInput, ctx: ActionRunContext) ->
     stream_response = ai.generate_stream(
         model=LIVE_TEST_MODEL,
         prompt=f'Write a short poem about {data.topic}.',
-        config={'maxOutputTokens': 64},
+        config=_provider_config(maxOutputTokens=64),
     )
     chunks: list[str] = []
     async for chunk in stream_response.stream:
@@ -156,7 +163,7 @@ async def haiku_opus_4_7(data: TopicInput) -> str:
     response = await ai.generate(
         model='anthropic/claude-opus-4-7',
         prompt=f'Write a haiku about {data.topic}.',
-        config={'apiVersion': 'stable'},
+        config=_provider_config(apiVersion='stable'),
     )
     return response.text
 
@@ -167,7 +174,7 @@ async def cat_opus_4_7(data: CatInput) -> Cat:
     response = await ai.generate(
         model='anthropic/claude-opus-4-7',
         prompt=f'Invent a cat named {data.name}.',
-        config={'apiVersion': 'stable'},
+        config=_provider_config(apiVersion='stable'),
         output_format='json',
         output_schema=Cat,
     )
@@ -183,7 +190,7 @@ async def haiku_opus_4_8(data: TopicInput) -> str:
     response = await ai.generate(
         model='anthropic/claude-opus-4-8',
         prompt=f'Write a haiku about {data.topic}.',
-        config={'apiVersion': 'stable'},
+        config=_provider_config(apiVersion='stable'),
     )
     return response.text
 
@@ -194,7 +201,7 @@ async def cat_opus_4_8(data: CatInput) -> Cat:
     response = await ai.generate(
         model='anthropic/claude-opus-4-8',
         prompt=f'Invent a cat named {data.name}.',
-        config={'apiVersion': 'stable'},
+        config=_provider_config(apiVersion='stable'),
         output_format='json',
         output_schema=Cat,
     )
@@ -212,11 +219,11 @@ async def thinking_tool_round_trip(data: WeatherInput, ctx: ActionRunContext) ->
             'Think through the request before and after the tool call, then answer in one concise sentence.'
         ),
         tools=['current_weather'],
-        config={
-            'apiVersion': 'stable',
-            'thinking': {'type': 'adaptive', 'display': 'summarized'},
-            'max_tokens': 4096,
-        },
+        config=_provider_config(
+            apiVersion='stable',
+            thinking={'type': 'adaptive', 'display': 'summarized'},
+            max_tokens=4096,
+        ),
         max_turns=3,
     )
 
@@ -252,10 +259,10 @@ async def thinking_budget_story(data: TopicInput, ctx: ActionRunContext) -> dict
     stream_response = ai.generate_stream(
         model='anthropic/claude-haiku-4-5',
         prompt=f'Tell me a very short story about {data.topic}.',
-        config={
-            'thinking': {'enabled': True, 'budgetTokens': 1024},
-            'maxOutputTokens': 2048,
-        },
+        config=_provider_config(
+            thinking={'enabled': True, 'budgetTokens': 1024},
+            maxOutputTokens=2048,
+        ),
     )
 
     streamed_reasoning: list[str] = []

--- a/py/samples/google-genai-media/src/main.py
+++ b/py/samples/google-genai-media/src/main.py
@@ -85,10 +85,13 @@ def _first_media_url(response: Any) -> str | None:
 async def tts_speech_generator(input: SpeechInput) -> dict[str, str | None]:
     """Turn text into speech with one TTS call."""
 
+    tts_config: dict[str, Any] = {
+        'speech_config': {'voice_config': {'prebuilt_voice_config': {'voice_name': input.voice}}},
+    }
     response = await ai.generate(
         model='googleai/gemini-2.5-flash-preview-tts',
         prompt=input.text,
-        config={'speech_config': {'voice_config': {'prebuilt_voice_config': {'voice_name': input.voice}}}},
+        config=tts_config,
     )
     return {'model': 'googleai/gemini-2.5-flash-preview-tts', 'audio_url': _first_media_url(response)}
 
@@ -97,10 +100,11 @@ async def tts_speech_generator(input: SpeechInput) -> dict[str, str | None]:
 async def imagen_image_generator(input: ImageInput) -> dict[str, str | None]:
     """Generate one image with Imagen."""
 
+    imagen_config: dict[str, Any] = {'number_of_images': 1}
     response = await ai.generate(
         model='googleai/imagen-3.0-generate-002',
         prompt=input.prompt,
-        config={'number_of_images': 1},
+        config=imagen_config,
     )
     return {'model': 'googleai/imagen-3.0-generate-002', 'image_url': _first_media_url(response)}
 


### PR DESCRIPTION
## Summary
- Add hand-written `ModelConfigDict` TypedDict for common generation knobs (`temperature`, `max_output_tokens`, …).
- Swap app-facing `config=` unions on `generate` / `generate_stream` / `define_prompt` / `generate_operation` / `define_agent` from `ModelConfig` → `ModelConfigDict`, keeping `Mapping[str, Any]` as the escape hatch for provider-specific keys.
- Export `ModelConfigDict` from `genkit` and `genkit.model`. `ModelConfig` (Pydantic) stays for plugins/runtime.
- Update samples/tests that pass non-common keys so they go through a plain `dict[str, Any]` (ty rejects unknown keys on inline TypedDict literals).

Stacked on #5977 (`jh-model-ref-generate`).

## Test plan
- [x] Fast CI preflight (lint/type + pytest 3.12)
- [x] `test_model_config_dict_accepts_common_knobs`
- [ ] Confirm IDE autocomplete on `config={'temperature': ...}`
- [ ] Confirm provider-specific configs still work via `dict[str, Any]` / Mapping