### PR TITLE
feat(py/plugins/amazon-bedrock): add embedders (Titan, Cohere v3, Nova)

### DIFF
--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -2,10 +2,11 @@
 
 Amazon Bedrock plugin for Genkit Python. Provides text generation with
 Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama, Mistral,
-Cohere, and others) through the Bedrock Converse and ConverseStream APIs.
+Cohere, and others) through the Bedrock Converse and ConverseStream APIs, and
+embeddings through InvokeModel.
 
-> Status: in progress. Text generation is available, streaming and
-> non-streaming. Embedders, image generation, and reranking are still to come.
+> Status: in progress. Text generation (streaming and non-streaming) and
+> embedders are available. Image generation and reranking are still to come.
 
 ## Installation
 
@@ -71,6 +72,51 @@ through `additionalModelRequestFields` instead:
 ```python
 BedrockConfig(additional_model_request_fields={'top_k': 40})
 ```
+
+## Embedders
+
+Embedding models are listed separately from chat models, by bare model ID:
+
+```python
+from genkit import Genkit
+from genkit_amazon_bedrock import Bedrock
+
+ai = Genkit(plugins=[Bedrock(embedders=['amazon.titan-embed-text-v2:0'])])
+
+embeddings = await ai.embed(
+    embedder='bedrock/amazon.titan-embed-text-v2:0',
+    content='Bedrock hosts models from several providers.',
+)
+```
+
+| Model                                      | Dimensions | Modalities   |
+| ------------------------------------------ | ---------- | ------------ |
+| `amazon.titan-embed-text-v1`               | 1536       | text         |
+| `amazon.titan-embed-text-v2:0`             | 1024       | text         |
+| `amazon.titan-embed-image-v1`              | 1024       | text, image  |
+| `cohere.embed-english-v3`                  | 1024       | text         |
+| `cohere.embed-multilingual-v3`             | 1024       | text         |
+| `amazon.nova-2-multimodal-embeddings-v1:0` | 3072       | text         |
+
+Notes:
+
+- As with models, listing is optional: any routable embedding model ID
+  resolves on demand, including inference-profile and ARN forms. Listing one
+  only adds it to the Dev UI.
+- `amazon.titan-embed-image-v1` is the only image embedder here. It accepts
+  JPEG and PNG, one image per document, and averages the two vectors when a
+  document carries text as well.
+- **Cohere embedding is text-only on Bedrock.** The AWS parameters page
+  documents an `images` field for Embed v3, but `aws bedrock
+  get-foundation-model` reports `inputModalities: [TEXT]` for both v3 model IDs
+  and a live image request is refused. A document with no text is rejected
+  rather than sent; a media part alongside text is ignored.
+- `cohere.embed-v4` is not supported yet -- it uses a different request schema and fails with `UNIMPLEMENTED`. It is also where Cohere image embedding will arrive.
+- Per-request options are not honoured yet. Cohere requests are pinned to
+  `input_type: search_document`, so these embedders are for indexing
+  documents, not for embedding queries.
+- `amazon.nova-2-multimodal-embeddings-v1:0` is offered in `us-east-1` only,
+  and is text-only here; its image, audio, and video inputs are not ported.
 
 ## License
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
@@ -66,5 +66,6 @@ class ModelDefinition(BaseModel):
     name: str
     """Bedrock model ID, e.g. ``anthropic.claude-sonnet-4-5-20250929-v1:0``."""
 
-    type: Literal['chat', 'text', 'image', 'embedding'] = 'chat'
-    """Routes generate calls: chat/text via Converse, image via InvokeModel."""
+    type: Literal['chat', 'text', 'image'] = 'chat'
+    """Routes generate calls: chat/text via Converse, image via InvokeModel.
+    Embedders are configured separately, through ``Bedrock(embedders=...)``."""

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -57,14 +57,16 @@ from genkit.plugin_api import GenkitError
 from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
 from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
 
-# Caps simultaneous InvokeModel calls; large batches otherwise earn a
-# ThrottlingException. Ported from the Go plugin.
+# Caps simultaneous InvokeModel calls; large batches otherwise earn a ThrottlingException.
 EMBED_CONCURRENCY_LIMIT = 10
 
 # Bedrock's per-request document limit for Cohere text embeddings.
 COHERE_TEXT_BATCH_SIZE = 96
 
 TITAN_SUPPORTED_IMAGE_MIME = frozenset({'image/jpeg', 'image/jpg', 'image/png'})
+
+# InvokeModel carries the image inline, so it cannot fetch any of these.
+REMOTE_URL_SCHEMES = ('http://', 'https://', 's3://')
 
 EmbeddingFamily = Literal['titan_text', 'titan_multimodal', 'cohere_v3', 'cohere_v4', 'nova']
 
@@ -194,6 +196,9 @@ def image_from_document(document: DocumentData) -> tuple[str, str]:
 
     Returns:
         ``(mime, base64)``, or two empty strings when there is no image.
+
+    Raises:
+        GenkitError: INVALID_ARGUMENT when an image part holds a remote URL.
     """
     for part in document.content:
         if not isinstance(part.root, MediaPart):
@@ -207,10 +212,18 @@ def image_from_document(document: DocumentData) -> tuple[str, str]:
                 mime = header.split(';', 1)[0].removeprefix('data:').strip().lower()
         if not mime.startswith('image/'):
             continue
-        # No comma means it is not a data URL; skipping beats sending the whole
-        # string to the API as base64.
-        _, found, payload = data_url.partition(',')
-        if found:
+        if data_url.startswith(REMOTE_URL_SCHEMES):
+            raise GenkitError(
+                message='bedrock embed: remote URLs are not supported; use a data URL or base64-encoded data',
+                status='INVALID_ARGUMENT',
+            )
+        if data_url.startswith('data:'):
+            # No comma means the data URL carries no payload to send.
+            _, _, payload = data_url.partition(',')
+        else:
+            # Bare base64, the other shape converters accepts.
+            payload = data_url
+        if payload:
             return mime, payload
     return '', ''
 
@@ -376,7 +389,13 @@ class BedrockEmbedder:
         bodies: list[dict[str, Any]] = []
         for index, document in enumerate(documents):
             text = document_text(document)
-            mime, image = image_from_document(document)
+            try:
+                mime, image = image_from_document(document)
+            except GenkitError as error:
+                raise GenkitError(
+                    message=f'bedrock embed: document {index}: {_without_own_prefix(error.original_message)}',
+                    status=error.status,
+                ) from error
             if not text and not image:
                 raise GenkitError(
                     message=f'bedrock embed: document {index} has no text or image content',

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -1,0 +1,488 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bedrock embedder implementation (InvokeModel API).
+
+Embedding models predate Converse and have no unified request shape: each
+family takes its own raw JSON body and returns its own response shape, so
+routing by model ID is unavoidable.
+
+Ported from the Go plugin's ``embed.go``, with four corrections verified
+against the AWS docs and API: Nova targets the real
+``amazon.nova-2-multimodal-embeddings-v1:0`` schema rather than Go's
+unreachable Titan-shaped path, Cohere embedding is text-only, routing is on
+``cohere.embed`` so rerank model IDs are not swallowed, and Titan multimodal's
+in-band ``message`` field is raised instead of ignored.
+
+On Cohere: the AWS parameters page documents an ``images`` field and an
+``image`` input type for Embed v3, but ``get-foundation-model`` reports
+``inputModalities: [TEXT]`` for both v3 model IDs and a live image request is
+rejected with ``Invalid parameter combination``. Go's image path cannot work
+for that reason, not because of how it encodes the image. Image embedding needs
+``amazon.titan-embed-image-v1``, or Cohere Embed v4 once that lands.
+"""
+
+import asyncio
+import json
+from collections.abc import Coroutine
+from typing import Any, Literal, NamedTuple, Protocol, cast
+
+from botocore.exceptions import BotoCoreError, ClientError
+
+from genkit import MediaPart, TextPart
+
+# DocumentData has no public re-export yet; the embedder protocol is built on it.
+from genkit._core._typing import DocumentData
+from genkit.embedder import (
+    EmbedderOptions,
+    EmbedderSupports,
+    Embedding,
+    EmbedRequest,
+    EmbedResponse,
+)
+from genkit.plugin_api import GenkitError
+from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
+from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
+
+# Caps simultaneous InvokeModel calls; large batches otherwise earn a
+# ThrottlingException. Ported from the Go plugin.
+EMBED_CONCURRENCY_LIMIT = 10
+
+# Bedrock's per-request document limit for Cohere text embeddings.
+COHERE_TEXT_BATCH_SIZE = 96
+
+TITAN_SUPPORTED_IMAGE_MIME = frozenset({'image/jpeg', 'image/jpg', 'image/png'})
+
+EmbeddingFamily = Literal['titan_text', 'titan_multimodal', 'cohere_v3', 'cohere_v4', 'nova']
+
+# Substring matches over the base model ID, most specific first.
+_FAMILY_PATTERNS: tuple[tuple[str, EmbeddingFamily], ...] = (
+    ('titan-embed-image', 'titan_multimodal'),
+    ('titan-embed', 'titan_text'),
+    ('cohere.embed-v4', 'cohere_v4'),
+    # Not bare 'cohere': that would swallow cohere.rerank-* and cohere.command-*.
+    ('cohere.embed', 'cohere_v3'),
+    ('nova-2-multimodal-embeddings', 'nova'),
+)
+
+TEXT_ONLY = ('text',)
+TEXT_AND_IMAGE = ('text', 'image')
+
+_FAMILY_INPUTS: dict[EmbeddingFamily, tuple[str, ...]] = {
+    'titan_text': TEXT_ONLY,
+    'titan_multimodal': TEXT_AND_IMAGE,
+    'cohere_v3': TEXT_ONLY,
+    'cohere_v4': TEXT_AND_IMAGE,
+    'nova': TEXT_ONLY,
+}
+
+
+class EmbedderInfo(NamedTuple):
+    """Published capabilities of a Bedrock embedding model."""
+
+    dimensions: int
+    input: tuple[str, ...]
+
+
+EMBEDDER_INFO: dict[str, EmbedderInfo] = {
+    'amazon.titan-embed-text-v1': EmbedderInfo(dimensions=1536, input=TEXT_ONLY),
+    'amazon.titan-embed-text-v2:0': EmbedderInfo(dimensions=1024, input=TEXT_ONLY),
+    'amazon.titan-embed-image-v1': EmbedderInfo(dimensions=1024, input=TEXT_AND_IMAGE),
+    'cohere.embed-english-v3': EmbedderInfo(dimensions=1024, input=TEXT_ONLY),
+    'cohere.embed-multilingual-v3': EmbedderInfo(dimensions=1024, input=TEXT_ONLY),
+    'amazon.nova-2-multimodal-embeddings-v1:0': EmbedderInfo(dimensions=3072, input=TEXT_ONLY),
+}
+
+
+class InvokeModelTransport(Protocol):
+    """Structural contract for the transport seam (see ``transport.py``)."""
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
+        """Calls the InvokeModel API and returns the parsed response body."""
+        ...
+
+
+def _embedding_family(model_id: str) -> EmbeddingFamily | None:
+    """Routes a model ID to its embedding family, or None if it is not one."""
+    base_id = strip_inference_profile_prefix(model_id)
+    for pattern, family in _FAMILY_PATTERNS:
+        if pattern in base_id:
+            return family
+    return None
+
+
+def is_embedding_model(model_id: str) -> bool:
+    """Reports whether a Bedrock model ID names an embedding model.
+
+    Args:
+        model_id: Bedrock model ID, inference-profile ID, or ARN.
+
+    Returns:
+        True when the ID routes to a known embedding family.
+    """
+    return _embedding_family(model_id) is not None
+
+
+def get_embedder_options(model_id: str) -> EmbedderOptions:
+    """Builds the Genkit embedder metadata for a Bedrock embedding model.
+
+    Single source for both ``resolve`` and ``list_actions`` so the two can
+    never disagree.
+
+    Args:
+        model_id: Bedrock model ID, inference-profile ID, or ARN.
+
+    Returns:
+        EmbedderOptions with registry dimensions, or unset dimensions and
+        family-default modalities for a routable ID that is not registered.
+    """
+    info = EMBEDDER_INFO.get(strip_inference_profile_prefix(model_id))
+    family = _embedding_family(model_id)
+    if info is not None:
+        inputs = info.input
+    elif family is not None:
+        inputs = _FAMILY_INPUTS[family]
+    else:
+        inputs = TEXT_ONLY
+    return EmbedderOptions(
+        # The label keeps the prefix: it names what the caller asked for.
+        label=model_id,
+        dimensions=info.dimensions if info is not None else None,
+        supports=EmbedderSupports(input=list(inputs)),
+    )
+
+
+def document_text(document: DocumentData) -> str:
+    """Joins a document's text parts, mirroring the Go plugin's ``documentText``.
+
+    Whitespace-only parts are skipped, surviving parts are joined untrimmed,
+    and only the result is stripped. Text is never flattened across documents:
+    that would break the document-to-embedding alignment.
+
+    Args:
+        document: The document to read.
+
+    Returns:
+        The joined text, or an empty string when there is none.
+    """
+    texts = [part.root.text for part in document.content if isinstance(part.root, TextPart) and part.root.text.strip()]
+    return '\n'.join(texts).strip()
+
+
+def image_from_document(document: DocumentData) -> tuple[str, str]:
+    """Returns the MIME type and raw base64 of the first image media part.
+
+    Deliberately not ``converters._decode_media_payload``: Converse wants raw
+    bytes, InvokeModel bodies are JSON and want base64 text (Titan multimodal
+    takes it raw, Cohere wants it wrapped in a data URI).
+
+    Args:
+        document: The document to read.
+
+    Returns:
+        ``(mime, base64)``, or two empty strings when there is no image.
+    """
+    for part in document.content:
+        if not isinstance(part.root, MediaPart):
+            continue
+        data_url = part.root.media.url
+        mime = (part.root.media.content_type or '').split(';', 1)[0].strip().lower()
+        # Fall back to the MIME type inside the data URL when contentType is absent.
+        if not mime and data_url.startswith('data:'):
+            header, found, _ = data_url.partition(',')
+            if found:
+                mime = header.split(';', 1)[0].removeprefix('data:').strip().lower()
+        if not mime.startswith('image/'):
+            continue
+        # No comma means it is not a data URL; skipping beats sending the whole
+        # string to the API as base64.
+        _, found, payload = data_url.partition(',')
+        if found:
+            return mime, payload
+    return '', ''
+
+
+def decode_cohere_embeddings(payload: dict[str, Any]) -> list[list[float]]:
+    """Decodes a Cohere embedding response into float vectors.
+
+    Handles both the flat shape (``{"embeddings": [[...]]}``) and the typed
+    shape that ``embedding_types`` returns (``{"embeddings": {"float": [[...]]}}``).
+
+    Args:
+        payload: The parsed InvokeModel response body.
+
+    Returns:
+        One vector per input, in order.
+
+    Raises:
+        GenkitError: INTERNAL when the response carries no usable embeddings.
+    """
+    embeddings = payload.get('embeddings')
+    if isinstance(embeddings, dict):
+        vectors = embeddings.get('float')
+        if not vectors:
+            raise GenkitError(
+                message='bedrock embed: cohere typed response has no float embeddings',
+                status='INTERNAL',
+            )
+    elif isinstance(embeddings, list):
+        vectors = embeddings
+        if not vectors:
+            raise GenkitError(message='bedrock embed: cohere returned no embeddings', status='INTERNAL')
+    else:
+        raise GenkitError(message='bedrock embed: cohere response missing embeddings field', status='INTERNAL')
+    return [[float(value) for value in vector] for vector in vectors]
+
+
+def _single_embedding(payload: dict[str, Any]) -> list[float]:
+    """Reads the ``embedding`` vector off a Titan InvokeModel response."""
+    vector = payload.get('embedding')
+    return [float(value) for value in vector] if isinstance(vector, list) else []
+
+
+def _nova_embedding(payload: dict[str, Any]) -> list[float]:
+    """Reads the first vector off a Nova-2 response.
+
+    Nova-2 returns ``{"embeddings": [{"embedding": [...]}]}`` — a list of
+    objects, not the bare vector the Titan models return.
+    """
+    embeddings = payload.get('embeddings')
+    if not isinstance(embeddings, list) or not embeddings:
+        return []
+    first = embeddings[0]
+    vector = first.get('embedding') if isinstance(first, dict) else None
+    return [float(value) for value in vector] if isinstance(vector, list) else []
+
+
+def _require_vector(vector: list[float]) -> list[float]:
+    if not vector:
+        raise GenkitError(message='bedrock embed: model returned an empty embedding vector', status='INTERNAL')
+    return vector
+
+
+def _require_text(document: DocumentData, index: int) -> str:
+    text = document_text(document)
+    if not text:
+        raise GenkitError(message=f'bedrock embed: document {index} has no text content', status='INVALID_ARGUMENT')
+    return text
+
+
+def _require_cohere_text(document: DocumentData, index: int) -> str:
+    text = document_text(document)
+    if not text:
+        raise GenkitError(
+            message=(
+                f'bedrock embed: document {index} has no text content; Bedrock offers the Cohere Embed v3 '
+                'models as text-only (use amazon.titan-embed-image-v1 to embed images)'
+            ),
+            status='INVALID_ARGUMENT',
+        )
+    return text
+
+
+# This plugin's own message prefixes, longest first, so wrapping a message in
+# document context does not stack a second copy of the prefix.
+_OWN_PREFIXES = ('bedrock embed: ', 'bedrock: ', 'bedrock ')
+
+
+def _without_own_prefix(message: str) -> str:
+    for prefix in _OWN_PREFIXES:
+        if message.startswith(prefix):
+            return message.removeprefix(prefix)
+    return message
+
+
+class BedrockEmbedder:
+    """Handles an embed call for one Bedrock embedding model."""
+
+    def __init__(self, model_id: str, transport: InvokeModelTransport) -> None:
+        """Initializes the embedder.
+
+        Args:
+            model_id: Bedrock model ID, inference-profile ID, or ARN, sent to
+                the InvokeModel API verbatim.
+            transport: The shared transport seam owning the boto3 client.
+        """
+        self._model_id = model_id
+        self._transport = transport
+
+    async def embed(self, request: EmbedRequest) -> EmbedResponse:
+        """Embeds every document in the request.
+
+        ``request.options`` is ignored: the per-request config surface is not
+        ported yet, so Cohere stays pinned to ``search_document``.
+
+        Args:
+            request: The Genkit embed request.
+
+        Returns:
+            One embedding per input document, in input order.
+
+        Raises:
+            GenkitError: INVALID_ARGUMENT for an empty or malformed request,
+                UNIMPLEMENTED for a model this plugin cannot embed with, and
+                the mapped AWS status for a failed call.
+        """
+        if not request.input:
+            raise GenkitError(message='bedrock embed: request contains no documents', status='INVALID_ARGUMENT')
+        family = _embedding_family(self._model_id)
+        if family is None:
+            raise GenkitError(
+                message=f'bedrock embed: unsupported embedding model {self._model_id!r}',
+                status='UNIMPLEMENTED',
+            )
+        if family == 'cohere_v4':
+            raise GenkitError(
+                message=(
+                    f'bedrock embed: {self._model_id!r} uses the Cohere Embed v4 request schema, '
+                    'which is not supported yet; use cohere.embed-english-v3 or cohere.embed-multilingual-v3'
+                ),
+                status='UNIMPLEMENTED',
+            )
+
+        if family == 'titan_text':
+            vectors = await self._embed_titan_text(request.input)
+        elif family == 'titan_multimodal':
+            vectors = await self._embed_titan_multimodal(request.input)
+        elif family == 'cohere_v3':
+            vectors = await self._embed_cohere(request.input)
+        else:
+            vectors = await self._embed_nova(request.input)
+        return EmbedResponse(embeddings=[Embedding(embedding=vector) for vector in vectors])
+
+    async def _embed_titan_text(self, documents: list[DocumentData]) -> list[list[float]]:
+        # Every document is validated before the first call goes out, so a bad
+        # batch costs nothing. Go checks each one inside its own goroutine.
+        texts = [_require_text(document, index) for index, document in enumerate(documents)]
+        return await self._run_bounded([(index, self._titan_text_vector(text)) for index, text in enumerate(texts)])
+
+    async def _titan_text_vector(self, text: str) -> list[float]:
+        return _require_vector(_single_embedding(await self._invoke({'inputText': text})))
+
+    async def _embed_titan_multimodal(self, documents: list[DocumentData]) -> list[list[float]]:
+        bodies: list[dict[str, Any]] = []
+        for index, document in enumerate(documents):
+            text = document_text(document)
+            mime, image = image_from_document(document)
+            if not text and not image:
+                raise GenkitError(
+                    message=f'bedrock embed: document {index} has no text or image content',
+                    status='INVALID_ARGUMENT',
+                )
+            if image and mime not in TITAN_SUPPORTED_IMAGE_MIME:
+                raise GenkitError(
+                    message=(
+                        f'bedrock embed: document {index} image format {mime!r} is not supported '
+                        'by Titan (use JPEG or PNG)'
+                    ),
+                    status='INVALID_ARGUMENT',
+                )
+            # Absent keys, not empty ones: Titan rejects an empty inputImage.
+            body: dict[str, Any] = {}
+            if text:
+                body['inputText'] = text
+            if image:
+                body['inputImage'] = image
+            bodies.append(body)
+        return await self._run_bounded([
+            (index, self._titan_multimodal_vector(body)) for index, body in enumerate(bodies)
+        ])
+
+    async def _titan_multimodal_vector(self, body: dict[str, Any]) -> list[float]:
+        payload = await self._invoke(body)
+        # Titan multimodal reports input problems in-band, on an HTTP 200.
+        message = payload.get('message')
+        if message is not None:
+            raise GenkitError(message=f'bedrock embed: titan multimodal: {message}', status='INTERNAL')
+        return _require_vector(_single_embedding(payload))
+
+    async def _embed_cohere(self, documents: list[DocumentData]) -> list[list[float]]:
+        # Any media part is ignored: these models take text only.
+        texts = [_require_cohere_text(document, index) for index, document in enumerate(documents)]
+        # The one family with a batch API, so chunks replace the per-document
+        # fan-out. Sequential slices, hence extend rather than index assignment.
+        vectors: list[list[float]] = []
+        for start in range(0, len(texts), COHERE_TEXT_BATCH_SIZE):
+            chunk = texts[start : start + COHERE_TEXT_BATCH_SIZE]
+            payload = await self._invoke({
+                'texts': chunk,
+                'input_type': 'search_document',
+                'truncate': 'END',
+                'embedding_types': ['float'],
+            })
+            batch = decode_cohere_embeddings(payload)
+            if len(batch) != len(chunk):
+                raise GenkitError(
+                    message=f'bedrock embed: cohere returned {len(batch)} text embeddings for {len(chunk)} inputs',
+                    status='INTERNAL',
+                )
+            vectors.extend(batch)
+        return vectors
+
+    async def _embed_nova(self, documents: list[DocumentData]) -> list[list[float]]:
+        texts = [_require_text(document, index) for index, document in enumerate(documents)]
+        return await self._run_bounded([(index, self._nova_vector(text)) for index, text in enumerate(texts)])
+
+    async def _nova_vector(self, text: str) -> list[float]:
+        payload = await self._invoke({
+            'taskType': 'SINGLE_EMBEDDING',
+            'singleEmbeddingParams': {
+                'embeddingPurpose': 'GENERIC_INDEX',
+                'text': {'truncationMode': 'END', 'value': text},
+            },
+        })
+        return _require_vector(_nova_embedding(payload))
+
+    async def _run_bounded(self, calls: list[tuple[int, Coroutine[Any, Any, list[float]]]]) -> list[list[float]]:
+        """Runs per-document calls concurrently under the throttling cap.
+
+        The semaphore is built per call rather than once per module: it binds
+        to the running loop, and the Dev UI reflection server runs a second one.
+        """
+        semaphore = asyncio.Semaphore(EMBED_CONCURRENCY_LIMIT)
+
+        async def _bounded(index: int, call: Coroutine[Any, Any, list[float]]) -> list[float]:
+            async with semaphore:
+                try:
+                    return await call
+                except GenkitError as error:
+                    # A batch failure is opaque without the failing document,
+                    # but the inner message already names the plugin.
+                    raise GenkitError(
+                        message=f'bedrock embed: document {index}: {_without_own_prefix(error.original_message)}',
+                        status=error.status,
+                    ) from error
+
+        results = await asyncio.gather(*(_bounded(index, call) for index, call in calls), return_exceptions=True)
+        for result in results:
+            # Index order, not completion order, so the reported failure is
+            # deterministic; a CancelledError arrives here too and must re-raise.
+            if isinstance(result, BaseException):
+                raise result
+        return cast(list[list[float]], results)
+
+    async def _invoke(self, body: dict[str, Any]) -> dict[str, Any]:
+        try:
+            return await self._transport.invoke_model(
+                modelId=self._model_id,
+                body=json.dumps(body),
+                contentType='application/json',
+                accept='application/json',
+            )
+        except ClientError as error:
+            raise _from_client_error(error, 'invoke model') from error
+        except BotoCoreError as error:
+            raise _from_botocore_error(error, 'invoke model') from error

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -466,7 +466,7 @@ class BedrockEmbedder:
         return _require_vector(_nova_embedding(payload))
 
     async def _run_bounded(self, calls: list[tuple[int, Coroutine[Any, Any, list[float]]]]) -> list[list[float]]:
-        """Runs per-document calls concurrently under the throttling cap.
+        """Runs per-document calls concurrently, cancelling the rest on the first failure.
 
         The semaphore is built per call rather than once per module: it binds
         to the running loop, and the Dev UI reflection server runs a second one.
@@ -474,22 +474,34 @@ class BedrockEmbedder:
         semaphore = asyncio.Semaphore(EMBED_CONCURRENCY_LIMIT)
 
         async def _bounded(index: int, call: Coroutine[Any, Any, list[float]]) -> list[float]:
-            async with semaphore:
-                try:
-                    return await call
-                except GenkitError as error:
-                    # A batch failure is opaque without the failing document,
-                    # but the inner message already names the plugin.
-                    raise GenkitError(
-                        message=f'bedrock embed: document {index}: {_without_own_prefix(error.original_message)}',
-                        status=error.status,
-                    ) from error
+            try:
+                async with semaphore:
+                    try:
+                        return await call
+                    except GenkitError as error:
+                        # A batch failure is opaque without the failing document,
+                        # but the inner message already names the plugin.
+                        raise GenkitError(
+                            message=f'bedrock embed: document {index}: {_without_own_prefix(error.original_message)}',
+                            status=error.status,
+                        ) from error
+            except asyncio.CancelledError:
+                # Cancelled while queued on the semaphore, so nothing awaited it.
+                call.close()
+                raise
 
-        results = await asyncio.gather(*(_bounded(index, call) for index, call in calls), return_exceptions=True)
+        tasks = [asyncio.create_task(_bounded(index, call)) for index, call in calls]
+        _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+        for task in pending:
+            # Without this the rest of the batch still bills one call each.
+            task.cancel()
+        # Also retrieves the cancelled outcomes, so none resurfaces later as
+        # "Task exception was never retrieved".
+        results = await asyncio.gather(*tasks, return_exceptions=True)
         for result in results:
             # Index order, not completion order, so the reported failure is
-            # deterministic; a CancelledError arrives here too and must re-raise.
-            if isinstance(result, BaseException):
+            # deterministic across the calls that were left to run.
+            if isinstance(result, BaseException) and not isinstance(result, asyncio.CancelledError):
                 raise result
         return cast(list[list[float]], results)
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -38,7 +38,7 @@ for that reason, not because of how it encodes the image. Image embedding needs
 import asyncio
 import json
 from collections.abc import Coroutine
-from typing import Any, Literal, NamedTuple, Protocol, cast
+from typing import Any, Literal, NamedTuple, Protocol, TypeVar, cast
 
 from botocore.exceptions import BotoCoreError, ClientError
 
@@ -56,6 +56,9 @@ from genkit.embedder import (
 from genkit.plugin_api import GenkitError
 from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
 from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
+
+# One call's result: a single vector per document, or a chunk of them for Cohere.
+_T = TypeVar('_T')
 
 # Caps simultaneous InvokeModel calls; large batches otherwise earn a ThrottlingException.
 EMBED_CONCURRENCY_LIMIT = 10
@@ -432,24 +435,27 @@ class BedrockEmbedder:
         # Any media part is ignored: these models take text only.
         texts = [_require_cohere_text(document, index) for index, document in enumerate(documents)]
         # The one family with a batch API, so chunks replace the per-document
-        # fan-out. Sequential slices, hence extend rather than index assignment.
-        vectors: list[list[float]] = []
-        for start in range(0, len(texts), COHERE_TEXT_BATCH_SIZE):
-            chunk = texts[start : start + COHERE_TEXT_BATCH_SIZE]
-            payload = await self._invoke({
-                'texts': chunk,
-                'input_type': 'search_document',
-                'truncate': 'END',
-                'embedding_types': ['float'],
-            })
-            batch = decode_cohere_embeddings(payload)
-            if len(batch) != len(chunk):
-                raise GenkitError(
-                    message=f'bedrock embed: cohere returned {len(batch)} text embeddings for {len(chunk)} inputs',
-                    status='INTERNAL',
-                )
-            vectors.extend(batch)
-        return vectors
+        # fan-out. Each index is its chunk's first document, so a failure names it.
+        batches = await self._run_bounded([
+            (start, self._cohere_chunk_vectors(texts[start : start + COHERE_TEXT_BATCH_SIZE]))
+            for start in range(0, len(texts), COHERE_TEXT_BATCH_SIZE)
+        ])
+        return [vector for batch in batches for vector in batch]
+
+    async def _cohere_chunk_vectors(self, chunk: list[str]) -> list[list[float]]:
+        payload = await self._invoke({
+            'texts': chunk,
+            'input_type': 'search_document',
+            'truncate': 'END',
+            'embedding_types': ['float'],
+        })
+        batch = decode_cohere_embeddings(payload)
+        if len(batch) != len(chunk):
+            raise GenkitError(
+                message=f'bedrock embed: cohere returned {len(batch)} text embeddings for {len(chunk)} inputs',
+                status='INTERNAL',
+            )
+        return batch
 
     async def _embed_nova(self, documents: list[DocumentData]) -> list[list[float]]:
         texts = [_require_text(document, index) for index, document in enumerate(documents)]
@@ -465,15 +471,15 @@ class BedrockEmbedder:
         })
         return _require_vector(_nova_embedding(payload))
 
-    async def _run_bounded(self, calls: list[tuple[int, Coroutine[Any, Any, list[float]]]]) -> list[list[float]]:
-        """Runs per-document calls concurrently, cancelling the rest on the first failure.
+    async def _run_bounded(self, calls: list[tuple[int, Coroutine[Any, Any, _T]]]) -> list[_T]:
+        """Runs the calls concurrently, cancelling the rest on the first failure.
 
         The semaphore is built per call rather than once per module: it binds
         to the running loop, and the Dev UI reflection server runs a second one.
         """
         semaphore = asyncio.Semaphore(EMBED_CONCURRENCY_LIMIT)
 
-        async def _bounded(index: int, call: Coroutine[Any, Any, list[float]]) -> list[float]:
+        async def _bounded(index: int, call: Coroutine[Any, Any, _T]) -> _T:
             try:
                 async with semaphore:
                     try:
@@ -503,7 +509,7 @@ class BedrockEmbedder:
             # deterministic across the calls that were left to run.
             if isinstance(result, BaseException) and not isinstance(result, asyncio.CancelledError):
                 raise result
-        return cast(list[list[float]], results)
+        return cast(list[_T], results)
 
     async def _invoke(self, body: dict[str, Any]) -> dict[str, Any]:
         try:

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -140,6 +140,22 @@ def is_embedding_model(model_id: str) -> bool:
     return _embedding_family(model_id) is not None
 
 
+def looks_like_embedding_model(model_id: str) -> bool:
+    """Reports whether a model ID names an embedding model, routable or not.
+
+    Recognition only, never routing: an embedding ID from a family this plugin
+    has no request shape for still answers as an unsupported embedder rather
+    than as a Converse chat model.
+
+    Args:
+        model_id: Bedrock model ID, inference-profile ID, or ARN.
+
+    Returns:
+        True when the ID carries the token every Bedrock embedding family uses.
+    """
+    return 'embed' in strip_inference_profile_prefix(model_id)
+
+
 def get_embedder_options(model_id: str) -> EmbedderOptions:
     """Builds the Genkit embedder metadata for a Bedrock embedding model.
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -20,18 +20,17 @@ Embedding models predate Converse and have no unified request shape: each
 family takes its own raw JSON body and returns its own response shape, so
 routing by model ID is unavoidable.
 
-Ported from the Go plugin's ``embed.go``, with four corrections verified
-against the AWS docs and API: Nova targets the real
-``amazon.nova-2-multimodal-embeddings-v1:0`` schema rather than Go's
-unreachable Titan-shaped path, Cohere embedding is text-only, routing is on
-``cohere.embed`` so rerank model IDs are not swallowed, and Titan multimodal's
-in-band ``message`` field is raised instead of ignored.
+Bedrock behaviours that are easy to get wrong: Nova uses the
+``amazon.nova-2-multimodal-embeddings-v1:0`` schema rather than a Titan-shaped
+body; Cohere Embed v3 is text-only; Cohere text is chunked at Bedrock's
+96-document per-request limit; routing matches ``cohere.embed`` rather than
+bare ``cohere``, so rerank model IDs are not swallowed; and Titan multimodal
+reports input errors in-band, in a ``message`` field on an HTTP 200.
 
 On Cohere: the AWS parameters page documents an ``images`` field and an
 ``image`` input type for Embed v3, but ``get-foundation-model`` reports
 ``inputModalities: [TEXT]`` for both v3 model IDs and a live image request is
-rejected with ``Invalid parameter combination``. Go's image path cannot work
-for that reason, not because of how it encodes the image. Image embedding needs
+rejected with ``Invalid parameter combination``. Image embedding needs
 ``amazon.titan-embed-image-v1``, or Cohere Embed v4 once that lands.
 """
 
@@ -171,7 +170,7 @@ def get_embedder_options(model_id: str) -> EmbedderOptions:
 
 
 def document_text(document: DocumentData) -> str:
-    """Joins a document's text parts, mirroring the Go plugin's ``documentText``.
+    """Joins a document's text parts.
 
     Whitespace-only parts are skipped, surviving parts are joined untrimmed,
     and only the result is stripped. Text is never flattened across documents:
@@ -381,7 +380,7 @@ class BedrockEmbedder:
 
     async def _embed_titan_text(self, documents: list[DocumentData]) -> list[list[float]]:
         # Every document is validated before the first call goes out, so a bad
-        # batch costs nothing. Go checks each one inside its own goroutine.
+        # batch costs nothing.
         texts = [_require_text(document, index) for index, document in enumerate(documents)]
         return await self._run_bounded([(index, self._titan_text_vector(text)) for index, text in enumerate(texts)])
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -132,7 +132,7 @@ def strip_inference_profile_prefix(model_id: str) -> str:
 
 def get_model_info(
     model_name: str,
-    model_type: Literal['chat', 'text', 'image', 'embedding'] = 'chat',
+    model_type: Literal['chat', 'text', 'image'] = 'chat',
 ) -> ModelInfo:
     """Infers Genkit model info for a Bedrock model.
 
@@ -154,20 +154,6 @@ def get_model_info(
                 tool_choice=False,
                 system_role=False,
                 media=True,
-                constrained=Constrained.NONE,
-            ),
-        )
-
-    if model_type == 'embedding':
-        return ModelInfo(
-            label=model_name,
-            stage=Stage.STABLE,
-            supports=Supports(
-                multiturn=False,
-                tools=False,
-                tool_choice=False,
-                system_role=False,
-                media=False,
                 constrained=Constrained.NONE,
             ),
         )

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -18,13 +18,14 @@
 
 Registers Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama,
 Mistral, Cohere, and others) as Genkit model actions. Text generation uses the
-Bedrock Converse and ConverseStream APIs; embedders, image generation, and
-reranking are not supported yet.
+Bedrock Converse and ConverseStream APIs, and embedders use InvokeModel; image
+generation and reranking are not supported yet.
 """
 
 from typing import TYPE_CHECKING
 
 from genkit import ModelRequest, ModelResponse
+from genkit.embedder import EmbedRequest, EmbedResponse, embedder_action_metadata
 from genkit.model import model_action_metadata
 from genkit.plugin_api import (
     Action,
@@ -39,6 +40,7 @@ from genkit_amazon_bedrock.config import (
     BedrockConfig,
     ModelDefinition,
 )
+from genkit_amazon_bedrock.embedders import BedrockEmbedder, get_embedder_options, is_embedding_model
 from genkit_amazon_bedrock.model_info import get_model_info
 from genkit_amazon_bedrock.models import BedrockModel
 from genkit_amazon_bedrock.transport import BedrockTransport
@@ -76,6 +78,7 @@ class Bedrock(Plugin):
         total_timeout: float | None = DEFAULT_TOTAL_TIMEOUT,
         session: 'boto3.session.Session | None' = None,
         models: list[ModelDefinition] | None = None,
+        embedders: list[str] | None = None,
     ) -> None:
         """Initializes the Bedrock plugin.
 
@@ -101,6 +104,9 @@ class Bedrock(Plugin):
                 credentials or advanced SDK wiring.
             models: Bedrock models to register. Models not listed can still be
                 resolved dynamically by namespaced name.
+            embedders: Bedrock embedding model IDs to register, e.g.
+                ``amazon.titan-embed-text-v2:0``. As with models, unlisted IDs
+                still resolve dynamically.
         """
         self.region = region
         self.max_retries = max_retries
@@ -110,6 +116,7 @@ class Bedrock(Plugin):
         self.total_timeout = total_timeout
         self._session = session
         self.models = models or []
+        self.embedders = embedders or []
         self._transport = BedrockTransport(
             region=region,
             max_retries=max_retries,
@@ -145,13 +152,19 @@ class Bedrock(Plugin):
         Returns:
             Action object if resolvable, None otherwise.
         """
-        if action_type != ActionKind.MODEL:
-            return None
         prefix = f'{BEDROCK_PLUGIN_NAME}/'
         # Direct plugin.model() calls can pass any namespace; only ours resolves.
         if not name.startswith(prefix):
             return None
         model_id = name.removeprefix(prefix)
+        if action_type == ActionKind.EMBEDDER:
+            return self._create_embedder_action(model_id) if is_embedding_model(model_id) else None
+        if action_type != ActionKind.MODEL:
+            return None
+        if is_embedding_model(model_id):
+            # Embedding models speak InvokeModel, not Converse; resolving one
+            # as a chat model only defers the failure to call time.
+            return None
         model_type = self._configured_model_type(model_id)
         if model_type not in ('chat', 'text'):
             # Image generation lands in a later slice.
@@ -187,21 +200,42 @@ class Bedrock(Plugin):
             },
         )
 
-    async def list_actions(self) -> list[ActionMetadata]:
-        """List configured Bedrock models.
+    def _create_embedder_action(self, model_id: str) -> Action:
+        async def _embed(request: EmbedRequest) -> EmbedResponse:
+            embedder = BedrockEmbedder(model_id=model_id, transport=self._transport)
+            return await embedder.embed(request)
 
-        Only explicitly configured models are listed; the catalogue itself is
-        open-ended, and any model ID still resolves on demand.
+        return Action(
+            kind=ActionKind.EMBEDDER,
+            name=bedrock_name(model_id),
+            fn=_embed,
+            # Same helper as list_actions, so the two can never drift apart.
+            metadata=embedder_action_metadata(bedrock_name(model_id), get_embedder_options(model_id)).metadata,
+        )
+
+    async def list_actions(self) -> list[ActionMetadata]:
+        """List configured Bedrock models and embedders.
+
+        Only explicitly configured entries are listed, and only those ``resolve``
+        can serve: an ID in the wrong list would otherwise be advertised and then
+        answer 404. The catalogue itself is open-ended, and any model ID still
+        resolves on demand.
 
         Returns:
-            ActionMetadata for each configured chat model.
+            ActionMetadata for each configured chat model and embedder.
         """
-        return [
+        actions: list[ActionMetadata] = [
             model_action_metadata(
                 name=bedrock_name(definition.name),
                 info=get_model_info(definition.name, definition.type).model_dump(by_alias=True, exclude_none=True),
                 config_schema=BedrockConfig,
             )
             for definition in self.models
-            if definition.type in ('chat', 'text')
+            if definition.type in ('chat', 'text') and not is_embedding_model(definition.name)
         ]
+        actions.extend(
+            embedder_action_metadata(bedrock_name(model_id), get_embedder_options(model_id))
+            for model_id in self.embedders
+            if is_embedding_model(model_id)
+        )
+        return actions

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -40,7 +40,12 @@ from genkit_amazon_bedrock.config import (
     BedrockConfig,
     ModelDefinition,
 )
-from genkit_amazon_bedrock.embedders import BedrockEmbedder, get_embedder_options, is_embedding_model
+from genkit_amazon_bedrock.embedders import (
+    BedrockEmbedder,
+    get_embedder_options,
+    is_embedding_model,
+    looks_like_embedding_model,
+)
 from genkit_amazon_bedrock.model_info import get_model_info
 from genkit_amazon_bedrock.models import BedrockModel
 from genkit_amazon_bedrock.transport import BedrockTransport
@@ -158,10 +163,12 @@ class Bedrock(Plugin):
             return None
         model_id = name.removeprefix(prefix)
         if action_type == ActionKind.EMBEDDER:
-            return self._create_embedder_action(model_id) if is_embedding_model(model_id) else None
+            # An unroutable embedding ID still resolves, so embed() can name it
+            # as an unsupported embedder instead of the registry saying 404.
+            return self._create_embedder_action(model_id) if looks_like_embedding_model(model_id) else None
         if action_type != ActionKind.MODEL:
             return None
-        if is_embedding_model(model_id):
+        if looks_like_embedding_model(model_id):
             # Embedding models speak InvokeModel, not Converse; resolving one
             # as a chat model only defers the failure to call time.
             return None
@@ -216,10 +223,10 @@ class Bedrock(Plugin):
     async def list_actions(self) -> list[ActionMetadata]:
         """List configured Bedrock models and embedders.
 
-        Only explicitly configured entries are listed, and only those ``resolve``
-        can serve: an ID in the wrong list would otherwise be advertised and then
-        answer 404. The catalogue itself is open-ended, and any model ID still
-        resolves on demand.
+        Only explicitly configured entries are listed, and only those this
+        plugin can actually serve: an ID in the wrong list would otherwise be
+        advertised and then fail on use. The catalogue itself is open-ended, and
+        any model ID still resolves on demand.
 
         Returns:
             ActionMetadata for each configured chat model and embedder.
@@ -231,7 +238,7 @@ class Bedrock(Plugin):
                 config_schema=BedrockConfig,
             )
             for definition in self.models
-            if definition.type in ('chat', 'text') and not is_embedding_model(definition.name)
+            if definition.type in ('chat', 'text') and not looks_like_embedding_model(definition.name)
         ]
         actions.extend(
             embedder_action_metadata(bedrock_name(model_id), get_embedder_options(model_id))

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
@@ -24,6 +24,7 @@ matures without touching converters or models.
 """
 
 import asyncio
+import json
 import os
 import threading
 from collections.abc import AsyncGenerator
@@ -237,6 +238,34 @@ class BedrockTransport:
 
     def _converse_stream_sync(self, kwargs: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
         return self.client().converse_stream(**kwargs)
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
+        """Calls the InvokeModel API on a worker thread.
+
+        Args:
+            kwargs: Keyword arguments passed verbatim to ``invoke_model``.
+
+        Returns:
+            The parsed JSON response body.
+
+        Raises:
+            GenkitError: INTERNAL when the response carries no body, or a body
+                that is not JSON.
+        """
+        return await asyncio.to_thread(self._invoke_model_sync, kwargs)
+
+    def _invoke_model_sync(self, kwargs: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
+        response = self.client().invoke_model(**kwargs)
+        body = response.get('body')
+        if body is None:
+            raise GenkitError(message='bedrock: invoke model response has no body', status='INTERNAL')
+        # Read and parse here, not on the loop: the body is a StreamingBody and
+        # read() is a blocking socket read.
+        raw = body.read()
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise GenkitError(message=f'bedrock: invoke model response is not JSON: {e}', status='INTERNAL') from e
 
     def _resolve_region(self, session: Any) -> str:  # noqa: ANN401
         # botocore only began reading AWS_REGION in 1.41, above this package's

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
@@ -250,7 +250,7 @@ class BedrockTransport:
 
         Raises:
             GenkitError: INTERNAL when the response carries no body, or a body
-                that is not JSON.
+                that is not a JSON object.
         """
         return await asyncio.to_thread(self._invoke_model_sync, kwargs)
 
@@ -263,9 +263,12 @@ class BedrockTransport:
         # read() is a blocking socket read.
         raw = body.read()
         try:
-            return json.loads(raw)
+            payload = json.loads(raw)
         except json.JSONDecodeError as e:
             raise GenkitError(message=f'bedrock: invoke model response is not JSON: {e}', status='INTERNAL') from e
+        if not isinstance(payload, dict):
+            raise GenkitError(message='bedrock: invoke model response body is not a JSON object', status='INTERNAL')
+        return payload
 
     def _resolve_region(self, session: Any) -> str:  # noqa: ANN401
         # botocore only began reading AWS_REGION in 1.41, above this package's

--- a/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
@@ -580,6 +580,18 @@ async def test_fan_out_respects_the_concurrency_cap() -> None:
     assert transport.max_in_flight == EMBED_CONCURRENCY_LIMIT
 
 
+@pytest.mark.asyncio
+async def test_a_failing_batch_cancels_the_calls_that_have_not_started() -> None:
+    documents = [text_doc('bad')] + [text_doc(f'doc {i}') for i in range(49)]
+    transport = FakeInvokeTransport(dispatch=lambda body: titan_response([] if body['inputText'] == 'bad' else [1.0]))
+    with pytest.raises(GenkitError, match='document 0'):
+        await embed(TITAN_TEXT, transport, documents)
+
+    # Go cancels its context on the first error. Without that the semaphore
+    # drains and every remaining document still bills a call.
+    assert len(transport.calls) < len(documents)
+
+
 def test_the_semaphore_is_built_per_call_not_per_module() -> None:
     # A module-level semaphore binds to the first loop that has to wait on it,
     # and the Dev UI reflection server runs a second one. This needs more
@@ -610,9 +622,9 @@ async def test_results_keep_input_order_when_calls_finish_out_of_order() -> None
 
 
 @pytest.mark.asyncio
-async def test_the_first_failure_by_index_wins_not_the_first_to_land() -> None:
-    # The later document fails first in wall-clock terms; the reported error
-    # still has to be the earlier one, as in the Go plugin.
+async def test_the_first_failure_to_land_wins_and_the_slower_one_is_cancelled() -> None:
+    # Go returns the first error off its results channel and cancels the rest,
+    # so the earlier document's slower failure never gets reported.
     class RacingTransport:
         async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
             text = json.loads(kwargs['body'])['inputText']
@@ -620,7 +632,7 @@ async def test_the_first_failure_by_index_wins_not_the_first_to_land() -> None:
                 await asyncio.sleep(0.02)
             raise ClientError({'Error': {'Code': 'ValidationException', 'Message': text}}, 'InvokeModel')
 
-    with pytest.raises(GenkitError, match='slow-bad'):
+    with pytest.raises(GenkitError, match='fast-bad'):
         await embed(TITAN_TEXT, RacingTransport(), [text_doc('slow-bad'), text_doc('fast-bad')])
 
 

--- a/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
@@ -373,9 +373,11 @@ async def test_cohere_chunks_above_the_batch_limit() -> None:
     transport = FakeInvokeTransport(dispatch=lambda body: cohere_response(len(body['texts'])))
     vectors = await embed(COHERE, transport, documents)
 
-    bodies = transport.bodies()
-    assert [len(body['texts']) for body in bodies] == [COHERE_TEXT_BATCH_SIZE, 4]
-    assert bodies[1]['texts'] == ['doc 96', 'doc 97', 'doc 98', 'doc 99']
+    # Chunks go out concurrently, so sort rather than depend on call order.
+    chunks = sorted((body['texts'] for body in transport.bodies()), key=len, reverse=True)
+    assert [len(chunk) for chunk in chunks] == [COHERE_TEXT_BATCH_SIZE, 4]
+    assert chunks[1] == ['doc 96', 'doc 97', 'doc 98', 'doc 99']
+    assert transport.max_in_flight == 2
     # Reassembled by original index, so the second chunk restarts at 0.0.
     assert vectors[96] == [0.0, 0.5]
     assert len(vectors) == 100
@@ -387,6 +389,17 @@ async def test_cohere_arity_mismatch_is_internal() -> None:
     with pytest.raises(GenkitError, match='returned 1 text embeddings for 2 inputs') as excinfo:
         await embed(COHERE, transport, [text_doc('a'), text_doc('b')])
     assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_a_failing_cohere_chunk_names_its_first_document() -> None:
+    documents = [text_doc(f'doc {i}') for i in range(100)]
+    # The second chunk holds documents 96-99 and comes back one embedding short.
+    transport = FakeInvokeTransport(
+        dispatch=lambda body: cohere_response(1 if len(body['texts']) == 4 else len(body['texts']))
+    )
+    with pytest.raises(GenkitError, match='document 96: cohere returned 1 text embeddings for 4 inputs'):
+        await embed(COHERE, transport, documents)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
@@ -318,6 +318,14 @@ async def test_titan_multimodal_rejects_unsupported_mime_before_calling() -> Non
 
 
 @pytest.mark.asyncio
+async def test_titan_multimodal_names_the_document_holding_a_remote_url() -> None:
+    documents = [media_doc(PNG_DATA_URL), media_doc('https://example.com/i.png', 'image/png')]
+    with pytest.raises(GenkitError, match='document 1: remote URLs are not supported') as excinfo:
+        await embed(TITAN_MM, ForbiddenTransport(), documents)
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
 async def test_titan_multimodal_requires_some_content() -> None:
     with pytest.raises(GenkitError, match='no text or image content') as excinfo:
         await embed(TITAN_MM, ForbiddenTransport(), [text_doc('')])
@@ -507,16 +515,41 @@ def test_document_text_ignores_media_parts() -> None:
         (media_doc(PNG_DATA_URL, 'image/jpeg'), ('image/jpeg', PNG_B64)),
         # Parameters are stripped and the type is lower-cased.
         (media_doc(PNG_DATA_URL, 'IMAGE/PNG; charset=binary'), ('image/png', PNG_B64)),
-        # No comma: not a data URL, so the part is skipped rather than sent whole.
+        # Bare base64, the other shape converters accepts.
+        (media_doc(PNG_B64, 'image/png'), ('image/png', PNG_B64)),
+        # A data URL with no payload to send is skipped, comma or not.
         (media_doc('data:image/png;base64'), ('', '')),
+        (media_doc('data:image/png;base64,'), ('', '')),
+        (media_doc('', 'image/png'), ('', '')),
         (media_doc(f'data:application/pdf;base64,{PNG_B64}'), ('', '')),
+        # No content type and no data-URL header, so the type is unknown.
         (media_doc(PNG_B64), ('', '')),
+        # Remote URLs only raise once the part is known to be an image.
+        (media_doc('https://example.com/notes.pdf', 'application/pdf'), ('', '')),
         (text_doc('no media here'), ('', '')),
         (DocumentData(content=[]), ('', '')),
     ],
 )
 def test_image_from_document(document: DocumentData, expected: tuple[str, str]) -> None:
     assert image_from_document(document) == expected
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'https://example.com/i.png',
+        'http://example.com/i.png',
+        's3://bucket/i.png',
+        # A comma in a remote URL used to pass for a data-URL separator, which
+        # sent the fragment after it as the image payload.
+        'https://cdn.example.com/i.png?tags=a,b',
+        's3://bucket/a,b/i.png',
+    ],
+)
+def test_image_from_document_rejects_remote_urls(url: str) -> None:
+    with pytest.raises(GenkitError, match='remote URLs are not supported') as excinfo:
+        image_from_document(media_doc(url, 'image/png'))
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
 
 
 def test_image_from_document_returns_the_first_image() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
@@ -154,7 +154,7 @@ async def test_empty_input_is_rejected() -> None:
         ('cohere.embed-v4:0', True),
         ('amazon.nova-2-multimodal-embeddings-v1:0', True),
         ('us.amazon.titan-embed-text-v2:0', True),
-        # Bare 'cohere' routing in the Go plugin would swallow these two.
+        # Bare 'cohere' routing would swallow these two.
         ('cohere.rerank-v3-5:0', False),
         ('cohere.command-r-v1:0', False),
         ('anthropic.claude-sonnet-4-5-20250929-v1:0', False),
@@ -199,8 +199,8 @@ async def test_empty_document_fails_before_any_call(model_id: str) -> None:
 
 @pytest.mark.asyncio
 async def test_mixed_validity_names_the_first_bad_document_and_calls_nothing() -> None:
-    # Upfront validation, unlike Go's per-goroutine checks: a bad batch costs
-    # nothing rather than paying for every document that happens to be fine.
+    # Upfront validation: a bad batch costs nothing rather than paying for
+    # every document that happens to be fine.
     transport = FakeInvokeTransport()
     with pytest.raises(GenkitError, match='document 2 has no text content'):
         await embed(TITAN_TEXT, transport, [text_doc('a'), text_doc('b'), text_doc(''), text_doc('')])
@@ -334,8 +334,8 @@ async def test_titan_multimodal_requires_some_content() -> None:
 
 @pytest.mark.asyncio
 async def test_titan_multimodal_raises_the_in_band_message() -> None:
-    # Titan multimodal reports input problems on an HTTP 200; the Go plugin
-    # drops this field and returns "empty embedding vector" instead.
+    # Titan multimodal reports input problems on an HTTP 200, so dropping this
+    # field surfaces "empty embedding vector" instead.
     transport = FakeInvokeTransport([{'message': 'image too large'}])
     with pytest.raises(GenkitError, match='image too large') as excinfo:
         await embed(TITAN_MM, transport, [text_doc('hi')])
@@ -475,8 +475,7 @@ async def test_nova_sends_the_single_embedding_body() -> None:
 
 @pytest.mark.asyncio
 async def test_nova_reads_the_vector_off_the_embeddings_list() -> None:
-    # A list of objects, not the bare vector Titan returns; the Go plugin's
-    # test asserts a fabricated Titan-shaped response here.
+    # A list of objects, not the bare vector Titan returns.
     transport = FakeInvokeTransport([nova_response([0.5, 0.6])])
     assert await embed(NOVA, transport, [text_doc('hi')]) == [[0.5, 0.6]]
 
@@ -600,8 +599,8 @@ async def test_a_failing_batch_cancels_the_calls_that_have_not_started() -> None
     with pytest.raises(GenkitError, match='document 0'):
         await embed(TITAN_TEXT, transport, documents)
 
-    # Go cancels its context on the first error. Without that the semaphore
-    # drains and every remaining document still bills a call.
+    # Without cancellation the semaphore drains and every remaining document
+    # still bills a call.
     assert len(transport.calls) < len(documents)
 
 
@@ -636,8 +635,8 @@ async def test_results_keep_input_order_when_calls_finish_out_of_order() -> None
 
 @pytest.mark.asyncio
 async def test_the_first_failure_to_land_wins_and_the_slower_one_is_cancelled() -> None:
-    # Go returns the first error off its results channel and cancels the rest,
-    # so the earlier document's slower failure never gets reported.
+    # The first error cancels the rest, so the earlier document's slower
+    # failure never gets reported.
     class RacingTransport:
         async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
             text = json.loads(kwargs['body'])['inputText']

--- a/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
@@ -1,0 +1,652 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Bedrock embedders (no AWS involved)."""
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
+from genkit_amazon_bedrock.embedders import (
+    COHERE_TEXT_BATCH_SIZE,
+    EMBED_CONCURRENCY_LIMIT,
+    EMBEDDER_INFO,
+    BedrockEmbedder,
+    decode_cohere_embeddings,
+    document_text,
+    get_embedder_options,
+    image_from_document,
+    is_embedding_model,
+)
+from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
+
+from genkit import DocumentPart, Media, MediaPart, TextPart
+from genkit._core._typing import DocumentData
+from genkit.embedder import EmbedRequest
+from genkit.plugin_api import GenkitError
+
+TITAN_TEXT = 'amazon.titan-embed-text-v2:0'
+TITAN_MM = 'amazon.titan-embed-image-v1'
+COHERE = 'cohere.embed-english-v3'
+NOVA = 'amazon.nova-2-multimodal-embeddings-v1:0'
+
+PNG_B64 = 'iVBORw0KGgoAAAANSUhEUg=='
+PNG_DATA_URL = f'data:image/png;base64,{PNG_B64}'
+
+
+class FakeInvokeTransport:
+    """Stands in for BedrockTransport; records the InvokeModel kwargs.
+
+    Responses come either from a queue (consumed in call order) or from
+    ``dispatch``, which maps a parsed request body to a response so tests that
+    fan out do not depend on completion order.
+    """
+
+    def __init__(
+        self,
+        responses: list[dict[str, Any]] | None = None,
+        error: Exception | None = None,
+        dispatch: Any = None,
+    ) -> None:
+        self.responses = list(responses or [])
+        self.error = error
+        self.dispatch = dispatch
+        self.calls: list[dict[str, Any]] = []
+        self.in_flight = 0
+        self.max_in_flight = 0
+
+    def bodies(self) -> list[dict[str, Any]]:
+        """The parsed request bodies, in call order."""
+        return [json.loads(call['body']) for call in self.calls]
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        try:
+            # Yields so concurrent calls actually overlap, which is what makes
+            # the observed peak deterministic.
+            await asyncio.sleep(0)
+            if self.error is not None:
+                raise self.error
+            if self.dispatch is not None:
+                return self.dispatch(json.loads(kwargs['body']))
+            return self.responses.pop(0)
+        finally:
+            self.in_flight -= 1
+
+
+class ForbiddenTransport:
+    """Fails the test if the embedder reaches the wire at all."""
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError(f'no InvokeModel call expected, got {kwargs}')
+
+
+def text_doc(*texts: str) -> DocumentData:
+    return DocumentData(content=[DocumentPart(root=TextPart(text=text)) for text in texts])
+
+
+def media_doc(url: str, content_type: str | None = None) -> DocumentData:
+    return DocumentData(content=[DocumentPart(root=MediaPart(media=Media(url=url, content_type=content_type)))])
+
+
+def mixed_doc(text: str, url: str, content_type: str | None = None) -> DocumentData:
+    return DocumentData(
+        content=[
+            DocumentPart(root=TextPart(text=text)),
+            DocumentPart(root=MediaPart(media=Media(url=url, content_type=content_type))),
+        ]
+    )
+
+
+def titan_response(vector: list[float] | None = None) -> dict[str, Any]:
+    return {'embedding': vector if vector is not None else [0.1, 0.2]}
+
+
+def nova_response(vector: list[float] | None = None) -> dict[str, Any]:
+    return {'embeddings': [{'embedding': vector if vector is not None else [0.1, 0.2, 0.3]}]}
+
+
+def cohere_response(count: int) -> dict[str, Any]:
+    return {'embeddings': {'float': [[float(i), 0.5] for i in range(count)]}}
+
+
+async def embed(model_id: str, transport: Any, documents: list[DocumentData], **kwargs: Any) -> list[list[float]]:
+    embedder = BedrockEmbedder(model_id=model_id, transport=transport)
+    response = await embedder.embed(EmbedRequest(input=documents, **kwargs))
+    return [embedding.embedding for embedding in response.embeddings]
+
+
+# ---- Routing and validation -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_input_is_rejected() -> None:
+    with pytest.raises(GenkitError, match='no documents') as excinfo:
+        await embed(TITAN_TEXT, ForbiddenTransport(), [])
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.parametrize(
+    ('model_id', 'routable'),
+    [
+        ('amazon.titan-embed-text-v1', True),
+        ('amazon.titan-embed-text-v2:0', True),
+        ('amazon.titan-embed-image-v1', True),
+        ('cohere.embed-english-v3', True),
+        ('cohere.embed-multilingual-v3', True),
+        ('cohere.embed-v4:0', True),
+        ('amazon.nova-2-multimodal-embeddings-v1:0', True),
+        ('us.amazon.titan-embed-text-v2:0', True),
+        # Bare 'cohere' routing in the Go plugin would swallow these two.
+        ('cohere.rerank-v3-5:0', False),
+        ('cohere.command-r-v1:0', False),
+        ('anthropic.claude-sonnet-4-5-20250929-v1:0', False),
+        ('amazon.nova-lite-v1:0', False),
+        ('amazon.titan-image-generator-v1', False),
+    ],
+)
+def test_embedding_model_routing(model_id: str, routable: bool) -> None:
+    assert is_embedding_model(model_id) is routable
+
+
+@pytest.mark.asyncio
+async def test_profile_prefixed_id_routes_but_the_wire_keeps_it() -> None:
+    transport = FakeInvokeTransport([titan_response()])
+    await embed(f'us.{TITAN_TEXT}', transport, [text_doc('hi')])
+    assert transport.calls[0]['modelId'] == f'us.{TITAN_TEXT}'
+
+
+@pytest.mark.asyncio
+async def test_unroutable_model_fails_as_unimplemented() -> None:
+    with pytest.raises(GenkitError, match='unsupported embedding model') as excinfo:
+        await embed('anthropic.claude-sonnet-4-5-20250929-v1:0', ForbiddenTransport(), [text_doc('hi')])
+    assert excinfo.value.status == 'UNIMPLEMENTED'
+
+
+@pytest.mark.asyncio
+async def test_cohere_v4_is_unimplemented_without_calling() -> None:
+    transport = FakeInvokeTransport()
+    with pytest.raises(GenkitError, match='Cohere Embed v4') as excinfo:
+        await embed('cohere.embed-v4:0', transport, [text_doc('hi')])
+    assert excinfo.value.status == 'UNIMPLEMENTED'
+    assert transport.calls == []
+
+
+@pytest.mark.parametrize('model_id', [TITAN_TEXT, TITAN_MM, COHERE, NOVA])
+@pytest.mark.asyncio
+async def test_empty_document_fails_before_any_call(model_id: str) -> None:
+    with pytest.raises(GenkitError, match='document 0 has no') as excinfo:
+        await embed(model_id, ForbiddenTransport(), [text_doc('   ')])
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_mixed_validity_names_the_first_bad_document_and_calls_nothing() -> None:
+    # Upfront validation, unlike Go's per-goroutine checks: a bad batch costs
+    # nothing rather than paying for every document that happens to be fine.
+    transport = FakeInvokeTransport()
+    with pytest.raises(GenkitError, match='document 2 has no text content'):
+        await embed(TITAN_TEXT, transport, [text_doc('a'), text_doc('b'), text_doc(''), text_doc('')])
+    assert transport.calls == []
+
+
+# ---- Titan text -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_titan_text_sends_the_documented_body() -> None:
+    transport = FakeInvokeTransport([titan_response([1.0, 2.0])])
+    vectors = await embed(TITAN_TEXT, transport, [text_doc('hello')])
+
+    assert vectors == [[1.0, 2.0]]
+    call = transport.calls[0]
+    assert call['modelId'] == TITAN_TEXT
+    assert call['contentType'] == 'application/json'
+    assert call['accept'] == 'application/json'
+    # Exactly one key: Titan text rejects anything else.
+    assert json.loads(call['body']) == {'inputText': 'hello'}
+
+
+@pytest.mark.asyncio
+async def test_titan_text_embeds_each_document_in_order() -> None:
+    transport = FakeInvokeTransport(dispatch=lambda body: titan_response([float(len(body['inputText']))]))
+    vectors = await embed(TITAN_TEXT, transport, [text_doc('a'), text_doc('bb'), text_doc('ccc')])
+
+    assert vectors == [[1.0], [2.0], [3.0]]
+    assert len(transport.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_titan_text_empty_vector_is_internal() -> None:
+    transport = FakeInvokeTransport([{'embedding': []}])
+    with pytest.raises(GenkitError, match='empty embedding vector') as excinfo:
+        await embed(TITAN_TEXT, transport, [text_doc('hi')])
+    assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_runtime_errors_name_the_document_without_repeating_the_prefix() -> None:
+    transport = FakeInvokeTransport(dispatch=lambda body: titan_response([] if body['inputText'] == 'bad' else [1.0]))
+    with pytest.raises(GenkitError, match='document 1: model returned an empty embedding vector'):
+        await embed(TITAN_TEXT, transport, [text_doc('ok'), text_doc('bad')])
+
+
+@pytest.mark.parametrize(
+    ('code', 'status'),
+    [
+        ('ThrottlingException', 'RESOURCE_EXHAUSTED'),
+        ('ValidationException', 'INVALID_ARGUMENT'),
+        ('AccessDeniedException', 'PERMISSION_DENIED'),
+        ('SomethingNewException', 'UNKNOWN'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_client_errors_map_to_genkit_statuses(code: str, status: str) -> None:
+    error = ClientError({'Error': {'Code': code, 'Message': 'boom'}}, 'InvokeModel')
+    transport = FakeInvokeTransport(error=error)
+    with pytest.raises(GenkitError, match='invoke model failed') as excinfo:
+        await embed(TITAN_TEXT, transport, [text_doc('hi')])
+    assert excinfo.value.status == status
+
+
+@pytest.mark.asyncio
+async def test_botocore_errors_map_to_genkit_statuses() -> None:
+    transport = FakeInvokeTransport(error=NoCredentialsError())
+    with pytest.raises(GenkitError, match='invoke model failed') as excinfo:
+        await embed(TITAN_TEXT, transport, [text_doc('hi')])
+    assert excinfo.value.status == 'UNAUTHENTICATED'
+
+
+# ---- Titan multimodal -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_titan_multimodal_text_only_omits_the_image_key() -> None:
+    transport = FakeInvokeTransport([titan_response()])
+    await embed(TITAN_MM, transport, [text_doc('hello')])
+    assert transport.bodies() == [{'inputText': 'hello'}]
+
+
+@pytest.mark.asyncio
+async def test_titan_multimodal_image_only_sends_raw_base64() -> None:
+    transport = FakeInvokeTransport([titan_response()])
+    await embed(TITAN_MM, transport, [media_doc(PNG_DATA_URL)])
+    # Raw base64, not a data URI: that polarity is Cohere's, not Titan's.
+    assert transport.bodies() == [{'inputImage': PNG_B64}]
+
+
+@pytest.mark.asyncio
+async def test_titan_multimodal_sends_text_and_image_in_one_call() -> None:
+    transport = FakeInvokeTransport([titan_response()])
+    await embed(TITAN_MM, transport, [mixed_doc('hello', PNG_DATA_URL)])
+    assert transport.bodies() == [{'inputText': 'hello', 'inputImage': PNG_B64}]
+    assert len(transport.calls) == 1
+
+
+@pytest.mark.parametrize('mime', ['image/jpeg', 'image/jpg', 'image/png'])
+@pytest.mark.asyncio
+async def test_titan_multimodal_accepts_its_supported_mime_types(mime: str) -> None:
+    transport = FakeInvokeTransport([titan_response()])
+    await embed(TITAN_MM, transport, [media_doc(f'data:{mime};base64,{PNG_B64}')])
+    assert len(transport.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_titan_multimodal_rejects_unsupported_mime_before_calling() -> None:
+    transport = FakeInvokeTransport()
+    with pytest.raises(GenkitError, match='not supported by Titan') as excinfo:
+        await embed(TITAN_MM, transport, [media_doc(f'data:image/webp;base64,{PNG_B64}')])
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_titan_multimodal_requires_some_content() -> None:
+    with pytest.raises(GenkitError, match='no text or image content') as excinfo:
+        await embed(TITAN_MM, ForbiddenTransport(), [text_doc('')])
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_titan_multimodal_raises_the_in_band_message() -> None:
+    # Titan multimodal reports input problems on an HTTP 200; the Go plugin
+    # drops this field and returns "empty embedding vector" instead.
+    transport = FakeInvokeTransport([{'message': 'image too large'}])
+    with pytest.raises(GenkitError, match='image too large') as excinfo:
+        await embed(TITAN_MM, transport, [text_doc('hi')])
+    assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_titan_multimodal_success_carries_no_message() -> None:
+    transport = FakeInvokeTransport([{'embedding': [1.0], 'message': None}])
+    assert await embed(TITAN_MM, transport, [text_doc('hi')]) == [[1.0]]
+
+
+# ---- Cohere -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohere_batches_texts_into_one_call() -> None:
+    transport = FakeInvokeTransport([cohere_response(2)])
+    vectors = await embed(COHERE, transport, [text_doc('a'), text_doc('b')])
+
+    assert vectors == [[0.0, 0.5], [1.0, 0.5]]
+    assert transport.bodies() == [
+        {
+            'texts': ['a', 'b'],
+            'input_type': 'search_document',
+            'truncate': 'END',
+            'embedding_types': ['float'],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cohere_chunks_above_the_batch_limit() -> None:
+    documents = [text_doc(f'doc {i}') for i in range(100)]
+    transport = FakeInvokeTransport(dispatch=lambda body: cohere_response(len(body['texts'])))
+    vectors = await embed(COHERE, transport, documents)
+
+    bodies = transport.bodies()
+    assert [len(body['texts']) for body in bodies] == [COHERE_TEXT_BATCH_SIZE, 4]
+    assert bodies[1]['texts'] == ['doc 96', 'doc 97', 'doc 98', 'doc 99']
+    # Reassembled by original index, so the second chunk restarts at 0.0.
+    assert vectors[96] == [0.0, 0.5]
+    assert len(vectors) == 100
+
+
+@pytest.mark.asyncio
+async def test_cohere_arity_mismatch_is_internal() -> None:
+    transport = FakeInvokeTransport([cohere_response(1)])
+    with pytest.raises(GenkitError, match='returned 1 text embeddings for 2 inputs') as excinfo:
+        await embed(COHERE, transport, [text_doc('a'), text_doc('b')])
+    assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_cohere_rejects_an_image_only_document_and_names_the_alternative() -> None:
+    # Bedrock reports inputModalities [TEXT] for both Cohere v3 IDs, so an image
+    # request fails with "Invalid parameter combination" however it is encoded.
+    with pytest.raises(GenkitError, match='text-only.*titan-embed-image-v1') as excinfo:
+        await embed(COHERE, ForbiddenTransport(), [media_doc(PNG_DATA_URL)])
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_cohere_ignores_a_media_part_alongside_text() -> None:
+    transport = FakeInvokeTransport([cohere_response(1)])
+    await embed(COHERE, transport, [mixed_doc('hello', PNG_DATA_URL)])
+    # Only the text travels, and nothing image-shaped reaches the body.
+    assert transport.bodies() == [
+        {
+            'texts': ['hello'],
+            'input_type': 'search_document',
+            'truncate': 'END',
+            'embedding_types': ['float'],
+        }
+    ]
+
+
+def test_decode_cohere_typed_shape() -> None:
+    assert decode_cohere_embeddings({'embeddings': {'float': [[1.0, 2.0]]}}) == [[1.0, 2.0]]
+
+
+def test_decode_cohere_flat_shape() -> None:
+    assert decode_cohere_embeddings({'embeddings': [[1.0, 2.0]]}) == [[1.0, 2.0]]
+
+
+def test_decode_cohere_coerces_integers() -> None:
+    assert decode_cohere_embeddings({'embeddings': [[1, 2]]}) == [[1.0, 2.0]]
+
+
+@pytest.mark.parametrize(
+    ('payload', 'match'),
+    [
+        ({}, 'missing embeddings field'),
+        ({'embeddings': None}, 'missing embeddings field'),
+        ({'embeddings': {'int8': [[1]]}}, 'no float embeddings'),
+        ({'embeddings': {'float': []}}, 'no float embeddings'),
+        ({'embeddings': []}, 'returned no embeddings'),
+    ],
+)
+def test_decode_cohere_rejects_unusable_payloads(payload: dict[str, Any], match: str) -> None:
+    with pytest.raises(GenkitError, match=match) as excinfo:
+        decode_cohere_embeddings(payload)
+    assert excinfo.value.status == 'INTERNAL'
+
+
+# ---- Nova-2 -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nova_sends_the_single_embedding_body() -> None:
+    transport = FakeInvokeTransport([nova_response()])
+    await embed(NOVA, transport, [text_doc('hello')])
+
+    assert transport.bodies() == [
+        {
+            'taskType': 'SINGLE_EMBEDDING',
+            'singleEmbeddingParams': {
+                'embeddingPurpose': 'GENERIC_INDEX',
+                'text': {'truncationMode': 'END', 'value': 'hello'},
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_nova_reads_the_vector_off_the_embeddings_list() -> None:
+    # A list of objects, not the bare vector Titan returns; the Go plugin's
+    # test asserts a fabricated Titan-shaped response here.
+    transport = FakeInvokeTransport([nova_response([0.5, 0.6])])
+    assert await embed(NOVA, transport, [text_doc('hi')]) == [[0.5, 0.6]]
+
+
+@pytest.mark.asyncio
+async def test_nova_embeds_each_document_in_order() -> None:
+    transport = FakeInvokeTransport(
+        dispatch=lambda body: nova_response([float(len(body['singleEmbeddingParams']['text']['value']))])
+    )
+    assert await embed(NOVA, transport, [text_doc('a'), text_doc('bb')]) == [[1.0], [2.0]]
+    assert len(transport.calls) == 2
+
+
+@pytest.mark.parametrize('payload', [{'embeddings': []}, {}, {'embeddings': [{}]}])
+@pytest.mark.asyncio
+async def test_nova_missing_embeddings_is_internal(payload: dict[str, Any]) -> None:
+    transport = FakeInvokeTransport([payload])
+    with pytest.raises(GenkitError, match='empty embedding vector') as excinfo:
+        await embed(NOVA, transport, [text_doc('hi')])
+    assert excinfo.value.status == 'INTERNAL'
+
+
+# ---- Helpers ----------------------------------------------------------------
+
+
+def test_document_text_joins_parts_with_newlines() -> None:
+    assert document_text(text_doc('a', 'b')) == 'a\nb'
+
+
+def test_document_text_skips_whitespace_only_parts() -> None:
+    assert document_text(text_doc('a', '   ', 'b')) == 'a\nb'
+
+
+def test_document_text_keeps_inner_padding_and_strips_only_the_result() -> None:
+    # Parts are appended untrimmed; only the joined string is stripped.
+    assert document_text(text_doc('  a  ', '  b  ')) == 'a  \n  b'
+
+
+def test_document_text_ignores_media_parts() -> None:
+    assert document_text(media_doc(PNG_DATA_URL)) == ''
+
+
+@pytest.mark.parametrize(
+    ('document', 'expected'),
+    [
+        (media_doc(PNG_DATA_URL), ('image/png', PNG_B64)),
+        (media_doc(f'data:image/jpeg;base64,{PNG_B64}'), ('image/jpeg', PNG_B64)),
+        # An explicit content type wins over the data-URL header.
+        (media_doc(PNG_DATA_URL, 'image/jpeg'), ('image/jpeg', PNG_B64)),
+        # Parameters are stripped and the type is lower-cased.
+        (media_doc(PNG_DATA_URL, 'IMAGE/PNG; charset=binary'), ('image/png', PNG_B64)),
+        # No comma: not a data URL, so the part is skipped rather than sent whole.
+        (media_doc('data:image/png;base64'), ('', '')),
+        (media_doc(f'data:application/pdf;base64,{PNG_B64}'), ('', '')),
+        (media_doc(PNG_B64), ('', '')),
+        (text_doc('no media here'), ('', '')),
+        (DocumentData(content=[]), ('', '')),
+    ],
+)
+def test_image_from_document(document: DocumentData, expected: tuple[str, str]) -> None:
+    assert image_from_document(document) == expected
+
+
+def test_image_from_document_returns_the_first_image() -> None:
+    document = DocumentData(
+        content=[
+            DocumentPart(root=MediaPart(media=Media(url=f'data:application/pdf;base64,{PNG_B64}'))),
+            DocumentPart(root=MediaPart(media=Media(url='data:image/png;base64,FIRST'))),
+            DocumentPart(root=MediaPart(media=Media(url='data:image/png;base64,SECOND'))),
+        ]
+    )
+    assert image_from_document(document) == ('image/png', 'FIRST')
+
+
+# ---- Concurrency ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fan_out_respects_the_concurrency_cap() -> None:
+    documents = [text_doc(f'doc {i}') for i in range(25)]
+    transport = FakeInvokeTransport(dispatch=lambda _body: titan_response([1.0]))
+    await embed(TITAN_TEXT, transport, documents)
+
+    assert len(transport.calls) == len(documents)
+    # Exactly the cap, not merely under it: `<=` also passes if the fan-out
+    # silently went sequential. gather queues every task in one loop iteration
+    # and Semaphore.acquire does not yield while permits remain, so the peak is
+    # deterministically min(len(documents), cap).
+    assert transport.max_in_flight == EMBED_CONCURRENCY_LIMIT
+
+
+def test_the_semaphore_is_built_per_call_not_per_module() -> None:
+    # A module-level semaphore binds to the first loop that has to wait on it,
+    # and the Dev UI reflection server runs a second one. This needs more
+    # documents than the cap: at or below it no waiter is created, so nothing
+    # binds and the regression escapes.
+    documents = [text_doc(f'doc {i}') for i in range(EMBED_CONCURRENCY_LIMIT + 1)]
+
+    def run_on_a_fresh_loop() -> None:
+        transport = FakeInvokeTransport(dispatch=lambda _body: titan_response([1.0]))
+        asyncio.run(embed(TITAN_TEXT, transport, documents))
+
+    run_on_a_fresh_loop()
+    run_on_a_fresh_loop()
+
+
+@pytest.mark.asyncio
+async def test_results_keep_input_order_when_calls_finish_out_of_order() -> None:
+    delays = {'a': 0.03, 'b': 0.02, 'c': 0.01}
+
+    class ReversingTransport:
+        async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+            text = json.loads(kwargs['body'])['inputText']
+            await asyncio.sleep(delays[text])
+            return titan_response([float(ord(text))])
+
+    vectors = await embed(TITAN_TEXT, ReversingTransport(), [text_doc('a'), text_doc('b'), text_doc('c')])
+    assert vectors == [[97.0], [98.0], [99.0]]
+
+
+@pytest.mark.asyncio
+async def test_the_first_failure_by_index_wins_not_the_first_to_land() -> None:
+    # The later document fails first in wall-clock terms; the reported error
+    # still has to be the earlier one, as in the Go plugin.
+    class RacingTransport:
+        async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+            text = json.loads(kwargs['body'])['inputText']
+            if text == 'slow-bad':
+                await asyncio.sleep(0.02)
+            raise ClientError({'Error': {'Code': 'ValidationException', 'Message': text}}, 'InvokeModel')
+
+    with pytest.raises(GenkitError, match='slow-bad'):
+        await embed(TITAN_TEXT, RacingTransport(), [text_doc('slow-bad'), text_doc('fast-bad')])
+
+
+@pytest.mark.asyncio
+async def test_request_options_are_ignored() -> None:
+    # No per-request config surface yet; input_type stays pinned.
+    transport = FakeInvokeTransport([cohere_response(1)])
+    await embed(COHERE, transport, [text_doc('hi')], options={'dimensions': 256, 'input_type': 'search_query'})
+    assert transport.bodies()[0] == {
+        'texts': ['hi'],
+        'input_type': 'search_document',
+        'truncate': 'END',
+        'embedding_types': ['float'],
+    }
+
+
+# ---- Registry ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('model_id', 'dimensions', 'inputs'),
+    [
+        ('amazon.titan-embed-text-v1', 1536, ['text']),
+        ('amazon.titan-embed-text-v2:0', 1024, ['text']),
+        ('amazon.titan-embed-image-v1', 1024, ['text', 'image']),
+        ('cohere.embed-english-v3', 1024, ['text']),
+        ('cohere.embed-multilingual-v3', 1024, ['text']),
+        ('amazon.nova-2-multimodal-embeddings-v1:0', 3072, ['text']),
+    ],
+)
+def test_registry_dimensions_and_modalities(model_id: str, dimensions: int, inputs: list[str]) -> None:
+    options = get_embedder_options(model_id)
+    assert options.dimensions == dimensions
+    assert options.supports is not None and options.supports.input == inputs
+    assert options.label == model_id
+
+
+@pytest.mark.parametrize(
+    ('model_id', 'inputs'),
+    [
+        ('amazon.titan-embed-image-v9', ['text', 'image']),
+        ('amazon.titan-embed-text-v9:0', ['text']),
+        # A future Cohere v3 point release must not inherit image support.
+        ('cohere.embed-english-v3-5', ['text']),
+        ('amazon.nova-2-multimodal-embeddings-v9:0', ['text']),
+    ],
+)
+def test_unregistered_but_routable_model_falls_back_to_family_defaults(model_id: str, inputs: list[str]) -> None:
+    options = get_embedder_options(model_id)
+    assert options.dimensions is None
+    assert options.supports is not None and options.supports.input == inputs
+
+
+def test_profile_prefixed_lookup_strips_but_the_label_keeps_the_prefix() -> None:
+    options = get_embedder_options(f'us.{TITAN_TEXT}')
+    assert options.dimensions == 1024
+    assert options.label == f'us.{TITAN_TEXT}'
+
+
+def test_all_registry_keys_are_base_ids() -> None:
+    for model_id in EMBEDDER_INFO:
+        assert strip_inference_profile_prefix(model_id) == model_id

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -19,7 +19,8 @@
 Opt-in: set ``BEDROCK_LIVE_TESTS=1`` plus working AWS credentials and a
 region (``AWS_REGION`` or ``~/.aws/config``). These call real models and
 incur cost. The Anthropic models additionally need the account's one-time
-use-case agreement (Bedrock console -> Model access).
+use-case agreement (Bedrock console -> Model access); the embedding models
+each need their own model-access grant, separate from the chat models.
 """
 
 import os
@@ -29,11 +30,25 @@ from genkit_amazon_bedrock.config import BedrockConfig
 from genkit_amazon_bedrock.converters import (
     REASONING_SIGNATURE_METADATA_KEY,
 )
+from genkit_amazon_bedrock.embedders import BedrockEmbedder
 from genkit_amazon_bedrock.models import BedrockModel
 from genkit_amazon_bedrock.transport import BedrockTransport
 
-from genkit import FinishReason, Message, ModelRequest, Part, Role, TextPart, ToolDefinition
-from genkit.plugin_api import ActionRunContext
+from genkit import (
+    DocumentPart,
+    FinishReason,
+    Media,
+    MediaPart,
+    Message,
+    ModelRequest,
+    Part,
+    Role,
+    TextPart,
+    ToolDefinition,
+)
+from genkit._core._typing import DocumentData
+from genkit.embedder import EmbedRequest
+from genkit.plugin_api import ActionRunContext, GenkitError
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -47,16 +62,44 @@ CLAUDE = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
 NOVA = 'us.amazon.nova-lite-v1:0'
 DEEPSEEK = 'us.deepseek.r1-v1:0'
 
+TITAN_EMBED_V1 = 'amazon.titan-embed-text-v1'
+TITAN_EMBED_V2 = 'amazon.titan-embed-text-v2:0'
+TITAN_EMBED_IMAGE = 'amazon.titan-embed-image-v1'
+COHERE_EMBED = 'cohere.embed-english-v3'
+COHERE_EMBED_MULTI = 'cohere.embed-multilingual-v3'
+NOVA_EMBED = 'amazon.nova-2-multimodal-embeddings-v1:0'
 
-def make_model(model_id: str) -> BedrockModel:
-    transport = BedrockTransport(
+# Smallest PNG Titan accepts, ported from the Go plugin's live tests.
+PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
+PNG_1X1_DATA_URL = f'data:image/png;base64,{PNG_1X1}'
+
+
+def make_transport() -> BedrockTransport:
+    return BedrockTransport(
         region=os.environ.get('AWS_REGION'),
         max_retries=3,
         read_timeout=300.0,
         connect_timeout=60.0,
         max_pool_connections=10,
     )
-    return BedrockModel(model_id=model_id, transport=transport)
+
+
+def make_model(model_id: str) -> BedrockModel:
+    return BedrockModel(model_id=model_id, transport=make_transport())
+
+
+async def embed(model_id: str, documents: list[DocumentData]) -> list[list[float]]:
+    embedder = BedrockEmbedder(model_id=model_id, transport=make_transport())
+    response = await embedder.embed(EmbedRequest(input=documents))
+    return [embedding.embedding for embedding in response.embeddings]
+
+
+def text_doc(text: str) -> DocumentData:
+    return DocumentData(content=[DocumentPart(root=TextPart(text=text))])
+
+
+def image_doc(data_url: str = PNG_1X1_DATA_URL) -> DocumentData:
+    return DocumentData(content=[DocumentPart(root=MediaPart(media=Media(url=data_url)))])
 
 
 def text_request(text: str, **kwargs) -> ModelRequest:
@@ -277,3 +320,64 @@ async def test_deepseek_reasoning_sync_and_round_trip() -> None:
         config=config,
     )
     assert (await model.generate(follow_up)).finish_reason == FinishReason.STOP
+
+
+async def test_embed_titan_text_v1() -> None:
+    vectors = await embed(TITAN_EMBED_V1, [text_doc('a red apple'), text_doc('a green pear')])
+    assert len(vectors) == 2
+    assert all(len(vector) == 1536 for vector in vectors)
+
+
+async def test_embed_titan_text_v2() -> None:
+    vectors = await embed(TITAN_EMBED_V2, [text_doc('a red apple')])
+    assert len(vectors[0]) == 1024
+
+
+async def test_embed_titan_multimodal_text() -> None:
+    vectors = await embed(TITAN_EMBED_IMAGE, [text_doc('a red apple')])
+    assert len(vectors[0]) == 1024
+
+
+async def test_embed_titan_multimodal_image() -> None:
+    vectors = await embed(TITAN_EMBED_IMAGE, [image_doc()])
+    assert len(vectors[0]) == 1024
+
+
+async def test_embed_titan_multimodal_text_and_image() -> None:
+    document = DocumentData(
+        content=[
+            DocumentPart(root=TextPart(text='a white square')),
+            DocumentPart(root=MediaPart(media=Media(url=PNG_1X1_DATA_URL))),
+        ]
+    )
+    vectors = await embed(TITAN_EMBED_IMAGE, [document])
+    assert len(vectors) == 1
+    assert len(vectors[0]) == 1024
+
+
+async def test_embed_cohere_text_batch() -> None:
+    vectors = await embed(COHERE_EMBED, [text_doc('one'), text_doc('two'), text_doc('three')])
+    assert len(vectors) == 3
+    assert len({len(vector) for vector in vectors}) == 1
+    assert len(vectors[0]) > 0
+
+
+async def test_embed_cohere_multilingual() -> None:
+    vectors = await embed(COHERE_EMBED_MULTI, [text_doc('bonjour le monde')])
+    assert len(vectors[0]) > 0
+
+
+async def test_embed_cohere_rejects_an_image() -> None:
+    # Bedrock reports inputModalities [TEXT] for the Cohere v3 models, so this
+    # is refused locally rather than sent and rejected as a bad request.
+    with pytest.raises(GenkitError, match='text-only'):
+        await embed(COHERE_EMBED, [image_doc()])
+
+
+@pytest.mark.skipif(
+    os.environ.get('AWS_REGION') != 'us-east-1',
+    reason='amazon.nova-2-multimodal-embeddings-v1:0 is only offered in us-east-1',
+)
+async def test_embed_nova_2() -> None:
+    vectors = await embed(NOVA_EMBED, [text_doc('a red apple')])
+    assert len(vectors[0]) == 3072

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -111,15 +111,6 @@ def test_image_model_supports_media_output_only() -> None:
     assert info.supports.system_role is False
 
 
-def test_embedding_model_supports_nothing() -> None:
-    info = get_model_info('amazon.titan-embed-text-v2:0', model_type='embedding')
-    assert info.stage == Stage.STABLE
-    assert info.supports is not None
-    assert info.supports.media is False
-    assert info.supports.multiturn is False
-    assert info.supports.tools is False
-
-
 def test_registry_matches_go_plugin_size() -> None:
     assert len(MODEL_CAPABILITIES) == 47
 

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -23,6 +23,8 @@ import boto3.session
 import pytest
 from genkit_amazon_bedrock import Bedrock, BedrockConfig, ModelDefinition, bedrock_name
 
+from genkit import Document
+from genkit.embedder import EmbedRequest
 from genkit.plugin_api import ActionKind, GenkitError
 
 
@@ -49,6 +51,7 @@ def test_constructor_defaults() -> None:
     assert plugin.max_pool_connections is None
     assert plugin.total_timeout == 3600.0
     assert plugin.models == []
+    assert plugin.embedders == []
 
 
 def test_model_definition_defaults_to_chat() -> None:
@@ -141,3 +144,113 @@ async def test_list_actions_lists_configured_chat_models() -> None:
     actions = await plugin.list_actions()
     assert [a.name for a in actions] == ['bedrock/amazon.nova-lite-v1:0']
     assert actions[0].action_type == ActionKind.MODEL
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_embedder_action_with_registry_metadata() -> None:
+    plugin = Bedrock(region='us-east-1')
+    action = await plugin.resolve(ActionKind.EMBEDDER, bedrock_name('amazon.titan-embed-text-v2:0'))
+
+    assert action is not None
+    assert action.kind == ActionKind.EMBEDDER
+    assert action.name == 'bedrock/amazon.titan-embed-text-v2:0'
+    assert action.metadata is not None
+    embedder_metadata = cast(dict[str, Any], action.metadata['embedder'])
+    assert embedder_metadata['dimensions'] == 1024
+    assert embedder_metadata['supports'] == {'input': ['text']}
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_embedder_requests_for_chat_models() -> None:
+    plugin = Bedrock(region='us-east-1')
+    assert await plugin.resolve(ActionKind.EMBEDDER, bedrock_name('amazon.nova-lite-v1:0')) is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_ignores_foreign_namespaces_for_embedders() -> None:
+    plugin = Bedrock(region='us-east-1')
+    assert await plugin.resolve(ActionKind.EMBEDDER, 'openai/text-embedding-3-small') is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_accepts_a_profile_prefixed_embedder_id() -> None:
+    plugin = Bedrock(region='us-east-1')
+    action = await plugin.resolve(ActionKind.EMBEDDER, bedrock_name('us.amazon.titan-embed-text-v2:0'))
+    assert action is not None
+    assert action.name == 'bedrock/us.amazon.titan-embed-text-v2:0'
+
+
+@pytest.mark.asyncio
+async def test_embedding_models_do_not_resolve_as_chat_models() -> None:
+    # Without the guard this returns a Converse action that only fails when called.
+    plugin = Bedrock(region='us-east-1')
+    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.titan-embed-text-v2:0')) is None
+    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('cohere.embed-english-v3')) is None
+
+
+@pytest.mark.asyncio
+async def test_the_cross_guard_leaves_cohere_chat_models_alone() -> None:
+    plugin = Bedrock(region='us-east-1')
+    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('cohere.command-r-v1:0')) is not None
+    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('cohere.rerank-v3-5:0')) is not None
+
+
+@pytest.mark.asyncio
+async def test_cohere_v4_resolves_but_fails_when_called() -> None:
+    plugin = Bedrock(region='us-east-1')
+    action = await plugin.resolve(ActionKind.EMBEDDER, bedrock_name('cohere.embed-v4:0'))
+
+    assert action is not None
+    with pytest.raises(GenkitError, match='Cohere Embed v4') as excinfo:
+        await action.run(EmbedRequest(input=[Document.from_text('hi')]))
+    assert excinfo.value.status == 'UNIMPLEMENTED'
+
+
+@pytest.mark.asyncio
+async def test_list_actions_includes_configured_embedders() -> None:
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[ModelDefinition(name='amazon.nova-lite-v1:0')],
+        embedders=['amazon.titan-embed-text-v2:0', 'cohere.embed-english-v3'],
+    )
+    actions = await plugin.list_actions()
+
+    assert [a.name for a in actions] == [
+        'bedrock/amazon.nova-lite-v1:0',
+        'bedrock/amazon.titan-embed-text-v2:0',
+        'bedrock/cohere.embed-english-v3',
+    ]
+    assert [a.action_type for a in actions[1:]] == [ActionKind.EMBEDDER, ActionKind.EMBEDDER]
+
+
+@pytest.mark.asyncio
+async def test_everything_listed_can_actually_resolve() -> None:
+    # An ID in the wrong list used to be advertised anyway, leaving a Dev UI row
+    # that answers 404 in both directions.
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[
+            ModelDefinition(name='amazon.nova-lite-v1:0'),
+            ModelDefinition(name='amazon.titan-embed-text-v2:0'),
+        ],
+        embedders=['cohere.embed-english-v3', 'amazon.nova-lite-v1:0'],
+    )
+    listed = await plugin.list_actions()
+
+    assert [a.name for a in listed] == ['bedrock/amazon.nova-lite-v1:0', 'bedrock/cohere.embed-english-v3']
+    for metadata in listed:
+        assert metadata.action_type is not None
+        assert await plugin.resolve(ActionKind(metadata.action_type), metadata.name) is not None
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_list_publish_the_same_embedder_metadata() -> None:
+    # One helper feeds both paths, so the Dev UI listing can never disagree
+    # with what the resolved action reports.
+    plugin = Bedrock(region='us-east-1', embedders=['cohere.embed-multilingual-v3'])
+    action = await plugin.resolve(ActionKind.EMBEDDER, bedrock_name('cohere.embed-multilingual-v3'))
+    listed = await plugin.list_actions()
+
+    assert action is not None
+    assert action.metadata is not None and listed[0].metadata is not None
+    assert action.metadata['embedder'] == listed[0].metadata['embedder']

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -207,6 +207,21 @@ async def test_cohere_v4_resolves_but_fails_when_called() -> None:
 
 
 @pytest.mark.asyncio
+async def test_an_unknown_embedding_family_resolves_but_fails_when_called() -> None:
+    # A family with no request shape here is still an embedder, not a chat model.
+    plugin = Bedrock(region='us-east-1')
+    model_id = 'amazon.some-new-embed-v9:0'
+
+    assert await plugin.resolve(ActionKind.MODEL, bedrock_name(model_id)) is None
+    action = await plugin.resolve(ActionKind.EMBEDDER, bedrock_name(model_id))
+
+    assert action is not None
+    with pytest.raises(GenkitError, match='unsupported embedding model') as excinfo:
+        await action.run(EmbedRequest(input=[Document.from_text('hi')]))
+    assert excinfo.value.status == 'UNIMPLEMENTED'
+
+
+@pytest.mark.asyncio
 async def test_list_actions_includes_configured_embedders() -> None:
     plugin = Bedrock(
         region='us-east-1',

--- a/py/packages/genkit-amazon-bedrock/tests/transport_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/transport_test.py
@@ -547,6 +547,17 @@ async def test_invoke_model_rejects_a_non_json_body() -> None:
 
 
 @pytest.mark.asyncio
+async def test_invoke_model_rejects_a_json_body_that_is_not_an_object() -> None:
+    # Callers read the result with .get(); a list would raise AttributeError there.
+    transport, _client = invoking_transport(b'[1.0, 2.0]')
+
+    with pytest.raises(GenkitError, match='not a JSON object') as excinfo:
+        await transport.invoke_model(modelId='m')
+
+    assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
 async def test_invoke_model_without_a_body_member_fails_loudly() -> None:
     transport, _client = invoking_transport(None)
 

--- a/py/packages/genkit-amazon-bedrock/tests/transport_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/transport_test.py
@@ -481,3 +481,76 @@ async def test_converse_stream_without_a_stream_member_fails_loudly() -> None:
             pass
 
     assert excinfo.value.status == 'INTERNAL'
+
+
+class FakeStreamingBody:
+    """Stands in for botocore's StreamingBody; ``read`` is a blocking call."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self.read_threads: list[int] = []
+
+    def read(self) -> bytes:
+        self.read_threads.append(threading.get_ident())
+        return self._payload
+
+
+class FakeInvokeClient:
+    """Minimal bedrock-runtime stand-in for InvokeModel."""
+
+    def __init__(self, body: FakeStreamingBody | None) -> None:
+        self.body = body
+        self.calls: list[dict[str, Any]] = []
+
+    def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {'body': self.body} if self.body is not None else {}
+
+
+def invoking_transport(payload: bytes | None) -> tuple[BedrockTransport, FakeInvokeClient]:
+    client = FakeInvokeClient(FakeStreamingBody(payload) if payload is not None else None)
+    transport = make_transport(region='eu-west-1')
+    transport._client = client  # noqa: SLF001
+    return transport, client
+
+
+@pytest.mark.asyncio
+async def test_invoke_model_parses_the_response_body() -> None:
+    transport, client = invoking_transport(b'{"embedding": [1.0, 2.0]}')
+
+    result = await transport.invoke_model(modelId='m', body='{}')
+
+    assert result == {'embedding': [1.0, 2.0]}
+    assert client.calls == [{'modelId': 'm', 'body': '{}'}]
+
+
+@pytest.mark.asyncio
+async def test_invoke_model_reads_the_body_off_the_event_loop() -> None:
+    transport, client = invoking_transport(b'{}')
+
+    await transport.invoke_model(modelId='m')
+
+    # StreamingBody.read() is a blocking socket read; on the loop it stalls
+    # every other in-flight call.
+    assert client.body is not None
+    assert client.body.read_threads and threading.get_ident() not in client.body.read_threads
+
+
+@pytest.mark.asyncio
+async def test_invoke_model_rejects_a_non_json_body() -> None:
+    transport, _client = invoking_transport(b'<html>gateway timeout</html>')
+
+    with pytest.raises(GenkitError, match='not JSON') as excinfo:
+        await transport.invoke_model(modelId='m')
+
+    assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_invoke_model_without_a_body_member_fails_loudly() -> None:
+    transport, _client = invoking_transport(None)
+
+    with pytest.raises(GenkitError, match='no body') as excinfo:
+        await transport.invoke_model(modelId='m')
+
+    assert excinfo.value.status == 'INTERNAL'

--- a/py/samples/amazon-bedrock-sample/README.md
+++ b/py/samples/amazon-bedrock-sample/README.md
@@ -1,16 +1,24 @@
 # Amazon Bedrock
 
-Run text generation, streaming, structured output, tool calling, and
-reasoning through Genkit with Amazon Bedrock's Converse and ConverseStream
-APIs.
+Run text generation, streaming, structured output, tool calling, reasoning,
+and embeddings through Genkit with Amazon Bedrock's Converse, ConverseStream,
+and InvokeModel APIs.
 
-You need an AWS account with Amazon Bedrock model access granted for the four
-models the sample uses:
+You need an AWS account with Amazon Bedrock model access granted for the models
+the sample runs on startup:
 
 - `us.amazon.nova-lite-v1:0`
 - `us.meta.llama3-3-70b-instruct-v1:0`
 - `us.deepseek.r1-v1:0`
 - `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+- `amazon.titan-embed-text-v2:0`
+
+The other embedders need one grant each, and only fail when you run their flow:
+
+- `amazon.titan-embed-image-v1` for `embed_image`
+- `cohere.embed-english-v3` for `embed_batch` with `embedder` set to Cohere
+- `amazon.nova-2-multimodal-embeddings-v1:0` is offered in `us-east-1` only, and
+  fails everywhere else however you invoke it
 
 The Anthropic model additionally needs the account's one-time use-case
 agreement (Bedrock console, Model access, Anthropic use case details); the
@@ -49,6 +57,10 @@ Then open [http://localhost:4000](http://localhost:4000) and try:
 - `reasoning`
 - `thinking`
 - `thinking_stream`
+- `embed_text`
+- `embed_batch`
+- `embed_similarity`
+- `embed_image`
 
 The `*_stream` flows go through ConverseStream. Chunks are deltas rather than
 snapshots, so the Dev UI's streamed output is the concatenation of them; a tool
@@ -63,3 +75,42 @@ Bedrock has no constrained-decoding mode, so structured output is carried by
 prompt instructions: pass `output_instructions=True` alongside `output_format`
 and `output_schema`, as `cat_profile` does. Without it the schema never reaches
 the model and it answers in prose.
+
+## Embedders
+
+Embedding models go through InvokeModel, not Converse, and each family has its
+own request shape. Four flows cover them:
+
+- `embed_text` embeds one document with Titan Text v2 and reports the vector's
+  1024 dimensions, its first few values, and its magnitude (~1.0, since Titan
+  v2 normalizes).
+- `embed_batch` embeds several documents in one `embed_many` call. The last
+  default text repeats the first, so `repeated_text_pairs` showing a similarity
+  of 1.0 proves the vectors came back aligned to their inputs. Titan has no
+  batch API and is fanned out into concurrent calls; set `embedder` to
+  `cohere.embed-english-v3` to send up to 96 texts in a single call instead, or
+  to `amazon.nova-2-multimodal-embeddings-v1:0` (us-east-1 only) for 3072
+  dimensions.
+- `embed_similarity` ranks candidate texts against a query by cosine
+  similarity, so the output shows the embeddings are meaningful and not merely
+  well shaped. It stays on Titan because Cohere requests are pinned to
+  `input_type: search_document` for now, which is the wrong side of that
+  asymmetry for a query.
+- `embed_image` puts a caption and an inline 1x1 PNG in one document and gets a
+  single joint 1024-float vector from Titan Multimodal. It embeds the caption on
+  its own too: the similarity below 1.0 is the evidence the image reached the
+  model. Titan accepts PNG and JPEG only, one image per document, as a data URL.
+
+Cohere embedding is text-only on Bedrock, so there is no Cohere image flow; use
+Titan Multimodal for images.
+
+Declared embedders also appear in the Dev UI's Embedders section, where they can
+be invoked directly with a raw request — useful for a model no flow covers:
+
+```json
+{"input": [{"content": [{"text": "a red apple"}]}]}
+```
+
+The response is the raw vector, which is why the flows above summarize instead.
+Declaring an embedder costs nothing at startup: no call is made until a flow or
+the Dev UI runs one.

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -14,25 +14,49 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Amazon Bedrock samples for the Converse and ConverseStream paths.
+"""Amazon Bedrock samples for the Converse, ConverseStream, and embedding paths.
 
 Needs AWS credentials and a region (``AWS_REGION`` or ``~/.aws/config``) with
 model access granted for the models below. The flows named ``*_stream`` go
-through ConverseStream; the rest are a single Converse call.
+through ConverseStream; the ``embed_*`` flows go through InvokeModel; the rest
+are a single Converse call.
 """
+
+import math
 
 from genkit_amazon_bedrock import Bedrock, ModelDefinition
 from pydantic import BaseModel, Field
 
-from genkit import ActionRunContext, Genkit, ModelResponse, ReasoningPart
+from genkit import (
+    ActionRunContext,
+    Document,
+    DocumentPart,
+    Genkit,
+    Media,
+    MediaPart,
+    ModelResponse,
+    ReasoningPart,
+    TextPart,
+)
 
 NOVA = 'bedrock/us.amazon.nova-lite-v1:0'
 LLAMA = 'bedrock/us.meta.llama3-3-70b-instruct-v1:0'
 DEEPSEEK = 'bedrock/us.deepseek.r1-v1:0'
 CLAUDE = 'bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+TITAN_EMBED = 'amazon.titan-embed-text-v2:0'
+TITAN_EMBED_IMAGE = 'amazon.titan-embed-image-v1'
+COHERE_EMBED = 'cohere.embed-english-v3'
+NOVA_EMBED = 'amazon.nova-2-multimodal-embeddings-v1:0'
 
-# Declaring models is optional — resolve() serves any Bedrock model ID or ARN
-# on demand — but declared ones show up in the Dev UI model list.
+# The smallest PNG Titan accepts (1x1 pixel), inline so the multimodal flow
+# needs no asset file. Titan wants raw base64 in the request body; the plugin
+# strips this data URL's prefix before the call.
+PNG_1X1_DATA_URL = (
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
+)
+
+# Declaring an embedder costs nothing at startup: no AWS call happens until a flow runs one,
+# so a missing model-access grant only surfaces when you use it.
 ai = Genkit(
     plugins=[
         Bedrock(
@@ -41,7 +65,8 @@ ai = Genkit(
                 ModelDefinition(name='us.meta.llama3-3-70b-instruct-v1:0'),
                 ModelDefinition(name='us.deepseek.r1-v1:0'),
                 ModelDefinition(name='us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-            ]
+            ],
+            embedders=[TITAN_EMBED, TITAN_EMBED_IMAGE, COHERE_EMBED, NOVA_EMBED],
         )
     ],
     model=NOVA,
@@ -73,6 +98,48 @@ class CityInput(BaseModel):
     """Input for the weather tool."""
 
     city: str = Field(default='Lagos', description='City to look up')
+
+
+class EmbedInput(BaseModel):
+    """Input for the embedding flow."""
+
+    text: str = Field(default='Bedrock hosts models from several providers.', description='Text to embed')
+
+
+class EmbedBatchInput(BaseModel):
+    """Input for the batch embedding flow."""
+
+    embedder: str = Field(default=TITAN_EMBED, description='Bedrock embedding model ID to use')
+    texts: list[str] = Field(
+        default=[
+            'Bedrock hosts models from several providers.',
+            'A tabby cat naps on the windowsill.',
+            'Rust and Go both compile to native binaries.',
+            'Bedrock hosts models from several providers.',
+        ],
+        description='Documents to embed in one call; the last repeats the first on purpose',
+    )
+
+
+class SimilarityInput(BaseModel):
+    """Input for the semantic-similarity flow."""
+
+    query: str = Field(default='How do I deploy a machine learning model?', description='Query text')
+    candidates: list[str] = Field(
+        default=[
+            'Serving a trained model behind an HTTP endpoint in production.',
+            'Sourdough needs a starter fed for several days before it can leaven bread.',
+            'The tabby cat sleeps in the afternoon sun.',
+        ],
+        description='Candidate texts to rank against the query',
+    )
+
+
+class MultimodalEmbedInput(BaseModel):
+    """Input for the Titan multimodal embedding flow."""
+
+    text: str = Field(default='a white square', description='Caption embedded alongside the image')
+    image_data_url: str = Field(default=PNG_1X1_DATA_URL, description='PNG or JPEG image as a data URL')
 
 
 @ai.tool()
@@ -224,6 +291,144 @@ async def thinking(data: TopicInput) -> dict[str, object]:
     return _reasoning_summary(response)
 
 
+@ai.flow()
+async def embed_text(data: EmbedInput) -> dict[str, object]:
+    """Embed one document with Titan Text v2 through InvokeModel.
+
+    Titan text embeds one document per call, so this is the plain single-call
+    path. Only the head of the vector is returned: 1024 floats are unreadable
+    in the Dev UI. Titan v2 normalizes its output, so the magnitude is ~1.0.
+    """
+    embeddings = await ai.embed(embedder=f'bedrock/{TITAN_EMBED}', content=data.text)
+    if not embeddings:
+        raise RuntimeError('Bedrock embedder returned no embeddings for a non-empty input.')
+    vector = embeddings[0].embedding
+    return {
+        'model': TITAN_EMBED,
+        'dimensions': len(vector),
+        'first_values': [round(value, 5) for value in vector[:5]],
+        'magnitude': round(_magnitude(vector), 5),
+    }
+
+
+@ai.flow()
+async def embed_batch(data: EmbedBatchInput) -> dict[str, object]:
+    """Embed several documents in one ``embed_many`` call.
+
+    Titan text has no batch API, so the plugin fans the documents out into
+    concurrent InvokeModel calls capped by a semaphore and reassembles them by
+    index; Cohere instead sends up to 96 texts in a single call. Either way the
+    results come back aligned to their inputs, which is what the repeated text
+    shows: its similarity to its own copy is 1.0, at both ends of the list.
+
+    Switch ``embedder`` to ``cohere.embed-english-v3`` for the single-call batch
+    path, or to ``amazon.nova-2-multimodal-embeddings-v1:0`` (us-east-1 only)
+    for 3072 dimensions.
+    """
+    embeddings = await ai.embed_many(embedder=f'bedrock/{data.embedder}', content=data.texts)
+    if len(embeddings) != len(data.texts):
+        raise RuntimeError(f'Expected {len(data.texts)} embeddings, got {len(embeddings)}.')
+    vectors = [embedding.embedding for embedding in embeddings]
+    return {
+        'model': data.embedder,
+        'count': len(vectors),
+        'documents': [
+            {'index': index, 'text': text, 'dimensions': len(vector), 'first_value': round(vector[0], 5)}
+            for index, (text, vector) in enumerate(zip(data.texts, vectors, strict=True))
+        ],
+        'repeated_text_pairs': [
+            {'a': first, 'b': second, 'similarity': round(_cosine_similarity(vectors[first], vectors[second]), 5)}
+            for first, second in _repeated_pairs(data.texts)
+        ],
+    }
+
+
+@ai.flow()
+async def embed_similarity(data: SimilarityInput) -> dict[str, object]:
+    """Rank candidate texts against a query by cosine similarity.
+
+    A dimension count only proves the vector is well shaped. Ranking proves the
+    numbers carry meaning: the candidate on the query's subject scores well
+    above the unrelated ones. Titan is used rather than Cohere because Cohere
+    requests are pinned to ``input_type: search_document`` for now, which is the
+    wrong side of the asymmetry for a query.
+    """
+    query_embeddings = await ai.embed(embedder=f'bedrock/{TITAN_EMBED}', content=data.query)
+    if not query_embeddings:
+        raise RuntimeError('Bedrock embedder returned no embeddings for the query.')
+    candidate_embeddings = await ai.embed_many(embedder=f'bedrock/{TITAN_EMBED}', content=data.candidates)
+    query_vector = query_embeddings[0].embedding
+    scored = [
+        (text, _cosine_similarity(query_vector, embedding.embedding))
+        for text, embedding in zip(data.candidates, candidate_embeddings, strict=True)
+    ]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return {
+        'model': TITAN_EMBED,
+        'query': data.query,
+        'dimensions': len(query_vector),
+        'best_match': scored[0][0] if scored else None,
+        'ranked': [{'text': text, 'similarity': round(similarity, 5)} for text, similarity in scored],
+    }
+
+
+@ai.flow()
+async def embed_image(data: MultimodalEmbedInput) -> dict[str, object]:
+    """Embed a caption and an image together with Titan Multimodal.
+
+    One document carrying both a text part and a media part becomes one joint
+    1024-float vector; this is the only flow that exercises the media path. The
+    caption is also embedded on its own, so the output shows the image really
+    reached the model: the two vectors are not the same.
+    """
+    joint_document = Document(
+        content=[
+            DocumentPart(root=TextPart(text=data.text)),
+            DocumentPart(root=MediaPart(media=Media(url=data.image_data_url, content_type='image/png'))),
+        ]
+    )
+    embeddings = await ai.embed_many(
+        embedder=f'bedrock/{TITAN_EMBED_IMAGE}',
+        content=[joint_document, Document.from_text(data.text)],
+    )
+    if len(embeddings) != 2:
+        raise RuntimeError(f'Expected 2 embeddings, got {len(embeddings)}.')
+    joint = embeddings[0].embedding
+    text_only = embeddings[1].embedding
+    return {
+        'model': TITAN_EMBED_IMAGE,
+        'dimensions': len(joint),
+        'first_values': [round(value, 5) for value in joint[:5]],
+        'text_only_dimensions': len(text_only),
+        'similarity_to_caption_alone': round(_cosine_similarity(joint, text_only), 5),
+    }
+
+
+def _magnitude(vector: list[float]) -> float:
+    """Euclidean length of a vector; stdlib math only, the sample has no numpy."""
+    return math.sqrt(math.fsum(value * value for value in vector))
+
+
+def _cosine_similarity(left: list[float], right: list[float]) -> float:
+    """Cosine similarity of two vectors, in [-1.0, 1.0] for non-zero inputs."""
+    if len(left) != len(right):
+        raise ValueError(f'Vectors must be the same length, got {len(left)} and {len(right)}.')
+    dot = math.fsum(a * b for a, b in zip(left, right, strict=True))
+    scale = _magnitude(left) * _magnitude(right)
+    return dot / scale if scale else 0.0
+
+
+def _repeated_pairs(texts: list[str]) -> list[tuple[int, int]]:
+    """Index pairs of identical texts, so per-document alignment can be checked."""
+    seen: dict[str, int] = {}
+    pairs: list[tuple[int, int]] = []
+    for index, text in enumerate(texts):
+        first = seen.setdefault(text, index)
+        if first != index:
+            pairs.append((first, index))
+    return pairs
+
+
 def _reasoning_summary(response: ModelResponse) -> dict[str, object]:
     """Summarize the reasoning parts on a response."""
     reasoning_text: list[str] = []
@@ -248,11 +453,13 @@ async def main() -> None:
         print(await haiku(TopicInput()))  # noqa: T201
         print(await haiku_stream(TopicInput()))  # noqa: T201
         print(await weather_report(CityInput()))  # noqa: T201
+        print(await embed_text(EmbedInput()))  # noqa: T201
+        print(await embed_similarity(SimilarityInput()))  # noqa: T201
     except Exception as error:
         # Printed, not raised: in dev mode the Dev UI stays up either way.
         print(  # noqa: T201
-            f'Set AWS credentials and a region, and grant model access for {NOVA}, {LLAMA}, and {DEEPSEEK}, '
-            f'before running this sample.\n{error}'
+            f'Set AWS credentials and a region, and grant model access for {NOVA}, {LLAMA}, {DEEPSEEK}, and '
+            f'{TITAN_EMBED}, before running this sample.\n{error}'
         )
 
 


### PR DESCRIPTION
## Why

Slice 5 of #5820: embedders. Stacked on #5970. Embedding isn't part of Converse (bedrock-runtime has no embedding operation), so embedders go through InvokeModel with a raw per-provider JSON body. So this slice routes by model ID instead of reusing the Converse converters.

## Changes

New `embedders.py`: Titan text (one call per document), Titan multimodal (text and/or image in one call), Cohere v3 (text batched 96 per call) and Nova-2, plus `invoke_model` on the transport seam. Per-document calls fan out under a semaphore of 10 and reassemble by index; a batch cancels its outstanding calls on the first failure, matching Go's `context.WithCancel`, and reports the lowest-indexed failure among the calls that ran. `resolve()` gains an embedder branch and a cross-guard, so an embedding model ID no longer resolves as a Converse chat model, and `list_actions` only lists what `resolve` can serve.

Four divergences from the Go plugin, all checked against AWS:

- Nova targets the real `amazon.nova-2-multimodal-embeddings-v1:0` SINGLE_EMBEDDING schema. Go registers `amazon.nova-embed-text-v1:0`, which doesn't exist, sends a Titan-shaped body, and routes on a substring that can't match the real ID.
- Cohere is text-only. The parameters page documents an `images` field for v3, but `get-foundation-model` reports `inputModalities: [TEXT]` and a live image call returns `Invalid parameter combination`. Go's image path can't work whatever the encoding.
- Routing is on `cohere.embed`, not bare `cohere`, which would swallow `cohere.rerank-*` and `cohere.command-*`.
- Titan multimodal's in-band `message` is raised. Bedrock reports input errors there on a 200, and Go drops it.

`cohere.embed-v4` is recognised and fails UNIMPLEMENTED: different request schema, and where Cohere image embedding will land. Per-request options aren't wired yet, so Cohere is pinned to `input_type: search_document`. 

## Verification

Unit tests pin each family's request body, Cohere's 96-document chunking, ordering when calls finish out of order, and the concurrency cap. Live tests (`BEDROCK_LIVE_TESTS=1`) hit all six models against real Bedrock, Nova-2 in us-east-1. The sample app gains `embed_text`, `embed_batch`, `embed_similarity` and `embed_image`.

## Worth a closer look

`invoke_model` is new in this slice and slice 6 will reuse it, so flagging it while it is still cheap to change.

It returns the parsed body: the boto3 call, the `body.read()` and the `json.loads` all happen inside one `to_thread` hop. The read has to be off the loop regardless since botocore classes InvokeModel as a streaming-output operation, so it hands back an unread `StreamingBody` and `read()` blocks on the socket. Keeping the parse in that same hop means the decode stays off the loop too, which is cheap for a 1 KB vector but less so for the base64 image bodies slice 6 pulls back.

The tradeoff is that the codec sits on both sides of the seam: `embedders.py` does the `json.dumps` going in, transport does the `json.loads` coming out. Would like your read on whether that is the right home for the parse. Worth stating that there is no Go precedent to lean on here as aws-sdk-go-v2 materialises the InvokeModel body as `[]byte` before the caller sees it, so Go has no read to place and no seam to place it across. Would like your read on whether that is the right home for the parse.

## Screenshots
<img width="524" height="343" alt="Screenshot 2026-08-11 at 09 09 21" src="https://github.com/user-attachments/assets/b9ebe411-01bc-4edf-9cf7-667ab1479a2e" />
<img width="992" height="551" alt="Screenshot 2026-08-11 at 09 09 42" src="https://github.com/user-attachments/assets/697cc984-3882-4a96-8852-cfbce935a5a5" />
<img width="990" height="571" alt="Screenshot 2026-08-11 at 09 10 04" src="https://github.com/user-attachments/assets/aa1707fa-e6a0-4c24-9af2-1a5643aa6ef4" />
<img width="990" height="577" alt="Screenshot 2026-08-11 at 09 10 20" src="https://github.com/user-attachments/assets/09393caf-896a-47ab-9da5-b4a74a97403c" />
<img width="893" height="514" alt="Screenshot 2026-08-11 at 09 10 44" src="https://github.com/user-attachments/assets/1c124cbb-7ac9-44dd-8a6c-0484d47ec820" />
<img width="989" height="439" alt="Screenshot 2026-08-11 at 09 15 05" src="https://github.com/user-attachments/assets/f2a2ad14-427d-4cc3-be6f-11bbd1eabc83" />
<img width="989" height="489" alt="Screenshot 2026-08-11 at 09 15 40" src="https://github.com/user-attachments/assets/86101d63-3927-4835-b23f-2474e961848f" />

