### PR TITLE
fix(py): resolve_model falls back to background models so generate_operation can find them

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -1413,7 +1413,7 @@ class Genkit:
                 message='No model specified for generate_operation.',
             )
 
-        model_action = await self.registry.resolve_action(ActionKind.MODEL, resolved_model)
+        model_action = await self.registry.resolve_model(resolved_model)
         if not model_action:
             raise GenkitError(
                 status='NOT_FOUND',

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -767,6 +767,9 @@ class Registry:
         """
         action = await self.resolve_action(ActionKind.MODEL, name)
         if action is None:
+            # background-only models (Veo, Deep Research) live under a different kind
+            action = await self.resolve_action(ActionKind.BACKGROUND_MODEL, name)
+        if action is None:
             return None
         return cast(
             Action[ModelRequest, ModelResponse, ModelResponseChunk],

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -54,6 +54,7 @@ from genkit._core._typing import (
     EmbedResponse,
     EvalRequest,
     EvalResponse,
+    Operation,
 )
 
 logger = get_logger(__name__)
@@ -756,7 +757,9 @@ class Registry:
             return None
         return cast(Action[EmbedRequest, EmbedResponse, Never], action)
 
-    async def resolve_model(self, name: str) -> Action[ModelRequest, ModelResponse, ModelResponseChunk] | None:
+    async def resolve_model(
+        self, name: str
+    ) -> Action[ModelRequest, ModelResponse | Operation, ModelResponseChunk] | None:
         """Resolve a model action by name with full type information.
 
         Args:
@@ -772,7 +775,7 @@ class Registry:
         if action is None:
             return None
         return cast(
-            Action[ModelRequest, ModelResponse, ModelResponseChunk],
+            Action[ModelRequest, ModelResponse | Operation, ModelResponseChunk],
             action,
         )
 

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -12,10 +12,12 @@ functionality, ensuring proper registration and management of Genkit resources.
 import pytest
 
 from genkit import Genkit, Plugin
-from genkit._core._action import Action, ActionKind, create_action_key
+from genkit._core._action import Action, ActionKind, ActionRunContext, create_action_key
+from genkit._core._background import define_background_model
 from genkit._core._dap import DapValue, define_dynamic_action_provider
+from genkit._core._model import ModelRequest
 from genkit._core._registry import Registry
-from genkit._core._typing import ActionMetadata
+from genkit._core._typing import ActionMetadata, ModelInfo, Operation, Supports
 
 
 async def _identity(x: object) -> object:
@@ -449,11 +451,6 @@ async def test_resolve_model_falls_back_to_background_model() -> None:
     kind when no foreground MODEL action exists. This is what lets
     generate_operation() find them.
     """
-    from genkit._core._action import ActionRunContext
-    from genkit._core._background import define_background_model
-    from genkit._core._model import ModelRequest
-    from genkit._core._typing import ModelInfo, Operation, Supports
-
     registry = Registry()
 
     async def start(request: ModelRequest, _: ActionRunContext) -> Operation:

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -438,3 +438,41 @@ def test_registry_satisfies_registry_like() -> None:
     from genkit._core._registry import Registry
 
     assert isinstance(Registry(None), RegistryLike)
+
+
+@pytest.mark.asyncio
+async def test_resolve_model_falls_back_to_background_model() -> None:
+    """resolve_model finds models registered only under BACKGROUND_MODEL.
+
+    Background-only models (e.g. Veo, Deep Research) register under
+    ActionKind.BACKGROUND_MODEL, so resolve_model must fall back to that
+    kind when no foreground MODEL action exists. This is what lets
+    generate_operation() find them.
+    """
+    from genkit._core._action import ActionRunContext
+    from genkit._core._background import define_background_model
+    from genkit._core._model import ModelRequest
+    from genkit._core._typing import ModelInfo, Operation, Supports
+
+    registry = Registry()
+
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id='bg-start', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    define_background_model(
+        registry=registry,
+        name='veo-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    assert await registry.resolve_action(ActionKind.MODEL, 'veo-model') is None
+
+    resolved = await registry.resolve_model('veo-model')
+    assert resolved is not None
+    assert resolved.kind == ActionKind.BACKGROUND_MODEL
+    assert resolved.name == 'veo-model'


### PR DESCRIPTION
### Product Context & Motivation
Genkit Python provides `generate_operation()` to trigger asynchronous long-running generation tasks (such as Veo video generation or Deep Research). Previously, `Registry.resolve_model()` only looked up models registered under the standard `ActionKind.MODEL` namespace. Consequently, background-only models registered under `ActionKind.BACKGROUND_MODEL` could not be resolved by `generate_operation()`, causing model lookup errors.

This PR fixes model resolution by enabling `resolve_model` to fall back to `BACKGROUND_MODEL` when a model is not found in the foreground `MODEL` registry.

### Key Changes
- Updated `Registry.resolve_model()` in `genkit._core._registry` to fall back to `ActionKind.BACKGROUND_MODEL` when standard lookup returns `None`.
- Updated `Genkit.generate_operation()` in `genkit._ai._aio` to call `resolve_model()`, ensuring background models are correctly discovered.
- Added comprehensive unit test in `registry_test.py` covering background model resolution.

### Behavioral Nuance & Safety
- Standard `MODEL` actions retain precedence: if a model exists in both namespaces, the foreground model is returned first.
- Standalone bugfix extracted from #5854.
- Verified with `pytest py/packages/genkit/tests/genkit/core/registry_test.py` (20 passed).