### PR TITLE
test(py): run full generate.yaml conformance spec

### DIFF
--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -2262,7 +2262,6 @@ spec_path = pathlib.Path(__file__).parent / '../../../../../../tests/specs/gener
 with spec_path.resolve().open() as stream:
     tests_spec = yaml.safe_load(stream)
     specs = tests_spec['tests']
-    specs = [x for x in tests_spec['tests'] if x['name'] == 'calls tools']
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
This pull request enables the full `generate.yaml` cross-language conformance spec suite for Python SDK generation tests.

## Changes
- Removed test filters in `generate_test.py` to execute the entire `generate.yaml` spec suite across generation requests, options, and streaming outputs.

## Verification
- Ran `pytest packages/genkit/tests/genkit/ai/generate_test.py`: 50 passed (0 failed).