### PR TITLE
fix(py): avoid Event loop is closed on warm sync Cloud Run callers

### DIFF
--- a/py/packages/genkit-flask/src/genkit_flask/handler.py
+++ b/py/packages/genkit-flask/src/genkit_flask/handler.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 from asyncio import AbstractEventLoop
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterable
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, Protocol, TypeAlias, TypeVar
 
 from flask import Response, request
 from pydantic import BaseModel
@@ -65,7 +65,24 @@ def _create_loop() -> AbstractEventLoop:
     return loop
 
 
-def _iter_over_async(ait: AsyncIterable[T], loop: AbstractEventLoop) -> Iterable[T]:
+class _LoopRunner(Protocol):
+    def run_until_complete(self, coro: Awaitable[Any]) -> Any: ...
+
+
+class _LazyLoop:
+    """Resolve a live event loop when sync streaming iteration actually starts.
+
+    Flask may run the async ``handler`` on a temporary loop (e.g. asgiref
+    ``async_to_sync``) that is closed as soon as ``handler()`` returns — before
+    the returned streaming iterable is consumed. Resolving the loop lazily
+    avoids ``RuntimeError: Event loop is closed`` (#4925).
+    """
+
+    def run_until_complete(self, coro: Awaitable[Any]) -> Any:
+        return _create_loop().run_until_complete(coro)
+
+
+def _iter_over_async(ait: AsyncIterable[T], loop: _LoopRunner) -> Iterable[T]:
     """Synchronously iterates over an AsyncIterable using a specified event loop."""
     ait_iter = ait.__aiter__()
 
@@ -164,9 +181,9 @@ def genkit_flask_handler(
                             ex = ex.cause
                         yield f'data: {json.dumps({"error": get_callable_json(ex)}, separators=_JSON_SEPARATORS)}\n\n'
 
-                # Resolve a live loop per request so warm instances that closed the
-                # previous loop do not stream on a dead event loop (#4925).
-                iter = _iter_over_async(async_gen(), _create_loop())
+                # Lazily resolve the loop at iteration time — Flask may close the
+                # temporary async-runner loop before consuming this iterable (#4925).
+                iter = _iter_over_async(async_gen(), _LazyLoop())
                 return iter
             else:
                 try:

--- a/py/packages/genkit-flask/src/genkit_flask/handler.py
+++ b/py/packages/genkit-flask/src/genkit_flask/handler.py
@@ -46,11 +46,23 @@ T = TypeVar('T')
 
 
 def _create_loop() -> AbstractEventLoop:
-    """Creates a new asyncio event loop or returns the current one."""
+    """Return a live asyncio event loop for sync Flask streaming bridges.
+
+    Never reuse a closed loop: warm Cloud Run / sync hosts often close the
+    previous request's loop (#4925), and ``asyncio.get_event_loop()`` can still
+    return that closed object.
+    """
     try:
-        return asyncio.get_event_loop()
-    except Exception:
-        return asyncio.new_event_loop()
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+    if loop.is_closed():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop
 
 
 def _iter_over_async(ait: AsyncIterable[T], loop: AbstractEventLoop) -> Iterable[T]:
@@ -112,7 +124,6 @@ def genkit_flask_handler(
     ```
 
     """
-    loop = _create_loop()
 
     def decorator(flow: Action) -> Callable[..., Awaitable[FlaskRouteReturn]]:
         if not isinstance(flow, Action):
@@ -153,7 +164,9 @@ def genkit_flask_handler(
                             ex = ex.cause
                         yield f'data: {json.dumps({"error": get_callable_json(ex)}, separators=_JSON_SEPARATORS)}\n\n'
 
-                iter = _iter_over_async(async_gen(), loop)
+                # Resolve a live loop per request so warm instances that closed the
+                # previous loop do not stream on a dead event loop (#4925).
+                iter = _iter_over_async(async_gen(), _create_loop())
                 return iter
             else:
                 try:

--- a/py/packages/genkit-flask/tests/flask_handler_test.py
+++ b/py/packages/genkit-flask/tests/flask_handler_test.py
@@ -16,8 +16,10 @@
 
 """Tests for Flask handler decorator validation."""
 
+import asyncio
+
 import pytest
-from genkit_flask.handler import genkit_flask_handler
+from genkit_flask.handler import _create_loop, genkit_flask_handler
 
 from genkit._core._error import GenkitError
 
@@ -54,6 +56,20 @@ class TestGenkitFlaskHandlerValidation:
         handler = genkit_flask_handler(FakeGenkit())  # type: ignore[arg-type]
         with pytest.raises(GenkitError, match='must apply @genkit_flask_handler on a @flow'):
             handler(None)  # type: ignore[arg-type]
+
+
+class TestCreateLoop:
+    """_create_loop must never hand back a closed event loop (#4925)."""
+
+    def test_returns_live_loop_when_current_is_closed(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.close()
+        assert loop.is_closed()
+
+        live = _create_loop()
+        assert not live.is_closed()
+        live.close()
 
 
 class TestFlaskHandlerImports:

--- a/py/packages/genkit-flask/tests/flask_handler_test.py
+++ b/py/packages/genkit-flask/tests/flask_handler_test.py
@@ -19,7 +19,12 @@
 import asyncio
 
 import pytest
-from genkit_flask.handler import _create_loop, genkit_flask_handler
+from genkit_flask.handler import (
+    _LazyLoop,
+    _create_loop,
+    _iter_over_async,
+    genkit_flask_handler,
+)
 
 from genkit._core._error import GenkitError
 
@@ -70,6 +75,25 @@ class TestCreateLoop:
         live = _create_loop()
         assert not live.is_closed()
         live.close()
+
+
+class TestLazyLoop:
+    """Streaming must not capture a loop that Flask closes before iteration (#4925)."""
+
+    def test_iter_over_async_works_after_handler_loop_closes(self) -> None:
+        async def agen() -> object:
+            yield 'a'
+            yield 'b'
+
+        # Simulate Flask: create/close the temporary loop used to run the handler,
+        # then consume the streaming iterable afterward with a lazy loop.
+        handler_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(handler_loop)
+        handler_loop.close()
+        assert handler_loop.is_closed()
+
+        chunks = list(_iter_over_async(agen(), _LazyLoop()))
+        assert chunks == ['a', 'b']
 
 
 class TestFlaskHandlerImports:

--- a/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
+++ b/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
@@ -145,6 +145,70 @@ async def test_googleai_runtime_clients_are_loop_local(mock_client_ctor: MagicMo
     assert other_loop_client is not first
 
 
+@patch('genkit_google_genai.google.genai.client.Client')
+def test_googleai_model_action_survives_closed_event_loops(mock_client_ctor: MagicMock) -> None:
+    """Warm Cloud Run sync bridge must not raise Event loop is closed (#4925).
+
+    Simulates google-genai's aiohttp session binding: a client created on loop A
+    fails if reused after A is closed. Loop-local clients make each request use
+    a fresh Client for its live loop.
+    """
+    created: list[MagicMock] = []
+
+    def _new_client(*args: object, **kwargs: object) -> MagicMock:
+        client = MagicMock(name=f'client-{len(created)}')
+        client._bound_loop = asyncio.get_running_loop()
+
+        async def _generate_content(*_a: object, **_k: object) -> MagicMock:
+            if client._bound_loop.is_closed():
+                raise RuntimeError('Event loop is closed')
+            # Minimal GenerateContent-like response consumed by GeminiModel.
+            from google.genai import types as genai_types
+
+            return genai_types.GenerateContentResponse(
+                candidates=[
+                    genai_types.Candidate(
+                        content=genai_types.Content(
+                            parts=[genai_types.Part(text='ok')],
+                            role='model',
+                        ),
+                        finish_reason=genai_types.FinishReason.STOP,
+                    )
+                ]
+            )
+
+        client.aio.models.generate_content = _generate_content
+        created.append(client)
+        return client
+
+    mock_client_ctor.side_effect = _new_client
+    plugin = GoogleAI(api_key='test-key')
+    action = plugin._resolve_model('googleai/gemini-2.0-flash')
+
+    from genkit import Message, ModelRequest, Part, Role, TextPart
+
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+    )
+
+    def call_once() -> object:
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(action.run(request))
+        finally:
+            loop.close()
+
+    # First warm-instance request
+    result1 = call_once()
+    # Second request on a new loop after the previous one was closed
+    result2 = call_once()
+
+    assert result1.response is not None
+    assert result2.response is not None
+    assert len(created) >= 2
+    assert created[0] is not created[1]
+
+
 def test_genai_models_container() -> None:
     """Test GenaiModels container initialization."""
     models = GenaiModels()

--- a/py/packages/genkit/src/genkit/_core/_loop_cache.py
+++ b/py/packages/genkit/src/genkit/_core/_loop_cache.py
@@ -26,13 +26,27 @@ T = TypeVar('T')
 
 
 def _loop_local_client(factory: Callable[[], T]) -> Callable[[], T]:
-    """Return a getter that caches one resource instance per event loop."""
+    """Return a getter that caches one resource instance per event loop.
+
+    Sync Cloud Run / Cloud Functions callers commonly bridge into Genkit with
+    ``asyncio.new_event_loop()`` + ``run_until_complete`` + ``loop.close()`` per
+    request (#4925). Caching a single HTTP client for the process then leaves
+    aiohttp/httpx sessions bound to a closed loop. Keying by the running loop
+    (and dropping closed-loop entries) keeps each warm-instance request on a
+    live client.
+    """
     by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, T] = weakref.WeakKeyDictionary()
     lock = threading.Lock()
+
+    def _prune_closed_loops() -> None:
+        for loop in list(by_loop.keys()):
+            if loop.is_closed():
+                del by_loop[loop]
 
     def _get() -> T:
         loop = asyncio.get_running_loop()
         with lock:
+            _prune_closed_loops()
             existing = by_loop.get(loop)
             if existing is not None:
                 return existing

--- a/py/packages/genkit/src/genkit/_core/_loop_cache.py
+++ b/py/packages/genkit/src/genkit/_core/_loop_cache.py
@@ -41,7 +41,7 @@ def _loop_local_client(factory: Callable[[], T]) -> Callable[[], T]:
     def _prune_closed_loops() -> None:
         for loop in list(by_loop.keys()):
             if loop.is_closed():
-                del by_loop[loop]
+                by_loop.pop(loop, None)
 
     def _get() -> T:
         loop = asyncio.get_running_loop()

--- a/py/packages/genkit/tests/genkit/core/loop_cache_test.py
+++ b/py/packages/genkit/tests/genkit/core/loop_cache_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for per-event-loop client caching (#4925)."""
+
+import asyncio
+
+from genkit._core._loop_cache import _loop_local_client
+
+
+def test_loop_local_client_caches_within_same_loop() -> None:
+    getter = _loop_local_client(object)
+    created: list[object] = []
+
+    async def once() -> tuple[object, object]:
+        a = getter()
+        b = getter()
+        created.extend([a, b])
+        return a, b
+
+    a, b = asyncio.run(once())
+    assert a is b
+    assert len(created) == 2
+
+
+def test_loop_local_client_new_client_after_closed_loop() -> None:
+    """Cloud Run warm-instance sync bridge: new loop per request must not reuse a closed-loop client."""
+    created: list[object] = []
+    getter = _loop_local_client(lambda: created.append(object()) or created[-1])
+
+    def call_once() -> object:
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def _get() -> object:
+                return getter()
+
+            return loop.run_until_complete(_get())
+        finally:
+            loop.close()
+
+    first = call_once()
+    second = call_once()
+    assert first is not second
+    assert len(created) == 2
+
+
+def test_loop_local_client_prunes_closed_loop_entries() -> None:
+    created: list[object] = []
+    getter = _loop_local_client(lambda: created.append(object()) or created[-1])
+
+    loop1 = asyncio.new_event_loop()
+    try:
+
+        async def _get() -> object:
+            return getter()
+
+        first = loop1.run_until_complete(_get())
+    finally:
+        loop1.close()
+
+    # Access from a live loop should prune the closed loop1 entry and create fresh.
+    loop2 = asyncio.new_event_loop()
+    try:
+
+        async def _get2() -> object:
+            return getter()
+
+        second = loop2.run_until_complete(_get2())
+    finally:
+        loop2.close()
+
+    assert first is not second
+    assert len(created) == 2


### PR DESCRIPTION
## Summary
- Harden `loop_local_client` to prune closed-loop cache entries so warm Cloud Run / sync callers that do `new_event_loop()` → `run_until_complete` → `loop.close()` per request get a fresh google-genai client on the live loop (#4925).
- Fix `genkit_flask` streaming to resolve a live event loop **per request** (never reuse a closed `get_event_loop()` result captured at decorator time).
- Add regression tests for loop-cache warm-instance reuse, Flask closed-loop recovery, and GoogleAI model actions across sequential closed loops.

Fixes #4925

cc @Blevene

## Test plan
- [x] `pytest` `loop_cache_test.py`, flask handler tests, and `test_googleai_model_action_survives_closed_event_loops` (12 passed)
- [ ] Reproduce the issue sync bridge on a warm Cloud Run instance and confirm no `Event loop is closed` / retry noise
