### PR TITLE
feat(py/plugins/amazon-bedrock): add image generation (Nova Canvas, Stability)

### DIFF
--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -3,10 +3,10 @@
 Amazon Bedrock plugin for Genkit Python. Provides text generation with
 Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama, Mistral,
 Cohere, and others) through the Bedrock Converse and ConverseStream APIs, and
-embeddings through InvokeModel.
+embeddings and image generation through InvokeModel.
 
-> Status: in progress. Text generation (streaming and non-streaming) and
-> embedders are available. Image generation and reranking are still to come.
+> Status: in progress. Text generation (streaming and non-streaming),
+> embedders, and image generation are available. Reranking is still to come.
 
 ## Installation
 
@@ -117,6 +117,128 @@ Notes:
   documents, not for embedding queries.
 - `amazon.nova-2-multimodal-embeddings-v1:0` is offered in `us-east-1` only,
   and is text-only here; its image, audio, and video inputs are not ported.
+
+## Image generation
+
+Image models go through InvokeModel rather than Converse, but they are ordinary
+Genkit model actions: `ai.generate` returns the result as media parts carrying
+data URLs. Declare one with `type='image'`:
+
+```python
+from genkit import Genkit
+from genkit_amazon_bedrock import Bedrock, ModelDefinition
+
+ai = Genkit(
+    plugins=[
+        Bedrock(
+            # us-west-2: the active text-to-image models are offered there only.
+            region='us-west-2',
+            models=[ModelDefinition(name='stability.sd3-5-large-v1:0', type='image')],
+        )
+    ]
+)
+
+response = await ai.generate(
+    model='bedrock/stability.sd3-5-large-v1:0',
+    prompt='A tabby cat asleep on a sunlit windowsill, watercolour.',
+)
+image = response.media[0].url  # data:image/png;base64,...
+```
+
+Declaring is optional here too. An undeclared ID in one of the two families
+below is classified as an image model on the spot, so a bare
+`ai.generate(model='bedrock/<id>')` resolves and takes the InvokeModel path;
+declaring adds the model to the Dev UI and pins the routing. The prompt is the
+text of the most recent user message, concatenated across its text parts; other
+parts are ignored, as these models are text-to-image only.
+
+Streaming callbacks are never invoked for image models. There is nothing to
+stream, so `generate_stream` yields no chunks and the images arrive on the
+final response.
+
+### Request shapes
+
+The two families take incompatible bodies, so the request is built from the
+model ID.
+
+Amazon (IDs containing `titan-image` or `nova-canvas`) nests its options under
+`imageGenerationConfig`, and that is the only config key read: any other
+top-level key is dropped. Your entries are merged key by key over these
+defaults:
+
+```python
+config={
+    'imageGenerationConfig': {
+        'numberOfImages': 1,
+        'height': 1024,
+        'width': 1024,
+        'cfgScale': 8.0,
+        'seed': 0,
+        'quality': 'standard',  # Nova Canvas only, not sent for Titan Image
+    }
+}
+```
+
+Output is always `image/png`.
+
+Stability (IDs containing `sd3-`, `stable-image-core`, or `stable-image-ultra`)
+takes flat top-level fields, and the whole config dict is merged over the
+defaults (`{'prompt': ..., 'output_format': 'png'}`), so `aspect_ratio`,
+`seed`, `negative_prompt`, `output_format` and the rest all apply:
+
+```python
+config={'aspect_ratio': '16:9', 'output_format': 'jpeg', 'seed': 42}
+```
+
+The media part's MIME type follows `output_format`.
+
+`BedrockImageConfig` is the exported config type for these calls. It declares
+no fields and rejects nothing, on purpose: the two families take disjoint keys,
+and `BedrockConfig` describes Converse parameters, so it would reject every
+family-specific key here.
+
+Genkit's generic generation options (`temperature`, `topP`, `maxOutputTokens`,
+`apiKey`, and the rest of the common config) are not forwarded to image models,
+since Bedrock's image APIs do not accept them.
+
+### Availability
+
+Verified against `aws bedrock get-foundation-model` on 2026-08-11:
+
+| Model                               | Status                         | Regions                                    |
+| ----------------------------------- | ------------------------------ | ------------------------------------------ |
+| `stability.sd3-5-large-v1:0`        | Active                         | `us-west-2`                                |
+| `stability.stable-image-core-v1:1`  | Active                         | `us-west-2`                                |
+| `stability.stable-image-ultra-v1:1` | Active                         | `us-west-2`                                |
+| `amazon.nova-canvas-v1:0`           | Legacy, end of life 2026-09-30 | `us-east-1`, `eu-west-1`, `ap-northeast-1` |
+
+**The active text-to-image models are offered in `us-west-2` only.** Every image
+model on offer in `us-east-1` is an editing service (inpaint, upscale, and the
+rest), not text-to-image, so a text-to-image call needs `us-west-2`.
+
+`amazon.nova-canvas-v1:0` is the one Amazon option and it is Legacy, which is a
+stronger restriction than the end-of-life date suggests: new accounts cannot
+enable it at all, and an account that has enabled it loses access after 30 days
+of disuse. Bedrock reports both as `ResourceNotFoundException`, which the plugin
+surfaces verbatim, so a working integration can start failing without any change
+on your side. Prefer a Stability model unless you specifically need Canvas.
+
+Notes:
+
+- Amazon Titan Image Generator (v1 and v2), Stable Diffusion XL, and the `v1:0`
+  Stability SKUs (`sd3-large-v1:0`, `stable-image-core-v1:0`,
+  `stable-image-ultra-v1:0`) are end of life on Bedrock and no longer callable.
+- The `titan-image` family is still recognised, since it shares its request
+  shape with Nova Canvas. The legacy Stable Diffusion XL schema
+  (`text_prompts`/`artifacts`) is deliberately not ported.
+- `amazon.nova-canvas-v1:0` has no `us.` cross-region inference profile, so
+  those three regions are the whole of it.
+- Stability's `stable-image-*` editing services (inpaint, erase object, search
+  and replace, background removal, style guide, control sketch) are not
+  text-to-image and are out of scope.
+- Nova Canvas may return fewer images than `numberOfImages` asked for.
+  Individually content-filtered images are dropped silently, and the plugin
+  returns whatever arrived.
 
 ## License
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/__init__.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/__init__.py
@@ -16,13 +16,14 @@
 
 """Amazon Bedrock plugin for Genkit."""
 
-from genkit_amazon_bedrock.config import BedrockConfig, ModelDefinition
+from genkit_amazon_bedrock.config import BedrockConfig, BedrockImageConfig, ModelDefinition
 from genkit_amazon_bedrock.converters import cache_point_part
 from genkit_amazon_bedrock.plugin import Bedrock, bedrock_name
 
 __all__ = [
     'Bedrock',
     'BedrockConfig',
+    'BedrockImageConfig',
     'ModelDefinition',
     'bedrock_name',
     'cache_point_part',

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/config.py
@@ -56,6 +56,20 @@ class BedrockConfig(ModelConfig):
     """Forwarded verbatim to the Converse API (e.g. Claude extended thinking)."""
 
 
+class BedrockImageConfig(BaseModel):
+    """Per-call configuration for Bedrock image models.
+
+    Deliberately declares no properties and rejects nothing. Image config
+    shapes vary per model family (Titan Image and Nova Canvas nest their
+    options under ``imageGenerationConfig``; the Stability models take flat
+    fields like ``aspect_ratio``, ``output_format``, and ``seed``), so any
+    strict schema would silently reject every family-specific override at
+    Genkit's request validation.
+    """
+
+    model_config = ConfigDict(extra='allow')
+
+
 class ModelDefinition(BaseModel):
     """A Bedrock model to register with Genkit.
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
@@ -1,0 +1,361 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bedrock image generation implementation (InvokeModel API).
+
+Image models predate Converse and have no unified request shape: the Amazon
+families nest their options under ``imageGenerationConfig`` while the modern
+Stability models take flat top-level fields, so routing by model ID is
+unavoidable.
+
+Ported from the Go plugin's ``image.go``, with three deviations. Go's legacy
+SDXL builder (``stable-diffusion``, ``text_prompts``/``artifacts``) is dropped
+because every model of that shape is end-of-life on Bedrock. The Stability
+family patterns are narrower than Go's bare ``stable-image``. And the response
+MIME type follows the requested ``output_format`` instead of Go's hardcoded
+``image/png``, which mislabels a jpeg or webp response.
+"""
+
+import json
+from typing import Any, Literal, cast
+
+from botocore.exceptions import BotoCoreError, ClientError
+
+from genkit import (
+    FinishReason,
+    Media,
+    MediaPart,
+    Message,
+    ModelConfig,
+    ModelRequest,
+    ModelResponse,
+    Part,
+    Role,
+    TextPart,
+)
+from genkit.plugin_api import ActionRunContext, GenkitError
+from genkit_amazon_bedrock.embedders import InvokeModelTransport
+from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
+from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
+
+ImageFamily = Literal['titan_image', 'nova_canvas', 'stability']
+
+# Substring matches over the base model ID, most specific first.
+_IMAGE_FAMILY_PATTERNS: tuple[tuple[str, ImageFamily], ...] = (
+    ('titan-image', 'titan_image'),
+    ('nova-canvas', 'nova_canvas'),
+    # Not bare 'stable-image': that would swallow the stability.stable-image-*
+    # editing services (inpaint, erase-object, search-replace, ...) which are
+    # not text-to-image and take entirely different request bodies.
+    ('sd3-', 'stability'),
+    ('stable-image-core', 'stability'),
+    ('stable-image-ultra', 'stability'),
+)
+
+# Amazon Titan Image and Nova Canvas only ever return PNG.
+_AMAZON_IMAGE_MIME = 'image/png'
+
+_NO_IMAGES_MESSAGE = 'bedrock image: no images generated'
+
+# Both spellings of Genkit's own generation knobs: none is a Bedrock image
+# parameter, and apiKey on an outbound body would leak a credential.
+_GENKIT_CONFIG_KEYS: frozenset[str] = frozenset(
+    key for name, field in ModelConfig.model_fields.items() for key in (name, field.alias) if key is not None
+)
+
+
+def _image_family(model_id: str) -> ImageFamily | None:
+    """Routes a model ID to its image family, or None if it is not one."""
+    base_id = strip_inference_profile_prefix(model_id)
+    for pattern, family in _IMAGE_FAMILY_PATTERNS:
+        if pattern in base_id:
+            return family
+    return None
+
+
+def is_image_model(model_id: str) -> bool:
+    """Reports whether a Bedrock model ID names a text-to-image model.
+
+    Args:
+        model_id: Bedrock model ID, inference-profile ID, or ARN.
+
+    Returns:
+        True when the ID routes to a known image family.
+    """
+    return _image_family(model_id) is not None
+
+
+def image_prompt(request: ModelRequest[Any]) -> str:
+    """Extracts the image prompt from the most recent user message.
+
+    Ported from the Go plugin's ``imagePrompt``: messages are scanned newest
+    first, only user messages count, and their text parts are concatenated
+    without a separator. A user message with no text is skipped rather than
+    ending the scan. Non-text parts are ignored; these models are text-to-image
+    only.
+
+    Args:
+        request: The Genkit model request.
+
+    Returns:
+        The prompt text, or an empty string when there is none.
+    """
+    for message in reversed(request.messages):
+        if message.role != Role.USER:
+            continue
+        prompt = ''.join(part.root.text for part in message.content if isinstance(part.root, TextPart))
+        if prompt:
+            return prompt
+    return ''
+
+
+def build_amazon_image_body(prompt: str, config: dict[str, Any], *, include_quality: bool) -> dict[str, Any]:
+    """Builds the InvokeModel body for Titan Image and Nova Canvas.
+
+    Only ``imageGenerationConfig`` is honoured, and only when it is a mapping;
+    every other config key is dropped, matching the Go plugin. Its entries are
+    merged key-by-key over the defaults. ``image_generation_config`` is accepted
+    as an alternative spelling, as BedrockConfig accepts both casings, and the
+    camelCase key wins when a caller passes both.
+
+    Args:
+        prompt: The text prompt.
+        config: The normalized per-call config.
+        include_quality: Whether to default ``quality``; Nova Canvas takes it,
+            Titan Image does not.
+
+    Returns:
+        The request body to marshal.
+    """
+    image_generation_config: dict[str, Any] = {
+        'numberOfImages': 1,
+        'height': 1024,
+        'width': 1024,
+        'cfgScale': 8.0,
+        'seed': 0,
+    }
+    if include_quality:
+        image_generation_config['quality'] = 'standard'
+    # Keyed on presence, not value, so the camelCase wire name wins over both.
+    key = 'imageGenerationConfig' if 'imageGenerationConfig' in config else 'image_generation_config'
+    overrides = config.get(key)
+    if isinstance(overrides, dict):
+        image_generation_config.update(overrides)
+
+    return {
+        'taskType': 'TEXT_IMAGE',
+        'textToImageParams': {'text': prompt},
+        'imageGenerationConfig': image_generation_config,
+    }
+
+
+def build_stability_image_body(prompt: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Builds the InvokeModel body for the modern Stability models.
+
+    The whole config is merged over the defaults at the top level, so a caller
+    can override ``prompt`` and ``output_format`` as well as add flat fields
+    like ``aspect_ratio`` or ``seed``. Matches the Go plugin. Genkit's generic
+    generation knobs are already gone by here; see ``_normalize_image_config``.
+
+    Args:
+        prompt: The text prompt.
+        config: The normalized per-call config.
+
+    Returns:
+        The request body to marshal.
+    """
+    body: dict[str, Any] = {'prompt': prompt, 'output_format': 'png'}
+    body.update(config)
+    return body
+
+
+def _image_config_dict(config: dict[str, Any]) -> dict[str, Any]:
+    """Copies a config dict, dropping Genkit's generic generation knobs."""
+    return {key: value for key, value in config.items() if key not in _GENKIT_CONFIG_KEYS}
+
+
+def _normalize_image_config(config: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Coerces the request config into a plain dict.
+
+    Deliberately not ``converters.normalize_config``: that returns a
+    BedrockConfig rather than a plain dict, and its declared Converse fields
+    (``maxTokens``, ``toolChoice``, ...) would end up on an image body.
+
+    Genkit's own generation knobs (``temperature``, ``apiKey``, and the rest of
+    the common config) are dropped in either spelling: the framework coerces
+    every config into ModelConfig, and Bedrock's image APIs take none of them.
+
+    Args:
+        config: The raw ``request.config`` value.
+
+    Returns:
+        The config as a mutable dict, minus Genkit's generic knobs; empty when
+        none was given.
+
+    Raises:
+        GenkitError: INVALID_ARGUMENT for unsupported config types. Go silently
+            drops anything that is not a map; failing loudly beats sending a
+            body that quietly ignores the caller's settings.
+    """
+    if config is None:
+        return {}
+    if isinstance(config, dict):
+        return _image_config_dict(config)
+    dump = getattr(config, 'model_dump', None)
+    if callable(dump):
+        return _image_config_dict(cast(dict[str, Any], dump(exclude_none=True)))
+    raise GenkitError(
+        message=f'bedrock image: unexpected config type {type(config).__name__}, want a mapping or pydantic model',
+        status='INVALID_ARGUMENT',
+    )
+
+
+def _response_images(payload: dict[str, Any]) -> list[Any]:
+    """Reads the ``images`` array off an InvokeModel response body."""
+    images = payload.get('images')
+    return images if isinstance(images, list) else []
+
+
+def _media_parts(images: list[Any], mime: str) -> list[Part]:
+    """Wraps base64 image strings as Genkit media parts, skipping blanks."""
+    return [
+        Part(root=MediaPart(media=Media(url=f'data:{mime};base64,{image}', content_type=mime)))
+        for image in images
+        if isinstance(image, str) and image
+    ]
+
+
+class BedrockImageModel:
+    """Handles a generate call for one Bedrock image model."""
+
+    def __init__(self, model_id: str, transport: InvokeModelTransport) -> None:
+        """Initializes the image model handler.
+
+        Args:
+            model_id: Bedrock model ID, inference-profile ID, or ARN, sent to
+                the InvokeModel API verbatim.
+            transport: The shared transport seam owning the boto3 client.
+        """
+        self._model_id = model_id
+        self._transport = transport
+
+    async def generate(self, request: ModelRequest[Any], ctx: ActionRunContext | None = None) -> ModelResponse:
+        """Runs an InvokeModel call and returns the generated images.
+
+        Args:
+            request: The Genkit model request.
+            ctx: Action run context, accepted for signature parity and never
+                used: image generation emits no chunks, only a final response.
+
+        Returns:
+            A ModelResponse carrying one media part per generated image.
+
+        Raises:
+            GenkitError: UNIMPLEMENTED for a model this plugin cannot generate
+                images with, INVALID_ARGUMENT for a request carrying no prompt
+                or an unusable config, INTERNAL when the service returns no
+                usable image, and the mapped AWS status for a failed call.
+        """
+        # ctx is never used: there is nothing to stream, only a final response.
+        family = _image_family(self._model_id)
+        if family is None:
+            raise GenkitError(
+                message=f'bedrock image: unsupported image generation model {self._model_id!r}',
+                status='UNIMPLEMENTED',
+            )
+        prompt = image_prompt(request)
+        if not prompt:
+            raise GenkitError(
+                message='bedrock image: no text prompt found for image generation',
+                status='INVALID_ARGUMENT',
+            )
+        config = _normalize_image_config(request.config)
+
+        if family == 'stability':
+            body = build_stability_image_body(prompt, config)
+            payload = await self._invoke(body)
+            # The wire body keeps the caller's casing; only the MIME is lowered.
+            output_format = str(body.get('output_format') or 'png').lower()
+            mime = f'image/{output_format}'
+            images = self._stability_images(payload)
+        else:
+            body = build_amazon_image_body(prompt, config, include_quality=family == 'nova_canvas')
+            payload = await self._invoke(body)
+            mime = _AMAZON_IMAGE_MIME
+            images = self._amazon_images(payload)
+
+        parts = _media_parts(images, mime)
+        if not parts:
+            raise GenkitError(message=_NO_IMAGES_MESSAGE, status='INTERNAL')
+        return ModelResponse(
+            message=Message(role=Role.MODEL, content=parts),
+            # Image generation always stops on its own and reports no tokens.
+            finish_reason=FinishReason.STOP,
+            request=request,
+        )
+
+    def _amazon_images(self, payload: dict[str, Any]) -> list[Any]:
+        """Reads the images off a Titan Image or Nova Canvas response.
+
+        Raises:
+            GenkitError: INTERNAL when no image came back, carrying the
+                response's in-band ``error`` text when there is one. Images
+                and an error together mean partial success: Nova Canvas drops
+                individually content-filtered images that way, so the images
+                win.
+        """
+        images = _response_images(payload)
+        if any(isinstance(image, str) and image for image in images):
+            return images
+        # In-band failure on an HTTP 200, as with Titan multimodal embeddings.
+        error = payload.get('error')
+        message = f'bedrock image: {error}' if isinstance(error, str) and error else _NO_IMAGES_MESSAGE
+        raise GenkitError(message=message, status='INTERNAL')
+
+    def _stability_images(self, payload: dict[str, Any]) -> list[Any]:
+        """Reads the images off a modern Stability response.
+
+        ``seeds`` is ignored. ``finish_reasons`` is checked before the images,
+        as in the Go plugin, so a refusal is reported by its reason rather than
+        as a missing image. JSON ``null`` is the success value on that field.
+
+        Raises:
+            GenkitError: INTERNAL for a non-success finish reason, or when no
+                image came back.
+        """
+        for reason in payload.get('finish_reasons') or []:
+            if reason is not None and reason not in ('', 'SUCCESS'):
+                raise GenkitError(
+                    message=f'bedrock image: image generation finished with reason: {reason}',
+                    status='INTERNAL',
+                )
+        images = _response_images(payload)
+        if not images:
+            raise GenkitError(message=_NO_IMAGES_MESSAGE, status='INTERNAL')
+        return images
+
+    async def _invoke(self, body: dict[str, Any]) -> dict[str, Any]:
+        try:
+            return await self._transport.invoke_model(
+                modelId=self._model_id,
+                body=json.dumps(body),
+                contentType='application/json',
+                accept='application/json',
+            )
+        except ClientError as error:
+            raise _from_client_error(error, 'invoke model') from error
+        except BotoCoreError as error:
+            raise _from_botocore_error(error, 'invoke model') from error

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -109,19 +109,21 @@ MODEL_CAPABILITIES: dict[str, ModelCapability] = {
 
 
 def strip_inference_profile_prefix(model_id: str) -> str:
-    """Strips a cross-region inference-profile prefix from a model ID.
+    """Reduces a model ID to the lowercase base ID used for lookup.
 
-    Used for capability lookup only; requests always carry the original ID.
-    Full Bedrock ARNs (foundation-model, inference-profile) are reduced to
-    their resource ID first, across all partitions (``arn:aws:``,
-    ``arn:aws-us-gov:``, ``arn:aws-cn:``).
+    Used for capability lookup and family routing only; requests always carry
+    the original ID. Full Bedrock ARNs (foundation-model, inference-profile)
+    are reduced to their resource ID first, across all partitions
+    (``arn:aws:``, ``arn:aws-us-gov:``, ``arn:aws-cn:``).
 
     Args:
         model_id: Bedrock model ID, inference-profile ID, or full ARN.
 
     Returns:
-        The base model ID without the inference-profile prefix.
+        The base model ID, lowercased, without the inference-profile prefix.
     """
+    # Bedrock's own IDs are lowercase; a custom-model ARN's resource name is not.
+    model_id = model_id.lower()
     if model_id.startswith('arn:'):
         model_id = model_id.rsplit('/', 1)[-1]
     for prefix in INFERENCE_PROFILE_PREFIXES:

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -153,7 +153,9 @@ def get_model_info(
                 tools=False,
                 tool_choice=False,
                 system_role=False,
-                media=True,
+                # Genkit reads media as an input capability; these take text only.
+                media=False,
+                output=['media'],
                 constrained=Constrained.NONE,
             ),
         )

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -18,11 +18,11 @@
 
 Registers Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama,
 Mistral, Cohere, and others) as Genkit model actions. Text generation uses the
-Bedrock Converse and ConverseStream APIs, and embedders use InvokeModel; image
-generation and reranking are not supported yet.
+Bedrock Converse and ConverseStream APIs; embedders and image generation use
+InvokeModel. Reranking is not supported yet.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from genkit import ModelRequest, ModelResponse
 from genkit.embedder import EmbedRequest, EmbedResponse, embedder_action_metadata
@@ -38,6 +38,7 @@ from genkit.plugin_api import (
 from genkit_amazon_bedrock.config import (
     DEFAULT_TOTAL_TIMEOUT,
     BedrockConfig,
+    BedrockImageConfig,
     ModelDefinition,
 )
 from genkit_amazon_bedrock.embedders import (
@@ -46,6 +47,7 @@ from genkit_amazon_bedrock.embedders import (
     is_embedding_model,
     looks_like_embedding_model,
 )
+from genkit_amazon_bedrock.image import BedrockImageModel, is_image_model
 from genkit_amazon_bedrock.model_info import get_model_info
 from genkit_amazon_bedrock.models import BedrockModel
 from genkit_amazon_bedrock.transport import BedrockTransport
@@ -172,22 +174,28 @@ class Bedrock(Plugin):
             # Embedding models speak InvokeModel, not Converse; resolving one
             # as a chat model only defers the failure to call time.
             return None
-        model_type = self._configured_model_type(model_id)
-        if model_type not in ('chat', 'text'):
-            # Image generation lands in a later slice.
-            return None
-        return self._create_model_action(model_id)
+        declared = self._declared_model_type(model_id)
+        # Classifying undeclared IDs diverges from Go, which routes on the
+        # declared type alone: this plugin resolves lazily, so without it
+        # bedrock/amazon.nova-canvas-v1:0 would take the Converse path and fail
+        # at call time. Embedders already classify by ID the same way.
+        model_type = declared if declared is not None else ('image' if is_image_model(model_id) else 'chat')
+        return self._create_model_action(model_id, model_type)
 
-    def _configured_model_type(self, model_id: str) -> str:
+    def _declared_model_type(self, model_id: str) -> Literal['chat', 'text', 'image'] | None:
         for definition in self.models:
             if definition.name == model_id:
                 return definition.type
-        return 'chat'
+        return None
 
-    def _create_model_action(self, model_id: str) -> Action:
-        model_info = get_model_info(model_id)
+    def _create_model_action(self, model_id: str, model_type: Literal['chat', 'text', 'image'] = 'chat') -> Action:
+        model_info = get_model_info(model_id, model_type)
+        is_image = model_type == 'image'
 
         async def _generate(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+            if is_image:
+                image_model = BedrockImageModel(model_id=model_id, transport=self._transport)
+                return await image_model.generate(request, ctx)
             model = BedrockModel(model_id=model_id, transport=self._transport)
             return await model.generate(request, ctx)
 
@@ -202,7 +210,7 @@ class Bedrock(Plugin):
                     'supports': (
                         model_info.supports.model_dump(by_alias=True, exclude_none=True) if model_info.supports else {}
                     ),
-                    'customOptions': to_json_schema(BedrockConfig),
+                    'customOptions': to_json_schema(BedrockImageConfig if is_image else BedrockConfig),
                 },
             },
         )
@@ -224,21 +232,25 @@ class Bedrock(Plugin):
         """List configured Bedrock models and embedders.
 
         Only explicitly configured entries are listed, and only those this
-        plugin can actually serve: an ID in the wrong list would otherwise be
-        advertised and then fail on use. The catalogue itself is open-ended, and
-        any model ID still resolves on demand.
+        plugin can actually serve: an ID in the wrong list, or a chat model
+        declared ``type='image'``, would otherwise be advertised and then fail
+        on use. Such a declaration still resolves, so the caller reads the
+        image path's reason rather than a generic model-not-found. The
+        catalogue itself is open-ended, and any model ID still resolves on
+        demand.
 
         Returns:
-            ActionMetadata for each configured chat model and embedder.
+            ActionMetadata for each configured model and embedder.
         """
         actions: list[ActionMetadata] = [
             model_action_metadata(
                 name=bedrock_name(definition.name),
                 info=get_model_info(definition.name, definition.type).model_dump(by_alias=True, exclude_none=True),
-                config_schema=BedrockConfig,
+                config_schema=BedrockImageConfig if definition.type == 'image' else BedrockConfig,
             )
             for definition in self.models
-            if definition.type in ('chat', 'text') and not looks_like_embedding_model(definition.name)
+            if not looks_like_embedding_model(definition.name)
+            and (definition.type != 'image' or is_image_model(definition.name))
         ]
         actions.extend(
             embedder_action_metadata(bedrock_name(model_id), get_embedder_options(model_id))

--- a/py/packages/genkit-amazon-bedrock/tests/image_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/image_test.py
@@ -153,6 +153,11 @@ def media(response: ModelResponse) -> list[Media]:
         ('stability.stable-image-ultra-v1:1', True),
         ('us.amazon.nova-canvas-v1:0', True),
         ('us.stability.sd3-5-large-v1:0', True),
+        # Bedrock's own IDs are lowercase, but a custom-model ARN carries a
+        # caller-chosen resource name, so matching is case-insensitive.
+        ('AMAZON.NOVA-CANVAS-V1:0', True),
+        ('US.stability.SD3-5-large-v1:0', True),
+        ('arn:aws:bedrock:us-east-1:123456789012:custom-model/amazon.nova-canvas-v1:0/Nova-Canvas-Tuned', True),
         # An embedder: 'titan-embed-image' is not 'titan-image'.
         ('amazon.titan-embed-image-v1', False),
         # Legacy SDXL (text_prompts/artifacts) is deliberately not ported.

--- a/py/packages/genkit-amazon-bedrock/tests/image_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/image_test.py
@@ -1,0 +1,586 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Bedrock image generation (no AWS involved)."""
+
+import json
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
+from genkit_amazon_bedrock.config import BedrockConfig, BedrockImageConfig
+from genkit_amazon_bedrock.image import BedrockImageModel, build_amazon_image_body, is_image_model
+
+from genkit import (
+    FinishReason,
+    Media,
+    MediaPart,
+    Message,
+    ModelConfig,
+    ModelRequest,
+    ModelResponse,
+    Part,
+    Role,
+    TextPart,
+)
+from genkit.plugin_api import ActionRunContext, GenkitError, to_json_schema
+
+TITAN_IMAGE = 'amazon.titan-image-generator-v1'
+NOVA_CANVAS = 'amazon.nova-canvas-v1:0'
+SD3 = 'stability.sd3-5-large-v1:0'
+STABLE_CORE = 'stability.stable-image-core-v1:1'
+OPAQUE_ARN = 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123opaque'
+
+PROMPT = 'a serene mountain landscape'
+
+PNG_B64 = 'iVBORw0KGgoAAAANSUhEUg=='
+PNG_DATA_URL = f'data:image/png;base64,{PNG_B64}'
+
+TITAN_DEFAULTS: dict[str, Any] = {
+    'numberOfImages': 1,
+    'height': 1024,
+    'width': 1024,
+    'cfgScale': 8.0,
+    'seed': 0,
+}
+# Nova Canvas takes a quality knob; Titan Image rejects one.
+NOVA_CANVAS_DEFAULTS: dict[str, Any] = {**TITAN_DEFAULTS, 'quality': 'standard'}
+
+
+class FakeInvokeTransport:
+    """Stands in for BedrockTransport; records the InvokeModel kwargs."""
+
+    def __init__(self, response: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+        self.response = response if response is not None else {}
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    def bodies(self) -> list[dict[str, Any]]:
+        """The parsed request bodies, in call order."""
+        return [json.loads(call['body']) for call in self.calls]
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+class ForbiddenTransport:
+    """Fails the test if the model reaches the wire at all."""
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError(f'no InvokeModel call expected, got {kwargs}')
+
+
+def text_part(text: str) -> Part:
+    return Part(root=TextPart(text=text))
+
+
+def media_part(url: str = PNG_DATA_URL) -> Part:
+    return Part(root=MediaPart(media=Media(url=url, content_type='image/png')))
+
+
+def user_message(*parts: Part) -> Message:
+    return Message(role=Role.USER, content=list(parts))
+
+
+def image_request(prompt: str = PROMPT, config: Any = None) -> ModelRequest:  # noqa: ANN401
+    request = ModelRequest(messages=[user_message(text_part(prompt))])
+    # Assigned rather than passed to the constructor: ModelRequest coerces a
+    # mapping into GenerationCommonConfig, and these tests pin what the plugin
+    # does with the config value it is actually handed.
+    request.config = config
+    return request
+
+
+def amazon_response(*images: str, error: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {'images': list(images)}
+    if error is not None:
+        payload['error'] = error
+    return payload
+
+
+def stability_response(*images: str, finish_reasons: list[Any] | None = None) -> dict[str, Any]:
+    # seeds ride along on every real response and are ignored.
+    payload: dict[str, Any] = {'images': list(images), 'seeds': [0] * len(images)}
+    if finish_reasons is not None:
+        payload['finish_reasons'] = finish_reasons
+    return payload
+
+
+async def generate(
+    model_id: str,
+    transport: Any,  # noqa: ANN401
+    request: ModelRequest | None = None,
+    ctx: ActionRunContext | None = None,
+) -> ModelResponse:
+    model = BedrockImageModel(model_id=model_id, transport=transport)
+    return await model.generate(request if request is not None else image_request(), ctx)
+
+
+def media(response: ModelResponse) -> list[Media]:
+    """The media payloads of a response, in order."""
+    assert response.message is not None
+    return [part.root.media for part in response.message.content if isinstance(part.root, MediaPart)]
+
+
+# ---- Classification ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('model_id', 'routable'),
+    [
+        ('amazon.titan-image-generator-v1', True),
+        ('amazon.titan-image-generator-v2:0', True),
+        ('amazon.nova-canvas-v1:0', True),
+        ('stability.sd3-5-large-v1:0', True),
+        ('stability.sd3-large-v1:0', True),
+        ('stability.stable-image-core-v1:1', True),
+        ('stability.stable-image-ultra-v1:1', True),
+        ('us.amazon.nova-canvas-v1:0', True),
+        ('us.stability.sd3-5-large-v1:0', True),
+        # An embedder: 'titan-embed-image' is not 'titan-image'.
+        ('amazon.titan-embed-image-v1', False),
+        # Legacy SDXL (text_prompts/artifacts) is deliberately not ported.
+        ('stability.stable-diffusion-xl-v1', False),
+        # A bare 'stable-image' pattern would swallow these editing services,
+        # which are not text-to-image and take different request bodies. Some
+        # are inference-profile-only in a given region, hence the us. form.
+        ('stability.stable-image-inpaint-v1:0', False),
+        ('us.stability.stable-image-erase-object-v1:0', False),
+        ('stability.stable-image-remove-background-v1:0', False),
+        ('stability.stable-image-search-replace-v1:0', False),
+        ('stability.stable-image-style-guide-v1:0', False),
+        ('stability.stable-image-control-sketch-v1:0', False),
+        ('amazon.nova-lite-v1:0', False),
+        ('anthropic.claude-sonnet-4-5-20250929-v1:0', False),
+    ],
+)
+def test_image_model_routing(model_id: str, routable: bool) -> None:
+    assert is_image_model(model_id) is routable
+
+
+@pytest.mark.asyncio
+async def test_profile_prefixed_id_routes_but_the_wire_keeps_it() -> None:
+    transport = FakeInvokeTransport(amazon_response('nova-image'))
+    await generate(f'us.{NOVA_CANVAS}', transport)
+
+    call = transport.calls[0]
+    assert call['modelId'] == f'us.{NOVA_CANVAS}'
+    assert call['contentType'] == 'application/json'
+    assert call['accept'] == 'application/json'
+
+
+@pytest.mark.parametrize(
+    'model_id',
+    ['stability.stable-diffusion-xl-v1', OPAQUE_ARN, 'stability.stable-image-inpaint-v1:0'],
+)
+@pytest.mark.asyncio
+async def test_unsupported_model_fails_before_any_call(model_id: str) -> None:
+    with pytest.raises(GenkitError, match='unsupported image generation model') as excinfo:
+        await generate(model_id, ForbiddenTransport())
+    assert excinfo.value.status == 'UNIMPLEMENTED'
+    assert model_id in str(excinfo.value)
+
+
+# ---- Prompt extraction ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_last_user_message_wins_and_its_text_parts_concatenate() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    request = ModelRequest(
+        messages=[
+            user_message(text_part('old prompt')),
+            Message(role=Role.MODEL, content=[text_part('ignore model')]),
+            user_message(text_part('new prompt'), text_part(' detail')),
+        ]
+    )
+    await generate(TITAN_IMAGE, transport, request)
+
+    # Concatenated with no separator, as in the Go plugin.
+    assert transport.bodies()[0]['textToImageParams'] == {'text': 'new prompt detail'}
+
+
+@pytest.mark.asyncio
+async def test_a_media_only_user_message_falls_back_to_an_older_one() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    request = ModelRequest(messages=[user_message(text_part('older prompt')), user_message(media_part())])
+    await generate(TITAN_IMAGE, transport, request)
+
+    assert transport.bodies()[0]['textToImageParams'] == {'text': 'older prompt'}
+
+
+@pytest.mark.asyncio
+async def test_missing_prompt_fails_before_any_call() -> None:
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.SYSTEM, content=[text_part('system text')]),
+            user_message(media_part()),
+        ]
+    )
+    with pytest.raises(GenkitError, match='no text prompt') as excinfo:
+        await generate(TITAN_IMAGE, ForbiddenTransport(), request)
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+# ---- Amazon request bodies --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_titan_sends_the_documented_defaults() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    await generate(TITAN_IMAGE, transport, image_request('a mountain'))
+
+    # Exact equality: Titan Image rejects a quality key, so it must be absent.
+    assert transport.bodies() == [
+        {
+            'taskType': 'TEXT_IMAGE',
+            'textToImageParams': {'text': 'a mountain'},
+            'imageGenerationConfig': TITAN_DEFAULTS,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_nested_override_leaves_the_other_defaults_alone() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    await generate(TITAN_IMAGE, transport, image_request(config={'imageGenerationConfig': {'height': 512, 'seed': 42}}))
+
+    assert transport.bodies()[0]['imageGenerationConfig'] == {**TITAN_DEFAULTS, 'height': 512, 'seed': 42}
+
+
+@pytest.mark.asyncio
+async def test_amazon_drops_top_level_config_keys() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    config = {'height': 512, 'aspect_ratio': '16:9', 'imageGenerationConfig': {'seed': 42}}
+    await generate(TITAN_IMAGE, transport, image_request(config=config))
+
+    body = transport.bodies()[0]
+    # Only the nested map is honoured; a flat merge would leak both of these.
+    assert body['imageGenerationConfig'] == {**TITAN_DEFAULTS, 'seed': 42}
+    assert 'aspect_ratio' not in body
+
+
+@pytest.mark.asyncio
+async def test_amazon_accepts_the_snake_case_nested_key() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    await generate(TITAN_IMAGE, transport, image_request(config={'image_generation_config': {'seed': 3}}))
+
+    # BedrockConfig takes either casing, so this spelling must not be dropped.
+    assert transport.bodies()[0]['imageGenerationConfig'] == {**TITAN_DEFAULTS, 'seed': 3}
+
+
+@pytest.mark.asyncio
+async def test_the_camel_case_nested_key_wins_over_the_snake_case_one() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    config = {'imageGenerationConfig': {'seed': 1}, 'image_generation_config': {'seed': 2}}
+    await generate(TITAN_IMAGE, transport, image_request(config=config))
+
+    # camelCase is the AWS wire name.
+    assert transport.bodies()[0]['imageGenerationConfig'] == {**TITAN_DEFAULTS, 'seed': 1}
+
+
+def test_the_amazon_body_does_not_alias_the_callers_nested_dict() -> None:
+    overrides: dict[str, Any] = {'height': 512}
+    config: dict[str, Any] = {'imageGenerationConfig': overrides}
+    body = build_amazon_image_body('a mountain', config, include_quality=False)
+
+    body['imageGenerationConfig']['width'] = 256
+    assert overrides == {'height': 512}
+    assert config == {'imageGenerationConfig': {'height': 512}}
+
+
+@pytest.mark.parametrize('overrides', ['not a dict', 42, ['seed', 7], None])
+@pytest.mark.asyncio
+async def test_amazon_ignores_a_non_mapping_image_generation_config(overrides: Any) -> None:  # noqa: ANN401
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    await generate(TITAN_IMAGE, transport, image_request(config={'imageGenerationConfig': overrides}))
+
+    assert transport.bodies()[0]['imageGenerationConfig'] == TITAN_DEFAULTS
+
+
+@pytest.mark.asyncio
+async def test_nova_canvas_defaults_include_quality() -> None:
+    transport = FakeInvokeTransport(amazon_response('nova-image'))
+    await generate(NOVA_CANVAS, transport, image_request('a city'))
+
+    assert transport.bodies() == [
+        {
+            'taskType': 'TEXT_IMAGE',
+            'textToImageParams': {'text': 'a city'},
+            'imageGenerationConfig': NOVA_CANVAS_DEFAULTS,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_nova_canvas_keeps_a_nested_override() -> None:
+    transport = FakeInvokeTransport(amazon_response('nova-image'))
+    config = {'imageGenerationConfig': {'quality': 'premium', 'width': 512}}
+    await generate(NOVA_CANVAS, transport, image_request(config=config))
+
+    assert transport.bodies()[0]['imageGenerationConfig'] == {
+        **NOVA_CANVAS_DEFAULTS,
+        'quality': 'premium',
+        'width': 512,
+    }
+
+
+# ---- Stability request bodies -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stability_sends_the_documented_defaults() -> None:
+    transport = FakeInvokeTransport(stability_response('modern-image', finish_reasons=['SUCCESS']))
+    await generate(SD3, transport, image_request('a reef'))
+
+    # Exact equality: the legacy text_prompts array must not be sent.
+    assert transport.bodies() == [{'prompt': 'a reef', 'output_format': 'png'}]
+
+
+@pytest.mark.asyncio
+async def test_stability_merges_a_flat_config_over_the_defaults() -> None:
+    transport = FakeInvokeTransport(stability_response('modern-image', finish_reasons=['SUCCESS']))
+    config = {'aspect_ratio': '16:9', 'seed': 42, 'output_format': 'jpeg'}
+    await generate(STABLE_CORE, transport, image_request('a reef', config=config))
+
+    assert transport.bodies() == [{'prompt': 'a reef', 'output_format': 'jpeg', 'aspect_ratio': '16:9', 'seed': 42}]
+
+
+@pytest.mark.asyncio
+async def test_stability_drops_genkit_generic_config_keys() -> None:
+    transport = FakeInvokeTransport(stability_response('modern-image', finish_reasons=['SUCCESS']))
+    config = {'aspect_ratio': '16:9', 'temperature': 0.9}
+    await generate(SD3, transport, image_request('a reef', config=config))
+
+    # Exact equality: temperature is one of Genkit's own knobs and InvokeModel
+    # has no such field, so a flat merge of the whole config would send it.
+    assert transport.bodies() == [{'prompt': 'a reef', 'output_format': 'png', 'aspect_ratio': '16:9'}]
+
+
+@pytest.mark.parametrize('spelling', ['api_key', 'apiKey'])
+@pytest.mark.asyncio
+async def test_an_api_key_never_reaches_the_wire(spelling: str) -> None:
+    transport = FakeInvokeTransport(stability_response('modern-image', finish_reasons=['SUCCESS']))
+    await generate(SD3, transport, image_request(config={spelling: 'SECRET-VALUE'}))
+
+    body = transport.bodies()[0]
+    assert 'api_key' not in body
+    assert 'apiKey' not in body
+    # The credential must not survive under any key at all.
+    assert 'SECRET-VALUE' not in transport.calls[0]['body']
+
+
+@pytest.mark.asyncio
+async def test_stability_mime_follows_the_requested_output_format() -> None:
+    transport = FakeInvokeTransport(stability_response('modern-image', finish_reasons=['SUCCESS']))
+    response = await generate(SD3, transport, image_request(config={'output_format': 'jpeg'}))
+
+    assert [item.content_type for item in media(response)] == ['image/jpeg']
+    assert [item.url for item in media(response)] == ['data:image/jpeg;base64,modern-image']
+
+
+@pytest.mark.asyncio
+async def test_stability_mime_lowercases_while_the_wire_keeps_the_casing() -> None:
+    transport = FakeInvokeTransport(stability_response('modern-image', finish_reasons=['SUCCESS']))
+    response = await generate(SD3, transport, image_request(config={'output_format': 'JPEG'}))
+
+    assert transport.bodies()[0]['output_format'] == 'JPEG'
+    assert [item.content_type for item in media(response)] == ['image/jpeg']
+
+
+# ---- Stability finish reasons -----------------------------------------------
+
+
+@pytest.mark.parametrize('images', [['blocked-image'], []])
+@pytest.mark.asyncio
+async def test_a_non_success_finish_reason_is_internal(images: list[str]) -> None:
+    # Checked before the images: a filtered result still returns a slot, and an
+    # empty array must still report the reason rather than "no images".
+    transport = FakeInvokeTransport({'images': images, 'finish_reasons': ['CONTENT_FILTERED']})
+    with pytest.raises(GenkitError, match='CONTENT_FILTERED') as excinfo:
+        await generate(SD3, transport)
+    assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.parametrize('reason', [None, 'SUCCESS', ''])
+@pytest.mark.asyncio
+async def test_success_shaped_finish_reasons_pass(reason: Any) -> None:  # noqa: ANN401
+    # JSON null is the success value here; '' is what a terse service sends.
+    transport = FakeInvokeTransport(stability_response('modern-image', finish_reasons=[reason]))
+    assert len(media(await generate(SD3, transport))) == 1
+
+
+# ---- Responses --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_carries_one_media_part_per_image() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image-1', 'titan-image-2'))
+    request = image_request()
+    response = await generate(TITAN_IMAGE, transport, request)
+
+    assert [item.url for item in media(response)] == [
+        'data:image/png;base64,titan-image-1',
+        'data:image/png;base64,titan-image-2',
+    ]
+    assert [item.content_type for item in media(response)] == ['image/png', 'image/png']
+    assert response.finish_reason is FinishReason.STOP
+    assert response.message is not None and response.message.role is Role.MODEL
+    # Genkit backfills an empty usage object; image generation reports no tokens.
+    assert response.usage is not None
+    assert (response.usage.input_tokens, response.usage.output_tokens, response.usage.total_tokens) == (
+        None,
+        None,
+        None,
+    )
+    assert response.request is request
+
+
+@pytest.mark.asyncio
+async def test_a_streaming_context_receives_no_chunks() -> None:
+    transport = FakeInvokeTransport(amazon_response('titan-image'))
+    chunks: list[Any] = []
+    response = await generate(TITAN_IMAGE, transport, ctx=ActionRunContext(streaming_callback=chunks.append))
+
+    assert chunks == []
+    assert len(media(response)) == 1
+
+
+@pytest.mark.parametrize(
+    ('model_id', 'payload'),
+    [
+        (TITAN_IMAGE, {'images': []}),
+        (TITAN_IMAGE, {}),
+        (NOVA_CANVAS, {'images': None}),
+        (SD3, {'images': [], 'finish_reasons': ['SUCCESS']}),
+        (SD3, {}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_no_usable_image_is_internal(model_id: str, payload: dict[str, Any]) -> None:
+    with pytest.raises(GenkitError, match='no images generated') as excinfo:
+        await generate(model_id, FakeInvokeTransport(payload))
+    assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_an_in_band_error_surfaces_the_service_text() -> None:
+    # Amazon reports a blocked prompt on an HTTP 200; "no images generated"
+    # would throw away the only usable diagnostic.
+    transport = FakeInvokeTransport(amazon_response(error='prompt blocked by content filter'))
+    with pytest.raises(GenkitError, match='prompt blocked by content filter') as excinfo:
+        await generate(NOVA_CANVAS, transport)
+    assert excinfo.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_images_alongside_an_error_are_partial_success() -> None:
+    # Nova Canvas drops individually filtered images this way; the rest stand.
+    transport = FakeInvokeTransport(amazon_response('nova-image', error='1 image was filtered'))
+    response = await generate(NOVA_CANVAS, transport)
+
+    assert [item.url for item in media(response)] == ['data:image/png;base64,nova-image']
+
+
+@pytest.mark.asyncio
+async def test_blank_base64_strings_are_skipped() -> None:
+    transport = FakeInvokeTransport(amazon_response('', 'titan-image', ''))
+    response = await generate(TITAN_IMAGE, transport)
+
+    assert [item.url for item in media(response)] == ['data:image/png;base64,titan-image']
+
+
+@pytest.mark.parametrize('model_id', [TITAN_IMAGE, SD3])
+@pytest.mark.asyncio
+async def test_an_all_blank_image_array_is_internal(model_id: str) -> None:
+    with pytest.raises(GenkitError, match='no images generated') as excinfo:
+        await generate(model_id, FakeInvokeTransport({'images': ['', '']}))
+    assert excinfo.value.status == 'INTERNAL'
+
+
+# ---- Config handling --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_pydantic_config_and_the_equivalent_dict_agree() -> None:
+    overrides: dict[str, Any] = {'imageGenerationConfig': {'seed': 7}}
+    typed = FakeInvokeTransport(amazon_response('titan-image'))
+    plain = FakeInvokeTransport(amazon_response('titan-image'))
+
+    await generate(TITAN_IMAGE, typed, image_request(config=BedrockImageConfig.model_validate(overrides)))
+    await generate(TITAN_IMAGE, plain, image_request(config=overrides))
+
+    assert typed.bodies() == plain.bodies()
+    assert typed.bodies()[0]['imageGenerationConfig'] == {**TITAN_DEFAULTS, 'seed': 7}
+
+
+@pytest.mark.asyncio
+async def test_a_generic_config_model_and_the_equivalent_dict_agree() -> None:
+    # ModelConfig is what the framework coerces a raw mapping into, so the two
+    # input paths must drop the same keys.
+    typed = FakeInvokeTransport(stability_response('modern-image', finish_reasons=['SUCCESS']))
+    plain = FakeInvokeTransport(stability_response('modern-image', finish_reasons=['SUCCESS']))
+    overrides: dict[str, Any] = {'temperature': 0.9, 'max_output_tokens': 100, 'seed': 42}
+
+    await generate(SD3, typed, image_request(config=ModelConfig.model_validate(overrides)))
+    await generate(SD3, plain, image_request(config=overrides))
+
+    assert typed.bodies() == plain.bodies()
+    assert typed.bodies() == [{'prompt': PROMPT, 'output_format': 'png', 'seed': 42}]
+
+
+@pytest.mark.asyncio
+async def test_a_non_mapping_config_is_rejected_before_any_call() -> None:
+    with pytest.raises(GenkitError, match='unexpected config type') as excinfo:
+        await generate(TITAN_IMAGE, ForbiddenTransport(), image_request(config=42))
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+# ---- Error mapping ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_errors_map_to_genkit_statuses() -> None:
+    error = ClientError({'Error': {'Code': 'ThrottlingException', 'Message': 'boom'}}, 'InvokeModel')
+    with pytest.raises(GenkitError, match='invoke model failed') as excinfo:
+        await generate(TITAN_IMAGE, FakeInvokeTransport(error=error))
+    assert excinfo.value.status == 'RESOURCE_EXHAUSTED'
+
+
+@pytest.mark.asyncio
+async def test_botocore_errors_map_to_genkit_statuses() -> None:
+    with pytest.raises(GenkitError, match='invoke model failed') as excinfo:
+        await generate(SD3, FakeInvokeTransport(error=NoCredentialsError()))
+    assert excinfo.value.status == 'UNAUTHENTICATED'
+
+
+# ---- Config schema ----------------------------------------------------------
+
+
+def test_the_image_config_schema_stays_open() -> None:
+    # Genkit validates request config against this schema before the handler
+    # runs, so anything strict would reject every family-specific override.
+    image_schema = to_json_schema(BedrockImageConfig)
+    chat_schema = to_json_schema(BedrockConfig)
+
+    assert image_schema.get('additionalProperties') is not False
+    assert image_schema.get('properties') == {}
+    # Positive control: the chat schema really does declare properties, so the
+    # empty map above is a fact about BedrockImageConfig, not about the helper.
+    assert 'toolChoice' in chat_schema['properties']

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -20,10 +20,13 @@ Opt-in: set ``BEDROCK_LIVE_TESTS=1`` plus working AWS credentials and a
 region (``AWS_REGION`` or ``~/.aws/config``). These call real models and
 incur cost. The Anthropic models additionally need the account's one-time
 use-case agreement (Bedrock console -> Model access); the embedding models
-each need their own model-access grant, separate from the chat models.
+and the image models each need their own model-access grant, separate from
+the chat models and from each other.
 """
 
+import contextlib
 import os
+from collections.abc import Iterator
 
 import pytest
 from genkit_amazon_bedrock.config import BedrockConfig
@@ -31,6 +34,7 @@ from genkit_amazon_bedrock.converters import (
     REASONING_SIGNATURE_METADATA_KEY,
 )
 from genkit_amazon_bedrock.embedders import BedrockEmbedder
+from genkit_amazon_bedrock.image import BedrockImageModel
 from genkit_amazon_bedrock.models import BedrockModel
 from genkit_amazon_bedrock.transport import BedrockTransport
 
@@ -41,6 +45,7 @@ from genkit import (
     MediaPart,
     Message,
     ModelRequest,
+    ModelResponse,
     Part,
     Role,
     TextPart,
@@ -69,6 +74,9 @@ COHERE_EMBED = 'cohere.embed-english-v3'
 COHERE_EMBED_MULTI = 'cohere.embed-multilingual-v3'
 NOVA_EMBED = 'amazon.nova-2-multimodal-embeddings-v1:0'
 
+NOVA_CANVAS = 'amazon.nova-canvas-v1:0'
+SD3 = 'stability.sd3-5-large-v1:0'
+
 # Smallest PNG Titan accepts, ported from the Go plugin's live tests.
 PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
 PNG_1X1_DATA_URL = f'data:image/png;base64,{PNG_1X1}'
@@ -86,6 +94,45 @@ def make_transport() -> BedrockTransport:
 
 def make_model(model_id: str) -> BedrockModel:
     return BedrockModel(model_id=model_id, transport=make_transport())
+
+
+def make_image_model(model_id: str) -> BedrockImageModel:
+    return BedrockImageModel(model_id=model_id, transport=make_transport())
+
+
+# Bedrock refusing the model itself, rather than the request, ported from the Go
+# plugin's skipIfModelUnavailable. Model access is per account: a Legacy model
+# also drops out after 30 days of disuse, which no test can control.
+_UNAVAILABLE_MARKERS = (
+    'AccessDeniedException',
+    'ResourceNotFoundException',
+    'marked by provider as Legacy',
+)
+
+
+@contextlib.contextmanager
+def skip_if_model_unavailable(model_id: str) -> Iterator[None]:
+    """Turns a model-access failure into a skip, keeping real bugs failing."""
+    try:
+        yield
+    except GenkitError as error:
+        message = str(error)
+        invalid_id = 'ValidationException' in message and 'model identifier is invalid' in message
+        if invalid_id or any(marker in message for marker in _UNAVAILABLE_MARKERS):
+            pytest.skip(f'{model_id} unavailable to this account or region: {message}')
+        raise
+
+
+def assert_image_response(response: ModelResponse, mime: str = 'image/png') -> None:
+    assert response.finish_reason == FinishReason.STOP
+    assert response.message is not None
+    prefix = f'data:{mime};base64,'
+    media_parts = [part.root for part in response.message.content if isinstance(part.root, MediaPart)]
+    assert media_parts, 'expected at least one media part'
+    for part in media_parts:
+        assert part.media.content_type == mime
+        assert part.media.url.startswith(prefix)
+        assert part.media.url.removeprefix(prefix)
 
 
 async def embed(model_id: str, documents: list[DocumentData]) -> list[list[float]]:
@@ -381,3 +428,49 @@ async def test_embed_cohere_rejects_an_image() -> None:
 async def test_embed_nova_2() -> None:
     vectors = await embed(NOVA_EMBED, [text_doc('a red apple')])
     assert len(vectors[0]) == 3072
+
+
+@pytest.mark.skipif(
+    os.environ.get('AWS_REGION') != 'us-east-1',
+    reason=(
+        'amazon.nova-canvas-v1:0 is offered in us-east-1, eu-west-1 and ap-northeast-1 only, '
+        'and reaches end of life on 2026-09-30'
+    ),
+)
+async def test_image_nova_canvas() -> None:
+    # Legacy: new accounts cannot enable it at all, and an enabled one loses
+    # access after 30 days of disuse, so unavailability here is not a failure.
+    with skip_if_model_unavailable(NOVA_CANVAS):
+        response = await make_image_model(NOVA_CANVAS).generate(
+            text_request('A futuristic city skyline at dawn, digital art')
+        )
+        assert_image_response(response)
+
+
+@pytest.mark.skipif(
+    os.environ.get('AWS_REGION') != 'us-west-2',
+    reason='stability.sd3-5-large-v1:0 is only offered in us-west-2',
+)
+async def test_image_stability_sd3() -> None:
+    with skip_if_model_unavailable(SD3):
+        response = await make_image_model(SD3).generate(
+            text_request('A vibrant coral reef teeming with fish, photorealistic')
+        )
+        assert_image_response(response)
+
+
+@pytest.mark.skipif(
+    os.environ.get('AWS_REGION') != 'us-west-2',
+    reason='stability.sd3-5-large-v1:0 is only offered in us-west-2',
+)
+async def test_image_stability_sd3_with_config() -> None:
+    # Flat per-call overrides only reach the wire if nothing coerces them into
+    # the Converse config shape on the way in.
+    with skip_if_model_unavailable(SD3):
+        response = await make_image_model(SD3).generate(
+            text_request(
+                'A minimalist geometric pattern in blue and gold',
+                config={'aspect_ratio': '16:9', 'output_format': 'jpeg'},
+            )
+        )
+        assert_image_response(response, mime='image/jpeg')

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -67,6 +67,16 @@ def test_application_inference_profile_arn_falls_back_to_unstable() -> None:
     assert info.supports.tools is True
 
 
+def test_strip_lowercases_for_lookup() -> None:
+    assert strip_inference_profile_prefix('US.Amazon.Nova-Lite-V1:0') == 'amazon.nova-lite-v1:0'
+
+
+def test_a_mixed_case_id_still_finds_its_capabilities() -> None:
+    info = get_model_info('US.Amazon.Nova-Lite-V1:0')
+    assert info.stage == Stage.STABLE
+    assert info.label == 'US.Amazon.Nova-Lite-V1:0'
+
+
 def test_us_gov_wins_over_us() -> None:
     assert strip_inference_profile_prefix('us-gov.anthropic.claude-3-opus-20240229-v1:0') == (
         'anthropic.claude-3-opus-20240229-v1:0'

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -105,7 +105,9 @@ def test_image_model_supports_media_output_only() -> None:
     info = get_model_info('amazon.titan-image-generator-v1', model_type='image')
     assert info.stage == Stage.STABLE
     assert info.supports is not None
-    assert info.supports.media is True
+    assert info.supports.output == ['media']
+    # media is Genkit's input flag, and these models take text prompts only.
+    assert info.supports.media is False
     assert info.supports.multiturn is False
     assert info.supports.tools is False
     assert info.supports.system_role is False

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -16,14 +16,16 @@
 
 """Tests for the Amazon Bedrock plugin wiring."""
 
+import json
 from types import SimpleNamespace
 from typing import Any, cast
 
 import boto3.session
 import pytest
 from genkit_amazon_bedrock import Bedrock, BedrockConfig, ModelDefinition, bedrock_name
+from genkit_amazon_bedrock.transport import BedrockTransport
 
-from genkit import Document
+from genkit import Document, MediaPart, ModelRequest, ModelResponse
 from genkit.embedder import EmbedRequest
 from genkit.plugin_api import ActionKind, GenkitError
 
@@ -112,12 +114,48 @@ async def test_resolve_ignores_other_plugin_namespaces() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_skips_non_chat_model_definitions() -> None:
+async def test_resolve_returns_an_image_action_for_a_declared_image_model() -> None:
     plugin = Bedrock(
         region='us-east-1',
         models=[ModelDefinition(name='amazon.titan-image-generator-v1', type='image')],
     )
-    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.titan-image-generator-v1')) is None
+    action = await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.titan-image-generator-v1'))
+
+    assert action is not None
+    assert action.metadata is not None
+    model_metadata = cast(dict[str, Any], action.metadata['model'])
+    # The open image schema: a strict one would reject every family-specific
+    # override at Genkit's request validation.
+    assert model_metadata['customOptions']['properties'] == {}
+    assert model_metadata['customOptions'].get('additionalProperties') is not False
+
+
+@pytest.mark.asyncio
+async def test_resolve_classifies_an_undeclared_image_model_id() -> None:
+    # Lazy resolution means an unlisted image ID would otherwise take the
+    # Converse path and only fail at call time.
+    plugin = Bedrock(region='us-east-1')
+    action = await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.nova-canvas-v1:0'))
+
+    assert action is not None
+    assert action.metadata is not None
+    model_metadata = cast(dict[str, Any], action.metadata['model'])
+    assert model_metadata['supports']['output'] == ['media']
+    assert model_metadata['customOptions']['properties'] == {}
+
+
+@pytest.mark.asyncio
+async def test_a_declared_chat_type_wins_over_id_classification() -> None:
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[ModelDefinition(name='amazon.nova-canvas-v1:0', type='chat')],
+    )
+    action = await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.nova-canvas-v1:0'))
+
+    assert action is not None
+    assert action.metadata is not None
+    model_metadata = cast(dict[str, Any], action.metadata['model'])
+    assert model_metadata['customOptions']['properties'].get('toolChoice') is not None
 
 
 @pytest.mark.asyncio
@@ -133,7 +171,7 @@ async def test_text_type_routes_like_chat() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_actions_lists_configured_chat_models() -> None:
+async def test_list_actions_lists_configured_chat_and_image_models() -> None:
     plugin = Bedrock(
         region='us-east-1',
         models=[
@@ -142,8 +180,39 @@ async def test_list_actions_lists_configured_chat_models() -> None:
         ],
     )
     actions = await plugin.list_actions()
-    assert [a.name for a in actions] == ['bedrock/amazon.nova-lite-v1:0']
-    assert actions[0].action_type == ActionKind.MODEL
+
+    assert [a.name for a in actions] == [
+        'bedrock/amazon.nova-lite-v1:0',
+        'bedrock/amazon.titan-image-generator-v1',
+    ]
+    assert [a.action_type for a in actions] == [ActionKind.MODEL, ActionKind.MODEL]
+    assert actions[1].metadata is not None
+    image_metadata = cast(dict[str, Any], actions[1].metadata['model'])
+    assert image_metadata['supports']['output'] == ['media']
+    assert image_metadata['customOptions']['properties'] == {}
+
+
+@pytest.mark.asyncio
+async def test_a_chat_model_declared_as_an_image_model_is_not_listed() -> None:
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[
+            ModelDefinition(name='amazon.nova-lite-v1:0'),
+            ModelDefinition(name='anthropic.claude-sonnet-4-5-20250929-v1:0', type='image'),
+        ],
+    )
+    listed = await plugin.list_actions()
+
+    # Listing it would advertise image metadata this model can never honour.
+    assert [a.name for a in listed] == ['bedrock/amazon.nova-lite-v1:0']
+
+    # It still resolves, so the caller reads why it cannot work, not a 404.
+    action = await plugin.resolve(ActionKind.MODEL, bedrock_name('anthropic.claude-sonnet-4-5-20250929-v1:0'))
+    assert action is not None
+    request = ModelRequest.model_validate({'messages': [{'role': 'user', 'content': [{'text': 'a reef'}]}]})
+    with pytest.raises(GenkitError, match='unsupported image generation model') as excinfo:
+        await action.run(request)
+    assert excinfo.value.status == 'UNIMPLEMENTED'
 
 
 @pytest.mark.asyncio
@@ -246,13 +315,18 @@ async def test_everything_listed_can_actually_resolve() -> None:
         region='us-east-1',
         models=[
             ModelDefinition(name='amazon.nova-lite-v1:0'),
+            ModelDefinition(name='amazon.nova-canvas-v1:0', type='image'),
             ModelDefinition(name='amazon.titan-embed-text-v2:0'),
         ],
         embedders=['cohere.embed-english-v3', 'amazon.nova-lite-v1:0'],
     )
     listed = await plugin.list_actions()
 
-    assert [a.name for a in listed] == ['bedrock/amazon.nova-lite-v1:0', 'bedrock/cohere.embed-english-v3']
+    assert [a.name for a in listed] == [
+        'bedrock/amazon.nova-lite-v1:0',
+        'bedrock/amazon.nova-canvas-v1:0',
+        'bedrock/cohere.embed-english-v3',
+    ]
     for metadata in listed:
         assert metadata.action_type is not None
         assert await plugin.resolve(ActionKind(metadata.action_type), metadata.name) is not None
@@ -269,3 +343,67 @@ async def test_resolve_and_list_publish_the_same_embedder_metadata() -> None:
     assert action is not None
     assert action.metadata is not None and listed[0].metadata is not None
     assert action.metadata['embedder'] == listed[0].metadata['embedder']
+
+
+class FakeImageTransport:
+    """Stands in for BedrockTransport; records the InvokeModel kwargs."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {'images': ['modern-image'], 'finish_reasons': ['SUCCESS']}
+
+
+@pytest.mark.asyncio
+async def test_image_config_survives_the_action_boundary() -> None:
+    # The unit tests call the image model directly; only this path proves a
+    # family-specific key survives Genkit's config handling on the way in.
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[ModelDefinition(name='stability.sd3-5-large-v1:0', type='image')],
+    )
+    transport = FakeImageTransport()
+    plugin._transport = cast(BedrockTransport, transport)  # noqa: SLF001
+    action = await plugin.resolve(ActionKind.MODEL, bedrock_name('stability.sd3-5-large-v1:0'))
+    assert action is not None
+
+    # Validated from the wire shape, so the config goes through the same
+    # coercion a Dev UI or flow call would put it through.
+    request = ModelRequest.model_validate({
+        'messages': [{'role': 'user', 'content': [{'text': 'a coral reef'}]}],
+        'config': {'aspect_ratio': '16:9'},
+    })
+    response = cast(ModelResponse, (await action.run(request)).response)
+
+    assert json.loads(transport.calls[0]['body'])['aspect_ratio'] == '16:9'
+    assert response.message is not None
+    part = response.message.content[0].root
+    assert isinstance(part, MediaPart)
+    assert part.media.url == 'data:image/png;base64,modern-image'
+
+
+@pytest.mark.asyncio
+async def test_genkit_generic_config_never_reaches_the_image_body() -> None:
+    # The framework coerces a raw mapping into ModelConfig, so its own knobs
+    # arrive as declared fields; only this path proves they are dropped, and an
+    # api_key on an InvokeModel body would be a credential on the wire.
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[ModelDefinition(name='stability.sd3-5-large-v1:0', type='image')],
+    )
+    transport = FakeImageTransport()
+    plugin._transport = cast(BedrockTransport, transport)  # noqa: SLF001
+    action = await plugin.resolve(ActionKind.MODEL, bedrock_name('stability.sd3-5-large-v1:0'))
+    assert action is not None
+
+    request = ModelRequest.model_validate({
+        'messages': [{'role': 'user', 'content': [{'text': 'a coral reef'}]}],
+        'config': {'aspect_ratio': '16:9', 'temperature': 0.9, 'api_key': 'SECRET-VALUE'},
+    })
+    await action.run(request)
+
+    body = transport.calls[0]['body']
+    assert json.loads(body) == {'prompt': 'a coral reef', 'output_format': 'png', 'aspect_ratio': '16:9'}
+    assert 'SECRET-VALUE' not in body


### PR DESCRIPTION
## Why

Slice 6 of #5820: text-to-image generation over InvokeModel, ported from the Go plugin's `image.go`. Stacked on #6010

Go implements four model families and most no longer exist on Bedrock. As of 2026-08-11, Titan Image v1 and v2, Stable Diffusion XL, and every `v1:0` Stability SKU return `ResourceNotFoundException`, "reached the end of its life". What is live is `stability.sd3-5-large-v1:0`, `stable-image-core-v1:1` and `stable-image-ultra-v1:1`, on us-west-2 only. Every image model on offer in us-east-1 is an editing service, not text-to-image.

Amazon's only option, `amazon.nova-canvas-v1:0`, is Legacy and new accounts cannot enable it, and an enabled
one loses access after 30 days of disuse. The docs lead with Stability instead.

## Changes

New `image.py` covering two request shapes. The Amazon shape (Titan Image, Nova Canvas) nests options under `imageGenerationConfig` and merges only that key. The Stability shape takes flat top-level fields and merges the whole config. Go's legacy SDXL builder is not ported: every model of that shape is EOL.

Divergences from Go, each deliberate:

- `resolve` classifies undeclared IDs by family. Go routes on the declared `ModelDefinition.type` alone, which under lazy resolution sends `bedrock/amazon.nova-canvas-v1:0` down Converse and fails at call time.
- Stability patterns are `sd3-`, `stable-image-core`, `stable-image-ultra`, not Go's bare `stable-image`. Bedrock ships eight `stable-image-*` editing services (inpaint, erase object, search replace) that are not text-to-image.
- Response MIME follows `output_format`, where Go hardcodes `image/png`.
- Genkit's common config is not forwarded. The framework coerces `request.config` into `ModelConfig`, and the Stability merge is flat, so without that filter, `temperature` and the rest would ride along into the request body. Bedrock's image APIs accept none of them.
- Image models declare `media=False` with `output=['media']`. Genkit reads `media` as an image input capability and these take text only.

## Verification

Model IDs and regions come from `list-foundation-models` and `get-foundation-model`, not the AWS docs, which still publish full parameter pages for the retired models.

Unit tests assert whole request bodies rather than single keys, since the two merge rules are the easiest thing to get backwards. Live tests cover Canvas and sd3-5-large, including an `output_format` override returning jpeg, and skip when Bedrock refuses the model, as the Go live tests do.

## Screenshot
<img width="996" height="570" alt="Screenshot 2026-08-11 at 16 29 46" src="https://github.com/user-attachments/assets/746accee-7ead-46bf-a933-029ed6a6d47d" />
