### PR TITLE
refactor(py): rename OutputConfig.schema_ to json_schema, pin wire alias

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -719,7 +719,7 @@ async def to_generate_request(registry: Registry, options: GenerateActionOptions
     output_config = OutputConfig(
         content_type=options.output.content_type if options.output else None,
         format=options.output.format if options.output else None,
-        schema_=options.output.json_schema if options.output else None,
+        json_schema=options.output.json_schema if options.output else None,
         constrained=options.output.constrained if options.output else None,
     )
     return ModelRequest(
@@ -730,7 +730,7 @@ async def to_generate_request(registry: Registry, options: GenerateActionOptions
         tools=tool_defs,
         tool_choice=options.tool_choice,
         output_format=output_config.format,
-        output_schema=output_config.schema_,
+        output_schema=output_config.json_schema,
         output_constrained=output_config.constrained,
         output_content_type=output_config.content_type,
     )

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -719,7 +719,8 @@ async def to_generate_request(registry: Registry, options: GenerateActionOptions
     output_config = OutputConfig(
         content_type=options.output.content_type if options.output else None,
         format=options.output.format if options.output else None,
-        json_schema=options.output.json_schema if options.output else None,
+        # pyrefly: ignore[unexpected-keyword] - populate_by_name accepts the field name
+        json_schema=options.output.json_schema if options.output else None,  # pyright: ignore[reportCallIssue]
         constrained=options.output.constrained if options.output else None,
     )
     return ModelRequest(

--- a/py/packages/genkit/src/genkit/_core/_typing.py
+++ b/py/packages/genkit/src/genkit/_core/_typing.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Literal
 
-from pydantic import AliasChoices, ConfigDict, Field, RootModel
+from pydantic import ConfigDict, Field, RootModel
 from pydantic.alias_generators import to_camel
 
 from genkit._core._base import GenkitModel
@@ -583,9 +583,7 @@ class OutputConfig(GenkitModel):
         alias_generator=to_camel, extra='forbid', populate_by_name=True, protected_namespaces=()
     )
     format: str | None = None
-    json_schema: dict[str, Any] | None = Field(
-        default=None, validation_alias=AliasChoices('json_schema', 'schema'), serialization_alias='schema'
-    )
+    json_schema: dict[str, Any] | None = Field(default=None, alias='schema')
     constrained: bool | None = None
     content_type: str | None = None
 

--- a/py/packages/genkit/src/genkit/_core/_typing.py
+++ b/py/packages/genkit/src/genkit/_core/_typing.py
@@ -20,18 +20,13 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Any, ClassVar, Literal
 
-from pydantic import ConfigDict, Field, RootModel
+from pydantic import AliasChoices, ConfigDict, Field, RootModel
 from pydantic.alias_generators import to_camel
 
 from genkit._core._base import GenkitModel
 from genkit._core._compat import StrEnum
-
-warnings.filterwarnings(
-    'ignore', message='Field name "schema" in "OutputConfig" shadows an attribute in parent', category=UserWarning
-)
 
 
 class AgentFinishReason(StrEnum):
@@ -588,7 +583,9 @@ class OutputConfig(GenkitModel):
         alias_generator=to_camel, extra='forbid', populate_by_name=True, protected_namespaces=()
     )
     format: str | None = None
-    schema_: dict[str, Any] | None = None
+    json_schema: dict[str, Any] | None = Field(
+        default=None, validation_alias=AliasChoices('json_schema', 'schema'), serialization_alias='schema'
+    )
     constrained: bool | None = None
     content_type: str | None = None
 

--- a/py/packages/genkit/tests/genkit/core/output_config_test.py
+++ b/py/packages/genkit/tests/genkit/core/output_config_test.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pin OutputConfig's Python name vs wire key."""
+
+import pytest
+from pydantic import ValidationError
+
+from genkit._core._schema import to_json_schema
+from genkit._core._typing import OutputConfig
+
+_SAMPLE = {'type': 'object', 'properties': {'name': {'type': 'string'}}}
+
+
+def test_python_name_dumps_wire_schema() -> None:
+    dumped = OutputConfig(json_schema=_SAMPLE).model_dump()
+    assert dumped == {'schema': _SAMPLE}
+
+
+def test_accepts_wire_schema_key() -> None:
+    cfg = OutputConfig.model_validate({'schema': _SAMPLE})
+    assert cfg.json_schema == _SAMPLE
+    assert cfg.model_dump() == {'schema': _SAMPLE}
+
+
+def test_accepts_python_name_on_validate() -> None:
+    cfg = OutputConfig.model_validate({'json_schema': _SAMPLE})
+    assert cfg.json_schema == _SAMPLE
+    assert cfg.model_dump() == {'schema': _SAMPLE}
+
+
+def test_advertised_schema_uses_wire_key() -> None:
+    props = to_json_schema(OutputConfig)['properties']
+    assert 'schema' in props
+    assert 'json_schema' not in props
+    assert 'jsonSchema' not in props
+    assert 'schema_' not in props
+
+
+def test_rejects_old_python_name() -> None:
+    with pytest.raises(ValidationError, match='schema_'):
+        OutputConfig.model_validate({'schema_': _SAMPLE})

--- a/py/scripts/schema_to_typing.py
+++ b/py/scripts/schema_to_typing.py
@@ -87,7 +87,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Literal
 
-from pydantic import AliasChoices, ConfigDict, Field, RootModel
+from pydantic import ConfigDict, Field, RootModel
 from pydantic.alias_generators import to_camel
 
 from genkit._core._base import GenkitModel
@@ -281,20 +281,14 @@ def _emit_model(
         f'    model_config: ClassVar[ConfigDict] = {cfg}',
     ]
     for k, v in props.items():
-        # OutputConfig.schema would shadow BaseModel.schema; use json_schema
-        # (same Python name as GenerateActionOutputConfig) and pin the wire
-        # alias so dump/validate still speak `schema`.
+        # OutputConfig.schema would shadow BaseModel.schema, so the Python
+        # name is json_schema. alias pins the wire key; to_camel would emit
+        # jsonSchema.
         snake = _camel_to_snake(k)
         force_field = False
         if name == 'OutputConfig' and snake == 'schema':
-            # Field name for constructors/typecheckers; wire still uses `schema`.
-            # Split validation/serialization aliases so checkers agree on
-            # json_schema= rather than splitting on Field(alias=...).
             field_name = 'json_schema'
-            alias_extra = (
-                ", validation_alias=AliasChoices('json_schema', 'schema')"
-                ", serialization_alias='schema'"
-            )
+            alias_extra = ", alias='schema'"
             force_field = True
         elif snake in ('schema_', 'schema'):
             field_name = 'schema'

--- a/py/scripts/schema_to_typing.py
+++ b/py/scripts/schema_to_typing.py
@@ -85,16 +85,13 @@ HEADER = '''# Copyright {year} Google LLC
 
 from __future__ import annotations
 
-import warnings
 from typing import Any, ClassVar, Literal
 
-from pydantic import ConfigDict, Field, RootModel
+from pydantic import AliasChoices, ConfigDict, Field, RootModel
 from pydantic.alias_generators import to_camel
 
 from genkit._core._base import GenkitModel
 from genkit._core._compat import StrEnum
-
-warnings.filterwarnings('ignore', message='Field name "schema" in "OutputConfig" shadows an attribute in parent', category=UserWarning)
 
 '''
 
@@ -284,15 +281,24 @@ def _emit_model(
         f'    model_config: ClassVar[ConfigDict] = {cfg}',
     ]
     for k, v in props.items():
-        # Use schema_ for OutputConfig.schema to avoid shadowing GenkitModel.schema
+        # OutputConfig.schema would shadow BaseModel.schema; use json_schema
+        # (same Python name as GenerateActionOutputConfig) and pin the wire
+        # alias so dump/validate still speak `schema`.
         snake = _camel_to_snake(k)
         force_field = False
         if name == 'OutputConfig' and snake == 'schema':
-            field_name = 'schema_'
-            alias_extra = ", alias='schema'"
+            # Field name for constructors/typecheckers; wire still uses `schema`.
+            # Split validation/serialization aliases so checkers agree on
+            # json_schema= rather than splitting on Field(alias=...).
+            field_name = 'json_schema'
+            alias_extra = (
+                ", validation_alias=AliasChoices('json_schema', 'schema')"
+                ", serialization_alias='schema'"
+            )
+            force_field = True
         elif snake in ('schema_', 'schema'):
-            field_name = 'schema' if name != 'OutputConfig' else 'schema_'
-            alias_extra = ", alias='schema'" if name == 'OutputConfig' else ''
+            field_name = 'schema'
+            alias_extra = ''
         elif keyword.iskeyword(snake):
             # Field name is a Python reserved word (e.g. JSON Patch's `from`),
             # which is a keyword only in Python. Suffix the Python attribute
@@ -308,14 +314,11 @@ def _emit_model(
             field_name = snake
             alias_extra = ''
         py_type_str = _py_type(v, schema, defs, name, k)
-        # OutputConfig.schema is free-form JSON schema object; use dict for direct use
+        # Free-form JSON schema object, not the Schema model type.
         if name == 'OutputConfig' and snake == 'schema':
             py_type_str = 'dict[str, Any]'
         if name == 'MessageData' and k == 'role':
             py_type_str = 'Role | str'
-        # OutputConfig.schema is free-form JSON schema dict (not Schema model)
-        if name == 'OutputConfig' and snake == 'schema':
-            py_type_str = 'dict[str, Any]'
         desc = v.get('description')
         desc_extra = f', description={repr(desc)}' if desc else ''
         if k in req:


### PR DESCRIPTION
`OutputConfig` still uses `schema_` so it doesn’t shadow `BaseModel.schema`, and we suppress the warning. We already picked `json_schema` on `GenerateActionOutputConfig` — same idea, better name, no filter. This PR does that rename on the generated type and deletes the suppression.

#5986 already contains this hunk (it nests `output: OutputConfig` on `ModelRequest` and then this name matters). This slice is just that decision, so we can land it and rebase #5986 onto latest main.

Python name is `json_schema`. The field’s JSON key stays `schema` (`Field(alias='schema')`) — a bare `json_schema` would camelCase to `jsonSchema`, which is the generate-action key, not this type’s. `to_generate_request` is the only runtime constructor today; it is updated. `schema_=` is rejected on purpose (private type, not exported).

**Changes**
- `schema_` → `json_schema`; `_prompt.py` updated
- codegen emits `Field(alias='schema')` with `force_field=True` so the alias isn’t dropped
- drop `warnings.filterwarnings` for the shadow
- pin tests: construct `json_schema=`, validate `{schema: …}`, dump and `to_json_schema` speak `schema`, `schema_=` is rejected