### PR TITLE
fix(py): type evaluator callbacks as BaseEvalDataPoint

### DIFF
--- a/py/packages/genkit-evaluators/src/genkit_evaluators/plugin.py
+++ b/py/packages/genkit-evaluators/src/genkit_evaluators/plugin.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from genkit import Genkit
 from genkit._core._typing import (
-    BaseDataPoint,
+    BaseEvalDataPoint,
     EvalFnResponse,
     EvalStatusEnum,
     Score,
@@ -41,7 +41,7 @@ def genkit_eval_name(local: str) -> str:
     return f'{PROVIDER}/{local}'
 
 
-async def _regex_impl(datapoint: BaseDataPoint, _options: object | None = None) -> EvalFnResponse:
+async def _regex_impl(datapoint: BaseEvalDataPoint, _options: object | None = None) -> EvalFnResponse:
     """Regex evaluator: reference must be a regex string; output tested against it."""
     if datapoint.output is None:
         raise ValueError('output was not provided')
@@ -53,12 +53,12 @@ async def _regex_impl(datapoint: BaseDataPoint, _options: object | None = None) 
     match = bool(re.search(datapoint.reference, output_str))
     status = EvalStatusEnum.PASS if match else EvalStatusEnum.FAIL
     return EvalFnResponse(
-        test_case_id=datapoint.test_case_id or '',
+        test_case_id=datapoint.test_case_id,
         evaluation=Score(score=match, status=status),
     )
 
 
-async def _deep_equal_impl(datapoint: BaseDataPoint, _options: object | None = None) -> EvalFnResponse:
+async def _deep_equal_impl(datapoint: BaseEvalDataPoint, _options: object | None = None) -> EvalFnResponse:
     """Deep equal evaluator: output must equal reference."""
     if datapoint.output is None:
         raise ValueError('output was not provided')
@@ -67,12 +67,12 @@ async def _deep_equal_impl(datapoint: BaseDataPoint, _options: object | None = N
     equal = datapoint.output == datapoint.reference
     status = EvalStatusEnum.PASS if equal else EvalStatusEnum.FAIL
     return EvalFnResponse(
-        test_case_id=datapoint.test_case_id or '',
+        test_case_id=datapoint.test_case_id,
         evaluation=Score(score=equal, status=status),
     )
 
 
-async def _jsonata_impl(datapoint: BaseDataPoint, _options: object | None = None) -> EvalFnResponse:
+async def _jsonata_impl(datapoint: BaseEvalDataPoint, _options: object | None = None) -> EvalFnResponse:
     """JSONata evaluator: reference is a JSONata expression; evaluated against output."""
     if datapoint.output is None:
         raise ValueError('output was not provided')
@@ -87,7 +87,7 @@ async def _jsonata_impl(datapoint: BaseDataPoint, _options: object | None = None
     passed = result not in (False, '', None)
     status = EvalStatusEnum.PASS if passed else EvalStatusEnum.FAIL
     return EvalFnResponse(
-        test_case_id=datapoint.test_case_id or '',
+        test_case_id=datapoint.test_case_id,
         evaluation=Score(score=result, status=status),
     )
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/evaluators/evaluation.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/evaluators/evaluation.py
@@ -44,7 +44,7 @@ from google.auth.transport.requests import Request
 from pydantic import BaseModel, ConfigDict
 
 from genkit import GenkitError
-from genkit.evaluator import BaseDataPoint, Details, EvalFnResponse, Score
+from genkit.evaluator import BaseEvalDataPoint, Details, EvalFnResponse, Score
 from genkit.plugin_api import GENKIT_CLIENT_HEADER, Action, get_cached_client
 from genkit_google_genai.constants import GLOBAL_LOCATION, is_multi_regional_location, vertex_api_host
 
@@ -250,13 +250,13 @@ class EvaluatorFactory:
         """
 
         async def evaluator_fn(
-            datapoint: BaseDataPoint,
+            datapoint: BaseEvalDataPoint,
             options: dict[str, Any] | None = None,
         ) -> EvalFnResponse:
             """Evaluate a single datapoint.
 
             Args:
-                datapoint: The evaluation data point.
+                datapoint: The evaluation data point (test_case_id guaranteed).
                 options: Optional evaluation options.
 
             Returns:
@@ -268,7 +268,7 @@ class EvaluatorFactory:
 
             return EvalFnResponse(
                 evaluation=score,
-                test_case_id=datapoint.test_case_id or '',
+                test_case_id=datapoint.test_case_id,
             )
 
         return evaluator_fn

--- a/py/packages/genkit/src/genkit/_ai/_evaluator.py
+++ b/py/packages/genkit/src/genkit/_ai/_evaluator.py
@@ -33,6 +33,7 @@ from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     ActionMetadata,
     BaseDataPoint,
+    BaseEvalDataPoint,
     EvalFnResponse,
     EvalRequest,
     EvalResponse,
@@ -49,11 +50,25 @@ EVALUATOR_METADATA_KEY_IS_BILLED = 'evaluatorIsBilled'
 T = TypeVar('T')
 
 # User-provided evaluator function that evaluates a single datapoint.
-# Must be async (coroutine function).
-EvaluatorFn = Callable[[BaseDataPoint, T], Coroutine[Any, Any, EvalFnResponse]]
+# Must be async (coroutine function). Receives BaseEvalDataPoint because the
+# stepper always guarantees a test_case_id before invoking the callback
+# (mirrors JS EvaluatorFn / BaseEvalDataPoint).
+EvaluatorFn = Callable[[BaseEvalDataPoint, T], Coroutine[Any, Any, EvalFnResponse]]
 
 # User-provided batch evaluator function that evaluates an EvaluationRequest
 BatchEvaluatorFn = Callable[[EvalRequest, T], Coroutine[Any, Any, list[EvalFnResponse]]]
+
+
+def _as_eval_datapoint(datapoint: BaseDataPoint) -> BaseEvalDataPoint:
+    """Fill in a missing test_case_id and return a BaseEvalDataPoint for the callback."""
+    return BaseEvalDataPoint(
+        input=datapoint.input,
+        output=datapoint.output,
+        context=datapoint.context,
+        reference=datapoint.reference,
+        test_case_id=datapoint.test_case_id or str(uuid.uuid4()),
+        trace_ids=datapoint.trace_ids,
+    )
 
 
 class EvaluatorRef(BaseModel):
@@ -127,9 +142,8 @@ def define_evaluator(
     async def eval_stepper_fn(req: EvalRequest) -> EvalResponse:
         eval_responses: list[EvalFnResponse] = []
         for index in range(len(req.dataset)):
-            datapoint = req.dataset[index]
-            if datapoint.test_case_id is None:
-                datapoint.test_case_id = str(uuid.uuid4())
+            # Dataset keeps BaseDataPoint (optional id); callbacks get BaseEvalDataPoint.
+            datapoint = _as_eval_datapoint(req.dataset[index])
             span_metadata = SpanMetadata(
                 name=f'Test Case {datapoint.test_case_id}',
                 type='evaluator',

--- a/py/packages/genkit/tests/genkit/ai/evaluator_test.py
+++ b/py/packages/genkit/tests/genkit/ai/evaluator_test.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for evaluator datapoint typing helpers."""
+
+from genkit._ai._evaluator import _as_eval_datapoint
+from genkit._core._typing import BaseDataPoint, BaseEvalDataPoint
+
+
+def test_as_eval_datapoint_preserves_existing_id() -> None:
+    dp = BaseDataPoint(input='in', output='out', test_case_id='case-1')
+    eval_dp = _as_eval_datapoint(dp)
+    assert isinstance(eval_dp, BaseEvalDataPoint)
+    assert eval_dp.test_case_id == 'case-1'
+    assert eval_dp.input == 'in'
+    assert eval_dp.output == 'out'
+
+
+def test_as_eval_datapoint_generates_id_when_missing() -> None:
+    dp = BaseDataPoint(input='in', output='out')
+    assert dp.test_case_id is None
+    eval_dp = _as_eval_datapoint(dp)
+    assert isinstance(eval_dp, BaseEvalDataPoint)
+    assert isinstance(eval_dp.test_case_id, str)
+    assert eval_dp.test_case_id
+    # Does not mutate the dataset datapoint.
+    assert dp.test_case_id is None

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -34,6 +34,7 @@ from genkit._core._action import ActionKind, ActionRunContext
 from genkit._core._model import ModelRequest
 from genkit._core._typing import (
     BaseDataPoint,
+    BaseEvalDataPoint,
     Details,
     DocumentPart,
     EvalFnResponse,
@@ -1591,9 +1592,9 @@ def test_define_evaluator_simple(setup_test: SetupFixture) -> None:
     """Test that the define evaluator function works."""
     ai, _, _, *_ = setup_test
 
-    async def my_eval_fn(datapoint: BaseDataPoint, options: dict[str, Any] | None = None) -> EvalFnResponse:
+    async def my_eval_fn(datapoint: BaseEvalDataPoint, options: dict[str, Any] | None = None) -> EvalFnResponse:
         return EvalFnResponse(
-            test_case_id=datapoint.test_case_id or '',
+            test_case_id=datapoint.test_case_id,
             evaluation=Score(score=True, details=Details(reasoning='I think it is true')),
         )
 
@@ -1619,9 +1620,9 @@ def test_define_evaluator_custom_config(setup_test: SetupFixture) -> None:
     class CustomOption(BaseModel):
         foo_bar: str = Field('baz', description='foo_bar field')
 
-    async def my_eval_fn(datapoint: BaseDataPoint, options: dict[str, Any] | None = None) -> EvalFnResponse:
+    async def my_eval_fn(datapoint: BaseEvalDataPoint, options: dict[str, Any] | None = None) -> EvalFnResponse:
         return EvalFnResponse(
-            test_case_id=datapoint.test_case_id or '',
+            test_case_id=datapoint.test_case_id,
             evaluation=Score(
                 score=True, details=Details(reasoning=options.get('foo_bar', 'baz') if options else 'baz')
             ),
@@ -1745,9 +1746,9 @@ async def test_evaluate(setup_test: SetupFixture) -> None:
     """Test that the evaluate function works."""
     ai, _, _, *_ = setup_test
 
-    async def my_eval_fn(datapoint: BaseDataPoint, options: object | None) -> EvalFnResponse:
+    async def my_eval_fn(datapoint: BaseEvalDataPoint, options: object | None) -> EvalFnResponse:
         return EvalFnResponse(
-            test_case_id=datapoint.test_case_id or '',
+            test_case_id=datapoint.test_case_id,
             evaluation=Score(score=True, details=Details(reasoning='I think it is true')),
         )
 
@@ -1773,6 +1774,41 @@ async def test_evaluate(setup_test: SetupFixture) -> None:
     assert response.root[1].test_case_id == 'case2'
     assert isinstance(response.root[1].evaluation, Score)
     assert response.root[1].evaluation.score is True
+
+
+@pytest.mark.asyncio
+async def test_evaluate_fills_missing_test_case_id_as_base_eval_datapoint(
+    setup_test: SetupFixture,
+) -> None:
+    """Evaluator callbacks receive BaseEvalDataPoint with a guaranteed test_case_id (#5991)."""
+    ai, _, _, *_ = setup_test
+    seen: list[BaseEvalDataPoint] = []
+
+    async def my_eval_fn(datapoint: BaseEvalDataPoint, options: object | None) -> EvalFnResponse:
+        seen.append(datapoint)
+        # No `or ''` — test_case_id is required on BaseEvalDataPoint.
+        return EvalFnResponse(
+            test_case_id=datapoint.test_case_id,
+            evaluation=Score(score=True),
+        )
+
+    ai.define_evaluator(
+        name='my_eval',
+        display_name='Test evaluator',
+        definition='Captures callback datapoint type',
+        fn=my_eval_fn,
+    )
+
+    dataset = [BaseDataPoint(input='hi', output='hi')]  # no test_case_id
+    response = await ai.evaluate(evaluator='my_eval', dataset=dataset)
+
+    assert len(seen) == 1
+    assert isinstance(seen[0], BaseEvalDataPoint)
+    assert isinstance(seen[0].test_case_id, str)
+    assert seen[0].test_case_id  # non-empty UUID
+    assert response.root[0].test_case_id == seen[0].test_case_id
+    # Dataset input type stays BaseDataPoint with optional id (unmutated).
+    assert dataset[0].test_case_id is None
 
 
 def test_define_background_model_with_info(setup_test: SetupFixture) -> None:

--- a/py/samples/evaluators/src/main.py
+++ b/py/samples/evaluators/src/main.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 
 from genkit import Genkit
 from genkit.evaluator import (
-    BaseDataPoint,
+    BaseEvalDataPoint,
     Details,
     EvalFnResponse,
     EvalStatusEnum,
@@ -50,7 +50,7 @@ class MaliciousnessResponse(BaseModel):
     verdict: bool
 
 
-async def maliciousness(datapoint: BaseDataPoint, _options: dict | None = None) -> EvalFnResponse:
+async def maliciousness(datapoint: BaseEvalDataPoint, _options: dict | None = None) -> EvalFnResponse:
     """Score: true if output intends to harm, deceive, or exploit."""
     if not datapoint.input:
         raise ValueError('Input required')
@@ -71,7 +71,7 @@ async def maliciousness(datapoint: BaseDataPoint, _options: dict | None = None) 
     score_val = 1.0 if parsed.verdict else 0.0
     status = EvalStatusEnum.FAIL if parsed.verdict else EvalStatusEnum.PASS
     return EvalFnResponse(
-        test_case_id=datapoint.test_case_id or '',
+        test_case_id=datapoint.test_case_id,
         evaluation=Score(
             score=score_val,
             status=status,
@@ -89,7 +89,7 @@ ai.define_evaluator(
 
 
 # 2. Answer Accuracy (LLM)
-async def answer_accuracy(datapoint: BaseDataPoint, _options: dict | None = None) -> EvalFnResponse:
+async def answer_accuracy(datapoint: BaseEvalDataPoint, _options: dict | None = None) -> EvalFnResponse:
     """Score: 4=full match, 2=partial, 0=no match. Normalized to 0–1."""
     if not datapoint.output:
         raise ValueError('Output required')
@@ -107,7 +107,7 @@ async def answer_accuracy(datapoint: BaseDataPoint, _options: dict | None = None
     score_val = rating / 4.0
     status = EvalStatusEnum.PASS if score_val >= 0.5 else EvalStatusEnum.FAIL
     return EvalFnResponse(
-        test_case_id=datapoint.test_case_id or '',
+        test_case_id=datapoint.test_case_id,
         evaluation=Score(score=score_val, status=status),
     )
 


### PR DESCRIPTION
## Summary
- Change Python `EvaluatorFn` to take `BaseEvalDataPoint` (`test_case_id: str`) instead of `BaseDataPoint` (`test_case_id` optional), matching the JS evaluator API.
- Construct a `BaseEvalDataPoint` in the stepper (UUID fill-in) before calling the callback, without mutating the dataset `BaseDataPoint`.
- Update first-party evaluators (`genkit-evaluators`, google-genai Vertex evaluators) and the evaluators sample to use the required id directly.
- Add regression tests for id fill-in / non-mutation and callback typing.

Fixes #5991

cc @jeffdh5

## Test plan
- [x] `pytest` evaluator helper + veneer eval + `genkit-evaluators` tests (10 passed)
- [ ] Confirm a custom evaluator can use `datapoint.test_case_id` without `or ''` under the typechecker
