### PR TITLE
fix(js/ai): Add span metadata for render spans

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -266,6 +266,9 @@ function definePromptAsync<
         metadata: {
           name: 'render',
           input,
+          metadata: {
+            promptName: name,
+          },
         },
         labels: {
           [SPAN_TYPE_ATTR]: 'promptTemplate',


### PR DESCRIPTION
Adds prompt name to `render` spans for Dev UI usability. 

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually)
