### PR TITLE
feat(dev-ui): support Picoschema prompt export

### DIFF
--- a/genkit-tools/common/src/types/apis.ts
+++ b/genkit-tools/common/src/types/apis.ts
@@ -175,6 +175,7 @@ export type CancelActionRequest = z.infer<typeof CancelActionRequestSchema>;
 export const CreatePromptRequestSchema = z.object({
   model: z.string(),
   messages: z.array(MessageSchema),
+  picoSchema: z.boolean().optional(),
   config: GenerationCommonConfigSchema.passthrough().optional(),
   tools: z.array(ToolDefinitionSchema).optional(),
   use: z.array(MiddlewareRefSchema).optional(),

--- a/genkit-tools/common/src/utils/prompt.ts
+++ b/genkit-tools/common/src/utils/prompt.ts
@@ -53,7 +53,7 @@ function convertJsonSchemaNode(schema: Record<string, unknown>): unknown {
     return description ? `any, ${description}` : 'any';
   }
 
-  if (type === 'array') {
+  if (type === 'array' || isRecord(schema.items)) {
     return isRecord(schema.items) && Object.keys(schema.items).length > 0
       ? convertJsonSchemaNode(schema.items)
       : 'any';
@@ -129,7 +129,7 @@ function convertJsonSchemaObject(
 
 function scalarType(type: unknown): string | undefined {
   if (typeof type === 'string') return type;
-  if (!Array.isArray(type) || !type.includes('null')) return undefined;
+  if (!Array.isArray(type)) return undefined;
   const nonNullTypes = type.filter(
     (value): value is string => typeof value === 'string' && value !== 'null'
   );

--- a/genkit-tools/common/src/utils/prompt.ts
+++ b/genkit-tools/common/src/utils/prompt.ts
@@ -18,12 +18,149 @@ import { stringify } from 'yaml';
 import type { MessageData, Part } from '../types/model';
 import type { PromptFrontmatter } from '../types/prompt';
 
-function toFrontmatterSchema(config?: {
-  schema?: unknown;
-  jsonSchema?: unknown;
-}): unknown | undefined {
+const PICOSCHEMA_SCALAR_TYPES = new Set([
+  'boolean',
+  'integer',
+  'null',
+  'number',
+  'string',
+]);
+
+/**
+ * Converts JSON Schema into Dotprompt's compact Picoschema notation.
+ * Picoschema is a subset of JSON Schema, so constraints without a Picoschema
+ * equivalent are omitted as part of this opt-in, best-effort conversion.
+ */
+export function jsonSchemaToPicoschema(schema: unknown): unknown {
+  if (!isRecord(schema) || Object.keys(schema).length === 0) return undefined;
+  return convertJsonSchemaNode(schema);
+}
+
+function convertJsonSchemaNode(schema: Record<string, unknown>): unknown {
+  const description =
+    typeof schema.description === 'string' ? schema.description : undefined;
+  const type = scalarType(schema.type);
+
+  if (Array.isArray(schema.enum)) {
+    return schema.enum.filter((value) => value !== null);
+  }
+
+  if (type && PICOSCHEMA_SCALAR_TYPES.has(type)) {
+    return description ? `${type}, ${description}` : type;
+  }
+
+  if (!type && schema.properties === undefined && schema.items === undefined) {
+    return description ? `any, ${description}` : 'any';
+  }
+
+  if (type === 'array') {
+    return isRecord(schema.items) && Object.keys(schema.items).length > 0
+      ? convertJsonSchemaNode(schema.items)
+      : 'any';
+  }
+
+  if (type === 'object' || isRecord(schema.properties)) {
+    return convertJsonSchemaObject(schema);
+  }
+
+  if (type) {
+    return description ? `${type}, ${description}` : type;
+  }
+
+  return undefined;
+}
+
+function convertJsonSchemaObject(
+  schema: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const requiredProperties = new Set(
+    Array.isArray(schema.required)
+      ? schema.required.filter(
+          (propertyName): propertyName is string =>
+            typeof propertyName === 'string'
+        )
+      : []
+  );
+  const result: Record<string, unknown> = {};
+
+  for (const [propertyName, value] of Object.entries(properties)) {
+    if (!isPicoschemaPropertyName(propertyName) || !isRecord(value)) {
+      return undefined;
+    }
+
+    const key = requiredProperties.has(propertyName)
+      ? propertyName
+      : `${propertyName}?`;
+    const type = scalarType(value.type);
+
+    if (Array.isArray(value.enum)) {
+      result[`${key}(enum)`] = value.enum.filter(
+        (enumValue) => enumValue !== null
+      );
+    } else if (type === 'array') {
+      result[`${key}(array)`] =
+        isRecord(value.items) && Object.keys(value.items).length > 0
+          ? convertJsonSchemaNode(value.items)
+          : 'any';
+    } else if (type === 'object' || isRecord(value.properties)) {
+      const nestedObject = convertJsonSchemaObject(value);
+      if (!nestedObject) return undefined;
+      result[`${key}(object)`] = nestedObject;
+    } else {
+      const converted = convertJsonSchemaNode(value);
+      if (converted === undefined) return undefined;
+      result[key] = converted;
+    }
+  }
+
+  if (schema.additionalProperties === true) {
+    result['(*)'] = 'any';
+  } else if (isRecord(schema.additionalProperties)) {
+    const additionalProperties = convertJsonSchemaNode(
+      schema.additionalProperties
+    );
+    if (additionalProperties === undefined) return undefined;
+    result['(*)'] = additionalProperties;
+  }
+
+  return result;
+}
+
+function scalarType(type: unknown): string | undefined {
+  if (typeof type === 'string') return type;
+  if (!Array.isArray(type) || !type.includes('null')) return undefined;
+  const nonNullTypes = type.filter(
+    (value): value is string => typeof value === 'string' && value !== 'null'
+  );
+  return nonNullTypes.length === 1 ? nonNullTypes[0] : undefined;
+}
+
+function isPicoschemaPropertyName(propertyName: string): boolean {
+  return (
+    propertyName.length > 0 &&
+    propertyName !== '(*)' &&
+    !['__proto__', 'constructor', 'prototype'].includes(propertyName) &&
+    !propertyName.includes('(') &&
+    !propertyName.endsWith('?')
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && !Array.isArray(value) && typeof value === 'object';
+}
+
+function toFrontmatterSchema(
+  config?: {
+    schema?: unknown;
+    jsonSchema?: unknown;
+  },
+  picoSchema = false
+): unknown | undefined {
   const schema = config?.jsonSchema ?? config?.schema;
-  return schema && typeof schema === 'object' ? schema : undefined;
+  if (!schema || typeof schema !== 'object') return undefined;
+  if (!picoSchema) return schema;
+  return jsonSchemaToPicoschema(schema) ?? schema;
 }
 
 /**
@@ -32,11 +169,14 @@ function toFrontmatterSchema(config?: {
  * formats (json, jsonl, array, enum) map onto `json`. Returns undefined when
  * there is nothing to record.
  */
-export function toFrontmatterOutput(output?: {
-  format?: string;
-  jsonSchema?: unknown;
-  schema?: unknown;
-}): PromptFrontmatter['output'] | undefined {
+export function toFrontmatterOutput(
+  output?: {
+    format?: string;
+    jsonSchema?: unknown;
+    schema?: unknown;
+  },
+  picoSchema = false
+): PromptFrontmatter['output'] | undefined {
   if (!output) return undefined;
   const result: NonNullable<PromptFrontmatter['output']> = {};
   if (output.format === 'text') {
@@ -46,7 +186,7 @@ export function toFrontmatterOutput(output?: {
   } else if (output.format) {
     result.format = 'json';
   }
-  const schema = toFrontmatterSchema(output);
+  const schema = toFrontmatterSchema(output, picoSchema);
   if (schema !== undefined) {
     result.schema = schema;
   }
@@ -57,14 +197,17 @@ export function toFrontmatterOutput(output?: {
  * Maps a request's input config onto `.prompt` frontmatter. Returns undefined
  * when there is nothing to record.
  */
-export function toFrontmatterInput(input?: {
-  schema?: unknown;
-  jsonSchema?: unknown;
-  default?: unknown;
-}): PromptFrontmatter['input'] | undefined {
+export function toFrontmatterInput(
+  input?: {
+    schema?: unknown;
+    jsonSchema?: unknown;
+    default?: unknown;
+  },
+  picoSchema = false
+): PromptFrontmatter['input'] | undefined {
   if (!input) return undefined;
   const result: NonNullable<PromptFrontmatter['input']> = {
-    schema: toFrontmatterSchema(input),
+    schema: toFrontmatterSchema(input, picoSchema),
     default: input.default,
   };
   return result.schema || result.default !== undefined ? result : undefined;
@@ -76,6 +219,7 @@ export function toFrontmatterInput(input?: {
 export function toPromptFile(request: {
   model: string;
   messages: MessageData[];
+  picoSchema?: boolean;
   config?: Record<string, unknown>;
   tools?: { name: string }[];
   use?: PromptFrontmatter['use'];
@@ -95,8 +239,8 @@ export function toPromptFile(request: {
     config: request.config,
     tools: request.tools?.map((toolDefinition) => toolDefinition.name),
     use: request.use,
-    input: toFrontmatterInput(request.input),
-    output: toFrontmatterOutput(request.output),
+    input: toFrontmatterInput(request.input, request.picoSchema),
+    output: toFrontmatterOutput(request.output, request.picoSchema),
   };
   return renderPromptFile(frontmatter, request.messages);
 }

--- a/genkit-tools/common/tests/utils/prompt_test.ts
+++ b/genkit-tools/common/tests/utils/prompt_test.ts
@@ -99,6 +99,15 @@ describe('jsonSchemaToPicoschema', () => {
     expect(
       jsonSchemaToPicoschema({ type: 'array', items: { type: 'string' } })
     ).toBe('string');
+    expect(
+      jsonSchemaToPicoschema({
+        type: 'array',
+        items: { type: ['string'] },
+      })
+    ).toBe('string');
+    expect(jsonSchemaToPicoschema({ items: { type: 'string' } })).toBe(
+      'string'
+    );
     expect(jsonSchemaToPicoschema({ description: 'Anything goes' })).toBe(
       'any, Anything goes'
     );

--- a/genkit-tools/common/tests/utils/prompt_test.ts
+++ b/genkit-tools/common/tests/utils/prompt_test.ts
@@ -18,11 +18,93 @@ import { describe, expect, it } from '@jest/globals';
 import type { MessageData } from '../../src/types/model';
 import { PromptFrontmatter } from '../../src/types/prompt';
 import {
+  jsonSchemaToPicoschema,
   renderPromptFile,
   toFrontmatterInput,
   toFrontmatterOutput,
   toPromptFile,
 } from '../../src/utils/prompt';
+
+describe('jsonSchemaToPicoschema', () => {
+  it('converts supported JSON Schema constructs into Picoschema', () => {
+    const schema = {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        name: { type: 'string', description: 'Display name' },
+        age: { type: 'integer' },
+        active: { type: 'boolean' },
+        tags: {
+          type: 'array',
+          description: 'Search labels',
+          items: { type: 'string' },
+        },
+        address: {
+          type: 'object',
+          description: 'Mailing address',
+          additionalProperties: false,
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+        },
+        status: {
+          type: 'string',
+          description: 'Account status',
+          enum: ['ACTIVE', 'DISABLED'],
+        },
+      },
+      required: ['name', 'active', 'tags', 'address', 'status'],
+    };
+
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      name: 'string, Display name',
+      'age?': 'integer',
+      active: 'boolean',
+      'tags(array)': 'string',
+      'address(object)': { city: 'string' },
+      'status(enum)': ['ACTIVE', 'DISABLED'],
+    });
+  });
+
+  it('omits constraints that Picoschema cannot represent', () => {
+    expect(jsonSchemaToPicoschema({ type: 'string', minLength: 1 })).toBe(
+      'string'
+    );
+  });
+
+  it('converts additional properties into a wildcard', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      additionalProperties: { type: 'number' },
+    };
+
+    expect(jsonSchemaToPicoschema(schema)).toEqual({
+      name: 'string',
+      '(*)': 'number',
+    });
+  });
+
+  it('uses optional notation for a nullable optional property', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: ['string', 'null'] } },
+      required: [],
+    };
+
+    expect(jsonSchemaToPicoschema(schema)).toEqual({ 'name?': 'string' });
+  });
+
+  it('converts top-level arrays and unconstrained schemas', () => {
+    expect(
+      jsonSchemaToPicoschema({ type: 'array', items: { type: 'string' } })
+    ).toBe('string');
+    expect(jsonSchemaToPicoschema({ description: 'Anything goes' })).toBe(
+      'any, Anything goes'
+    );
+    expect(jsonSchemaToPicoschema({})).toBeUndefined();
+  });
+});
 
 describe('renderPromptFile', () => {
   it('builds a template from messages', () => {
@@ -289,5 +371,32 @@ describe('toPromptFile', () => {
       '{{role "user"}}\n' +
       'Hello\n';
     expect(toPromptFile(request)).toStrictEqual(expected);
+  });
+
+  it('uses compact Picoschema for input and output when requested', () => {
+    const request = {
+      model: '/model/googleai/gemini-pro',
+      picoSchema: true,
+      messages: [{ role: 'user' as const, content: [{ text: 'Hello' }] }],
+      input: {
+        schema: {
+          type: 'object',
+          properties: { topic: { type: 'string' } },
+          required: ['topic'],
+        },
+      },
+      output: {
+        format: 'json',
+        schema: {
+          type: 'object',
+          properties: { summary: { type: 'string' } },
+          required: ['summary'],
+        },
+      },
+    };
+
+    expect(toPromptFile(request)).toContain(
+      'input:\n  schema:\n    topic: string\noutput:\n  format: json\n  schema:\n    summary: string\n'
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add an opt-in `picoSchema` flag to the `createPrompt` request
- convert input and output JSON schemas to compact Dotprompt Picoschema during export
- cover scalar fields, optional/nullable fields, arrays, nested objects, enums, wildcards, and the input/output integration path
- preserve the existing JSON Schema export behavior by default

The converter follows the behavior of Google Dotprompt's existing JSON-Schema-to-Picoschema implementation. Because Picoschema is a subset, unsupported JSON Schema constraints are omitted only when callers explicitly enable the option.

Fixes #5907

## Validation

- `jest tests/utils/prompt_test.ts --runInBand --verbose` — 21 tests passed
- TypeScript CJS, ESM, and declaration builds passed
- generated output successfully round-tripped through Dotprompt 1.1.2's real Picoschema parser
- the broader tools-common suite passed the prompt tests and 170 tests overall; 15 unrelated Windows-only filesystem/process tests retain their existing path-separator and process-spawn failures