### PR TITLE
fix(js/plugins/google-genai): Do not persist clientOptions in the …

### DIFF
--- a/js/ai/src/cancel-operation.ts
+++ b/js/ai/src/cancel-operation.ts
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-import {
-  BackgroundActionRunOptions,
-  GenkitError,
-  Operation,
-} from '@genkit-ai/core';
+import { GenkitError, Operation } from '@genkit-ai/core';
 import { Registry } from '@genkit-ai/core/registry';
+import { toRunOptions, type OperationOptions } from './operation.js';
 
 export async function cancelOperation<T = unknown>(
   registry: Registry,
   operation: Operation<T>,
-  options?: BackgroundActionRunOptions
+  options?: OperationOptions
 ): Promise<Operation<T>> {
   if (!operation.action) {
     throw new GenkitError({
@@ -47,5 +44,5 @@ export async function cancelOperation<T = unknown>(
       message: `Background action ${operation.action} does not support cancellation.`,
     });
   }
-  return await backgroundAction.cancel(operation, options);
+  return await backgroundAction.cancel(operation, toRunOptions(options));
 }

--- a/js/ai/src/check-operation.ts
+++ b/js/ai/src/check-operation.ts
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-import {
-  BackgroundActionRunOptions,
-  GenkitError,
-  Operation,
-} from '@genkit-ai/core';
+import { GenkitError, Operation } from '@genkit-ai/core';
 import { Registry } from '@genkit-ai/core/registry';
+import { toRunOptions, type OperationOptions } from './operation.js';
 
 export async function checkOperation<T = unknown>(
   registry: Registry,
   operation: Operation<T>,
-  options?: BackgroundActionRunOptions
+  options?: OperationOptions
 ): Promise<Operation<T>> {
   if (!operation.action) {
     throw new GenkitError({
@@ -41,5 +38,5 @@ export async function checkOperation<T = unknown>(
       message: `Failed to resolve background action from original request: ${operation.action}`,
     });
   }
-  return await backgroundAction.check(operation, options);
+  return await backgroundAction.check(operation, toRunOptions(options));
 }

--- a/js/ai/src/genkit-ai.ts
+++ b/js/ai/src/genkit-ai.ts
@@ -20,7 +20,6 @@ import {
   run,
   z,
   type ActionContext,
-  type BackgroundActionRunOptions,
   type Operation,
 } from '@genkit-ai/core';
 import { type Registry } from '@genkit-ai/core/registry';
@@ -44,6 +43,7 @@ import {
   type GenerateStreamResponse,
 } from './generate.js';
 import { GenerationCommonConfigSchema, type Part } from './model-types.js';
+import { type OperationOptions } from './operation.js';
 import { Session, getCurrentSession } from './session.js';
 
 /**
@@ -281,12 +281,23 @@ export class GenkitAI {
    * }
    * ```
    *
+   * Critical configuration (e.g. `baseUrl`) and secrets (e.g. `apiKey`) that
+   * can't be inferred from the operation can be supplied at call time. Config
+   * overrides go in the top-level `config`, secrets go in `context`:
+   *
+   * ```ts
+   * operation = await ai.checkOperation(operation, {
+   *   config: { baseUrl: '...' },
+   *   context: { secrets: { apiKey: '...' } },
+   * });
+   * ```
+   *
    * @param operation
    * @returns
    */
   checkOperation<T>(
     operation: Operation<T>,
-    options?: BackgroundActionRunOptions
+    options?: OperationOptions
   ): Promise<Operation<T>> {
     return checkOperation(this.registry, operation, options);
   }
@@ -294,12 +305,23 @@ export class GenkitAI {
   /**
    * Cancels a given operation. Returns a new operation which will contain the updated status.
    *
+   * Critical configuration (e.g. `baseUrl`) and secrets (e.g. `apiKey`) that
+   * can't be inferred from the operation can be supplied at call time. Config
+   * overrides go in the top-level `config`, secrets go in `context`:
+   *
+   * ```ts
+   * operation = await ai.cancelOperation(operation, {
+   *   config: { baseUrl: '...' },
+   *   context: { secrets: { apiKey: '...' } },
+   * });
+   * ```
+   *
    * @param operation
    * @returns
    */
   cancelOperation<T>(
     operation: Operation<T>,
-    options?: BackgroundActionRunOptions
+    options?: OperationOptions
   ): Promise<Operation<T>> {
     return cancelOperation(this.registry, operation, options);
   }

--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -96,6 +96,7 @@ export {
   type ToolRequestPart,
   type ToolResponsePart,
 } from './model.js';
+export { type OperationOptions } from './operation.js';
 export { type ToolRequest, type ToolResponse } from './parts.js';
 export { type GenkitPluginV2 } from './plugin.js';
 export {

--- a/js/ai/src/operation.ts
+++ b/js/ai/src/operation.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BackgroundActionRunOptions } from '@genkit-ai/core';
+
+/**
+ * The reserved context key under which per-call `config` overrides are carried
+ * when invoking a background operation's `check`/`cancel`. This is an internal
+ * transport detail: callers set a top-level `config` on {@link OperationOptions}
+ * and plugins read it back from `options.context.config`.
+ */
+export const OPERATION_CONFIG_CONTEXT_KEY = 'config';
+
+/**
+ * Options for {@link Genkit.checkOperation} and {@link Genkit.cancelOperation}.
+ *
+ * Extends the generic {@link BackgroundActionRunOptions} with a top-level
+ * `config` field so callers can supply per-call configuration overrides (e.g.
+ * `baseUrl`, `location`) for calls that don't otherwise carry a request config.
+ */
+export interface OperationOptions extends BackgroundActionRunOptions {
+  /**
+   * Per-call configuration overrides. Because operation `check`/`cancel` calls
+   * don't include the original request's `config`, this is the mechanism for
+   * supplying critical config options (e.g. `baseUrl`, `location`) at call
+   * time.
+   *
+   * Under the hood this is delivered to plugins via
+   * `options.context.config`.
+   */
+  config?: Record<string, any>;
+}
+
+/**
+ * Folds the top-level `config` from {@link OperationOptions} into the run
+ * options' `context` (under a reserved key), producing a
+ * {@link BackgroundActionRunOptions} suitable for dispatching to a core
+ * background action. `config` is an AI-layer concept, so it never leaks into
+ * core's generic options; it rides through `context`, which is the only side
+ * channel plumbed all the way through to a plugin's `check`/`cancel`.
+ */
+export function toRunOptions(
+  options?: OperationOptions
+): BackgroundActionRunOptions | undefined {
+  if (!options) {
+    return undefined;
+  }
+  const { config, context, ...rest } = options;
+  if (config === undefined) {
+    return { ...rest, context };
+  }
+  return {
+    ...rest,
+    context: {
+      ...context,
+      [OPERATION_CONFIG_CONTEXT_KEY]: config,
+    },
+  };
+}

--- a/js/genkit/src/common.ts
+++ b/js/genkit/src/common.ts
@@ -94,6 +94,7 @@ export {
   type ModelRequest,
   type ModelResponseData,
   type MultipartToolAction,
+  type OperationOptions,
   type OutputOptions,
   type Part,
   type PromptAction,

--- a/js/plugins/google-genai/src/googleai/deep-research.ts
+++ b/js/plugins/google-genai/src/googleai/deep-research.ts
@@ -42,6 +42,7 @@ import {
   Model,
 } from './types.js';
 import {
+  applyContextOverrides,
   calculateApiKey,
   checkApiKey,
   checkModelName,
@@ -259,7 +260,7 @@ export function defineModel(
     name: ref.name,
     ...ref.info,
     configSchema: ref.configSchema,
-    async start(request) {
+    async start(request, options) {
       const {
         apiKey: apiKeyConfig,
         baseUrl,
@@ -277,13 +278,15 @@ export function defineModel(
         mcpServers,
         ...rest
       } = request.config || {};
-      const apiKey = calculateApiKey(pluginOptions?.apiKey, apiKeyConfig);
-      const newClientOptions: ClientOptions = {
-        ...clientOptions,
-        apiKey,
-        baseUrl: baseUrl || clientOptions.baseUrl,
-        apiVersion: apiVersion || clientOptions.apiVersion,
-      };
+      const newClientOptions = applyContextOverrides(
+        {
+          ...clientOptions,
+          apiKey: calculateApiKey(pluginOptions?.apiKey, apiKeyConfig),
+          baseUrl: baseUrl || clientOptions.baseUrl,
+          apiVersion: apiVersion || clientOptions.apiVersion,
+        },
+        options?.context
+      );
 
       const messages = structuredClone(request.messages);
       // Deep Research does not support system instructions, so we map them to
@@ -384,47 +387,47 @@ export function defineModel(
         ...rest,
       };
 
-      const response = await createInteraction(apiKey, req, newClientOptions);
+      const response = await createInteraction(
+        newClientOptions.apiKey,
+        req,
+        newClientOptions
+      );
 
-      return fromInteraction<ClientOptions>(response, newClientOptions);
+      return fromInteraction(response);
     },
-    async check(operation) {
-      const storedOptions = operation.metadata?.clientOptions as
-        | ClientOptions
-        | undefined;
-      const apiKey =
-        storedOptions?.apiKey ||
-        calculateApiKey(pluginOptions?.apiKey, undefined);
+    async check(operation, options) {
+      const checkOptions = applyContextOverrides(
+        {
+          ...clientOptions,
+          apiKey: calculateApiKey(pluginOptions?.apiKey, undefined),
+        },
+        options?.context
+      );
 
-      const checkOptions: ClientOptions = {
-        ...clientOptions,
-        ...storedOptions,
-      };
+      const response = await getInteraction(
+        checkOptions.apiKey,
+        operation.id,
+        checkOptions
+      );
 
-      const response = await getInteraction(apiKey, operation.id, checkOptions);
-
-      return fromInteraction<ClientOptions>(response, checkOptions);
+      return fromInteraction(response);
     },
-    async cancel(operation) {
-      const storedOptions = operation.metadata?.clientOptions as
-        | ClientOptions
-        | undefined;
-      const apiKey =
-        storedOptions?.apiKey ||
-        calculateApiKey(pluginOptions?.apiKey, undefined);
-
-      const cancelOptions: ClientOptions = {
-        ...clientOptions,
-        ...storedOptions,
-      };
+    async cancel(operation, options) {
+      const cancelOptions = applyContextOverrides(
+        {
+          ...clientOptions,
+          apiKey: calculateApiKey(pluginOptions?.apiKey, undefined),
+        },
+        options?.context
+      );
 
       const response = await cancelInteraction(
-        apiKey,
+        cancelOptions.apiKey,
         operation.id,
         cancelOptions
       );
 
-      return fromInteraction<ClientOptions>(response, cancelOptions);
+      return fromInteraction(response);
     },
   });
 }

--- a/js/plugins/google-genai/src/googleai/interaction-converters.ts
+++ b/js/plugins/google-genai/src/googleai/interaction-converters.ts
@@ -654,14 +654,10 @@ export function fromInteractionSync(
   return response;
 }
 
-export function fromInteraction<T extends Object>(
-  interaction: GeminiInteraction,
-  clientOptions?: T
+export function fromInteraction(
+  interaction: GeminiInteraction
 ): Operation<GenerateResponseData> {
   const op = { id: interaction.id } as Operation<GenerateResponseData>;
-  if (clientOptions) {
-    op.metadata = { clientOptions };
-  }
   if (interaction.status === 'in_progress') {
     op.done = false;
   } else if (interaction.status === 'cancelled') {

--- a/js/plugins/google-genai/src/googleai/utils.ts
+++ b/js/plugins/google-genai/src/googleai/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { GenerateRequest, GenkitError, z } from 'genkit';
+import { GenerateRequest, GenkitError, z, type ActionContext } from 'genkit';
 import process from 'process';
 import { extractMedia } from '../common/utils.js';
 import { ClientOptions, ImagenInstance, VeoImage, VeoVideo } from './types.js';
@@ -224,4 +224,40 @@ export function removeClientOptionOverrides<
   delete newConfig?.customHeaders;
 
   return newConfig;
+}
+
+/**
+ * Applies connection-related overrides carried in the action run context
+ * (e.g. `options.context` on `start`/`check`/`cancel` for background models)
+ * on top of the given client options. This is the mechanism by which callers
+ * can supply per-call `apiKey`, `apiVersion`, and `baseUrl` overrides for
+ * calls (like `checkOperation`/`cancelOperation`) that don't have access to
+ * the original request's `config`.
+ *
+ * Context fields take precedence over whatever is already in `clientOptions`.
+ *
+ * @param clientOptions The base client options to apply overrides on top of.
+ * @param context The action run context (`options.context`), if any.
+ */
+export function applyContextOverrides(
+  clientOptions: ClientOptions,
+  context?: ActionContext
+): ClientOptions {
+  if (!context) {
+    return clientOptions;
+  }
+
+  let newOptions = { ...clientOptions };
+
+  if (typeof context.auth?.apiKey === 'string') {
+    newOptions.apiKey = context.auth.apiKey;
+  }
+  if (typeof context.apiVersion === 'string') {
+    newOptions.apiVersion = context.apiVersion;
+  }
+  if (typeof context.baseUrl === 'string') {
+    newOptions.baseUrl = context.baseUrl;
+  }
+
+  return newOptions;
 }

--- a/js/plugins/google-genai/src/googleai/utils.ts
+++ b/js/plugins/google-genai/src/googleai/utils.ts
@@ -249,8 +249,8 @@ export function applyContextOverrides(
 
   let newOptions = { ...clientOptions };
 
-  if (typeof context.auth?.apiKey === 'string') {
-    newOptions.apiKey = context.auth.apiKey;
+  if (typeof context.secrets?.apiKey === 'string') {
+    newOptions.apiKey = context.secrets.apiKey;
   }
   if (typeof context.apiVersion === 'string') {
     newOptions.apiVersion = context.apiVersion;

--- a/js/plugins/google-genai/src/googleai/utils.ts
+++ b/js/plugins/google-genai/src/googleai/utils.ts
@@ -230,11 +230,18 @@ export function removeClientOptionOverrides<
  * Applies connection-related overrides carried in the action run context
  * (e.g. `options.context` on `start`/`check`/`cancel` for background models)
  * on top of the given client options. This is the mechanism by which callers
- * can supply per-call `apiKey`, `apiVersion`, and `baseUrl` overrides for
- * calls (like `checkOperation`/`cancelOperation`) that don't have access to
- * the original request's `config`.
+ * can supply per-call overrides for calls (like
+ * `checkOperation`/`cancelOperation`) that don't have access to the original
+ * request's `config`.
  *
- * Context fields take precedence over whatever is already in `clientOptions`.
+ * The API key is read from `context.secrets.apiKey` (scrubbed from traces).
+ * All other overrides (e.g. `baseUrl`, `apiVersion`) are read from
+ * `context.config`, which is where `checkOperation`/`cancelOperation` fold
+ * their top-level `config` option. This lets callers write
+ * `ai.checkOperation(op, { config: { baseUrl } })`.
+ *
+ * All context-derived values take precedence over whatever is already in
+ * `clientOptions`.
  *
  * @param clientOptions The base client options to apply overrides on top of.
  * @param context The action run context (`options.context`), if any.
@@ -252,12 +259,9 @@ export function applyContextOverrides(
   if (typeof context.secrets?.apiKey === 'string') {
     newOptions.apiKey = context.secrets.apiKey;
   }
-  if (typeof context.apiVersion === 'string') {
-    newOptions.apiVersion = context.apiVersion;
-  }
-  if (typeof context.baseUrl === 'string') {
-    newOptions.baseUrl = context.baseUrl;
-  }
 
-  return newOptions;
+  // All non-secret overrides (e.g. baseUrl, apiVersion) are carried in
+  // `context.config` (from checkOperation/cancelOperation's top-level
+  // `config`).
+  return calculateRequestOptions(newOptions, context.config);
 }

--- a/js/plugins/google-genai/src/googleai/veo.ts
+++ b/js/plugins/google-genai/src/googleai/veo.ts
@@ -198,7 +198,7 @@ export function defineModel(
     ...ref.info,
     configSchema: ref.configSchema,
     async start(request, options) {
-      // apiKey in config is deprecated in favor of options.context.auth.apiKey
+      // apiKey in config is deprecated in favor of options.context.secrets.apiKey
       const newClientOptions = applyContextOverrides(
         {
           ...clientOptions,

--- a/js/plugins/google-genai/src/googleai/veo.ts
+++ b/js/plugins/google-genai/src/googleai/veo.ts
@@ -40,6 +40,7 @@ import {
   VeoPredictRequest,
 } from './types.js';
 import {
+  applyContextOverrides,
   calculateApiKey,
   checkModelName,
   extractText,
@@ -54,10 +55,6 @@ import {
  */
 export const VeoConfigSchema = z
   .object({
-    apiKey: z
-      .string()
-      .describe('Override the API key provided at plugin initialization.')
-      .optional(),
     negativePrompt: z.string().optional(),
     aspectRatio: z
       .enum(['9:16', '16:9'])
@@ -200,15 +197,19 @@ export function defineModel(
     name: ref.name,
     ...ref.info,
     configSchema: ref.configSchema,
-    async start(request) {
-      const apiKey = calculateApiKey(
-        pluginOptions?.apiKey,
-        request.config?.apiKey
+    async start(request, options) {
+      // apiKey in config is deprecated in favor of options.context.auth.apiKey
+      const newClientOptions = applyContextOverrides(
+        {
+          ...clientOptions,
+          apiKey: calculateApiKey(
+            pluginOptions?.apiKey,
+            request.config?.apiKey as string | undefined
+          ),
+        },
+        options?.context
       );
-      const newClientOptions: ClientOptions = {
-        ...clientOptions,
-        apiKey,
-      };
+      const apiKey = newClientOptions.apiKey;
 
       const veoPredictRequest: VeoPredictRequest = {
         instances: [
@@ -228,27 +229,23 @@ export function defineModel(
         newClientOptions
       );
 
-      return fromVeoOperation(response, newClientOptions);
+      return fromVeoOperation(response);
     },
-    async check(operation) {
-      const storedOptions = operation.metadata?.clientOptions as
-        | ClientOptions
-        | undefined;
-      const apiKey =
-        storedOptions?.apiKey ||
-        calculateApiKey(pluginOptions?.apiKey, undefined);
-
-      const checkOptions: ClientOptions = {
-        ...clientOptions,
-        ...storedOptions,
-      };
+    async check(operation, options) {
+      const checkOptions = applyContextOverrides(
+        {
+          ...clientOptions,
+          apiKey: calculateApiKey(pluginOptions?.apiKey, undefined),
+        },
+        options?.context
+      );
 
       const response = await veoCheckOperation(
-        apiKey,
+        checkOptions.apiKey,
         operation.id,
         checkOptions
       );
-      return fromVeoOperation(response, checkOptions);
+      return fromVeoOperation(response);
     },
   });
 }
@@ -278,15 +275,11 @@ function toVeoParameters(
 }
 
 function fromVeoOperation(
-  apiOp: VeoOperation,
-  clientOpt?: ClientOptions
+  apiOp: VeoOperation
 ): Operation<GenerateResponseData> {
   const res = { id: apiOp.name } as Operation<GenerateResponseData>;
   if (apiOp.done !== undefined) {
     res.done = apiOp.done;
-  }
-  if (clientOpt) {
-    res.metadata = { clientOptions: clientOpt };
   }
 
   if (apiOp.error) {

--- a/js/plugins/google-genai/src/vertexai/converters.ts
+++ b/js/plugins/google-genai/src/vertexai/converters.ts
@@ -41,7 +41,6 @@ import {
 } from './imagen.js';
 import { LyriaConfigSchemaType } from './lyria.js';
 import {
-  ClientOptions,
   LyriaInstance,
   LyriaParameters,
   LyriaPredictRequest,
@@ -431,15 +430,11 @@ export function toVeoMedia(media: MediaPart['media']): VeoMedia {
 }
 
 export function fromVeoOperation(
-  fromOp: VeoOperation,
-  clientOpt?: ClientOptions
+  fromOp: VeoOperation
 ): Operation<GenerateResponseData> {
   const toOp: Operation<GenerateResponseData> = { id: fromOp.name };
   if (fromOp.done !== undefined) {
     toOp.done = fromOp.done;
-  }
-  if (clientOpt) {
-    toOp.metadata = { clientOptions: clientOpt };
   }
   if (fromOp.error) {
     toOp.error = { message: fromOp.error.message };
@@ -488,11 +483,4 @@ export function toVeoOperationRequest(
   return {
     operationName: op.id,
   };
-}
-
-export function toVeoClientOptions(
-  op: Operation<GenerateResponseData>,
-  clientOpt: ClientOptions
-): ClientOptions {
-  return op.metadata?.clientOptions ?? clientOpt;
 }

--- a/js/plugins/google-genai/src/vertexai/converters.ts
+++ b/js/plugins/google-genai/src/vertexai/converters.ts
@@ -446,9 +446,10 @@ export function fromVeoOperation(
     // the safety (RAI) filters, there are no videos to return. Surface the
     // filter reasons as an error instead of returning empty content.
     if (videos.length === 0 && fromOp.response.raiMediaFilteredCount) {
+      const reasons = fromOp.response.raiMediaFilteredReasons?.join('; ');
       toOp.error = {
         message:
-          fromOp.response.raiMediaFilteredReasons?.join('; ') ??
+          reasons ||
           'All generated videos were filtered out by safety filters.',
       };
     }

--- a/js/plugins/google-genai/src/vertexai/converters.ts
+++ b/js/plugins/google-genai/src/vertexai/converters.ts
@@ -441,12 +441,23 @@ export function fromVeoOperation(
   }
 
   if (fromOp.response) {
+    const videos = fromOp.response.videos ?? [];
+    // If the operation completed but every generated video was removed by
+    // the safety (RAI) filters, there are no videos to return. Surface the
+    // filter reasons as an error instead of returning empty content.
+    if (videos.length === 0 && fromOp.response.raiMediaFilteredCount) {
+      toOp.error = {
+        message:
+          fromOp.response.raiMediaFilteredReasons?.join('; ') ??
+          'All generated videos were filtered out by safety filters.',
+      };
+    }
     toOp.output = {
-      finishReason: 'stop',
+      finishReason: toOp.error ? 'blocked' : 'stop',
       raw: fromOp.response,
       message: {
         role: 'model',
-        content: fromOp.response.videos.map((veoMedia) => {
+        content: videos.map((veoMedia) => {
           if (veoMedia.bytesBase64Encoded) {
             return {
               media: {

--- a/js/plugins/google-genai/src/vertexai/interaction-converters.ts
+++ b/js/plugins/google-genai/src/vertexai/interaction-converters.ts
@@ -418,14 +418,10 @@ export function fromInteractionSync(
   return response;
 }
 
-export function fromInteraction<T extends Object>(
-  interaction: GeminiInteraction,
-  clientOptions?: T
+export function fromInteraction(
+  interaction: GeminiInteraction
 ): Operation<GenerateResponseData> {
   const op = { id: interaction.id } as Operation<GenerateResponseData>;
-  if (clientOptions) {
-    op.metadata = { clientOptions };
-  }
   if (interaction.status === 'in_progress') {
     op.done = false;
   } else if (interaction.status === 'cancelled') {

--- a/js/plugins/google-genai/src/vertexai/types.ts
+++ b/js/plugins/google-genai/src/vertexai/types.ts
@@ -380,7 +380,10 @@ export declare interface Operation {
 export declare interface VeoOperation extends Operation {
   response?: {
     raiMediaFilteredCount?: number;
-    videos: VeoMedia[];
+    raiMediaFilteredReasons?: string[];
+    // `videos` is omitted when every generated sample is filtered out by
+    // the safety (RAI) filters, so it must be treated as optional.
+    videos?: VeoMedia[];
   };
 }
 

--- a/js/plugins/google-genai/src/vertexai/utils.ts
+++ b/js/plugins/google-genai/src/vertexai/utils.ts
@@ -368,25 +368,22 @@ export function calculateRequestOptions<T extends z.ZodObject<any, any, any>>(
   return newOptions;
 }
 
-const VERTEX_API_VERSIONS = ['v1', 'v1beta1'] as const;
-function isVertexApiVersion(
-  value: unknown
-): value is (typeof VERTEX_API_VERSIONS)[number] {
-  return (
-    typeof value === 'string' &&
-    (VERTEX_API_VERSIONS as readonly string[]).includes(value)
-  );
-}
-
 /**
  * Applies connection-related overrides carried in the action run context
  * (e.g. `options.context` on `start`/`check`/`cancel` for background models)
  * on top of the given client options. This is the mechanism by which callers
- * can supply per-call `apiKey`, `apiVersion`, and `location` overrides for
- * calls (like `checkOperation`/`cancelOperation`) that don't have access to
- * the original request's `config`.
+ * can supply per-call overrides for calls (like
+ * `checkOperation`/`cancelOperation`) that don't have access to the original
+ * request's `config`.
  *
- * Context fields take precedence over whatever is already in `clientOptions`.
+ * The API key is read from `context.secrets.apiKey` (scrubbed from traces).
+ * All other overrides (e.g. `location`, `apiVersion`) are read from
+ * `context.config`, which is where `checkOperation`/`cancelOperation` fold
+ * their top-level `config` option. This lets callers write
+ * `ai.checkOperation(op, { config: { location } })`.
+ *
+ * All context-derived values take precedence over whatever is already in
+ * `clientOptions`.
  *
  * @param clientOptions The base client options to apply overrides on top of.
  * @param context The action run context (`options.context`), if any.
@@ -399,31 +396,6 @@ export function applyContextOverrides(
     return clientOptions;
   }
   let newOptions = { ...clientOptions };
-  if (context.apiVersion !== undefined) {
-    if (!isVertexApiVersion(context.apiVersion)) {
-      throw new GenkitError({
-        status: 'INVALID_ARGUMENT',
-        message: `context.apiVersion must be one of ${VERTEX_API_VERSIONS.join(', ')}, got: ${context.apiVersion}`,
-      });
-    }
-    newOptions.apiVersion = context.apiVersion;
-  }
-  if (
-    typeof context.location === 'string' &&
-    newOptions.kind != 'express' &&
-    newOptions.location != context.location
-  ) {
-    if (context.location == 'global') {
-      newOptions.location = 'global';
-      newOptions.kind = 'global';
-    } else if (isMultiRegionalLocation(context.location)) {
-      newOptions.kind = 'multi-regional';
-      newOptions.location = context.location;
-    } else {
-      newOptions.kind = 'regional';
-      newOptions.location = context.location;
-    }
-  }
   const contextApiKey = context.secrets?.apiKey;
   if (typeof contextApiKey === 'string') {
     if (newOptions.kind == 'express') {
@@ -433,7 +405,10 @@ export function applyContextOverrides(
       newOptions.apiKey = contextApiKey;
     }
   }
-  return newOptions;
+  // All non-secret overrides (e.g. location, apiVersion) are carried in
+  // `context.config` (from checkOperation/cancelOperation's top-level
+  // `config`).
+  return calculateRequestOptions(newOptions, context.config);
 }
 
 /**

--- a/js/plugins/google-genai/src/vertexai/utils.ts
+++ b/js/plugins/google-genai/src/vertexai/utils.ts
@@ -424,7 +424,7 @@ export function applyContextOverrides(
       newOptions.location = context.location;
     }
   }
-  const contextApiKey = context.auth?.apiKey;
+  const contextApiKey = context.secrets?.apiKey;
   if (typeof contextApiKey === 'string') {
     if (newOptions.kind == 'express') {
       newOptions.apiKey = calculateApiKey(newOptions.apiKey, contextApiKey);

--- a/js/plugins/google-genai/src/vertexai/utils.ts
+++ b/js/plugins/google-genai/src/vertexai/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { GenkitError, z } from 'genkit';
+import { GenkitError, z, type ActionContext } from 'genkit';
 import { GoogleAuth } from 'google-auth-library';
 import {
   isMultiRegionalLocation,
@@ -364,6 +364,74 @@ export function calculateRequestOptions<T extends z.ZodObject<any, any, any>>(
   } else if (reqConfig?.apiKey && typeof reqConfig.apiKey == 'string') {
     // Regional or Global can still use APIKey for billing (not auth)
     newOptions.apiKey = reqConfig.apiKey;
+  }
+  return newOptions;
+}
+
+const VERTEX_API_VERSIONS = ['v1', 'v1beta1'] as const;
+function isVertexApiVersion(
+  value: unknown
+): value is (typeof VERTEX_API_VERSIONS)[number] {
+  return (
+    typeof value === 'string' &&
+    (VERTEX_API_VERSIONS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Applies connection-related overrides carried in the action run context
+ * (e.g. `options.context` on `start`/`check`/`cancel` for background models)
+ * on top of the given client options. This is the mechanism by which callers
+ * can supply per-call `apiKey`, `apiVersion`, and `location` overrides for
+ * calls (like `checkOperation`/`cancelOperation`) that don't have access to
+ * the original request's `config`.
+ *
+ * Context fields take precedence over whatever is already in `clientOptions`.
+ *
+ * @param clientOptions The base client options to apply overrides on top of.
+ * @param context The action run context (`options.context`), if any.
+ */
+export function applyContextOverrides(
+  clientOptions: ClientOptions,
+  context?: ActionContext
+): ClientOptions {
+  if (!context) {
+    return clientOptions;
+  }
+  let newOptions = { ...clientOptions };
+  if (context.apiVersion !== undefined) {
+    if (!isVertexApiVersion(context.apiVersion)) {
+      throw new GenkitError({
+        status: 'INVALID_ARGUMENT',
+        message: `context.apiVersion must be one of ${VERTEX_API_VERSIONS.join(', ')}, got: ${context.apiVersion}`,
+      });
+    }
+    newOptions.apiVersion = context.apiVersion;
+  }
+  if (
+    typeof context.location === 'string' &&
+    newOptions.kind != 'express' &&
+    newOptions.location != context.location
+  ) {
+    if (context.location == 'global') {
+      newOptions.location = 'global';
+      newOptions.kind = 'global';
+    } else if (isMultiRegionalLocation(context.location)) {
+      newOptions.kind = 'multi-regional';
+      newOptions.location = context.location;
+    } else {
+      newOptions.kind = 'regional';
+      newOptions.location = context.location;
+    }
+  }
+  const contextApiKey = context.auth?.apiKey;
+  if (typeof contextApiKey === 'string') {
+    if (newOptions.kind == 'express') {
+      newOptions.apiKey = calculateApiKey(newOptions.apiKey, contextApiKey);
+    } else {
+      // Regional or Global can still use APIKey for billing (not auth)
+      newOptions.apiKey = contextApiKey;
+    }
   }
   return newOptions;
 }

--- a/js/plugins/google-genai/src/vertexai/veo.ts
+++ b/js/plugins/google-genai/src/vertexai/veo.ts
@@ -27,13 +27,13 @@ import { isKnownKey } from '../common/utils.js';
 import { veoCheckOperation, veoPredict } from './client.js';
 import {
   fromVeoOperation,
-  toVeoClientOptions,
   toVeoModel,
   toVeoOperationRequest,
   toVeoPredictRequest,
 } from './converters.js';
 import { ClientOptions, Model, VertexPluginOptions } from './types.js';
 import {
+  applyContextOverrides,
   calculateRequestOptions,
   checkModelName,
   extractVersion,
@@ -218,8 +218,11 @@ export function defineModel(
     name: ref.name,
     ...ref.info,
     configSchema: ref.configSchema,
-    async start(request) {
-      const clientOpt = calculateRequestOptions(clientOptions, request.config);
+    async start(request, options) {
+      const clientOpt = applyContextOverrides(
+        calculateRequestOptions(clientOptions, request.config),
+        options?.context
+      );
       const veoPredictRequest = toVeoPredictRequest(request);
 
       const response = await veoPredict(
@@ -228,16 +231,19 @@ export function defineModel(
         clientOpt
       );
 
-      return fromVeoOperation(response, clientOpt);
+      return fromVeoOperation(response);
     },
-    async check(operation) {
-      const checkClientOptions = toVeoClientOptions(operation, clientOptions);
+    async check(operation, options) {
+      const checkClientOptions = applyContextOverrides(
+        clientOptions,
+        options?.context
+      );
       const response = await veoCheckOperation(
         toVeoModel(operation),
         toVeoOperationRequest(operation),
         checkClientOptions
       );
-      return fromVeoOperation(response, checkClientOptions);
+      return fromVeoOperation(response);
     },
   });
 }

--- a/js/plugins/google-genai/tests/googleai/deep-research_test.ts
+++ b/js/plugins/google-genai/tests/googleai/deep-research_test.ts
@@ -298,7 +298,7 @@ describe('Deep Research', () => {
       const operation = await model.start(minimalRequest);
 
       await model.check!(operation, {
-        context: { auth: { apiKey: 'context-api-key' } },
+        context: { secrets: { apiKey: 'context-api-key' } },
       });
 
       // fetchStub should be called twice: once for start, once for check

--- a/js/plugins/google-genai/tests/googleai/deep-research_test.ts
+++ b/js/plugins/google-genai/tests/googleai/deep-research_test.ts
@@ -263,7 +263,7 @@ describe('Deep Research', () => {
       assert.strictEqual(body.tools[0].name, 'myFunc');
     });
 
-    it('persists client options to metadata', async () => {
+    it('applies request-level apiKey and baseUrl overrides to start', async () => {
       const model = defineModel(
         'deep-research-pro-preview-12-2025',
         defaultPluginOptions
@@ -278,18 +278,16 @@ describe('Deep Research', () => {
         },
       };
 
-      const operation = await model.start(request);
+      await model.start(request);
 
-      assert.deepStrictEqual(operation.metadata?.clientOptions, {
-        apiVersion: undefined,
-        apiKey: 'request-api-key',
-        baseUrl: 'https://custom.url',
-        customHeaders: undefined,
-        experimental_debugTraces: undefined,
-      });
+      sinon.assert.calledOnce(fetchStub);
+      const url = fetchStub.lastCall.args[0] as string;
+      const options = fetchStub.lastCall.args[1];
+      assert.ok(url.startsWith('https://custom.url'));
+      assert.strictEqual(options.headers['x-goog-api-key'], 'request-api-key');
     });
 
-    it('uses persisted options in check', async () => {
+    it('applies apiKey override from options.context on check', async () => {
       const model = defineModel(
         'deep-research-pro-preview-12-2025',
         defaultPluginOptions
@@ -297,42 +295,18 @@ describe('Deep Research', () => {
       mockFetchResponse(mockInteractionResponse); // For start
       mockFetchResponse(mockInteractionResponse); // For check
 
-      const request: GenerateRequest<typeof DeepResearchConfigSchema> = {
-        ...minimalRequest,
-        config: {
-          apiKey: 'request-api-key',
-          baseUrl: 'https://custom.url',
-        },
-      };
+      const operation = await model.start(minimalRequest);
 
-      const operation = await model.start(request);
-
-      // Now call check with the operation that has metadata
-      await model.check!(operation);
+      await model.check!(operation, {
+        context: { auth: { apiKey: 'context-api-key' } },
+      });
 
       // fetchStub should be called twice: once for start, once for check
       sinon.assert.calledTwice(fetchStub);
 
       const checkCall = fetchStub.getCall(1);
-      const url = checkCall.args[0] as string;
       const options = checkCall.args[1];
-
-      // Check URL uses custom base URL
-      assert.ok(url.startsWith('https://custom.url'));
-
-      // Check API Key header
-      // The client usually adds it to x-goog-api-key or key query param.
-      // We need to know how `client.ts` implements `getInteraction`.
-      // Assuming it adds it to headers or query params.
-      // Based on googleai/client.ts (which I haven't read, but assuming standard behavior):
-      // The `fetch` mock args[1] contains headers.
-      const headers = options.headers as any;
-      if (headers['x-goog-api-key']) {
-        assert.strictEqual(headers['x-goog-api-key'], 'request-api-key');
-      } else {
-        // Check query param if not in header (though likely in header)
-        assert.ok(url.includes('key=request-api-key'));
-      }
+      assert.strictEqual(options.headers['x-goog-api-key'], 'context-api-key');
     });
 
     it('maps usage statistics', async () => {

--- a/js/plugins/google-genai/tests/googleai/veo_test.ts
+++ b/js/plugins/google-genai/tests/googleai/veo_test.ts
@@ -493,15 +493,18 @@ describe('Google AI Veo', () => {
         );
       });
 
-      it('should apply apiVersion and baseUrl override from options.context', async () => {
+      it('should apply apiVersion and baseUrl override from context.config', async () => {
         mockFetchResponse({ name: operationId, done: true });
 
         const { check } = captureModelRunner({ apiKey: defaultApiKey });
 
+        // This is what checkOperation folds a top-level `config` into.
         await check(pendingOp, {
           context: {
-            apiVersion: 'v1context',
-            baseUrl: 'https://context.example.com',
+            config: {
+              apiVersion: 'v1config',
+              baseUrl: 'https://config.example.com',
+            },
           },
         });
 
@@ -510,8 +513,8 @@ describe('Google AI Veo', () => {
         const expectedUrl = getGoogleAIUrl({
           resourcePath: operationId,
           clientOptions: {
-            apiVersion: 'v1context',
-            baseUrl: 'https://context.example.com',
+            apiVersion: 'v1config',
+            baseUrl: 'https://config.example.com',
           },
         });
         assert.strictEqual(fetchArgs[0], expectedUrl);

--- a/js/plugins/google-genai/tests/googleai/veo_test.ts
+++ b/js/plugins/google-genai/tests/googleai/veo_test.ts
@@ -227,9 +227,13 @@ describe('Google AI Veo', () => {
       } = {}
     ): {
       start: (
-        request: GenerateRequest
+        request: GenerateRequest,
+        options?: any
       ) => Promise<Operation<GenerateResponseData>>;
-      check: (operation: Operation) => Promise<Operation<GenerateResponseData>>;
+      check: (
+        operation: Operation,
+        options?: any
+      ) => Promise<Operation<GenerateResponseData>>;
     } {
       const name = defineOptions.name || modelName;
       const apiVersion = defineOptions.apiVersion;
@@ -240,8 +244,8 @@ describe('Google AI Veo', () => {
       assert.strictEqual(model.__action.name, `googleai/${name}`);
       assert.strictEqual(model.__configSchema, VeoConfigSchema);
       return {
-        start: (req) => model.start(req),
-        check: (op) => model.check(op),
+        start: (req, options) => model.start(req, options),
+        check: (op, options) => model.check(op, options),
       };
     }
 
@@ -380,26 +384,20 @@ describe('Google AI Veo', () => {
         );
       });
 
-      it('persists client options to metadata', async () => {
+      it('should apply apiKey override from options.context', async () => {
         mockFetchResponse({ name: 'operations/start123', done: false });
         const { start } = captureModelRunner({ apiKey: defaultApiKey });
 
-        const req: GenerateRequest<typeof VeoConfigSchema> = {
-          ...request,
-          config: {
-            apiKey: 'request-level-api-key',
-          },
-        };
-
-        const operation = await start(req);
-
-        assert.deepStrictEqual(operation.metadata?.clientOptions, {
-          apiVersion: undefined,
-          apiKey: 'request-level-api-key',
-          baseUrl: undefined,
-          customHeaders: undefined,
-          experimental_debugTraces: undefined,
+        await start(request, {
+          context: { auth: { apiKey: 'context-api-key' } },
         });
+
+        sinon.assert.calledOnce(fetchStub);
+        const fetchArgs = fetchStub.lastCall.args;
+        assert.strictEqual(
+          fetchArgs[1].headers['x-goog-api-key'],
+          'context-api-key'
+        );
       });
     });
 
@@ -478,28 +476,45 @@ describe('Google AI Veo', () => {
         );
       });
 
-      it('uses persisted options in check', async () => {
+      it('should apply apiKey override from options.context', async () => {
         mockFetchResponse({ name: operationId, done: true });
 
         const { check } = captureModelRunner({ apiKey: defaultApiKey });
 
-        const opWithMetadata: Operation = {
-          ...pendingOp,
-          metadata: {
-            clientOptions: {
-              apiKey: 'request-level-api-key',
-            },
-          },
-        };
-
-        await check(opWithMetadata);
+        await check(pendingOp, {
+          context: { auth: { apiKey: 'context-api-key' } },
+        });
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
         assert.strictEqual(
           fetchArgs[1].headers['x-goog-api-key'],
-          'request-level-api-key'
+          'context-api-key'
         );
+      });
+
+      it('should apply apiVersion and baseUrl override from options.context', async () => {
+        mockFetchResponse({ name: operationId, done: true });
+
+        const { check } = captureModelRunner({ apiKey: defaultApiKey });
+
+        await check(pendingOp, {
+          context: {
+            apiVersion: 'v1context',
+            baseUrl: 'https://context.example.com',
+          },
+        });
+
+        sinon.assert.calledOnce(fetchStub);
+        const fetchArgs = fetchStub.lastCall.args;
+        const expectedUrl = getGoogleAIUrl({
+          resourcePath: operationId,
+          clientOptions: {
+            apiVersion: 'v1context',
+            baseUrl: 'https://context.example.com',
+          },
+        });
+        assert.strictEqual(fetchArgs[0], expectedUrl);
       });
     });
   });

--- a/js/plugins/google-genai/tests/googleai/veo_test.ts
+++ b/js/plugins/google-genai/tests/googleai/veo_test.ts
@@ -389,7 +389,7 @@ describe('Google AI Veo', () => {
         const { start } = captureModelRunner({ apiKey: defaultApiKey });
 
         await start(request, {
-          context: { auth: { apiKey: 'context-api-key' } },
+          context: { secrets: { apiKey: 'context-api-key' } },
         });
 
         sinon.assert.calledOnce(fetchStub);
@@ -482,7 +482,7 @@ describe('Google AI Veo', () => {
         const { check } = captureModelRunner({ apiKey: defaultApiKey });
 
         await check(pendingOp, {
-          context: { auth: { apiKey: 'context-api-key' } },
+          context: { secrets: { apiKey: 'context-api-key' } },
         });
 
         sinon.assert.calledOnce(fetchStub);

--- a/js/plugins/google-genai/tests/vertexai/converters_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/converters_test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import { GenerateRequest, Operation, z } from 'genkit';
+import { GenerateRequest, z } from 'genkit';
 import { describe, it } from 'node:test';
 import { HarmBlockThreshold, HarmCategory } from '../../src/common/types.js';
 import {
@@ -26,7 +26,6 @@ import {
   toGeminiSafetySettings,
   toImagenPredictRequest,
   toLyriaPredictRequest,
-  toVeoClientOptions,
   toVeoMedia,
   toVeoModel,
   toVeoOperationRequest,
@@ -39,7 +38,6 @@ import {
 } from '../../src/vertexai/imagen.js';
 import { LyriaConfigSchema } from '../../src/vertexai/lyria.js';
 import {
-  ClientOptions,
   ImagenPredictResponse,
   LyriaPredictResponse,
   VeoOperation,
@@ -659,27 +657,6 @@ describe('Vertex AI Converters', () => {
         error: { message: 'Invalid argument' },
       });
     });
-
-    it('should convert operation with clientOptions', () => {
-      const clientOptions: ClientOptions = {
-        kind: 'regional',
-        location: 'us-west1',
-        projectId: 'foo',
-        authClient: {} as any,
-      };
-      const veoOp: VeoOperation = {
-        name: 'operations/789',
-        done: false,
-      };
-      const result = fromVeoOperation(veoOp, clientOptions);
-      assert.deepStrictEqual(result, {
-        id: 'operations/789',
-        done: false,
-        metadata: {
-          clientOptions: clientOptions,
-        },
-      });
-    });
   });
 
   describe('toVeoModel', () => {
@@ -701,52 +678,6 @@ describe('Vertex AI Converters', () => {
       assert.deepStrictEqual(result, {
         operationName: 'operations/abcdef',
       });
-    });
-  });
-
-  describe('toVeoClientOptions', () => {
-    const defaultClientOptions: ClientOptions = {
-      kind: 'regional',
-      location: 'us-central1',
-      projectId: 'default-project',
-      authClient: {} as any,
-    };
-    const opClientOptions: ClientOptions = {
-      kind: 'global',
-      location: 'global',
-      projectId: 'op-project',
-      authClient: {} as any,
-    };
-
-    it('should return client options from operation metadata if present', () => {
-      const op: Operation = {
-        id: 'op1',
-        done: false,
-        metadata: {
-          clientOptions: opClientOptions,
-        },
-      };
-      const result = toVeoClientOptions(op, defaultClientOptions);
-      assert.deepStrictEqual(result, opClientOptions);
-    });
-
-    it('should return default client options if not in operation metadata', () => {
-      const op: Operation = {
-        id: 'op2',
-        done: false,
-      };
-      const result = toVeoClientOptions(op, defaultClientOptions);
-      assert.deepStrictEqual(result, defaultClientOptions);
-    });
-
-    it('should return default client options if metadata is empty', () => {
-      const op: Operation = {
-        id: 'op3',
-        done: false,
-        metadata: {},
-      };
-      const result = toVeoClientOptions(op, defaultClientOptions);
-      assert.deepStrictEqual(result, defaultClientOptions);
     });
   });
 });

--- a/js/plugins/google-genai/tests/vertexai/converters_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/converters_test.ts
@@ -657,6 +657,49 @@ describe('Vertex AI Converters', () => {
         error: { message: 'Invalid argument' },
       });
     });
+
+    it('should not throw and should surface an error when all videos are filtered', () => {
+      // When every generated video is filtered by the safety (RAI) filters,
+      // the API returns a response with no `videos` array.
+      const veoOp: VeoOperation = {
+        name: 'operations/rai',
+        done: true,
+        response: {
+          raiMediaFilteredCount: 1,
+          raiMediaFilteredReasons: ['1 videos were filtered out.'],
+        },
+      };
+      const result = fromVeoOperation(veoOp);
+      assert.deepStrictEqual(result, {
+        id: 'operations/rai',
+        done: true,
+        error: { message: '1 videos were filtered out.' },
+        output: {
+          finishReason: 'blocked',
+          raw: veoOp.response,
+          message: {
+            role: 'model',
+            content: [],
+          },
+        },
+      });
+    });
+
+    it('should use a default message when videos are filtered with no reasons', () => {
+      const veoOp: VeoOperation = {
+        name: 'operations/rai2',
+        done: true,
+        response: {
+          raiMediaFilteredCount: 2,
+        },
+      };
+      const result = fromVeoOperation(veoOp);
+      assert.strictEqual(
+        result.error?.message,
+        'All generated videos were filtered out by safety filters.'
+      );
+      assert.strictEqual(result.output?.finishReason, 'blocked');
+    });
   });
 
   describe('toVeoModel', () => {

--- a/js/plugins/google-genai/tests/vertexai/veo_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/veo_test.ts
@@ -275,12 +275,13 @@ describe('Vertex AI Veo', () => {
         );
       });
 
-      it('should apply location override from options.context', async () => {
+      it('should apply location override from context.config', async () => {
         mockFetchResponse({ name: operationId, done: true });
 
         const { check } = captureModelRunner(defaultRegionalClientOptions);
+        // This is what checkOperation folds a top-level `config` into.
         await check(pendingOp, {
-          context: { location: 'europe-west1' },
+          context: { config: { location: 'europe-west1' } },
         });
 
         sinon.assert.calledOnce(fetchStub);

--- a/js/plugins/google-genai/tests/vertexai/veo_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/veo_test.ts
@@ -108,12 +108,12 @@ describe('Vertex AI Veo', () => {
       start: (
         request: GenerateRequest<typeof VeoConfigSchema>
       ) => Promise<Operation>;
-      check: (operation: Operation) => Promise<Operation>;
+      check: (operation: Operation, options?: any) => Promise<Operation>;
     } {
       const model = defineModel(modelName, clientOptions);
       return {
         start: (req) => model.start(req),
-        check: (op) => model.check(op),
+        check: (op, options) => model.check(op, options),
       };
     }
 
@@ -199,6 +199,23 @@ describe('Vertex AI Veo', () => {
         controller.abort();
         sinon.assert.calledOnce(abortSpy);
       });
+
+      it('should apply apiKey override from options.context', async () => {
+        mockFetchResponse({ name: 'operations/ctx-key', done: false });
+
+        const { start } = captureModelRunner(defaultRegionalClientOptions);
+        await await defineModel(modelName, defaultRegionalClientOptions).start(
+          request,
+          { context: { auth: { apiKey: 'context-api-key' } } }
+        );
+
+        sinon.assert.calledOnce(fetchStub);
+        const fetchArgs = fetchStub.lastCall.args;
+        assert.strictEqual(
+          fetchArgs[1].headers['x-goog-api-key'],
+          'context-api-key'
+        );
+      });
     });
 
     describe('check()', () => {
@@ -259,27 +276,34 @@ describe('Vertex AI Veo', () => {
         );
       });
 
-      it('should use clientOptions from operation metadata if available', async () => {
-        const opClientOptions: ClientOptions = {
-          kind: 'regional',
-          projectId: 'op-project',
-          location: 'europe-west1',
-          authClient: authMock as any,
-        };
-        const opWithClientOptions: Operation = {
-          ...pendingOp,
-          metadata: { clientOptions: opClientOptions },
-        };
+      it('should apply location override from options.context', async () => {
         mockFetchResponse({ name: operationId, done: true });
 
         const { check } = captureModelRunner(defaultRegionalClientOptions);
-        await check(opWithClientOptions);
+        await check(pendingOp, {
+          context: { location: 'europe-west1' },
+        });
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
         const url = fetchArgs[0];
         assert.ok(url.includes('europe-west1'));
-        assert.ok(url.includes('op-project'));
+      });
+
+      it('should apply apiKey override from options.context', async () => {
+        mockFetchResponse({ name: operationId, done: true });
+
+        const { check } = captureModelRunner(defaultRegionalClientOptions);
+        await check(pendingOp, {
+          context: { auth: { apiKey: 'context-api-key' } },
+        });
+
+        sinon.assert.calledOnce(fetchStub);
+        const fetchArgs = fetchStub.lastCall.args;
+        assert.strictEqual(
+          fetchArgs[1].headers['x-goog-api-key'],
+          'context-api-key'
+        );
       });
     });
   });

--- a/js/plugins/google-genai/tests/vertexai/veo_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/veo_test.ts
@@ -205,7 +205,7 @@ describe('Vertex AI Veo', () => {
 
         const model = defineModel(modelName, defaultRegionalClientOptions);
         await model.start(request, {
-          context: { auth: { apiKey: 'context-api-key' } },
+          context: { secrets: { apiKey: 'context-api-key' } },
         });
 
         sinon.assert.calledOnce(fetchStub);
@@ -294,7 +294,7 @@ describe('Vertex AI Veo', () => {
 
         const { check } = captureModelRunner(defaultRegionalClientOptions);
         await check(pendingOp, {
-          context: { auth: { apiKey: 'context-api-key' } },
+          context: { secrets: { apiKey: 'context-api-key' } },
         });
 
         sinon.assert.calledOnce(fetchStub);

--- a/js/plugins/google-genai/tests/vertexai/veo_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/veo_test.ts
@@ -203,11 +203,10 @@ describe('Vertex AI Veo', () => {
       it('should apply apiKey override from options.context', async () => {
         mockFetchResponse({ name: 'operations/ctx-key', done: false });
 
-        const { start } = captureModelRunner(defaultRegionalClientOptions);
-        await await defineModel(modelName, defaultRegionalClientOptions).start(
-          request,
-          { context: { auth: { apiKey: 'context-api-key' } } }
-        );
+        const model = defineModel(modelName, defaultRegionalClientOptions);
+        await model.start(request, {
+          context: { auth: { apiKey: 'context-api-key' } },
+        });
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;

--- a/js/testapps/basic-gemini/src/index-vertexai.ts
+++ b/js/testapps/basic-gemini/src/index-vertexai.ts
@@ -648,7 +648,7 @@ ai.defineFlow('veo-photo-move', async (_, { sendChunk }) => {
 });
 
 // An example of overriding the region used by a Veo background model at
-// call time via options.context.location, rather than relying on the
+// call time via config overrides, rather than relying on the
 // plugin-configured location ('global', from the plugin init above). This
 // is useful when per-request routing (e.g. picking a region closer to the
 // caller, or a region where a specific model is available) should override
@@ -686,9 +686,12 @@ ai.defineFlow('veo-photo-move-location-override', async (_, { sendChunk }) => {
       personGeneration: 'allow_adult',
     },
     // The plugin is initialized with location: 'global' above; override it
-    // to 'us-central1' here to prove the context override takes effect.
+    // to 'us-central1' here to prove the override takes effect. On
+    // generate(), config overrides ride in context.config.
     context: {
-      location: 'us-central1',
+      config: {
+        location: 'us-central1',
+      },
     },
   });
 
@@ -698,8 +701,9 @@ ai.defineFlow('veo-photo-move-location-override', async (_, { sendChunk }) => {
 
   while (!operation.done) {
     sendChunk('check status of operation ' + operation.id);
+    // On checkOperation(), config overrides go in the top-level `config`.
     operation = await ai.checkOperation(operation, {
-      context: { location: 'us-central1' },
+      config: { location: 'us-central1' },
     });
     await new Promise((resolve) => setTimeout(resolve, 5000));
   }

--- a/js/testapps/basic-gemini/src/index-vertexai.ts
+++ b/js/testapps/basic-gemini/src/index-vertexai.ts
@@ -647,6 +647,82 @@ ai.defineFlow('veo-photo-move', async (_, { sendChunk }) => {
   return mediaPart.media;
 });
 
+// An example of overriding the region used by a Veo background model at
+// call time via options.context.location, rather than relying on the
+// plugin-configured location ('global', from the plugin init above). This
+// is useful when per-request routing (e.g. picking a region closer to the
+// caller, or a region where a specific model is available) should override
+// the plugin-wide default. Because Veo is a background model, the same
+// context must be supplied on both the initial ai.generate() call and every
+// subsequent ai.checkOperation() call.
+//
+// Note: apiKey overrides can't be demonstrated with Veo on Vertex AI
+// because (a) standard (non-Express) Vertex AI mode authenticates via
+// Application Default Credentials, not an apiKey (apiKey there is only a
+// supplementary header, never a replacement for the Bearer token), and
+// (b) Vertex AI Express mode -- which *does* use an apiKey for auth --
+// does not support Veo's predictLongRunning/fetchPredictOperation methods
+// at all. Overriding location is a good stand-in to demonstrate the same
+// context-override mechanism working end-to-end.
+ai.defineFlow('veo-photo-move-location-override', async (_, { sendChunk }) => {
+  const startingImage = fs.readFileSync('photo.jpg', { encoding: 'base64' });
+
+  let { operation } = await ai.generate({
+    model: vertexAI.model('veo-3.1-generate-001'),
+    prompt: [
+      {
+        text: 'make the subject in the photo move',
+      },
+      {
+        media: {
+          contentType: 'image/jpeg',
+          url: `data:image/jpeg;base64,${startingImage}`,
+        },
+      },
+    ],
+    config: {
+      durationSeconds: 8,
+      aspectRatio: '9:16',
+      personGeneration: 'allow_adult',
+    },
+    // The plugin is initialized with location: 'global' above; override it
+    // to 'us-central1' here to prove the context override takes effect.
+    context: {
+      location: 'us-central1',
+    },
+  });
+
+  if (!operation) {
+    throw new Error('Expected the model to return an operation');
+  }
+
+  while (!operation.done) {
+    sendChunk('check status of operation ' + operation.id);
+    operation = await ai.checkOperation(operation, {
+      context: { location: 'us-central1' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+
+  if (operation.error) {
+    sendChunk('Error: ' + operation.error.message);
+    throw new Error('failed to generate video: ' + operation.error.message);
+  }
+
+  const mediaPart = operation.output?.message?.content.find(
+    (p: Part) => !!p.media
+  );
+  if (!mediaPart) {
+    throw new Error('Failed to find the generated video');
+  }
+
+  // Download for now until we have DevUI support for video
+  const videoBuffer = Buffer.from(mediaPart.media.url.split(',')[1], 'base64');
+  fs.writeFileSync('veo-output.mp4', videoBuffer);
+
+  return mediaPart.media;
+});
+
 ai.defineFlow('veo-reference-images', async (_, { sendChunk }) => {
   const roomImage = fs.readFileSync('my_room.png', { encoding: 'base64' });
   const palmImage = fs.readFileSync('palm_tree.png', { encoding: 'base64' });

--- a/js/testapps/basic-gemini/src/index.ts
+++ b/js/testapps/basic-gemini/src/index.ts
@@ -798,6 +798,73 @@ ai.defineFlow('photo-move-veo', async (_, { sendChunk }) => {
   return operation;
 });
 
+// An example of overriding the apiKey used by a Veo background model at call
+// time via options.context.auth.apiKey, rather than relying on the
+// plugin-configured apiKey (env var or plugin init option). This is useful
+// when per-request auth (e.g. from an authenticated HTTP caller) should be
+// used instead of a single, plugin-wide key. Because Veo is a background
+// model, the same context must be supplied on both the initial
+// ai.generate() call and every subsequent ai.checkOperation() call.
+ai.defineFlow('photo-move-veo-apikey-override', async (_, { sendChunk }) => {
+  const startingImage = fs.readFileSync('woman.png', { encoding: 'base64' });
+
+  let { operation } = await ai.generate({
+    model: googleAI.model('veo-3.1-lite-generate-preview'),
+    prompt: [
+      {
+        text: 'make the subject in the photo move',
+      },
+      {
+        media: {
+          contentType: 'image/png',
+          url: `data:image/png;base64,${startingImage}`,
+        },
+      },
+    ],
+    config: {
+      resolution: '1080p',
+      durationSeconds: 8,
+      aspectRatio: '9:16',
+      personGeneration: 'allow_adult',
+      seed: 42,
+    },
+    context: {
+      auth: {
+        apiKey: process.env.CUSTOM_KEY,
+      },
+    },
+  });
+
+  if (!operation) {
+    throw new Error('Expected the model to return an operation');
+  }
+
+  while (!operation.done) {
+    sendChunk('check status of operation ' + operation.id);
+    operation = await ai.checkOperation(operation, {
+      context: { auth: { apiKey: process.env.CUSTOM_KEY } },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+
+  if (operation.error) {
+    sendChunk('Error: ' + operation.error.message);
+    throw new Error('failed to generate video: ' + operation.error.message);
+  }
+
+  // operation done, download generated video to disk
+  const video = operation.output?.message?.content.find((p) => !!p.media);
+  if (!video) {
+    sendChunk(operation);
+    throw new Error('Failed to find the generated video');
+  }
+  sendChunk('Writing results to photo.mp4');
+  await downloadVideo(video, 'photo.mp4');
+  sendChunk('Done!');
+
+  return operation;
+});
+
 async function waitForOperation(
   operation?: Operation,
   sendChunk?: StreamingCallback<any>
@@ -1113,6 +1180,43 @@ ai.defineFlow('deep-research', async (_, { sendChunk }) => {
   while (!operation.done) {
     sendChunk('check status of operation ' + operation.id);
     operation = await ai.checkOperation(operation);
+    await new Promise((resolve) => setTimeout(resolve, 30000));
+  }
+
+  if (operation.error) {
+    sendChunk('Error: ' + operation.error.message);
+    throw new Error('failed to deep research: ' + operation.error.message);
+  }
+
+  return operation.output?.message?.content.find((p) => !!p.text)?.text;
+});
+
+// An example of overriding the apiKey used by the Deep Research background
+// model at call time via options.context.auth.apiKey, rather than relying
+// on the plugin-configured apiKey. Because Deep Research is also a
+// background model, the same context must be supplied on both the initial
+// ai.generate() call and every subsequent ai.checkOperation() call.
+ai.defineFlow('deep-research-apikey-override', async (_, { sendChunk }) => {
+  let { operation } = await ai.generate({
+    model: googleAI.model('deep-research-pro-preview-12-2025'),
+    prompt:
+      'Compare the differences between TCP and UDP protocols. Provide the answer in a markdown table focusing on reliability, connection type, and speed.',
+    context: {
+      auth: {
+        apiKey: process.env.CUSTOM_KEY,
+      },
+    },
+  });
+
+  if (!operation) {
+    throw new Error('Expected the model to return an operation');
+  }
+
+  while (!operation.done) {
+    sendChunk('check status of operation ' + operation.id);
+    operation = await ai.checkOperation(operation, {
+      context: { auth: { apiKey: process.env.CUSTOM_KEY } },
+    });
     await new Promise((resolve) => setTimeout(resolve, 30000));
   }
 

--- a/js/testapps/basic-gemini/src/index.ts
+++ b/js/testapps/basic-gemini/src/index.ts
@@ -799,11 +799,11 @@ ai.defineFlow('photo-move-veo', async (_, { sendChunk }) => {
 });
 
 // An example of overriding the apiKey used by a Veo background model at call
-// time via options.context.auth.apiKey, rather than relying on the
+// time via options.context.secrets.apiKey, rather than relying on the
 // plugin-configured apiKey (env var or plugin init option). This is useful
-// when per-request auth (e.g. from an authenticated HTTP caller) should be
-// used instead of a single, plugin-wide key. Because Veo is a background
-// model, the same context must be supplied on both the initial
+// when per-request credentials (e.g. from an authenticated HTTP caller)
+// should be used instead of a single, plugin-wide key. Because Veo is a
+// background model, the same context must be supplied on both the initial
 // ai.generate() call and every subsequent ai.checkOperation() call.
 ai.defineFlow('photo-move-veo-apikey-override', async (_, { sendChunk }) => {
   const startingImage = fs.readFileSync('woman.png', { encoding: 'base64' });
@@ -829,7 +829,7 @@ ai.defineFlow('photo-move-veo-apikey-override', async (_, { sendChunk }) => {
       seed: 42,
     },
     context: {
-      auth: {
+      secrets: {
         apiKey: process.env.CUSTOM_KEY,
       },
     },
@@ -842,7 +842,7 @@ ai.defineFlow('photo-move-veo-apikey-override', async (_, { sendChunk }) => {
   while (!operation.done) {
     sendChunk('check status of operation ' + operation.id);
     operation = await ai.checkOperation(operation, {
-      context: { auth: { apiKey: process.env.CUSTOM_KEY } },
+      context: { secrets: { apiKey: process.env.CUSTOM_KEY } },
     });
     await new Promise((resolve) => setTimeout(resolve, 5000));
   }
@@ -1192,8 +1192,8 @@ ai.defineFlow('deep-research', async (_, { sendChunk }) => {
 });
 
 // An example of overriding the apiKey used by the Deep Research background
-// model at call time via options.context.auth.apiKey, rather than relying
-// on the plugin-configured apiKey. Because Deep Research is also a
+// model at call time via options.context.secrets.apiKey, rather than
+// relying on the plugin-configured apiKey. Because Deep Research is also a
 // background model, the same context must be supplied on both the initial
 // ai.generate() call and every subsequent ai.checkOperation() call.
 ai.defineFlow('deep-research-apikey-override', async (_, { sendChunk }) => {
@@ -1202,7 +1202,7 @@ ai.defineFlow('deep-research-apikey-override', async (_, { sendChunk }) => {
     prompt:
       'Compare the differences between TCP and UDP protocols. Provide the answer in a markdown table focusing on reliability, connection type, and speed.',
     context: {
-      auth: {
+      secrets: {
         apiKey: process.env.CUSTOM_KEY,
       },
     },
@@ -1215,7 +1215,7 @@ ai.defineFlow('deep-research-apikey-override', async (_, { sendChunk }) => {
   while (!operation.done) {
     sendChunk('check status of operation ' + operation.id);
     operation = await ai.checkOperation(operation, {
-      context: { auth: { apiKey: process.env.CUSTOM_KEY } },
+      context: { secrets: { apiKey: process.env.CUSTOM_KEY } },
     });
     await new Promise((resolve) => setTimeout(resolve, 30000));
   }


### PR DESCRIPTION
operation for long running models

This is a breaking change for certain edge cases involving background models with per request overrides only.

Previously the clientOptions were persisted in the operation metadata so it was easier to poll using the same information, however apparently people were just returning the full operation including auth to untrusted third parties without any modification, so there was a potential for leaking apiKeys if they did not remove the metadata from the operation first. This implementation removes that leak potential for security purposes and the operation no longer persists any client options passed in to the original generate request. Unfortunately this breaks an edge case that previously worked: If any overrides were present for longrunning models  (such as apiKeys), previously it just worked, but now those overrides must also be passed in for each checkOperation or cancelOperation. 

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
