### PR TITLE
fix(py): drop vacuous assert in generate logging test

### DIFF
--- a/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
@@ -172,7 +172,6 @@ async def test_generate_logs_nothing_at_default_level() -> None:
         await _generate_once()
 
     events = [entry['event'] for entry in entries]
-    assert events, 'capture_logs saw nothing, so the assertion below would be vacuous'
     assert 'generate response' not in events
 
 

--- a/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_logging_test.py
@@ -172,7 +172,7 @@ async def test_generate_logs_nothing_at_default_level() -> None:
         await _generate_once()
 
     events = [entry['event'] for entry in entries]
-    assert 'generate response' not in events
+    assert events == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change Summary

The test is about what a user sees at the default log level: a normal generate should not dump the model response into the logs.

The old check tried to prove that indirectly — "we saw some logs, and none of them was generate response." That falls apart in two ways:

1. At default info, a happy-path generate often logs nothing at all. Requiring a non-empty capture fails on the real success case. (This is causing CI to fail on main, the original motivation for this PR).

2. "generate response not in events" on an empty list is a free pass. It doesn't prove logging is quiet; it only proves that one event name is absent, which is always true when nothing was captured.

assert events == [] states the actual product expectation for this path: under default configuration, that generate doesn't emit log events. No response dump, and no relying on unrelated noise to make the assertion meaningful.

(When debug is on, the sibling tests still cover that the response is logged and that big payloads stay truncated.)
