### PR TITLE
refactor(go): deduplicate plugin helpers and fix the defects the copies hid

### DIFF
--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -203,22 +203,21 @@ func NewBackgroundModelAction[Config any](
 		panic("ai.NewBackgroundModelAction: checkFn is required")
 	}
 
-	if opts == nil {
-		opts = &BackgroundModelOptions{}
+	o := BackgroundModelOptions{}
+	if opts != nil {
+		o = *opts
 	}
-	labelExplicit := opts.Label != ""
+	labelExplicit := o.Label != ""
 	if !labelExplicit {
-		opts.Label = name
+		o.Label = name
 	}
-	if opts.Supports == nil {
-		opts.Supports = &ModelSupports{}
-	}
+	o.Supports = cloneModelSupports(o.Supports)
 
-	configSchema, inputSchema := modelConfigSchemas[Config](opts.ConfigSchema, opts.Versions)
+	configSchema, inputSchema := modelConfigSchemas[Config](o.ConfigSchema, o.Versions)
 
 	// The top-level Metadata wins over the embedded ModelOptions.Metadata on
 	// key conflicts.
-	metadata := modelActionMetadata(api.ActionTypeBackgroundModel, &opts.ModelOptions, configSchema, opts.ModelOptions.Metadata, opts.Metadata)
+	metadata := modelActionMetadata(api.ActionTypeBackgroundModel, &o.ModelOptions, configSchema, o.ModelOptions.Metadata, o.Metadata)
 
 	typedStartFn := func(ctx context.Context, req *ModelRequest) (*ModelOperation, error) {
 		// req.Config was normalized to the exact Config type by
@@ -230,12 +229,12 @@ func NewBackgroundModelAction[Config any](
 		return startFn(ctx, req, cfg)
 	}
 
-	mopts := &opts.ModelOptions
+	mopts := &o.ModelOptions
 
 	// normalizeConfig runs outermost so that the built-in wrappers and the
 	// start function all see the typed, converted config on the request.
 	fn := core.ChainMiddleware(
-		normalizeConfig[Config](name, opts.Versions),
+		normalizeConfig[Config](name, o.Versions),
 		simulateSystemPrompt(mopts, nil),
 		augmentWithContext(mopts, nil),
 		validateSupport(name, mopts),
@@ -255,7 +254,7 @@ func NewBackgroundModelAction[Config any](
 	// defaulted from the name yields to an explicit caller
 	// Metadata["description"]: leaving Description empty lets core's
 	// metadata fallback apply it.
-	description := opts.Label
+	description := o.Label
 	if !labelExplicit {
 		if _, ok := metadata["description"].(string); ok {
 			description = ""
@@ -266,7 +265,7 @@ func NewBackgroundModelAction[Config any](
 		Metadata:    metadata,
 		InputSchema: inputSchema,
 		Check:       checkFn,
-		Cancel:      opts.Cancel,
+		Cancel:      o.Cancel,
 	}, wrappedFn)}
 }
 

--- a/go/ai/config.go
+++ b/go/ai/config.go
@@ -19,11 +19,11 @@ package ai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"maps"
 	"slices"
 
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/base"
 )
 
@@ -33,6 +33,46 @@ import (
 // the raw value is deserialized into the Config type parameter before the
 // function runs, and the request's type-erased config slot is normalized to
 // that same converted value so the two views never disagree.
+
+// typedConfigFn wraps fn so it receives the typed config alongside a request
+// whose type-erased config slot has been normalized to the same value, meaning
+// the request's two views of the config never disagree. slot points at that
+// slot on the shallow copy this makes: the incoming request is caller-owned
+// memory that may be reused across actions or turns, so it keeps carrying the
+// raw config.
+//
+// Models go through [normalizeConfig] instead, which does the same thing as
+// middleware so the built-in wrappers see the typed value too.
+func typedConfigFn[Req, Resp, Config any](
+	slot func(*Req) *any,
+	fn func(context.Context, *Req, Config) (*Resp, error),
+) func(context.Context, *Req) (*Resp, error) {
+	return func(ctx context.Context, req *Req) (*Resp, error) {
+		reqCopy := *req
+		cfg, err := resolveConfigInto[Config](slot(&reqCopy))
+		if err != nil {
+			return nil, err
+		}
+		return fn(ctx, &reqCopy, cfg)
+	}
+}
+
+// actionMetadata builds an action descriptor's metadata: the caller's maps are
+// merged in order, then the built-in entries and the action type are stamped
+// over them so they cannot be corrupted. Registry discovery depends on those.
+func actionMetadata(atype api.ActionType, builtin map[string]any, callerMetadata ...map[string]any) map[string]any {
+	size := len(builtin) + 1
+	for _, m := range callerMetadata {
+		size += len(m)
+	}
+	metadata := make(map[string]any, size)
+	for _, m := range callerMetadata {
+		maps.Copy(metadata, m)
+	}
+	maps.Copy(metadata, builtin)
+	metadata["type"] = atype
+	return metadata
+}
 
 // nullableConfigSchema wraps a config schema for the request input-schema
 // slot so that an explicit JSON null is accepted on the wire: a typed-nil Go
@@ -87,19 +127,17 @@ func actionConfigSchemas[Config any](override map[string]any, reqZero any, key s
 }
 
 // configSchemas returns the config schema the action advertises and the one it
-// enforces on the wire. They are the same schema for an explicit override,
-// which is the caller's contract. They differ for an inferred one: enforcement
-// additionally tolerates the nulls a partial config marshals to, while the
-// advertised copy stays free of that noise for the dev UI.
+// enforces on the wire. The advertised one is the contract, verbatim from the
+// plugin or inferred from Config; the enforced one is a copy that additionally
+// tolerates the nulls a partial config marshals to, which stays out of the
+// advertised copy so the dev UI is not littered with it.
+//
+// Both a declared and an inferred schema are widened, so a config behaves the
+// same whichever way its schema was arrived at. The copy is what keeps that
+// safe: a plugin's declared schema is usually a package-level value.
 func configSchemas[Config any](override map[string]any) (advertised, enforced map[string]any) {
-	if override != nil {
-		return override, override
-	}
-	// Two independent builds rather than a deep copy: SchemaMapFor hands out a
-	// fresh map per call, and this only runs at define time for actions whose
-	// plugin declares no schema.
-	advertised = effectiveConfigSchema[Config](nil)
-	enforced = effectiveConfigSchema[Config](nil)
+	advertised = effectiveConfigSchema[Config](override)
+	enforced = base.CloneSchema(advertised)
 	tolerateNulls(enforced)
 	return advertised, enforced
 }
@@ -139,30 +177,18 @@ func effectiveConfigSchema[Config any](override map[string]any) map[string]any {
 	return schema
 }
 
-// stripRequired removes "required" lists from schema and its nested object
-// schemas (properties, items, and schema-valued additionalProperties).
+// stripRequired removes "required" from schema and every subschema: a config
+// is partial by nature, so a field lacking omitempty must not become mandatory.
 func stripRequired(schema map[string]any) {
-	if schema == nil {
-		return
-	}
 	delete(schema, "required")
-	if props, ok := schema["properties"].(map[string]any); ok {
-		for _, sub := range props {
-			if m, ok := sub.(map[string]any); ok {
-				stripRequired(m)
-			}
-		}
-	}
-	if items, ok := schema["items"].(map[string]any); ok {
-		stripRequired(items)
-	}
-	if extra, ok := schema["additionalProperties"].(map[string]any); ok {
-		stripRequired(extra)
-	}
+	base.WalkSubschemas(schema, func(sub map[string]any) map[string]any {
+		delete(sub, "required")
+		return sub
+	})
 }
 
-// tolerateNulls widens every property of an inferred config schema, at every
-// depth, to also accept an explicit JSON null.
+// tolerateNulls widens every subschema of an inferred config schema to also
+// accept an explicit JSON null.
 //
 // A pointer, slice, or map field that lacks omitempty marshals to null when it
 // is unset, so enforcing the field's declared type would reject a partially
@@ -171,34 +197,12 @@ func stripRequired(schema map[string]any) {
 // the same "a config is partial by nature" reasoning that strips "required",
 // applied to the fields that are present but empty.
 //
-// Every property is widened, not just the nilable ones, because the inferred
+// Every field is widened, not just the nilable ones, because the inferred
 // schema cannot tell a *string from a string. Widening costs nothing: null
 // decodes to the zero value for every Go kind, which is what omitting the
-// field would have produced. The precise alternative, reflecting over Config
-// to find the nilable fields, would have to walk config types that are known
-// to be recursive (see the googlegenai plugin's IgnoredTypes guard).
+// field would have produced.
 func tolerateNulls(schema map[string]any) {
-	if schema == nil {
-		return
-	}
-	if props, ok := schema["properties"].(map[string]any); ok {
-		for name, sub := range props {
-			m, ok := sub.(map[string]any)
-			if !ok {
-				continue
-			}
-			tolerateNulls(m)
-			props[name] = allowNull(m)
-		}
-	}
-	if items, ok := schema["items"].(map[string]any); ok {
-		tolerateNulls(items)
-		schema["items"] = allowNull(items)
-	}
-	if extra, ok := schema["additionalProperties"].(map[string]any); ok {
-		tolerateNulls(extra)
-		schema["additionalProperties"] = allowNull(extra)
-	}
+	base.WalkSubschemas(schema, allowNull)
 }
 
 // allowNull returns schema widened to accept null, adding to its "type" when
@@ -249,10 +253,12 @@ func withVersionProperty(schema map[string]any) map[string]any {
 func resolveConfig[Config any](raw any) (Config, error) {
 	cfg, err := base.ConvertToExact[Config](raw)
 	if err != nil {
+		// Public: naming the config type is what tells a caller which
+		// provider's config they reached for, and it leaks nothing.
 		if errors.Is(err, base.ErrTypeMismatch) {
-			return cfg, core.NewPublicError(core.INVALID_ARGUMENT, fmt.Sprintf("invalid config type %T, want %T or map[string]any", raw, cfg), nil)
+			return cfg, status.PublicErrorf(status.ErrInvalidArgument, "invalid config type %T, want %T or map[string]any", raw, cfg)
 		}
-		return cfg, core.NewPublicError(core.INVALID_ARGUMENT, fmt.Sprintf("invalid config for %T; check that field names and value types match: %v", cfg, err), nil)
+		return cfg, status.PublicErrorf(status.ErrInvalidArgument, "invalid config for %T; check that field names and value types match: %w", cfg, err)
 	}
 	return cfg, nil
 }

--- a/go/ai/constructor_options_test.go
+++ b/go/ai/constructor_options_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"testing"
+)
+
+// TestConstructorsDoNotMutateOptions pins that a constructor owns its copy of
+// the options it is handed. Plugins reuse one options value across a whole
+// model table, and point every entry at one shared *ModelSupports, so a
+// constructor that wrote back through either would change models it was never
+// asked about.
+func TestConstructorsDoNotMutateOptions(t *testing.T) {
+	t.Run("model", func(t *testing.T) {
+		supports := &ModelSupports{Multiturn: true, Output: []string{"text"}}
+		opts := &ModelOptions{Supports: supports}
+		NewModelAction("first", opts, func(context.Context, *ModelRequest, any, ModelStreamCallback) (*ModelResponse, error) {
+			return nil, nil
+		})
+		if opts.Label != "" {
+			t.Errorf("constructor wrote Label %q back into the caller's options", opts.Label)
+		}
+		if opts.Supports != supports {
+			t.Error("constructor replaced the caller's Supports pointer")
+		}
+	})
+
+	t.Run("embedder", func(t *testing.T) {
+		opts := &EmbedderOptions{}
+		NewEmbedderAction("first", opts, func(context.Context, *EmbedRequest, any) (*EmbedResponse, error) {
+			return nil, nil
+		})
+		if opts.Label != "" || opts.Supports != nil {
+			t.Errorf("constructor mutated the caller's options: %+v", opts)
+		}
+	})
+
+	t.Run("retriever", func(t *testing.T) {
+		opts := &RetrieverOptions{}
+		NewRetrieverAction("first", opts, func(context.Context, *RetrieverRequest, any) (*RetrieverResponse, error) {
+			return nil, nil
+		})
+		if opts.Label != "" || opts.Supports != nil {
+			t.Errorf("constructor mutated the caller's options: %+v", opts)
+		}
+	})
+
+	t.Run("background model", func(t *testing.T) {
+		opts := &BackgroundModelOptions{}
+		NewBackgroundModelAction("first", opts,
+			func(context.Context, *ModelRequest, any) (*ModelOperation, error) { return nil, nil },
+			func(context.Context, *ModelOperation) (*ModelOperation, error) { return nil, nil })
+		if opts.Label != "" || opts.Supports != nil {
+			t.Errorf("constructor mutated the caller's options: %+v", opts)
+		}
+	})
+
+	// The capability struct a table shares must not be reachable through the
+	// action either: two models built from one *ModelSupports get their own.
+	t.Run("shared supports is copied", func(t *testing.T) {
+		shared := &ModelSupports{Tools: true, Output: []string{"text"}}
+		first := NewModelAction("first", &ModelOptions{Supports: shared}, nilModelFn)
+		second := NewModelAction("second", &ModelOptions{Supports: shared}, nilModelFn)
+
+		firstSupports := first.Desc().Metadata["model"].(map[string]any)["supports"].(map[string]any)
+		secondSupports := second.Desc().Metadata["model"].(map[string]any)["supports"].(map[string]any)
+		if firstSupports["tools"] != true || secondSupports["tools"] != true {
+			t.Fatal("shared capabilities did not reach both models")
+		}
+		shared.Tools = false
+		if firstSupports["tools"] != true {
+			t.Error("changing the shared struct reached a model built earlier")
+		}
+	})
+}
+
+// TestConstructorsDefaultLabelToName pins that every primitive labels an
+// unlabelled action with its name, whether or not options were supplied. The
+// dev UI lists actions by label, so a blank one is a blank row.
+func TestConstructorsDefaultLabelToName(t *testing.T) {
+	label := func(desc map[string]any, key string) any {
+		return desc[key].(map[string]any)["label"]
+	}
+	for _, tt := range []struct {
+		name  string
+		build func(string) map[string]any
+		key   string
+	}{
+		{"model", func(n string) map[string]any {
+			return NewModelAction(n, &ModelOptions{Versions: []string{"v1"}}, nilModelFn).Desc().Metadata
+		}, "model"},
+		{"embedder", func(n string) map[string]any {
+			return NewEmbedderAction(n, &EmbedderOptions{Dimensions: 3}, func(context.Context, *EmbedRequest, any) (*EmbedResponse, error) {
+				return nil, nil
+			}).Desc().Metadata
+		}, "info"},
+		{"retriever", func(n string) map[string]any {
+			return NewRetrieverAction(n, &RetrieverOptions{}, func(context.Context, *RetrieverRequest, any) (*RetrieverResponse, error) {
+				return nil, nil
+			}).Desc().Metadata
+		}, "info"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := label(tt.build("acme/thing"), tt.key); got != "acme/thing" {
+				t.Errorf("label = %v, want the action name; a non-nil options value must not lose the default", got)
+			}
+		})
+	}
+}
+
+func nilModelFn(context.Context, *ModelRequest, any, ModelStreamCallback) (*ModelResponse, error) {
+	return nil, nil
+}

--- a/go/ai/doc.go
+++ b/go/ai/doc.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package ai defines Genkit's AI primitives: models, prompts, tools, embedders,
+retrievers, and evaluators, and the options that configure a request to them.
+
+Applications reach these through the genkit package, whose Define* and
+Generate* functions register with a [github.com/firebase/genkit/go/genkit.Genkit]
+and forward here. Plugins use this package directly: New*Action builds an
+unregistered primitive to return from a plugin's Init.
+
+# Options
+
+Options follow the standard Go functional-options pattern: pass as many as you
+like, in any order, and they merge left to right. Two rules govern how repeats
+combine, so composing a request from several helpers is predictable:
+
+  - Collection options accumulate. Repeating one, or mixing its variants,
+    appends in call order: WithMessages(a), WithMessages(b) sends [a, b], and
+    [WithTools], [WithResources], [WithUse], [WithDocs], and [WithDataset]
+    behave the same.
+  - Single-value options take the last one set. [WithConfig], [WithModel],
+    [WithSystem], [WithPrompt], the output-schema options, and the like each
+    fill one slot, so the final call wins and earlier ones are overwritten
+    rather than rejected. Every option that fills a slot shares it:
+    [WithSystem], [WithSystemParts], [WithSystemFn], and [WithSystemPartsFn]
+    are four ways to write one system message, so they do not merge.
+
+A zero value does not fill a slot: WithMaxTurns(0), WithToolChoice(""), or
+WithConfig(nil) is a no-op, so an earlier non-zero value cannot be un-set by a
+later zero one. The rules apply within a single options list; APIs that layer
+two lists (a prompt's define-time options against Execute-time options) document
+their own precedence.
+
+One combination is refused rather than merged. [WithMessagesTemplate] lays out
+the whole conversation, down to where {{history}} puts the caller's, so
+separately supplied messages have no position relative to it. Passing it to
+DefinePrompt alongside [WithMessages] or [WithMessagesFn] panics. Repeating the
+template alone is an ordinary slot.
+
+Applying options therefore never fails on a "set more than once" conflict. What
+does fail is a genuinely invalid argument (a type that [WithInputType] cannot
+turn into a schema) or the refused combination above, and both panic at the call
+site where the mistake is rather than deferring to the request.
+
+# Errors
+
+Failures are classified with the sentinels in
+[github.com/firebase/genkit/go/core/status], so callers branch with errors.Is
+rather than on message text:
+
+	if errors.Is(err, ai.ErrMaxTurnsExceeded) { ... } // specific
+	if errors.Is(err, status.ErrAborted) { ... }      // broad
+
+# Writing a plugin
+
+A provider plugin builds primitives with the New*Action constructors and returns
+them from its Init. [ModelOptions] and its siblings describe what a model can
+do; the constructor copies what it is given, so a table of models may share one
+[ModelSupports] value. [ModelOptions.Overlay] is how a plugin lets an
+application correct that description without restating it: a zero-value field
+in the override keeps what the plugin already knows.
+*/
+package ai

--- a/go/ai/document.go
+++ b/go/ai/document.go
@@ -72,6 +72,7 @@ func (m *Message) Clone() *Message {
 	return &cp
 }
 
+// PartKind is what a [Part] carries: text, media, a tool request, and so on.
 type PartKind int8
 
 const (

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
@@ -169,52 +168,34 @@ func NewEmbedderAction[Config any](
 		panic("ai.NewEmbedderAction: name is required")
 	}
 
-	if opts == nil {
-		opts = &EmbedderOptions{
-			Label: name,
-		}
+	o := EmbedderOptions{}
+	if opts != nil {
+		o = *opts
 	}
-	if opts.Supports == nil {
-		opts.Supports = &EmbedderSupports{}
+	if o.Label == "" {
+		o.Label = name
 	}
+	o.Supports = cloneEmbedderSupports(o.Supports)
 
-	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EmbedRequest{}, "options")
-
-	// Seed from the caller's metadata, then stamp the built-in keys over it so
-	// they cannot be corrupted; registry discovery depends on them.
-	metadata := make(map[string]any, len(opts.Metadata)+3)
-	maps.Copy(metadata, opts.Metadata)
-	metadata["type"] = api.ActionTypeEmbedder
-	// TODO: This should be under "embedder" but JS has it as "info".
-	metadata["info"] = map[string]any{
-		"label":      opts.Label,
-		"dimensions": opts.Dimensions,
-		"supports": map[string]any{
-			"input":        opts.Supports.Input,
-			"multilingual": opts.Supports.Multilingual,
+	configSchema, inputSchema := actionConfigSchemas[Config](o.ConfigSchema, EmbedRequest{}, "options")
+	metadata := actionMetadata(api.ActionTypeEmbedder, map[string]any{
+		// TODO: This should be under "embedder" but JS has it as "info".
+		"info": map[string]any{
+			"label":      o.Label,
+			"dimensions": o.Dimensions,
+			"supports": map[string]any{
+				"input":        o.Supports.Input,
+				"multilingual": o.Supports.Multilingual,
+			},
 		},
-	}
-	metadata["embedder"] = map[string]any{
-		"customOptions": configSchema,
-	}
-
-	rawFn := func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
-		// Normalize a shallow copy so the type-erased Options and the typed
-		// parameter always agree without clobbering the caller-owned request.
-		reqCopy := *req
-		req = &reqCopy
-		cfg, err := resolveConfigInto[Config](&req.Options)
-		if err != nil {
-			return nil, err
-		}
-		return fn(ctx, req, cfg)
-	}
+		"embedder": map[string]any{"customOptions": configSchema},
+	}, o.Metadata)
 
 	return &EmbedderAction{
 		action: *core.NewActionOf(api.ActionTypeEmbedder, name, &core.ActionOptions{
 			Metadata:    metadata,
 			InputSchema: inputSchema,
-		}, rawFn),
+		}, typedConfigFn(func(r *EmbedRequest) *any { return &r.Options }, fn)),
 	}
 }
 

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
@@ -173,6 +172,8 @@ var statusName = map[ScoreStatus]string{
 	ScoreStatusPass:    "PASS",
 }
 
+// String returns the wire name of the score status ("PASS", "FAIL", or
+// "UNKNOWN").
 func (ss ScoreStatus) String() string {
 	return statusName[ss]
 }
@@ -203,6 +204,8 @@ type EvaluationResult struct {
 // represents the result on the entire input dataset.
 type EvaluatorResponse = []EvaluationResult
 
+// EvaluatorOptions configures an evaluator created with
+// [NewEvaluatorAction] or [NewBatchEvaluatorAction].
 type EvaluatorOptions struct {
 	// ConfigSchema is the JSON schema for the evaluator's config.
 	ConfigSchema map[string]any `json:"configSchema,omitempty"`
@@ -229,19 +232,14 @@ type EvaluatorCallbackResponse = EvaluationResult
 
 // evaluatorMetadata builds the shared action metadata for an evaluator.
 func evaluatorMetadata(opts *EvaluatorOptions, configSchema map[string]any) map[string]any {
-	// Seed from the caller's metadata, then stamp the built-in keys over it so
-	// they cannot be corrupted; registry discovery depends on them.
-	metadata := make(map[string]any, len(opts.Metadata)+2)
-	maps.Copy(metadata, opts.Metadata)
-	// TODO(ssbushi): Set this on `evaluator` key on action metadata
-	metadata["type"] = api.ActionTypeEvaluator
-	metadata["evaluator"] = map[string]any{
-		"evaluatorIsBilled":    opts.IsBilled,
-		"evaluatorDisplayName": opts.DisplayName,
-		"evaluatorDefinition":  opts.Definition,
-		"customOptions":        configSchema,
-	}
-	return metadata
+	return actionMetadata(api.ActionTypeEvaluator, map[string]any{
+		"evaluator": map[string]any{
+			"evaluatorIsBilled":    opts.IsBilled,
+			"evaluatorDisplayName": opts.DisplayName,
+			"evaluatorDefinition":  opts.Definition,
+			"customOptions":        configSchema,
+		},
+	}, opts.Metadata)
 }
 
 // NewEvaluatorAction creates an unregistered [EvaluatorAction]: return it from
@@ -262,29 +260,18 @@ func NewEvaluatorAction[Config any](
 	fn EvaluatorActionFunc[Config],
 ) *EvaluatorAction {
 	if name == "" {
-		panic("ai.NewEvaluatorAction: evaluator name is required")
+		panic("ai.NewEvaluatorAction: name is required")
 	}
 
-	if opts == nil {
-		opts = &EvaluatorOptions{}
+	o := EvaluatorOptions{}
+	if opts != nil {
+		o = *opts
 	}
 
-	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
+	configSchema, inputSchema := actionConfigSchemas[Config](o.ConfigSchema, EvaluatorRequest{}, "options")
 
-	return &EvaluatorAction{
-		action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
-			Metadata:    evaluatorMetadata(opts, configSchema),
-			InputSchema: inputSchema,
-		}, func(ctx context.Context, req *EvaluatorRequest) (output *EvaluatorResponse, err error) {
-			// Normalize a shallow copy so the type-erased Options and the
-			// typed parameter always agree without clobbering the caller-owned
-			// request.
-			reqCopy := *req
-			req = &reqCopy
-			cfg, err := resolveConfigInto[Config](&req.Options)
-			if err != nil {
-				return nil, err
-			}
+	rawFn := typedConfigFn(func(r *EvaluatorRequest) *any { return &r.Options },
+		func(ctx context.Context, req *EvaluatorRequest, cfg Config) (*EvaluatorResponse, error) {
 			// The callback's Options slot is type-erased like the request's,
 			// so it takes the same guard: boxing a typed nil would make it
 			// compare non-nil while dereferences still panic, and would split
@@ -341,7 +328,13 @@ func NewEvaluatorAction[Config any](
 				}
 			}
 			return &results, nil
-		}),
+		})
+
+	return &EvaluatorAction{
+		action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
+			Metadata:    evaluatorMetadata(&o, configSchema),
+			InputSchema: inputSchema,
+		}, rawFn),
 	}
 }
 
@@ -367,32 +360,21 @@ func NewBatchEvaluatorAction[Config any](
 	fn BatchEvaluatorActionFunc[Config],
 ) *EvaluatorAction {
 	if name == "" {
-		panic("ai.NewBatchEvaluatorAction: batch evaluator name is required")
+		panic("ai.NewBatchEvaluatorAction: name is required")
 	}
 
-	if opts == nil {
-		opts = &EvaluatorOptions{}
+	o := EvaluatorOptions{}
+	if opts != nil {
+		o = *opts
 	}
 
-	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
-
-	rawFn := func(ctx context.Context, req *EvaluatorRequest) (*EvaluatorResponse, error) {
-		// Normalize a shallow copy so the type-erased Options and the typed
-		// parameter always agree without clobbering the caller-owned request.
-		reqCopy := *req
-		req = &reqCopy
-		cfg, err := resolveConfigInto[Config](&req.Options)
-		if err != nil {
-			return nil, err
-		}
-		return fn(ctx, req, cfg)
-	}
+	configSchema, inputSchema := actionConfigSchemas[Config](o.ConfigSchema, EvaluatorRequest{}, "options")
 
 	return &EvaluatorAction{
 		action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
-			Metadata:    evaluatorMetadata(opts, configSchema),
+			Metadata:    evaluatorMetadata(&o, configSchema),
 			InputSchema: inputSchema,
-		}, rawFn),
+		}, typedConfigFn(func(r *EvaluatorRequest) *any { return &r.Options }, fn)),
 	}
 }
 
@@ -404,7 +386,7 @@ func NewBatchEvaluatorAction[Config any](
 // request.
 func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
 	if name == "" {
-		panic("ai.NewEvaluator: evaluator name is required")
+		panic("ai.NewEvaluator: name is required")
 	}
 	return NewEvaluatorAction(name, opts, func(ctx context.Context, req *EvaluatorCallbackRequest, _ any) (*EvaluatorCallbackResponse, error) {
 		return fn(ctx, req)
@@ -420,7 +402,7 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 // request.
 func NewBatchEvaluator(name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
 	if name == "" {
-		panic("ai.NewBatchEvaluator: batch evaluator name is required")
+		panic("ai.NewBatchEvaluator: name is required")
 	}
 	return NewBatchEvaluatorAction(name, opts, func(ctx context.Context, req *EvaluatorRequest, _ any) (*EvaluatorResponse, error) {
 		return fn(ctx, req)

--- a/go/ai/format.go
+++ b/go/ai/format.go
@@ -16,7 +16,6 @@ package ai
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -176,6 +175,68 @@ func injectInstructions(messages []*Message, instructions string) []*Message {
 	return out
 }
 
+// Every handler carries the same three things: the instructions it embeds in
+// the prompt, the output config it puts on the request, and the text streamed
+// so far for the turn it is parsing. baseHandler holds all three so a handler
+// is only its own parsing.
+type baseHandler struct {
+	instructions string
+	config       ModelOutputConfig
+	text         string // Text accumulated for the current turn.
+	index        int    // Index of that turn.
+	cursor       int    // How much of text has already been emitted.
+}
+
+// Instructions returns the instructions for the formatter.
+func (h *baseHandler) Instructions() string { return h.instructions }
+
+// Config returns the output config for the formatter.
+func (h *baseHandler) Config() ModelOutputConfig { return h.config }
+
+// ParseMessage returns the message unchanged. Handlers that rewrite a message
+// into parsed parts override it.
+func (h *baseHandler) ParseMessage(m *Message) (*Message, error) { return m, nil }
+
+// accumulate appends chunk's text to the turn in progress and returns the text
+// so far. A chunk from a new turn resets the state first: a handler instance
+// spans the whole request, and a tool loop starts a fresh message each turn.
+func (h *baseHandler) accumulate(chunk *ModelResponseChunk) string {
+	if chunk.Index != h.index {
+		h.text, h.index, h.cursor = "", chunk.Index, 0
+	}
+	for _, part := range chunk.Content {
+		if part.IsText() {
+			h.text += part.Text
+		}
+	}
+	return h.text
+}
+
+// splitTextParts separates a message's text, concatenated, from its other
+// parts, which the handlers that rewrite a message carry through untouched.
+func splitTextParts(m *Message) (text string, others []*Part) {
+	var b strings.Builder
+	for _, part := range m.Content {
+		if part.IsText() {
+			b.WriteString(part.Text)
+		} else {
+			others = append(others, part)
+		}
+	}
+	return b.String(), others
+}
+
+// requireContent rejects the messages a handler cannot parse at all.
+func requireContent(m *Message) error {
+	if m == nil {
+		return status.Errorf(status.ErrInvalidOutput, "message is empty")
+	}
+	if len(m.Content) == 0 {
+		return status.Errorf(status.ErrInvalidOutput, "message has no content")
+	}
+	return nil
+}
+
 type textFormatter struct{}
 
 // Name returns the name of the formatter.
@@ -185,31 +246,10 @@ func (t textFormatter) Name() string {
 
 // Handler returns a new formatter handler for the given schema.
 func (t textFormatter) Handler(schema map[string]any) (FormatHandler, error) {
-	handler := &textHandler{
-		config: ModelOutputConfig{
-			ContentType: "text/plain",
-		},
-	}
-
-	return handler, nil
+	return &textHandler{baseHandler{config: ModelOutputConfig{ContentType: "text/plain"}}}, nil
 }
 
-type textHandler struct {
-	instructions    string
-	config          ModelOutputConfig
-	accumulatedText string
-	currentIndex    int
-}
-
-// Config returns the output config for the formatter.
-func (t *textHandler) Config() ModelOutputConfig {
-	return t.config
-}
-
-// Instructions returns the instructions for the formatter.
-func (t *textHandler) Instructions() string {
-	return t.instructions
-}
+type textHandler struct{ baseHandler }
 
 // ParseOutput parses the final message and returns the text content.
 func (t *textHandler) ParseOutput(m *Message) (any, error) {
@@ -218,23 +258,7 @@ func (t *textHandler) ParseOutput(m *Message) (any, error) {
 
 // ParseChunk processes a streaming chunk and returns parsed output.
 func (t *textHandler) ParseChunk(chunk *ModelResponseChunk) (any, error) {
-	if chunk.Index != t.currentIndex {
-		t.accumulatedText = ""
-		t.currentIndex = chunk.Index
-	}
-
-	for _, part := range chunk.Content {
-		if part.IsText() {
-			t.accumulatedText += part.Text
-		}
-	}
-
-	return t.accumulatedText, nil
-}
-
-// ParseMessage parses the message and returns the formatted message.
-func (t *textHandler) ParseMessage(m *Message) (*Message, error) {
-	return m, nil
+	return t.accumulate(chunk), nil
 }
 
 type jsonFormatter struct{}
@@ -250,13 +274,13 @@ func (j jsonFormatter) Handler(schema map[string]any) (FormatHandler, error) {
 	if schema != nil {
 		jsonBytes, err := json.Marshal(schema)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling schema to JSON: %w", err)
+			return nil, status.Errorf(status.ErrInvalidSchema, "marshalling schema to JSON: %w", err)
 		}
 
 		instructions = fmt.Sprintf("Output should be in JSON format and conform to the following schema:\n\n```%s```", string(jsonBytes))
 	}
 
-	handler := &jsonHandler{
+	return &jsonHandler{baseHandler{
 		instructions: instructions,
 		config: ModelOutputConfig{
 			Constrained: true,
@@ -264,28 +288,11 @@ func (j jsonFormatter) Handler(schema map[string]any) (FormatHandler, error) {
 			Schema:      schema,
 			ContentType: "application/json",
 		},
-	}
-
-	return handler, nil
+	}}, nil
 }
 
 // jsonHandler is a handler for the JSON formatter.
-type jsonHandler struct {
-	instructions    string
-	config          ModelOutputConfig
-	accumulatedText string
-	currentIndex    int
-}
-
-// Instructions returns the instructions for the formatter.
-func (j *jsonHandler) Instructions() string {
-	return j.instructions
-}
-
-// Config returns the output config for the formatter.
-func (j *jsonHandler) Config() ModelOutputConfig {
-	return j.config
-}
+type jsonHandler struct{ baseHandler }
 
 // ParseOutput parses the final message and returns the parsed JSON value.
 func (j *jsonHandler) ParseOutput(m *Message) (any, error) {
@@ -305,59 +312,36 @@ func (j *jsonHandler) ParseOutput(m *Message) (any, error) {
 
 // ParseChunk processes a streaming chunk and returns parsed output.
 func (j *jsonHandler) ParseChunk(chunk *ModelResponseChunk) (any, error) {
-	if chunk.Index != j.currentIndex {
-		j.accumulatedText = ""
-		j.currentIndex = chunk.Index
-	}
-
-	for _, part := range chunk.Content {
-		if part.IsText() {
-			j.accumulatedText += part.Text
-		}
-	}
-
-	return j.parseJSON(j.accumulatedText)
+	return j.parseJSON(j.accumulate(chunk))
 }
 
-// ParseMessage parses the message and returns the formatted message.
+// ParseMessage rewrites the message's text as a single JSON part, validated
+// against the schema when there is one, and carries any non-text parts through.
 func (j *jsonHandler) ParseMessage(m *Message) (*Message, error) {
-	if m == nil {
-		return nil, errors.New("message is empty")
+	if err := requireContent(m); err != nil {
+		return nil, err
 	}
-	if len(m.Content) == 0 {
-		return nil, errors.New("message has no content")
-	}
-
-	var nonTextParts []*Part
-	accumulatedText := strings.Builder{}
-
-	for _, part := range m.Content {
-		if !part.IsText() {
-			nonTextParts = append(nonTextParts, part)
-		} else {
-			accumulatedText.WriteString(part.Text)
-		}
-	}
+	rawText, nonTextParts := splitTextParts(m)
 
 	newParts := []*Part{}
-	text := base.ExtractJSONFromMarkdown(accumulatedText.String())
+	text := base.ExtractJSONFromMarkdown(rawText)
 	if text == "" && len(nonTextParts) == 0 {
 		// Every part was empty text. Falling through would hand back a message
 		// with no content at all, which is the one input this method rejects.
-		return nil, errors.New("message has no content to parse as JSON")
+		return nil, status.Errorf(status.ErrInvalidOutput, "message has no content to parse as JSON")
 	}
 	if text != "" {
 		if j.config.Schema != nil {
 			schemaBytes, err := json.Marshal(j.config.Schema)
 			if err != nil {
-				return nil, fmt.Errorf("expected schema is not valid: %w", err)
+				return nil, status.Errorf(status.ErrInvalidSchema, "expected schema is not valid: %w", err)
 			}
 			if err = base.ValidateRaw([]byte(text), schemaBytes); err != nil {
 				return nil, err
 			}
 		} else {
 			if !base.ValidJSON(text) {
-				return nil, errors.New("message is not a valid JSON")
+				return nil, status.Errorf(status.ErrInvalidOutput, "message is not a valid JSON")
 			}
 		}
 		newParts = append(newParts, NewJSONPart(text))
@@ -399,56 +383,32 @@ func (j jsonlFormatter) Name() string {
 // Handler returns a new formatter handler for the given schema.
 func (j jsonlFormatter) Handler(schema map[string]any) (FormatHandler, error) {
 	if schema == nil || !base.ValidateIsJSONArray(schema) {
-		return nil, status.Errorf(status.ErrInvalidArgument, "schema must be an array of objects for JSONL format")
+		return nil, status.Errorf(status.ErrInvalidSchema, "schema must be an array of objects for JSONL format")
 	}
 
 	jsonBytes, err := json.Marshal(schema["items"])
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling schema to JSONL: %w", err)
+		return nil, status.Errorf(status.ErrInvalidSchema, "marshalling schema to JSONL: %w", err)
 	}
 
 	instructions := fmt.Sprintf("Output should be JSONL format, a sequence of JSON objects (one per line) separated by a newline '\\n' character. Each line should be a JSON object conforming to the following schema:\n\n```%s```", string(jsonBytes))
 
-	handler := &jsonlHandler{
+	return &jsonlHandler{baseHandler{
 		instructions: instructions,
 		config: ModelOutputConfig{
 			Format:      OutputFormatJSONL,
 			Schema:      schema,
 			ContentType: "application/jsonl",
 		},
-	}
-
-	return handler, nil
+	}}, nil
 }
 
-type jsonlHandler struct {
-	instructions    string
-	config          ModelOutputConfig
-	accumulatedText string
-	currentIndex    int
-	cursor          int
-}
-
-// Instructions returns the instructions for the formatter.
-func (j *jsonlHandler) Instructions() string {
-	return j.instructions
-}
-
-// Config returns the output config for the formatter.
-func (j *jsonlHandler) Config() ModelOutputConfig {
-	return j.config
-}
+type jsonlHandler struct{ baseHandler }
 
 // ParseOutput parses the final message and returns the parsed array of objects.
 func (j *jsonlHandler) ParseOutput(m *Message) (any, error) {
-	var sb strings.Builder
-	for _, part := range m.Content {
-		if part.IsText() {
-			sb.WriteString(part.Text)
-		}
-	}
-
-	result, _, err := j.parseJSONL(sb.String(), 0, false)
+	text, _ := splitTextParts(m)
+	result, _, err := j.parseJSONL(text, 0, false)
 	if err != nil {
 		return nil, err
 	}
@@ -464,29 +424,12 @@ func (j *jsonlHandler) ParseOutput(m *Message) (any, error) {
 
 // ParseChunk processes a streaming chunk and returns parsed output.
 func (j *jsonlHandler) ParseChunk(chunk *ModelResponseChunk) (any, error) {
-	if chunk.Index != j.currentIndex {
-		j.accumulatedText = ""
-		j.currentIndex = chunk.Index
-		j.cursor = 0
-	}
-
-	for _, part := range chunk.Content {
-		if part.IsText() {
-			j.accumulatedText += part.Text
-		}
-	}
-
-	items, newCursor, err := j.parseJSONL(j.accumulatedText, j.cursor, true)
+	items, cursor, err := j.parseJSONL(j.accumulate(chunk), j.cursor, true)
 	if err != nil {
 		return nil, err
 	}
-	j.cursor = newCursor
+	j.cursor = cursor
 	return items, nil
-}
-
-// ParseMessage parses the message and returns the formatted message.
-func (j *jsonlHandler) ParseMessage(m *Message) (*Message, error) {
-	return m, nil
 }
 
 // parseJSONL parses JSONL starting from the cursor position.
@@ -518,7 +461,7 @@ func (j *jsonlHandler) parseJSONL(text string, cursor int, allowPartial bool) ([
 					// Don't advance cursor for partial line.
 					break
 				}
-				return nil, cursor, fmt.Errorf("invalid JSON on line %d: %w", i+1, err)
+				return nil, cursor, status.Errorf(status.ErrInvalidOutput, "invalid JSON on line %d: %w", i+1, err)
 			}
 			if result != nil {
 				results = append(results, result)
@@ -549,16 +492,16 @@ func (a arrayFormatter) Name() string {
 // Handler returns a new formatter handler for the given schema.
 func (a arrayFormatter) Handler(schema map[string]any) (FormatHandler, error) {
 	if schema == nil || !base.ValidateIsJSONArray(schema) {
-		return nil, fmt.Errorf("schema is not valid JSON array")
+		return nil, status.Errorf(status.ErrInvalidSchema, "schema must be an array of objects for array format")
 	}
 
 	jsonBytes, err := json.Marshal(schema["items"])
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling schema to JSON, must supply an 'array' schema type when using the 'array' parser format.: %w", err)
+		return nil, status.Errorf(status.ErrInvalidSchema, "marshalling schema to JSON: %w", err)
 	}
 	instructions := fmt.Sprintf("Output should be a JSON array conforming to the following schema:\n\n```%s```", string(jsonBytes))
 
-	handler := &arrayHandler{
+	return &arrayHandler{baseHandler{
 		instructions: instructions,
 		config: ModelOutputConfig{
 			Constrained: true,
@@ -566,28 +509,10 @@ func (a arrayFormatter) Handler(schema map[string]any) (FormatHandler, error) {
 			Schema:      schema,
 			ContentType: "application/json",
 		},
-	}
-
-	return handler, nil
+	}}, nil
 }
 
-type arrayHandler struct {
-	instructions    string
-	config          ModelOutputConfig
-	accumulatedText string
-	currentIndex    int
-	cursor          int
-}
-
-// Instructions returns the instructions for the formatter.
-func (a *arrayHandler) Instructions() string {
-	return a.instructions
-}
-
-// Config returns the output config for the formatter.
-func (a *arrayHandler) Config() ModelOutputConfig {
-	return a.config
-}
+type arrayHandler struct{ baseHandler }
 
 // ParseOutput parses the final message and returns the parsed array.
 func (a *arrayHandler) ParseOutput(m *Message) (any, error) {
@@ -597,26 +522,9 @@ func (a *arrayHandler) ParseOutput(m *Message) (any, error) {
 
 // ParseChunk processes a streaming chunk and returns parsed output.
 func (a *arrayHandler) ParseChunk(chunk *ModelResponseChunk) (any, error) {
-	if chunk.Index != a.currentIndex {
-		a.accumulatedText = ""
-		a.currentIndex = chunk.Index
-		a.cursor = 0
-	}
-
-	for _, part := range chunk.Content {
-		if part.IsText() {
-			a.accumulatedText += part.Text
-		}
-	}
-
-	result := base.ExtractItems(a.accumulatedText, a.cursor)
+	result := base.ExtractItems(a.accumulate(chunk), a.cursor)
 	a.cursor = result.Cursor
 	return result.Items, nil
-}
-
-// ParseMessage parses the message and returns the formatted message.
-func (a *arrayHandler) ParseMessage(m *Message) (*Message, error) {
-	return m, nil
 }
 
 type enumFormatter struct{}
@@ -630,41 +538,28 @@ func (e enumFormatter) Name() string {
 func (e enumFormatter) Handler(schema map[string]any) (FormatHandler, error) {
 	enums := objectEnums(schema)
 	if schema == nil || len(enums) == 0 {
-		return nil, status.Errorf(status.ErrInvalidArgument, "schema must be an object with an 'enum' property for enum format")
+		return nil, status.Errorf(status.ErrInvalidSchema, "schema must be an object with an 'enum' property for enum format")
 	}
 
 	instructions := fmt.Sprintf("Output should be ONLY one of the following enum values. Do not output any additional information or add quotes.\n\n```%s```", strings.Join(enums, "\n"))
 
-	handler := &enumHandler{
-		instructions: instructions,
-		config: ModelOutputConfig{
-			Constrained: true,
-			Format:      OutputFormatEnum,
-			Schema:      schema,
-			ContentType: "text/enum",
+	return &enumHandler{
+		baseHandler: baseHandler{
+			instructions: instructions,
+			config: ModelOutputConfig{
+				Constrained: true,
+				Format:      OutputFormatEnum,
+				Schema:      schema,
+				ContentType: "text/enum",
+			},
 		},
 		enums: enums,
-	}
-
-	return handler, nil
+	}, nil
 }
 
 type enumHandler struct {
-	instructions    string
-	config          ModelOutputConfig
-	enums           []string
-	accumulatedText string
-	currentIndex    int
-}
-
-// Instructions returns the instructions for the formatter.
-func (e *enumHandler) Instructions() string {
-	return e.instructions
-}
-
-// Config returns the output config for the formatter.
-func (e *enumHandler) Config() ModelOutputConfig {
-	return e.config
+	baseHandler
+	enums []string
 }
 
 // ParseOutput parses the final message and returns the enum value.
@@ -674,56 +569,23 @@ func (e *enumHandler) ParseOutput(m *Message) (any, error) {
 
 // ParseChunk processes a streaming chunk and returns parsed output.
 func (e *enumHandler) ParseChunk(chunk *ModelResponseChunk) (any, error) {
-	if chunk.Index != e.currentIndex {
-		e.accumulatedText = ""
-		e.currentIndex = chunk.Index
-	}
-
-	for _, part := range chunk.Content {
-		if part.IsText() {
-			e.accumulatedText += part.Text
-		}
-	}
-
-	// Ignore error since we are doing best effort parsing.
-	enum, _ := e.parseEnum(e.accumulatedText)
-
+	// Ignore the error: a partial stream is not yet a whole enum value.
+	enum, _ := e.parseEnum(e.accumulate(chunk))
 	return enum, nil
 }
 
-// ParseMessage parses the message and returns the formatted message.
+// ParseMessage rewrites the message's text as the single enum value it names,
+// and carries any non-text parts through.
 func (e *enumHandler) ParseMessage(m *Message) (*Message, error) {
-	if e.config.Format == OutputFormatEnum {
-		if m == nil {
-			return nil, errors.New("message is empty")
-		}
-		if len(m.Content) == 0 {
-			return nil, errors.New("message has no content")
-		}
-
-		var nonTextParts []*Part
-		accumulatedText := strings.Builder{}
-		for _, part := range m.Content {
-			if !part.IsText() {
-				nonTextParts = append(nonTextParts, part)
-			} else {
-				accumulatedText.WriteString(part.Text)
-			}
-		}
-
-		// replace single and double quotes, then trim whitespace
-		trimmed := strings.TrimSpace(quoteStripper.Replace(accumulatedText.String()))
-
-		if !slices.Contains(e.enums, trimmed) {
-			return nil, fmt.Errorf("message %s not in list of valid enums: %s", trimmed, strings.Join(e.enums, ", "))
-		}
-
-		newParts := []*Part{NewTextPart(trimmed)}
-		newParts = append(newParts, nonTextParts...)
-
-		m.Content = newParts
+	if err := requireContent(m); err != nil {
+		return nil, err
 	}
-
+	text, nonTextParts := splitTextParts(m)
+	value, err := e.parseEnum(text)
+	if err != nil {
+		return nil, err
+	}
+	m.Content = append([]*Part{NewTextPart(value)}, nonTextParts...)
 	return m, nil
 }
 
@@ -774,13 +636,13 @@ func extractEnumStrings(v any) []string {
 // parseEnum is the shared parsing logic used by both ParseOutput and ParseChunk.
 func (e *enumHandler) parseEnum(text string) (string, error) {
 	if text == "" {
-		return "", nil
+		return "", status.Errorf(status.ErrInvalidOutput, "message has no enum value, want one of: %s", strings.Join(e.enums, ", "))
 	}
 
 	trimmed := strings.TrimSpace(quoteStripper.Replace(text))
 
 	if !slices.Contains(e.enums, trimmed) {
-		return "", fmt.Errorf("message %s not in list of valid enums: %s", trimmed, strings.Join(e.enums, ", "))
+		return "", status.Errorf(status.ErrInvalidOutput, "message %s not in list of valid enums: %s", trimmed, strings.Join(e.enums, ", "))
 	}
 
 	return trimmed, nil

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"iter"
-	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -175,12 +174,19 @@ type resumedToolRequestOutput struct {
 
 // ModelOptions represents the configuration options for a model.
 type ModelOptions struct {
-	ConfigSchema map[string]any // JSON schema for the model's config.
-	Label        string         // User-friendly name for the model.
-	Stage        ModelStage     // Indicates the maturity stage of the model.
-	Supports     *ModelSupports // Capabilities of the model.
-	Versions     []string       // Available versions of the model.
-	Metadata     map[string]any // Arbitrary key-value data attached to the action descriptor.
+	// ConfigSchema is the JSON schema for the model's config. Inferred from the
+	// constructor's Config type parameter when nil.
+	ConfigSchema map[string]any
+	// Label is a user-friendly name for the model. Defaults to its name.
+	Label string
+	// Stage indicates the maturity stage of the model.
+	Stage ModelStage
+	// Supports describes what the model can do. A nil value claims nothing.
+	Supports *ModelSupports
+	// Versions lists the model versions a request may pin through its config.
+	Versions []string
+	// Metadata is arbitrary key-value data attached to the action descriptor.
+	Metadata map[string]any
 }
 
 // DefineGenerateAction defines a utility generate action.
@@ -231,17 +237,17 @@ func NewModelAction[Config any](
 		panic("ai.NewModelAction: name is required")
 	}
 
-	if opts == nil {
-		opts = &ModelOptions{
-			Label: name,
-		}
+	o := ModelOptions{}
+	if opts != nil {
+		o = *opts
 	}
-	if opts.Supports == nil {
-		opts.Supports = &ModelSupports{}
+	if o.Label == "" {
+		o.Label = name
 	}
+	o.Supports = cloneModelSupports(o.Supports)
 
-	configSchema, inputSchema := modelConfigSchemas[Config](opts.ConfigSchema, opts.Versions)
-	metadata := modelActionMetadata(api.ActionTypeModel, opts, configSchema, opts.Metadata)
+	configSchema, inputSchema := modelConfigSchemas[Config](o.ConfigSchema, o.Versions)
+	metadata := modelActionMetadata(api.ActionTypeModel, &o, configSchema, o.Metadata)
 
 	typedFn := func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		// req.Config was normalized to the exact Config type by
@@ -256,10 +262,10 @@ func NewModelAction[Config any](
 	// normalizeConfig runs outermost so that the built-in wrappers and the
 	// model function all see the typed, converted config on the request.
 	rawFn := core.ChainMiddleware(
-		normalizeConfig[Config](name, opts.Versions),
-		simulateSystemPrompt(opts, nil),
-		augmentWithContext(opts, nil),
-		validateSupport(name, opts),
+		normalizeConfig[Config](name, o.Versions),
+		simulateSystemPrompt(&o, nil),
+		augmentWithContext(&o, nil),
+		validateSupport(name, &o),
 		addAutomaticTelemetry(),
 	)(typedFn)
 
@@ -270,20 +276,9 @@ func NewModelAction[Config any](
 }
 
 // modelActionMetadata builds the descriptor metadata shared by model and
-// background-model actions: the caller metadata maps are merged in order,
-// then the reserved type and model keys are stamped over them so they cannot
-// be corrupted; registry discovery depends on them.
+// background-model actions.
 func modelActionMetadata(actionType api.ActionType, opts *ModelOptions, configSchema map[string]any, callerMetadata ...map[string]any) map[string]any {
-	size := 2
-	for _, m := range callerMetadata {
-		size += len(m)
-	}
-	metadata := make(map[string]any, size)
-	for _, m := range callerMetadata {
-		maps.Copy(metadata, m)
-	}
-	metadata["type"] = actionType
-	metadata["model"] = map[string]any{
+	model := map[string]any{
 		"label": opts.Label,
 		"supports": map[string]any{
 			"media":       opts.Supports.Media,
@@ -301,7 +296,7 @@ func modelActionMetadata(actionType api.ActionType, opts *ModelOptions, configSc
 		"stage":         opts.Stage,
 		"customOptions": configSchema,
 	}
-	return metadata
+	return actionMetadata(actionType, map[string]any{"model": model}, callerMetadata...)
 }
 
 // NewModel creates a new [Model].
@@ -747,10 +742,12 @@ func buildToolRunner(mws []*Hooks) func(ctx context.Context, tool Tool, req *Too
 // what the tool call resolved to rather than how long the hooks took to
 // resolve it.
 func recordToolShortCircuit(ctx context.Context, name string, input any, resp *MultipartToolResponse, err error) (*MultipartToolResponse, error) {
+	// Mirrors the span core builds for a tool action, subtype included, so the
+	// two are indistinguishable in a trace.
 	spanMeta := &tracing.SpanMetadata{
 		Name:            name,
 		Type:            "action",
-		Subtype:         "tool",
+		Subtype:         string(api.ActionTypeToolV2),
 		Metadata:        map[string]string{},
 		TelemetryLabels: tracing.TelemetryLabelsFromContext(ctx),
 	}

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -169,6 +169,7 @@ type MiddlewareFunc func(ctx context.Context) (*Hooks, error)
 // in [resolveRefs] and never goes through a name-keyed registry lookup.
 func (MiddlewareFunc) Name() string { return "inline" }
 
+// New implements [Middleware] by calling f.
 func (f MiddlewareFunc) New(ctx context.Context) (*Hooks, error) { return f(ctx) }
 
 // middlewareRefArg is a lazy [Middleware] that carries only a registered

--- a/go/ai/middleware_test.go
+++ b/go/ai/middleware_test.go
@@ -679,7 +679,7 @@ func TestWrapToolShortCircuitEmitsToolSpan(t *testing.T) {
 			}
 			span := toolSpans[0]
 			assertSpanAttr(t, span, "genkit:type", "action")
-			assertSpanAttr(t, span, "genkit:metadata:subtype", "tool")
+			assertSpanAttr(t, span, "genkit:metadata:subtype", string(api.ActionTypeToolV2))
 			assertSpanAttr(t, span, "genkit:state", tt.wantState)
 			assertSpanAttr(t, span, "genkit:input", `{"value":"x"}`)
 		})
@@ -747,6 +747,10 @@ func TestWrapToolPassThroughEmitsSingleToolSpan(t *testing.T) {
 				t.Fatalf("got %d spans named %q, want exactly 1", len(toolSpans), tool.Name())
 			}
 			assertSpanAttr(t, toolSpans[0], "genkit:input", `{"value":"rewritten"}`)
+			// The short-circuit span is meant to be indistinguishable from
+			// this one, so pin them to the same shape from both sides.
+			assertSpanAttr(t, toolSpans[0], "genkit:type", "action")
+			assertSpanAttr(t, toolSpans[0], "genkit:metadata:subtype", string(api.ActionTypeToolV2))
 		})
 	}
 }

--- a/go/ai/model_middleware.go
+++ b/go/ai/model_middleware.go
@@ -48,6 +48,8 @@ type DownloadMediaOptions struct {
 	Filter   func(part *Part) bool // Filter to apply to parts that are media URLs.
 }
 
+// CalculateInputOutputUsage fills in the character, image, and video counts on
+// resp.Usage, for providers whose API reports token counts only.
 func CalculateInputOutputUsage(req *ModelRequest, resp *ModelResponse) {
 	if resp.Usage == nil {
 		resp.Usage = &GenerationUsage{}

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -26,38 +26,6 @@ import (
 	"github.com/firebase/genkit/go/internal/base"
 )
 
-// Options follow the standard Go functional-options pattern: pass as many as
-// you like, in any order, and they merge left to right. Two rules govern how
-// repeats combine, so composing a request from several helpers is predictable:
-//
-//   - Collection options accumulate. Repeating one, or mixing its variants,
-//     appends in call order: WithMessages(a), WithMessages(b) sends [a, b], and
-//     WithTools, WithResources, WithUse, WithMiddleware, WithDocs, and
-//     WithDataset behave the same.
-//   - Single-value options take the last one set. WithConfig, WithModel /
-//     WithModelName, WithSystem, WithPrompt, the output-schema options, and the
-//     like each fill one slot, so the final call wins and earlier ones are
-//     overwritten rather than rejected. Every option that fills a slot shares
-//     it: WithSystem, WithSystemParts, WithSystemFn, and WithSystemPartsFn are
-//     four ways to write one system message, so they do not merge.
-//
-// One combination is refused rather than merged. WithMessagesTemplate lays out
-// the whole conversation, down to where {{history}} puts the caller's, so
-// separately supplied messages have no position relative to it. Passing it to
-// DefinePrompt alongside WithMessages or WithMessagesFn panics. Repeating the
-// template alone is an ordinary slot.
-//
-// A zero value does not fill a slot: WithMaxTurns(0), WithToolChoice(""), or
-// WithConfig(nil) is a no-op, so an earlier non-zero value cannot be un-set by
-// a later zero one. The rules apply within a single options list; APIs that
-// layer two lists (a prompt's define-time options against Execute-time
-// options) document their own precedence.
-//
-// Applying options therefore never fails on a "set more than once" conflict.
-// What does fail is a genuinely invalid argument (a type that WithInputType
-// cannot turn into a schema) or the refused combination above, and both panic
-// at the call site where the mistake is rather than deferring to the request.
-
 // PromptFn is a function that generates a prompt from a prompt's input.
 //
 // The input is untyped. [WithPromptFn] and [WithSystemFn] take a function with
@@ -70,19 +38,22 @@ type PromptFn = func(context.Context, any) (string, error)
 // type and converts for you.
 type MessagesFn = func(context.Context, any) ([]*Message, error)
 
-// appendMessagesFn composes two message-producing functions so their outputs
-// concatenate in call order. It backs the accumulate semantics of
-// [WithMessages] and [WithMessagesFn]: passing several of them (in any mix)
-// appends their messages instead of overwriting. Either side may be nil, in
-// which case the other is returned unwrapped.
-func appendMessagesFn(existing, next MessagesFn) MessagesFn {
+// appendFn composes two content-producing functions so their outputs
+// concatenate in call order. It backs the accumulate semantics of the
+// collection options: passing several of them, in any mix, appends instead of
+// overwriting. Either side may be nil, in which case the other is returned
+// unwrapped.
+//
+// [MessagesFn] and [DocsFn] are aliases for this shape, so one helper serves
+// both.
+func appendFn[T any](existing, next func(context.Context, any) ([]T, error)) func(context.Context, any) ([]T, error) {
 	if existing == nil {
 		return next
 	}
 	if next == nil {
 		return existing
 	}
-	return func(ctx context.Context, input any) ([]*Message, error) {
+	return func(ctx context.Context, input any) ([]T, error) {
 		before, err := existing(ctx, input)
 		if err != nil {
 			return nil, err
@@ -95,28 +66,6 @@ func appendMessagesFn(existing, next MessagesFn) MessagesFn {
 		// hands the caller's slice straight through, so appending in place
 		// would write into the spare capacity of the array backing their
 		// history. Concat always allocates a fresh slice.
-		return slices.Concat(before, after), nil
-	}
-}
-
-// appendDocsFn is [appendMessagesFn] for documents, backing the accumulate
-// semantics of [WithDocsFn].
-func appendDocsFn(existing, next DocsFn) DocsFn {
-	if existing == nil {
-		return next
-	}
-	if next == nil {
-		return existing
-	}
-	return func(ctx context.Context, input any) ([]*Document, error) {
-		before, err := existing(ctx, input)
-		if err != nil {
-			return nil, err
-		}
-		after, err := next(ctx, input)
-		if err != nil {
-			return nil, err
-		}
 		return slices.Concat(before, after), nil
 	}
 }
@@ -247,7 +196,7 @@ type CommonGenOption interface {
 func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) {
 	o.configOptions.applyConfig(&opts.configOptions)
 
-	opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
+	opts.MessagesFn = appendFn(opts.MessagesFn, o.MessagesFn)
 	if o.MessagesText != nil {
 		opts.MessagesText = o.MessagesText
 	}
@@ -320,11 +269,7 @@ func WithMessages(messages ...*Message) CommonGenOption {
 // Compiling needs a prompt, so this is a [PromptOption]: passing it to
 // [Generate] or [Prompt.Execute] does not compile. Use [WithMessages] there.
 func WithMessagesTemplate(text string, args ...any) PromptOption {
-	if len(args) > 0 {
-		// Assigning avoids a compile-time warning about non-constant text.
-		t := text
-		text = fmt.Sprintf(t, args...)
-	}
+	text = sprintfText(text, args)
 	return &promptOptions{commonGenOptions: commonGenOptions{MessagesText: &text}}
 }
 
@@ -904,7 +849,7 @@ type DocumentOption interface {
 // the [WithDocsFn] functions compose the same way.
 func (o *documentOptions) applyDocument(opts *documentOptions) {
 	opts.Documents = append(opts.Documents, o.Documents...)
-	opts.DocsFn = appendDocsFn(opts.DocsFn, o.DocsFn)
+	opts.DocsFn = appendFn(opts.DocsFn, o.DocsFn)
 }
 
 func (o *documentOptions) applyPrompt(opts *promptOptions) {

--- a/go/ai/overlay.go
+++ b/go/ai/overlay.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import "slices"
+
+// A plugin's model catalog answers two questions that must agree: what
+// ListActions advertises, and what ResolveAction builds to serve a request. A
+// caller who knows better than the catalog supplies an override through plugin
+// config, and both paths lay it over what the plugin already knows.
+//
+// Overlaying rather than replacing is what lets a caller pin one capability
+// without restating the label, the config schema, and the rest a model needs
+// set to work at all. A zero-value field means "not specified": every field of
+// both options structs distinguishes its zero value from a meaningful one,
+// which [TestOverlayCoversEveryField] holds them to.
+
+// Overlay returns o with every field set in override replacing o's. A field
+// left at its zero value in override keeps o's.
+func (o ModelOptions) Overlay(override ModelOptions) ModelOptions {
+	if override.ConfigSchema != nil {
+		o.ConfigSchema = override.ConfigSchema
+	}
+	if override.Label != "" {
+		o.Label = override.Label
+	}
+	if override.Stage != "" {
+		o.Stage = override.Stage
+	}
+	if override.Supports != nil {
+		o.Supports = override.Supports
+	}
+	if override.Versions != nil {
+		o.Versions = override.Versions
+	}
+	if override.Metadata != nil {
+		o.Metadata = override.Metadata
+	}
+	return o
+}
+
+// Overlay returns o with every field set in override replacing o's. A field
+// left at its zero value in override keeps o's.
+func (o EmbedderOptions) Overlay(override EmbedderOptions) EmbedderOptions {
+	if override.ConfigSchema != nil {
+		o.ConfigSchema = override.ConfigSchema
+	}
+	if override.Label != "" {
+		o.Label = override.Label
+	}
+	if override.Supports != nil {
+		o.Supports = override.Supports
+	}
+	if override.Dimensions != 0 {
+		o.Dimensions = override.Dimensions
+	}
+	if override.Metadata != nil {
+		o.Metadata = override.Metadata
+	}
+	return o
+}
+
+// The Supports field of every options struct is a pointer, so that a zero value
+// can mean "not specified" for [ModelOptions.Overlay]. That makes it easy for a
+// plugin to point a whole table of models at one shared capability struct, so
+// the constructors copy it rather than keeping the caller's pointer, and take a
+// nil one to mean no capabilities.
+
+func cloneModelSupports(s *ModelSupports) *ModelSupports {
+	if s == nil {
+		return &ModelSupports{}
+	}
+	c := *s
+	c.ContentType = slices.Clone(s.ContentType)
+	c.Output = slices.Clone(s.Output)
+	return &c
+}
+
+func cloneEmbedderSupports(s *EmbedderSupports) *EmbedderSupports {
+	if s == nil {
+		return &EmbedderSupports{}
+	}
+	c := *s
+	c.Input = slices.Clone(s.Input)
+	return &c
+}
+
+func cloneRetrieverSupports(s *RetrieverSupports) *RetrieverSupports {
+	if s == nil {
+		return &RetrieverSupports{}
+	}
+	c := *s
+	return &c
+}

--- a/go/ai/overlay_test.go
+++ b/go/ai/overlay_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// TestOverlayCoversEveryField is the guard that keeps the hand-written Overlay
+// methods honest. A field added to either options struct and forgotten in
+// Overlay would silently drop a caller's value; here it fails the build's tests
+// instead, naming the field.
+//
+// It also holds both structs to the invariant Overlay is built on: every field
+// must distinguish its zero value from a meaningful one, so a bool field (whose
+// false is both "unset" and "off") is rejected outright rather than merged
+// wrongly.
+func TestOverlayCoversEveryField(t *testing.T) {
+	t.Run("ModelOptions", func(t *testing.T) {
+		checkOverlay(t, func(base, override ModelOptions) ModelOptions { return base.Overlay(override) })
+	})
+	t.Run("EmbedderOptions", func(t *testing.T) {
+		checkOverlay(t, func(base, override EmbedderOptions) EmbedderOptions { return base.Overlay(override) })
+	})
+}
+
+// checkOverlay exercises overlay once per field of T: the override's value must
+// win when set, and the base's must survive when the override leaves it zero.
+func checkOverlay[T any](t *testing.T, overlay func(base, override T) T) {
+	t.Helper()
+	typ := reflect.TypeFor[T]()
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		if field.Type.Kind() == reflect.Bool {
+			t.Errorf("%s.%s is a bool, whose zero value cannot mean 'not specified'; Overlay cannot merge it",
+				typ.Name(), field.Name)
+			continue
+		}
+		baseVal, err := nonZeroValue(field.Type, 1)
+		if err != nil {
+			t.Errorf("%s.%s: %v", typ.Name(), field.Name, err)
+			continue
+		}
+		overrideVal, _ := nonZeroValue(field.Type, 2)
+
+		var base, override T
+		reflect.ValueOf(&base).Elem().Field(i).Set(baseVal)
+		reflect.ValueOf(&override).Elem().Field(i).Set(overrideVal)
+
+		if got := reflect.ValueOf(overlay(base, override)).Field(i); !reflect.DeepEqual(got.Interface(), overrideVal.Interface()) {
+			t.Errorf("%s.%s: Overlay kept %v, want the override's %v; the field is missing from Overlay",
+				typ.Name(), field.Name, got.Interface(), overrideVal.Interface())
+		}
+		var zero T
+		if got := reflect.ValueOf(overlay(base, zero)).Field(i); !reflect.DeepEqual(got.Interface(), baseVal.Interface()) {
+			t.Errorf("%s.%s: an unset override replaced the base's %v with %v",
+				typ.Name(), field.Name, baseVal.Interface(), got.Interface())
+		}
+	}
+}
+
+// nonZeroValue builds a distinguishable non-zero value of type t. seed makes
+// two calls for the same type differ, so a field Overlay ignores shows up as
+// the base's value surviving where the override's was expected.
+func nonZeroValue(t reflect.Type, seed int) (reflect.Value, error) {
+	v := reflect.New(t).Elem()
+	switch t.Kind() {
+	case reflect.String:
+		v.SetString(fmt.Sprintf("value-%d", seed))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(int64(seed))
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(float64(seed))
+	case reflect.Pointer:
+		v.Set(reflect.New(t.Elem()))
+	case reflect.Slice:
+		elem, err := nonZeroValue(t.Elem(), seed)
+		if err != nil {
+			return v, err
+		}
+		v.Set(reflect.Append(v, elem))
+	case reflect.Map:
+		key, err := nonZeroValue(t.Key(), seed)
+		if err != nil {
+			return v, err
+		}
+		v.Set(reflect.MakeMap(t))
+		v.SetMapIndex(key, reflect.ValueOf(any(seed)))
+	default:
+		return v, fmt.Errorf("no non-zero value for kind %s; teach nonZeroValue about it", t.Kind())
+	}
+	return v, nil
+}
+
+// TestCloneSupportsDetachesEveryField is the same guard for the clone helpers:
+// a slice or map field added to a supports struct and not cloned would leave
+// two models built from one shared value aliasing each other's memory.
+func TestCloneSupportsDetachesEveryField(t *testing.T) {
+	t.Run("ModelSupports", func(t *testing.T) {
+		checkCloneDetaches(t, cloneModelSupports)
+	})
+	t.Run("EmbedderSupports", func(t *testing.T) {
+		checkCloneDetaches(t, cloneEmbedderSupports)
+	})
+	t.Run("RetrieverSupports", func(t *testing.T) {
+		checkCloneDetaches(t, cloneRetrieverSupports)
+	})
+}
+
+// checkCloneDetaches fills every field of T with a non-zero value, clones, and
+// checks the clone is equal but shares no reference-typed field with the
+// original.
+func checkCloneDetaches[T any](t *testing.T, clone func(*T) *T) {
+	t.Helper()
+	typ := reflect.TypeFor[T]()
+	orig := reflect.New(typ)
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		if !field.IsExported() || field.Type.Kind() == reflect.Bool {
+			continue
+		}
+		val, err := nonZeroValue(field.Type, 1)
+		if err != nil {
+			t.Fatalf("%s.%s: %v", typ.Name(), field.Name, err)
+		}
+		orig.Elem().Field(i).Set(val)
+	}
+	got := reflect.ValueOf(clone(orig.Interface().(*T))).Elem()
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		want := orig.Elem().Field(i)
+		if !reflect.DeepEqual(got.Field(i).Interface(), want.Interface()) {
+			t.Errorf("%s.%s: clone changed the value: got %v, want %v",
+				typ.Name(), field.Name, got.Field(i).Interface(), want.Interface())
+		}
+		switch field.Type.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Pointer:
+			if got.Field(i).Pointer() == want.Pointer() {
+				t.Errorf("%s.%s: clone aliases the original's %s; the field is missing from the clone helper",
+					typ.Name(), field.Name, field.Type.Kind())
+			}
+		}
+	}
+}

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -405,7 +405,7 @@ func buildVariables(variables any) (map[string]any, error) {
 		return resultVariables, nil
 	}
 	if v.Kind() != reflect.Struct {
-		return nil, errors.New("prompt.buildVariables: fields not a struct or pointer to a struct or a map")
+		return nil, status.Errorf(status.ErrInvalidArgument, "prompt input must be a struct, a pointer to one, or a map")
 	}
 	vt := v.Type()
 
@@ -820,7 +820,7 @@ func convertToPartPointers(parts []dotprompt.Part) ([]*Part, error) {
 // The dir parameter specifies the directory within the filesystem where prompts are located.
 func LoadPromptDirFromFS(r api.Registry, fsys fs.FS, dir, namespace string) {
 	if fsys == nil {
-		panic(errors.New("no prompt filesystem provided"))
+		panic("ai.LoadPrompt: no prompt filesystem provided")
 	}
 
 	if _, err := fs.Stat(fsys, dir); err != nil {
@@ -1011,24 +1011,24 @@ func parseDotpromptUse(raw any) ([]Middleware, error) {
 	}
 	entries, ok := raw.([]any)
 	if !ok {
-		return nil, fmt.Errorf("`use` must be a list, got %T", raw)
+		return nil, status.Errorf(status.ErrInvalidArgument, "`use` must be a list, got %T", raw)
 	}
 	uses := make([]Middleware, 0, len(entries))
 	for i, entry := range entries {
 		switch v := entry.(type) {
 		case string:
 			if v == "" {
-				return nil, fmt.Errorf("`use[%d]` is an empty string", i)
+				return nil, status.Errorf(status.ErrInvalidArgument, "`use[%d]` is an empty string", i)
 			}
 			uses = append(uses, middlewareRefArg{name: v})
 		case map[string]any:
 			name, _ := v["name"].(string)
 			if name == "" {
-				return nil, fmt.Errorf("`use[%d]` is missing required `name` field", i)
+				return nil, status.Errorf(status.ErrInvalidArgument, "`use[%d]` is missing required `name` field", i)
 			}
 			uses = append(uses, middlewareRefArg{name: name, config: v["config"]})
 		default:
-			return nil, fmt.Errorf("`use[%d]` must be a string or map, got %T", i, entry)
+			return nil, status.Errorf(status.ErrInvalidArgument, "`use[%d]` must be a string or map, got %T", i, entry)
 		}
 	}
 	return uses, nil
@@ -1063,7 +1063,7 @@ func variantKey(variant string) string {
 // contentType determines the MIME content type of the given data URI
 func contentType(ct, uri string) (string, []byte, error) {
 	if uri == "" {
-		return "", nil, errors.New("found empty URI in part")
+		return "", nil, status.Errorf(ErrInvalidPart, "found empty URI in part")
 	}
 
 	if strings.HasPrefix(uri, "gs://") || strings.HasPrefix(uri, "http") {
@@ -1078,7 +1078,7 @@ func contentType(ct, uri string) (string, []byte, error) {
 	if contents, isData := strings.CutPrefix(uri, "data:"); isData {
 		prefix, _, found := strings.Cut(contents, ",")
 		if !found {
-			return "", nil, errors.New("failed to parse data URI: missing comma")
+			return "", nil, status.Errorf(ErrInvalidPart, "failed to parse data URI: missing comma")
 		}
 
 		if p, isBase64 := strings.CutSuffix(prefix, ";base64"); isBase64 {
@@ -1089,7 +1089,7 @@ func contentType(ct, uri string) (string, []byte, error) {
 		}
 	}
 
-	return "", nil, errors.New("uri content type not found")
+	return "", nil, status.Errorf(ErrInvalidPart, "uri content type not found")
 }
 
 // DefineDataPrompt creates a new data prompt and registers it.
@@ -1232,7 +1232,7 @@ func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts
 // Render renders the typed prompt template with the given input.
 func (dp *DataPrompt[In, Out]) Render(ctx context.Context, input In) (*GenerateActionOptions, error) {
 	if dp == nil {
-		return nil, errors.New("DataPrompt.Render: prompt is nil")
+		return nil, status.Errorf(status.ErrInvalidArgument, "DataPrompt.Render: prompt is nil")
 	}
 
 	return dp.prompt.Render(ctx, input)

--- a/go/ai/prompt_fn_test.go
+++ b/go/ai/prompt_fn_test.go
@@ -337,11 +337,25 @@ func TestHistoryStaysOutOfGenerationContext(t *testing.T) {
 	}
 }
 
+// TestCallerMessagesAreNotMutated collects every angle on one invariant: a
+// message the caller owns is never written to by the framework. Messages reach
+// generation from four places and each has its own way of going wrong, so they
+// are one test rather than four unrelated ones with near-identical names.
+//
+// Callers reuse message slices across turns, so an in-place append would leak
+// output instructions or a metadata stamp into stored history.
+func TestCallerMessagesAreNotMutated(t *testing.T) {
+	t.Run("from a content function", messagesFromFnAreNotMutated)
+	t.Run("declared with WithMessages, stamped by the model", declaredMessagesSurviveMetadataStamping)
+	t.Run("declared with WithMessages, appended downstream", declaredMessagesAreCopiedPerExecution)
+	t.Run("passed straight to GenerateWithRequest", callerMessagesSurviveInstructionInjection)
+}
+
 // TestFnMessagesNotMutatedByInstructionInjection guards the uniform cloning in
 // renderMessages: messages returned by WithMessagesFn typically alias a
 // session or the caller's own slice, and a later stage that appends to its
 // target message in place would corrupt that caller-owned history.
-func TestFnMessagesNotMutatedByInstructionInjection(t *testing.T) {
+func messagesFromFnAreNotMutated(t *testing.T) {
 	r := newTestRegistry(t)
 	m := defineFakeModel(t, r, fakeModelConfig{
 		name: "test/fnMutModel",
@@ -703,7 +717,7 @@ func TestLiteralPercentSurvivesWithPrompt(t *testing.T) {
 // and are reused by every execution, so handing out the originals to a stage
 // that appends to a message in place would let one execution alter the prompt
 // for the next.
-func TestStaticMessagesNotSharedAcrossExecutions(t *testing.T) {
+func declaredMessagesSurviveMetadataStamping(t *testing.T) {
 	shared := NewUserTextMessage("stored on the prompt")
 	shared.Metadata = map[string]any{"origin": "config"}
 
@@ -1175,7 +1189,7 @@ func TestStaticMessagesAreVerbatim(t *testing.T) {
 // rather than forwarded by reference: a prompt's declared messages are shared
 // by every execution of it, so one execution's downstream mutation would
 // otherwise be visible to the next.
-func TestStaticMessagesCopiedPerExecution(t *testing.T) {
+func declaredMessagesAreCopiedPerExecution(t *testing.T) {
 	shared := NewUserTextMessage("history")
 	_, p, get := capturePrompt(t, "staticIsolation",
 		WithMessages(shared),
@@ -1293,7 +1307,7 @@ func TestStaticPartsConflictWithText(t *testing.T) {
 // tested in format_test.go; this runs it through the public entry point,
 // GenerateWithRequest, which takes the caller's own message slice and is what
 // made an in-place append reach a conversation the caller keeps.
-func TestInstructionInjectionDoesNotMutateCallerMessages(t *testing.T) {
+func callerMessagesSurviveInstructionInjection(t *testing.T) {
 	r := newTestRegistry(t)
 	var captured *ModelRequest
 	defineFakeModel(t, r, fakeModelConfig{

--- a/go/ai/resource.go
+++ b/go/ai/resource.go
@@ -96,10 +96,14 @@ type ResourceOutput struct {
 
 // ResourceOptions configures a resource definition.
 type ResourceOptions struct {
-	URI         string         // Static URI (mutually exclusive with Template)
-	Template    string         // URI template (mutually exclusive with URI)
-	Description string         // Optional description
-	Metadata    map[string]any // Optional metadata
+	// URI is the resource's static URI. Mutually exclusive with Template.
+	URI string
+	// Template is a URI template the resource matches. Mutually exclusive with URI.
+	Template string
+	// Description is the resource's human-readable description.
+	Description string
+	// Metadata is arbitrary key-value data attached to the action descriptor.
+	Metadata map[string]any
 }
 
 // ResourceFunc is a function that loads content for a resource.

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
@@ -162,52 +161,32 @@ func NewRetrieverAction[Config any](
 	fn RetrieverActionFunc[Config],
 ) *RetrieverAction {
 	if name == "" {
-		panic("ai.NewRetrieverAction: retriever name is required")
+		panic("ai.NewRetrieverAction: name is required")
 	}
 
-	if opts == nil {
-		opts = &RetrieverOptions{
-			Label: name,
-		}
+	o := RetrieverOptions{}
+	if opts != nil {
+		o = *opts
 	}
-	if opts.Supports == nil {
-		opts.Supports = &RetrieverSupports{}
+	if o.Label == "" {
+		o.Label = name
 	}
+	o.Supports = cloneRetrieverSupports(o.Supports)
 
-	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, RetrieverRequest{}, "options")
-
-	// Seed from the caller's metadata, then stamp the built-in keys over it so
-	// they cannot be corrupted; registry discovery depends on them.
-	metadata := make(map[string]any, len(opts.Metadata)+3)
-	maps.Copy(metadata, opts.Metadata)
-	metadata["type"] = api.ActionTypeRetriever
-	metadata["info"] = map[string]any{
-		"label": opts.Label,
-		"supports": map[string]any{
-			"media": opts.Supports.Media,
+	configSchema, inputSchema := actionConfigSchemas[Config](o.ConfigSchema, RetrieverRequest{}, "options")
+	metadata := actionMetadata(api.ActionTypeRetriever, map[string]any{
+		"info": map[string]any{
+			"label":    o.Label,
+			"supports": map[string]any{"media": o.Supports.Media},
 		},
-	}
-	metadata["retriever"] = map[string]any{
-		"customOptions": configSchema,
-	}
-
-	rawFn := func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
-		// Normalize a shallow copy so the type-erased Options and the typed
-		// parameter always agree without clobbering the caller-owned request.
-		reqCopy := *req
-		req = &reqCopy
-		cfg, err := resolveConfigInto[Config](&req.Options)
-		if err != nil {
-			return nil, err
-		}
-		return fn(ctx, req, cfg)
-	}
+		"retriever": map[string]any{"customOptions": configSchema},
+	}, o.Metadata)
 
 	return &RetrieverAction{
 		action: *core.NewActionOf(api.ActionTypeRetriever, name, &core.ActionOptions{
 			Metadata:    metadata,
 			InputSchema: inputSchema,
-		}, rawFn),
+		}, typedConfigFn(func(r *RetrieverRequest) *any { return &r.Options }, fn)),
 	}
 }
 
@@ -217,7 +196,7 @@ func NewRetrieverAction[Config any](
 // fn as a typed value instead of leaving them type-erased on the request.
 func NewRetriever(name string, opts *RetrieverOptions, fn RetrieverFunc) Retriever {
 	if name == "" {
-		panic("ai.NewRetriever: retriever name is required")
+		panic("ai.NewRetriever: name is required")
 	}
 	return NewRetrieverAction(name, opts, func(ctx context.Context, req *RetrieverRequest, _ any) (*RetrieverResponse, error) {
 		return fn(ctx, req)

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -553,7 +553,7 @@ func (t *ToolAction[In, Out]) RunRawMultipart(ctx context.Context, input any) (*
 
 	mi, err := json.Marshal(input)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling tool input for %v: %v", t.Name(), err)
+		return nil, status.Errorf(status.ErrInvalidInput, "marshalling input for tool %q: %w", t.Name(), err)
 	}
 	output, err := t.action.RunJSON(ctx, mi, nil)
 	if err != nil {
@@ -562,7 +562,7 @@ func (t *ToolAction[In, Out]) RunRawMultipart(ctx context.Context, input any) (*
 
 	var resp MultipartToolResponse
 	if err := json.Unmarshal(output, &resp); err != nil {
-		return nil, fmt.Errorf("error parsing tool output for %v: %v", t.Name(), err)
+		return nil, status.Errorf(status.ErrInvalidOutput, "parsing output of tool %q: %w", t.Name(), err)
 	}
 	return &resp, nil
 }

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -293,18 +293,16 @@ func (a *Action[In, Out, Stream]) runWithTelemetry(ctx context.Context, input In
 	}, err
 }
 
-// spanMetadata builds the trace span metadata for one run of this action,
-// injecting the flow name when ctx carries one. spanInit, when non-nil, is
-// recorded as the span's genkit:init attribute. IsRoot is determined later by
-// the tracing package from parent span presence.
+// spanMetadata builds the trace span metadata for one run of this action.
+// spanInit, when non-nil, is recorded as the span's genkit:init attribute.
 func (a *Action[In, Out, Stream]) spanMetadata(ctx context.Context, spanInit any) *tracing.SpanMetadata {
 	sm := &tracing.SpanMetadata{
 		Name:            a.desc.Name,
 		Type:            "action",
 		Subtype:         string(a.desc.Type), // The actual action type becomes the subtype.
+		Init:            spanInit,
 		Metadata:        make(map[string]string),
 		TelemetryLabels: tracing.TelemetryLabelsFromContext(ctx),
-		Init:            spanInit,
 	}
 	if flowName := FlowNameFromContext(ctx); flowName != "" {
 		sm.Metadata["flow:name"] = flowName

--- a/go/core/status/doc.go
+++ b/go/core/status/doc.go
@@ -57,6 +57,11 @@ When several [Error] values are in one chain, errors.As finds the outermost, so
 the last deliberate reclassification is the one transports report. [Of] follows
 the same rule.
 
+[Of] answers Internal for an unclassified error, which is right for a transport
+but not for code deciding what to do about the failure. Middleware branching on
+a status wants [Classified], which reports whether anything in the chain
+actually carried one.
+
 The pattern to avoid is restating the status on every frame as an error bubbles
 up. Wrapping with %v is the usual culprit: it flattens the cause into a string,
 so the sentinel, the status, and everything else in the chain are lost.

--- a/go/core/status/error.go
+++ b/go/core/status/error.go
@@ -223,26 +223,46 @@ func (e *Error) Stack() string {
 //
 // Of(nil) is OK.
 func Of(err error) Name {
+	s, _ := Classified(err)
+	return s
+}
+
+// Classified returns err's status and whether anything in its chain actually
+// carries one. It is [Of] with the one distinction Of cannot make: an
+// unclassified failure and one deliberately classified Internal both report
+// Internal, and only the second is a decision someone made.
+//
+// Middleware that acts on a status needs that distinction, since the action it
+// takes on an unclassified error (a network blip from a provider SDK, say)
+// should not follow from INTERNAL happening to be in a configured list:
+//
+//	if s, ok := status.Classified(err); ok && slices.Contains(retryOn, s) { ... }
+//
+// Cancellation and deadline expiry count as classified. Classified(nil) is
+// (OK, false).
+func Classified(err error) (Name, bool) {
 	if err == nil {
-		return OK
+		return OK, false
 	}
 	if e := firstError(err); e != nil {
-		return e.Status
+		return e.Status, true
 	}
 	if e, ok := err.(*Error); ok && e == nil {
-		return OK // a non-nil interface holding a nil *Error is not a failure
+		return OK, false // a non-nil interface holding a nil *Error is not a failure
 	}
+	// A typed-nil *Sentinel matches errors.As but carries nothing; skip it the
+	// way firstError skips a typed-nil *Error.
 	var s *Sentinel
-	if errors.As(err, &s) {
-		return s.status
+	if errors.As(err, &s) && s != nil {
+		return s.status, true
 	}
 	switch {
 	case errors.Is(err, context.Canceled):
-		return Cancelled
+		return Cancelled, true
 	case errors.Is(err, context.DeadlineExceeded):
-		return DeadlineExceeded
+		return DeadlineExceeded, true
 	}
-	return Internal
+	return Internal, false
 }
 
 // firstError returns the first non-nil [Error] in err's chain, or nil. It is

--- a/go/core/status/error_test.go
+++ b/go/core/status/error_test.go
@@ -474,3 +474,39 @@ func formatVerbs(format string) []rune {
 	}
 	return verbs
 }
+
+// TestClassifiedDistinguishesUnclassified covers the distinction Of cannot
+// make: it reports Internal for an unclassified error and for a deliberately
+// classified one alike, and only the second is a decision someone made.
+func TestClassifiedDistinguishesUnclassified(t *testing.T) {
+	var typedNil *Error
+	var nilSentinel *Sentinel
+	for _, tt := range []struct {
+		name string
+		err  error
+		want Name
+		ok   bool
+	}{
+		{"nil", nil, OK, false},
+		{"plain error", errors.New("network blip"), Internal, false},
+		// A chain can carry a typed-nil *Error (Convert returns one, and the
+		// generated AgentOutput.Error field is one whenever nothing failed). It
+		// must not read as a deliberate INTERNAL.
+		{"wrapped typed-nil", fmt.Errorf("provider: %w", typedNil), Internal, false},
+		// The same for a typed-nil *Sentinel: it matches errors.As but carries
+		// no classification, and must not panic the walk.
+		{"wrapped typed-nil sentinel", fmt.Errorf("provider: %w", nilSentinel), Internal, false},
+		{"classified internal", Errorf(ErrInternal, "boom"), Internal, true},
+		{"classified elsewhere", Errorf(ErrNotFound, "gone"), NotFound, true},
+		{"bare sentinel", ErrUnavailable, Unavailable, true},
+		{"wrapped sentinel", fmt.Errorf("calling: %w", ErrResourceExhausted), ResourceExhausted, true},
+		{"cancelled", context.Canceled, Cancelled, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := Classified(tt.err)
+			if got != tt.want || ok != tt.ok {
+				t.Errorf("Classified() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/go/core/status/sentinel.go
+++ b/go/core/status/sentinel.go
@@ -55,11 +55,18 @@ func (s *Sentinel) Subtype(label string) *Sentinel {
 func (s *Sentinel) Status() Name { return s.status }
 
 // Error implements error so a sentinel can be returned or wrapped directly.
-func (s *Sentinel) Error() string { return s.label }
+// A nil *Sentinel renders as "<nil>", matching how fmt prints a nil error, so
+// a typed nil in a chain cannot panic the errors.Is walk that finds it.
+func (s *Sentinel) Error() string {
+	if s == nil {
+		return "<nil>"
+	}
+	return s.label
+}
 
 // Unwrap returns the sentinel s was derived from, or nil for a base sentinel.
 func (s *Sentinel) Unwrap() error {
-	if s.parent == nil {
+	if s == nil || s.parent == nil {
 		return nil
 	}
 	return s.parent

--- a/go/core/status/sentinel_status_test.go
+++ b/go/core/status/sentinel_status_test.go
@@ -51,6 +51,17 @@ func TestBaseSentinelStatuses(t *testing.T) {
 	if len(want) != len(baseSentinels) {
 		t.Errorf("checked %d sentinels, table has %d", len(want), len(baseSentinels))
 	}
+	// Every canonical status needs a base sentinel, or code classifying at
+	// runtime through Base silently degrades that status to UNKNOWN. OK is the
+	// exception: success is not a failure to classify.
+	for n := range statuses {
+		if n == OK {
+			continue
+		}
+		if _, ok := baseSentinels[n]; !ok {
+			t.Errorf("status %q has no base sentinel; Base(%q) would answer ErrUnknown", n, n)
+		}
+	}
 }
 
 // The framework sentinels must keep the statuses their call sites sent before

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -499,67 +499,33 @@ func ListTools(g *Genkit) []ai.Tool {
 	return tools
 }
 
-// DefineModelAction defines a custom model implementation, registers it
-// as a [core.Action] of type Model, and returns the concrete [ai.ModelAction].
+// DefineModelAction defines a custom model implementation, registers it as a
+// [core.Action] of type Model, and returns the concrete [ai.ModelAction].
 //
-// The `name` argument is the unique identifier for the model (e.g., "myProvider/myModel").
-// The `opts` argument provides metadata about the model's capabilities ([ai.ModelOptions]).
-// The `fn` argument ([ai.ModelActionFunc]) implements the actual generation logic,
-// handling input requests ([ai.ModelRequest]) and producing responses ([ai.ModelResponse]),
-// potentially streaming chunks ([ai.ModelResponseChunk]) via the callback.
+// name identifies the model (e.g. "myProvider/myModel"), opts describes what it
+// supports, and fn implements generation, streaming chunks through its callback.
 //
 // Config is the model's typed configuration; it is usually inferred from fn's
 // signature. See [ai.NewModelAction] for how the request's config is
 // deserialized and validated.
 //
-// For models that don't need to be registered (e.g., for plugin development or testing),
-// use [ai.NewModelAction] instead.
+// For models that don't need to be registered (e.g., for plugin development or
+// testing), use [ai.NewModelAction] instead.
 //
 // Example:
 //
 //	echoModel := genkit.DefineModelAction(g, "custom/echo",
-//		&ai.ModelOptions{
-//			Label:    "Echo Model",
-//			Supports: &ai.ModelSupports{Multiturn: true},
-//		},
-//		func(ctx context.Context, req *ai.ModelRequest, config MyConfig, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
-//			// Simple echo implementation
-//			resp := &ai.ModelResponse{
-//				Message: &ai.Message{
-//					Role:    ai.RoleModel,
-//					Content: []*ai.Part{},
-//				},
-//			}
-//			// Combine content from the last user message
-//			var responseText strings.Builder
-//			if len(req.Messages) > 0 {
-//				lastMsg := req.Messages[len(req.Messages)-1]
-//				if lastMsg.Role == ai.RoleUser {
-//					for _, part := range lastMsg.Content {
-//						if part.IsText() {
-//							responseText.WriteString(part.Text)
-//						}
-//					}
-//				}
-//			}
-//			if responseText.Len() == 0 {
-//				responseText.WriteString("...")
-//			}
-//
-//			resp.Message.Content = append(resp.Message.Content, ai.NewTextPart(responseText.String()))
-//
-//			// Example of streaming (optional)
+//		&ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true}},
+//		func(ctx context.Context, req *ai.ModelRequest, cfg *echoConfig, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+//			text := req.Messages[len(req.Messages)-1].Text()
 //			if cb != nil {
-//				chunk := &ai.ModelResponseChunk{ Index: 0, Content: resp.Message.Content }
-//				if err := cb(ctx, chunk); err != nil {
-//					return nil, err // Handle streaming error
-//				}
+//				cb(ctx, &ai.ModelResponseChunk{Content: []*ai.Part{ai.NewTextPart(text)}})
 //			}
-//
-//			resp.FinishReason = ai.FinishReasonStop
-//			return resp, nil
-//		},
-//	)
+//			return &ai.ModelResponse{
+//				Message:      ai.NewModelTextMessage(text),
+//				FinishReason: ai.FinishReasonStop,
+//			}, nil
+//		})
 func DefineModelAction[Config any](
 	g *Genkit,
 	name string,
@@ -590,8 +556,11 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 // The `checkFn` is the function that checks the status of the background model.
 //
 // Config is the model's typed configuration; it is usually inferred from
-// startFn's signature. See [ai.NewModelAction] for how the request's
-// config is deserialized and validated.
+// startFn's signature. See [ai.NewModelAction] for how the request's config is
+// deserialized and validated.
+//
+// For background models that don't need to be registered (e.g., for plugin
+// development), use [ai.NewBackgroundModelAction] instead.
 func DefineBackgroundModelAction[Config any](
 	g *Genkit,
 	name string,
@@ -1574,8 +1543,11 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 // ([ai.EvaluatorCallbackRequest]) in the evaluation dataset.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewEvaluatorAction] for how the request's
-// options are deserialized.
+// fn's signature. See [ai.NewEvaluatorAction] for how the request's options are
+// deserialized.
+//
+// For evaluators that don't need to be registered (e.g., for plugin
+// development), use [ai.NewEvaluatorAction] instead.
 func DefineEvaluatorAction[Config any](
 	g *Genkit,
 	name string,
@@ -1608,8 +1580,11 @@ func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.Ev
 // such as batching calls to external services or parallelizing computations.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewEvaluatorAction] for how the request's
-// options are deserialized.
+// fn's signature. See [ai.NewEvaluatorAction] for how the request's options are
+// deserialized.
+//
+// For evaluators that don't need to be registered (e.g., for plugin
+// development), use [ai.NewBatchEvaluatorAction] instead.
 func DefineBatchEvaluatorAction[Config any](
 	g *Genkit,
 	name string,

--- a/go/internal/base/schema.go
+++ b/go/internal/base/schema.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package base
+
+// WalkSubschemas replaces every subschema reachable from schema with visit's
+// result: the members of properties, the items schema, a schema-valued
+// additionalProperties, and the branches of anyOf, oneOf, and allOf, at every
+// depth. Non-schema values (a boolean subschema, say) are left alone.
+//
+// schema itself is not visited, since a transform that widens or annotates
+// fields usually means something different for the root. Apply visit to it
+// directly when it should be included.
+func WalkSubschemas(schema map[string]any, visit func(map[string]any) map[string]any) {
+	if schema == nil {
+		return
+	}
+	replace := func(sub any) (any, bool) {
+		m, ok := sub.(map[string]any)
+		if !ok {
+			return sub, false
+		}
+		WalkSubschemas(m, visit)
+		return visit(m), true
+	}
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for name, sub := range props {
+			if next, ok := replace(sub); ok {
+				props[name] = next
+			}
+		}
+	}
+	for _, key := range []string{"items", "additionalProperties"} {
+		if next, ok := replace(schema[key]); ok {
+			schema[key] = next
+		}
+	}
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		branches, ok := schema[key].([]any)
+		if !ok {
+			continue
+		}
+		for i, sub := range branches {
+			if next, ok := replace(sub); ok {
+				branches[i] = next
+			}
+		}
+	}
+}
+
+// CloneSchema returns a deep copy of schema, so a transform applied to the
+// result cannot reach the caller's map. Values other than nested schemas and
+// their arrays are the scalars JSON decodes to, which are immutable.
+func CloneSchema(schema map[string]any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	out := make(map[string]any, len(schema))
+	for k, v := range schema {
+		out[k] = cloneSchemaValue(v)
+	}
+	return out
+}
+
+func cloneSchemaValue(v any) any {
+	switch v := v.(type) {
+	case map[string]any:
+		return CloneSchema(v)
+	case []any:
+		out := make([]any, len(v))
+		for i, e := range v {
+			out[i] = cloneSchemaValue(e)
+		}
+		return out
+	}
+	return v
+}

--- a/go/internal/base/schema_test.go
+++ b/go/internal/base/schema_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package base
+
+import (
+	"reflect"
+	"testing"
+)
+
+// walkTestSchema is shaped like a reflected SDK params struct: nested objects,
+// an array of objects, and a branch schema, each of which the walker must reach.
+func walkTestSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"model", "temperature"},
+		"properties": map[string]any{
+			"model":       map[string]any{"type": "string"},
+			"temperature": map[string]any{"type": "number"},
+			"thinking": map[string]any{
+				"type":     "object",
+				"required": []any{"budget"},
+				"properties": map[string]any{
+					"budget": map[string]any{"type": "integer"},
+				},
+			},
+			"tools": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
+					},
+				},
+			},
+			"effort": map[string]any{
+				"oneOf": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"type": "integer"},
+				},
+			},
+		},
+	}
+}
+
+func TestWalkSubschemasReachesEveryBranch(t *testing.T) {
+	schema := walkTestSchema()
+	var seen []string
+	WalkSubschemas(schema, func(sub map[string]any) map[string]any {
+		if t, ok := sub["type"].(string); ok {
+			seen = append(seen, t)
+		}
+		sub["visited"] = true
+		return sub
+	})
+
+	// One per named property, the array's items, the object inside it, and both
+	// oneOf branches. The root is deliberately not visited.
+	for _, want := range []string{"string", "number", "object", "array", "integer"} {
+		if !contains(seen, want) {
+			t.Errorf("walk never reached a %q subschema; saw %v", want, seen)
+		}
+	}
+	if _, ok := schema["visited"]; ok {
+		t.Error("walk visited the root, which callers handle themselves")
+	}
+	props := schema["properties"].(map[string]any)
+	items := props["tools"].(map[string]any)["items"].(map[string]any)
+	if got := items["properties"].(map[string]any)["name"].(map[string]any)["visited"]; got != true {
+		t.Error("walk did not reach a property inside an array's items")
+	}
+	branch := props["effort"].(map[string]any)["oneOf"].([]any)[0]
+	if got := branch.(map[string]any)["visited"]; got != true {
+		t.Error("walk did not reach a oneOf branch")
+	}
+}
+
+// A visit that returns a different map must replace the original, which is what
+// lets a transform widen a subschema rather than only annotate it.
+func TestWalkSubschemasHonorsReplacement(t *testing.T) {
+	schema := walkTestSchema()
+	WalkSubschemas(schema, func(sub map[string]any) map[string]any {
+		return map[string]any{"replaced": true}
+	})
+	props := schema["properties"].(map[string]any)
+	if got := props["model"].(map[string]any)["replaced"]; got != true {
+		t.Error("a replaced property schema was not written back")
+	}
+}
+
+// Reflected schemas carry non-schema values in the same slots (a boolean
+// subschema, or additionalProperties: false), and the walker must step over
+// them rather than panicking.
+func TestWalkSubschemasSkipsNonSchemas(t *testing.T) {
+	schema := map[string]any{
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"hidden": true,
+			"real":   map[string]any{"type": "string"},
+		},
+	}
+	WalkSubschemas(schema, func(sub map[string]any) map[string]any {
+		sub["visited"] = true
+		return sub
+	})
+	props := schema["properties"].(map[string]any)
+	if props["hidden"] != true {
+		t.Errorf("boolean subschema was rewritten to %v", props["hidden"])
+	}
+	if schema["additionalProperties"] != false {
+		t.Errorf("additionalProperties: false was rewritten to %v", schema["additionalProperties"])
+	}
+	if props["real"].(map[string]any)["visited"] != true {
+		t.Error("walk skipped the real subschema alongside the boolean one")
+	}
+}
+
+func TestCloneSchemaIsDeep(t *testing.T) {
+	original := walkTestSchema()
+	clone := CloneSchema(original)
+	if !reflect.DeepEqual(original, clone) {
+		t.Fatal("clone does not equal the original")
+	}
+	clone["properties"].(map[string]any)["thinking"].(map[string]any)["properties"].(map[string]any)["budget"].(map[string]any)["type"] = "mutated"
+	clone["required"].([]any)[0] = "mutated"
+
+	origBudget := original["properties"].(map[string]any)["thinking"].(map[string]any)["properties"].(map[string]any)["budget"].(map[string]any)
+	if got := origBudget["type"]; got != "integer" {
+		t.Errorf("mutating the clone reached the original: type = %v", got)
+	}
+	if got := original["required"].([]any)[0]; got != "model" {
+		t.Errorf("mutating the clone's array reached the original: %v", got)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/go/plugins/anthropic/anthropic.go
+++ b/go/plugins/anthropic/anthropic.go
@@ -22,7 +22,6 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -35,13 +34,13 @@ import (
 	ant "github.com/firebase/genkit/go/plugins/internal/anthropic"
 )
 
-const (
-	// provider prefixes the action name of every model this plugin serves.
-	provider = "anthropic"
-	// anthropicLabelPrefix opens the dev UI label of every model this plugin
-	// describes.
-	anthropicLabelPrefix = "Anthropic"
-)
+// provider prefixes the action name of every model this plugin serves.
+const provider = "anthropic"
+
+// anthropicLabelPrefix opens the dev UI label of every model this plugin
+// describes. It comes from [ant.DisplayName] so the curated labels cannot
+// drift from the ones NewModel defaults.
+var anthropicLabelPrefix = ant.DisplayName(provider)
 
 // modelCacheTTL is how long a discovered model list is reused before the API
 // is asked again. Anthropic's catalog changes on the order of weeks, so this
@@ -126,10 +125,6 @@ func (a *Anthropic) Name() string {
 // Opts, which is trusted to carry its own) and when called twice, both being
 // setup mistakes rather than conditions an application can recover from.
 func (a *Anthropic) Init(ctx context.Context) []api.Action {
-	if a == nil {
-		a = &Anthropic{}
-	}
-
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.initted {
@@ -180,7 +175,7 @@ func (a *Anthropic) ListActions(ctx context.Context) []api.ActionDesc {
 	for _, id := range models {
 		// A discovered model is named by the same ID the API serves it under,
 		// so the action name and the API model ID are identical here.
-		actions = append(actions, newModel(a.client, id, id, a.modelOptions(id)).Desc())
+		actions = append(actions, newModel(a.client, id, a.modelOptions(id)).Desc())
 	}
 	return actions
 }
@@ -197,7 +192,7 @@ func (a *Anthropic) ResolveAction(atype api.ActionType, id string) api.Action {
 	if atype != api.ActionTypeModel {
 		return nil
 	}
-	return newModel(a.client, id, id, a.modelOptions(id))
+	return newModel(a.client, id, a.modelOptions(id))
 }
 
 // DefineModel builds a Claude model and returns it, without registering it
@@ -216,13 +211,13 @@ func (a *Anthropic) DefineModel(g *genkit.Genkit, id string, opts *ai.ModelOptio
 	}
 
 	// Trim before resolving, so a prefixed ID still hits supportedModels.
-	id = strings.TrimPrefix(id, provider+"/")
+	id = internal.TrimProvider(provider, id)
 
 	modelOpts := a.modelOptions(id)
 	if opts != nil {
 		modelOpts = *opts
 	}
-	return newModel(a.client, id, id, modelOpts), nil
+	return newModel(a.client, id, modelOpts), nil
 }
 
 // Model returns a previously registered model.
@@ -256,29 +251,15 @@ func IsDefinedModel(g *genkit.Genkit, id string) bool {
 // This is the one source of model capabilities, shared by ListActions and
 // ResolveAction, which is what makes a caller's entry authoritative no matter
 // which path describes the model first.
-//
-// The caller trims the provider prefix off id; Models is keyed either way, so
-// both forms are accepted there.
 func (a *Anthropic) modelOptions(id string) ai.ModelOptions {
 	opts, ok := supportedModels[baseModelName(id)]
 	if !ok {
 		opts = dynamicModelOptions
 	}
-	if override, ok := a.modelOverride(id); ok {
-		opts = internal.OverlayModelOptions(opts, override)
+	if override, ok := internal.LookupOverride(a.Models, provider, id); ok {
+		opts = opts.Overlay(override)
 	}
 	return opts
-}
-
-// modelOverride returns the caller's entry for a bare model ID, accepting the
-// key in either the bare or the provider-prefixed form the rest of the package
-// takes.
-func (a *Anthropic) modelOverride(id string) (ai.ModelOptions, bool) {
-	if opts, ok := a.Models[id]; ok {
-		return opts, true
-	}
-	opts, ok := a.Models[provider+"/"+id]
-	return opts, ok
 }
 
 // discoveredModels returns the IDs the API advertises, from cache when it is
@@ -302,11 +283,11 @@ func (a *Anthropic) discoveredModels(ctx context.Context) ([]string, error) {
 	return models, nil
 }
 
-// newModel builds a model action without registering it. name is the Genkit
-// action name and apiModelID is the model the request is sent to, which differ
-// when the name is an alias for a dated release.
-func newModel(client anthropic.Client, name, apiModelID string, opts ai.ModelOptions) *ai.ModelAction {
-	return ant.NewModel(client, provider, name, apiModelID, opts)
+// newModel builds a model action without registering it. Anthropic resolves an
+// alias like claude-opus-4-5 to its current dated release itself, so the action
+// name is also the model ID requests are sent to.
+func newModel(client anthropic.Client, name string, opts ai.ModelOptions) *ai.ModelAction {
+	return ant.NewModel(client, provider, name, opts)
 }
 
 // modelName builds the action name for a Claude model ID, taking the ID either
@@ -314,7 +295,7 @@ func newModel(client anthropic.Client, name, apiModelID string, opts ai.ModelOpt
 // so without the trim an already-prefixed ID would double up and name a model
 // that resolves nowhere.
 func modelName(id string) string {
-	return api.NewName(provider, strings.TrimPrefix(id, provider+"/"))
+	return api.NewName(provider, internal.TrimProvider(provider, id))
 }
 
 // baseModelName strips the release date off a dated model ID, mapping it onto

--- a/go/plugins/anthropic/anthropic_test.go
+++ b/go/plugins/anthropic/anthropic_test.go
@@ -122,7 +122,7 @@ func TestNewModelDescriptor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			desc := newModel(anthropic.Client{}, tt.name, tt.name, (&Anthropic{}).modelOptions(tt.name)).Desc()
+			desc := newModel(anthropic.Client{}, tt.name, (&Anthropic{}).modelOptions(tt.name)).Desc()
 
 			model, ok := desc.Metadata["model"].(map[string]any)
 			if !ok {
@@ -177,26 +177,12 @@ func TestModelsOverlaysCuratedCapabilities(t *testing.T) {
 	}
 }
 
-// TestModelsKeyAcceptsEitherForm pins that an entry is found under the bare ID
-// and the provider-prefixed one, matching every other model entry point in the
-// package.
-func TestModelsKeyAcceptsEitherForm(t *testing.T) {
-	for _, key := range []string{"claude-opus-4-5", "anthropic/claude-opus-4-5"} {
-		a := &Anthropic{Models: map[string]ai.ModelOptions{
-			key: {Label: "Custom Claude"},
-		}}
-		if got := a.modelOptions("claude-opus-4-5").Label; got != "Custom Claude" {
-			t.Errorf("keyed by %q: Label = %q, want the entry to be found", key, got)
-		}
-	}
-}
-
 // TestModelConfigIsValidated pins that the config schema reaches the request
 // input schema, so the framework rejects a config the SDK type cannot hold
 // before it reaches the model function.
 func TestModelConfigIsValidated(t *testing.T) {
 	const name = "claude-opus-4-5"
-	inputSchema := newModel(anthropic.Client{}, name, name, (&Anthropic{}).modelOptions(name)).Desc().InputSchema
+	inputSchema := newModel(anthropic.Client{}, name, (&Anthropic{}).modelOptions(name)).Desc().InputSchema
 
 	req := func(config any) *ai.ModelRequest {
 		return &ai.ModelRequest{
@@ -598,5 +584,18 @@ func TestDefineModelRequiresInit(t *testing.T) {
 
 	if _, err := a.DefineModel(g, "claude-opus-4-5", nil); err == nil {
 		t.Error("DefineModel() error = nil on an uninitialized plugin, want it refused")
+	}
+}
+
+// TestOverrideKeysAcceptProviderPrefix mirrors the googlegenai test: both
+// spellings of a model ID must reach the same entry in Models.
+func TestOverrideKeysAcceptProviderPrefix(t *testing.T) {
+	for _, key := range []string{"claude-opus-4-5", "anthropic/claude-opus-4-5"} {
+		a := &Anthropic{Models: map[string]ai.ModelOptions{key: {Label: "custom"}}}
+		for _, id := range []string{"claude-opus-4-5", "anthropic/claude-opus-4-5"} {
+			if got := a.modelOptions(id).Label; got != "custom" {
+				t.Errorf("Models[%q] did not apply to %q: label = %q", key, id, got)
+			}
+		}
 	}
 }

--- a/go/plugins/anthropic/models.go
+++ b/go/plugins/anthropic/models.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/plugins/internal"
 )
 
 // Capability sets shared by the entries below. claudeSupports is what every
@@ -57,7 +58,7 @@ var (
 // is shared by every entry, so it lives here rather than in each one.
 func structuredModel(label string) ai.ModelOptions {
 	return ai.ModelOptions{
-		Label:    anthropicLabelPrefix + " - " + label,
+		Label:    internal.ProviderLabel(anthropicLabelPrefix, label),
 		Supports: &structuredClaudeSupports,
 		Versions: []string{},
 		Stage:    ai.ModelStageStable,

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -22,6 +22,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/internal"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 )
@@ -197,6 +198,7 @@ func (o *OpenAICompatible) IsDefinedModel(g *genkit.Genkit, name string) bool {
 	return genkit.LookupModel(g, name) != nil
 }
 
+// ListActions describes every model the configured endpoint advertises.
 func (o *OpenAICompatible) ListActions(ctx context.Context) []api.ActionDesc {
 	actions := []api.ActionDesc{}
 
@@ -232,11 +234,12 @@ func (o *OpenAICompatible) ListActions(ctx context.Context) []api.ActionDesc {
 	return actions
 }
 
+// ResolveAction builds a model action on demand for an ID the endpoint serves.
 func (o *OpenAICompatible) ResolveAction(atype api.ActionType, name string) api.Action {
 	switch atype {
 	case api.ActionTypeModel:
 		if model := o.DefineModel(o.Provider, name, ai.ModelOptions{
-			Label:    fmt.Sprintf("%s - %s", o.Provider, name),
+			Label:    internal.ProviderLabel(o.Provider, name),
 			Stage:    ai.ModelStageStable,
 			Versions: []string{},
 			Supports: &Multimodal,

--- a/go/plugins/compat_oai/dashscope/dashscope.go
+++ b/go/plugins/compat_oai/dashscope/dashscope.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package dashscope provides a Genkit plugin for Alibaba Cloud DashScope's Qwen models.
 package dashscope
 
 import (
@@ -226,10 +227,13 @@ func (d *DashScope) Init(ctx context.Context) []api.Action {
 	return actions
 }
 
+// Model returns a registered DashScope model.
 func (d *DashScope) Model(g *genkit.Genkit, id string) ai.Model {
 	return d.openAICompatible.Model(g, api.NewName(provider, id))
 }
 
+// DefineModel registers a DashScope model, including models not in the
+// built-in list.
 func (d *DashScope) DefineModel(id string, opts ai.ModelOptions) ai.Model {
 	return d.openAICompatible.DefineModel(provider, id, opts)
 }

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -55,6 +55,8 @@ var chatCompletionParamFields = func() map[string]struct{} {
 	return fields
 }()
 
+// GetRequest returns the request built so far, for tests and for plugins that
+// need to inspect what will be sent.
 func (g *ModelGenerator) GetRequest() *openai.ChatCompletionNewParams {
 	return g.request
 }

--- a/go/plugins/googlecloud/action.go
+++ b/go/plugins/googlecloud/action.go
@@ -49,7 +49,7 @@ func (a *ActionTelemetry) Tick(span sdktrace.ReadOnlySpan, logInputOutput bool, 
 
 	subtype := extractStringAttribute(attributes, "genkit:metadata:subtype")
 
-	if subtype != "tool" && actionName != "generate" {
+	if subtype != "tool" && subtype != "tool.v2" && actionName != "generate" {
 		return
 	}
 

--- a/go/plugins/googlecloud/googlecloud.go
+++ b/go/plugins/googlecloud/googlecloud.go
@@ -383,7 +383,7 @@ func (e *AdjustingTraceExporter) tickTelemetry(span sdktrace.ReadOnlySpan) {
 			// Report generate metrics for all model actions
 			generateTelemetry.Tick(span, e.logInputAndOutput, e.projectId)
 		}
-		if spanType == "action" && subtype == "tool" {
+		if spanType == "action" && (subtype == "tool" || subtype == "tool.v2") {
 			// TODO: Report input and output for tool actions
 		}
 		if spanType == "action" || spanType == "flow" || spanType == "flowStep" || spanType == "util" {

--- a/go/plugins/googlegenai/catalog.go
+++ b/go/plugins/googlegenai/catalog.go
@@ -35,8 +35,8 @@ func (v *VertexAI) catalog() catalog {
 // entry works the same for each.
 func (c catalog) modelOptions(id string) ai.ModelOptions {
 	base := GetModelOptions(id, c.provider)
-	if override, ok := c.models[id]; ok {
-		return internal.OverlayModelOptions(base, override)
+	if override, ok := internal.LookupOverride(c.models, c.provider, id); ok {
+		return base.Overlay(override)
 	}
 	return base
 }
@@ -44,7 +44,7 @@ func (c catalog) modelOptions(id string) ai.ModelOptions {
 // modelOverridden reports whether the caller described this model ID, which
 // makes an ID the plugin does not ship a known one.
 func (c catalog) modelOverridden(id string) bool {
-	_, ok := c.models[id]
+	_, ok := internal.LookupOverride(c.models, c.provider, id)
 	return ok
 }
 
@@ -53,8 +53,8 @@ func (c catalog) modelOverridden(id string) bool {
 // when there is one.
 func (c catalog) embedderOptions(id string) ai.EmbedderOptions {
 	base := GetEmbedderOptions(id, c.provider)
-	if override, ok := c.embedders[id]; ok {
-		return internal.OverlayEmbedderOptions(base, override)
+	if override, ok := internal.LookupOverride(c.embedders, c.provider, id); ok {
+		return base.Overlay(override)
 	}
 	return base
 }

--- a/go/plugins/googlegenai/catalog_test.go
+++ b/go/plugins/googlegenai/catalog_test.go
@@ -302,3 +302,25 @@ func TestDefineModelRejectsBackgroundModel(t *testing.T) {
 		t.Errorf("DefineModel(%q, opts) = nil error, want the modality checked before opts", veo31GeneratePreview)
 	}
 }
+
+// TestOverrideKeysAcceptProviderPrefix pins that both spellings of a model ID
+// reach the same entry. Callers write the prefixed form everywhere else
+// (ai.WithModelName("googleai/...")), and an ignored key is a silent no-op,
+// the worst way for a config map to fail.
+func TestOverrideKeysAcceptProviderPrefix(t *testing.T) {
+	for _, key := range []string{"gemini-flash-latest", "googleai/gemini-flash-latest"} {
+		ga := &GoogleAI{Models: map[string]ai.ModelOptions{key: {Label: "custom"}}}
+		for _, id := range []string{"gemini-flash-latest", "googleai/gemini-flash-latest"} {
+			if got := ga.catalog().modelOptions(id).Label; got != "custom" {
+				t.Errorf("Models[%q] did not apply to %q: label = %q", key, id, got)
+			}
+			if !ga.catalog().modelOverridden(id) {
+				t.Errorf("Models[%q] not reported as overriding %q", key, id)
+			}
+		}
+	}
+	v := &VertexAI{Embedders: map[string]ai.EmbedderOptions{"vertexai/text-embedding-005": {Label: "custom"}}}
+	if got := v.catalog().embedderOptions("text-embedding-005").Label; got != "custom" {
+		t.Errorf("prefixed embedder key did not apply: label = %q", got)
+	}
+}

--- a/go/plugins/googlegenai/config_overrides.go
+++ b/go/plugins/googlegenai/config_overrides.go
@@ -4,38 +4,19 @@
 package googlegenai
 
 import (
-	"strings"
-
-	"github.com/invopop/jsonschema"
+	"github.com/firebase/genkit/go/plugins/internal"
 	"google.golang.org/genai"
 )
 
-// configOverrides describes per-property metadata layered onto a reflected
-// JSON schema before it is exposed to the Genkit Developer UI. The genai
-// SDK structs do not carry JSON Schema descriptions, and a few of their
-// fields are managed by Genkit primitives and rejected when supplied
-// directly, so we curate that information here.
-//
-// All path application is best-effort: if the upstream SDK renames or
-// removes a field, the corresponding entry silently no-ops rather than
-// panicking. The cost is that stale entries quietly stop applying — caught
-// by the snapshot tests, not at runtime.
-type configOverrides struct {
-	// descriptions maps a JSON property path to the help text shown as the
-	// field's tooltip in the dev UI. Keys may be a top-level property name
-	// ("temperature") or a dotted path with "[]" denoting a descent into an
-	// array's item shape ("safetySettings[].category").
-	descriptions map[string]string
-	// hidden lists JSON property paths to hide from the schema. Same
-	// notation as descriptions. Use this for fields the plugin rejects at
-	// runtime or that the Genkit framework manages directly. Hidden means
-	// typeless rather than absent; see applyConfigOverrides.
-	hidden []string
-}
+// The presentation layered onto each reflected genai config schema before it
+// reaches the dev UI: the SDK structs carry no schema descriptions, and a few
+// of their fields are owned by a Genkit option and rejected when supplied
+// directly. See [internal.SchemaOverrides] for the path notation; a stale entry is
+// a no-op, which TestConfigOverridePathsResolve catches.
 
 // gccOverrides controls dev UI presentation of [genai.GenerateContentConfig].
-var gccOverrides = configOverrides{
-	descriptions: map[string]string{
+var gccOverrides = internal.SchemaOverrides{
+	Descriptions: map[string]string{
 		// Top-level fields.
 		"temperature":                "Controls the degree of randomness in token selection. Lower values produce more deterministic responses; higher values produce more diverse or creative ones.",
 		"topP":                       "Considers tokens whose cumulative probability exceeds this value. Lower values constrain the model to high-probability tokens; higher values allow more variety.",
@@ -114,7 +95,7 @@ var gccOverrides = configOverrides{
 		// modelSelectionConfig sub-fields.
 		"modelSelectionConfig.featureSelectionPreference": "Preference for which model features to prioritize (PRIORITIZE_QUALITY, BALANCED, PRIORITIZE_COST, etc.).",
 	},
-	hidden: []string{
+	Hidden: []string{
 		// Managed by Genkit primitives; the plugin rejects these when set.
 		"systemInstruction",            // ai.WithSystemPrompt
 		"cachedContent",                // ai.WithCacheTTL
@@ -128,8 +109,8 @@ var gccOverrides = configOverrides{
 }
 
 // gicOverrides controls dev UI presentation of [genai.GenerateImagesConfig].
-var gicOverrides = configOverrides{
-	descriptions: map[string]string{
+var gicOverrides = internal.SchemaOverrides{
+	Descriptions: map[string]string{
 		"numberOfImages":           "Number of images to generate. Defaults to 4 when unset.",
 		"aspectRatio":              "Aspect ratio of the generated images. Supported values: 1:1, 3:4, 4:3, 9:16, 16:9.",
 		"negativePrompt":           "Free-form description of what to discourage in the generated images.",
@@ -160,8 +141,8 @@ var gicOverrides = configOverrides{
 }
 
 // gvcOverrides controls dev UI presentation of [genai.GenerateVideosConfig].
-var gvcOverrides = configOverrides{
-	descriptions: map[string]string{
+var gvcOverrides = internal.SchemaOverrides{
+	Descriptions: map[string]string{
 		"numberOfVideos":     "Number of videos to generate per request.",
 		"fps":                "Frames per second for the generated video.",
 		"durationSeconds":    "Length of the generated clip in seconds.",
@@ -187,120 +168,9 @@ var gvcOverrides = configOverrides{
 	},
 }
 
-// applyConfigOverrides mutates schema in place: hides the managed properties
-// and writes descriptions onto the rest. Best-effort, so a path that no longer
-// resolves (because the upstream SDK renamed or removed a field) silently
-// no-ops rather than panicking.
-//
-// A hidden property is replaced by the permissive `true` schema rather than
-// deleted. Both hide it from the dev UI, which renders only properties whose
-// type it recognizes, but they differ on everything else. The config schema is
-// enforced by input validation on every request, and a hidden field must still
-// reach the plugin's own check, which names the Genkit option to use instead;
-// deleting it would instead fail validation as an unknown property. Deleting
-// also forces the parent open with additionalProperties: true to let the value
-// back through, which gives up rejecting genuinely unknown fields anywhere in
-// that object. Replacing keeps additionalProperties: false intact, so a typo
-// like maxTokens for maxOutputTokens is still caught.
-func applyConfigOverrides(schema *jsonschema.Schema, o configOverrides) {
-	if schema == nil || schema.Properties == nil {
-		return
-	}
-	hideTop := make(map[string]struct{})
-	for _, path := range o.hidden {
-		steps := parsePath(path)
-		if len(steps) == 1 {
-			hideTop[steps[0]] = struct{}{}
-		}
-		hideAtPath(schema, steps)
-	}
-	if len(hideTop) > 0 && len(schema.Required) > 0 {
-		kept := schema.Required[:0]
-		for _, r := range schema.Required {
-			if _, drop := hideTop[r]; !drop {
-				kept = append(kept, r)
-			}
-		}
-		schema.Required = kept
-	}
-	for path, desc := range o.descriptions {
-		if target := schemaAtPath(schema, parsePath(path)); target != nil {
-			target.Description = desc
-		}
-	}
-}
-
-// parsePath splits an override path into navigation steps. Each step is
-// either a property name or the literal "[]" meaning "descend into an
-// array's item schema." Examples:
-//
-//	"systemInstruction"             -> ["systemInstruction"]
-//	"tools[].functionDeclarations"  -> ["tools", "[]", "functionDeclarations"]
-//	"foo[].bar[].baz"               -> ["foo", "[]", "bar", "[]", "baz"]
-func parsePath(path string) []string {
-	var steps []string
-	for _, tok := range strings.Split(path, ".") {
-		if name := strings.TrimSuffix(tok, "[]"); name != tok {
-			steps = append(steps, name, "[]")
-		} else {
-			steps = append(steps, tok)
-		}
-	}
-	return steps
-}
-
-// schemaAtPath descends a schema by walking `Items` for "[]" steps and
-// `Properties` for named ones. Returns nil if any step doesn't resolve —
-// callers should treat that as a no-op, not an error.
-func schemaAtPath(schema *jsonschema.Schema, steps []string) *jsonschema.Schema {
-	cur := schema
-	for _, step := range steps {
-		if cur == nil {
-			return nil
-		}
-		if step == "[]" {
-			cur = cur.Items
-			continue
-		}
-		if cur.Properties == nil {
-			return nil
-		}
-		next, ok := cur.Properties.Get(step)
-		if !ok {
-			return nil
-		}
-		cur = next
-	}
-	return cur
-}
-
-// hideAtPath replaces the leaf property at the given path with the permissive
-// `true` schema, which hides it from the dev UI while still accepting whatever
-// value a caller sends so the plugin's own check can answer it. Reports
-// whether it applied, so a path that no longer resolves is distinguishable
-// from one that did.
-func hideAtPath(schema *jsonschema.Schema, steps []string) bool {
-	if len(steps) == 0 {
-		return false
-	}
-	leaf := steps[len(steps)-1]
-	if leaf == "[]" {
-		return false
-	}
-	parent := schemaAtPath(schema, steps[:len(steps)-1])
-	if parent == nil || parent.Properties == nil {
-		return false
-	}
-	if _, ok := parent.Properties.Get(leaf); !ok {
-		return false
-	}
-	parent.Properties.Set(leaf, jsonschema.TrueSchema)
-	return true
-}
-
-// overridesFor returns the overrides matching a given config struct value,
-// or a zero (no-op) value for unknown types.
-func overridesFor(config any) configOverrides {
+// overridesFor returns the overrides matching a config struct value, or a zero
+// (no-op) value for unknown types.
+func overridesFor(config any) internal.SchemaOverrides {
 	switch config.(type) {
 	case genai.GenerateContentConfig, *genai.GenerateContentConfig:
 		return gccOverrides
@@ -309,5 +179,5 @@ func overridesFor(config any) configOverrides {
 	case genai.GenerateVideosConfig, *genai.GenerateVideosConfig:
 		return gvcOverrides
 	}
-	return configOverrides{}
+	return internal.SchemaOverrides{}
 }

--- a/go/plugins/googlegenai/config_overrides_test.go
+++ b/go/plugins/googlegenai/config_overrides_test.go
@@ -5,204 +5,121 @@ package googlegenai
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
-	"github.com/invopop/jsonschema"
+	"github.com/firebase/genkit/go/plugins/internal"
 	"google.golang.org/genai"
 )
 
-// TestConfigToMap_GenerateContentConfig verifies that the schema exposed for
-// the Gemini chat config drops fields the plugin manages on the user's behalf
-// and adds the curated descriptions used by the Genkit Developer UI.
-func TestConfigToMap_GenerateContentConfig(t *testing.T) {
-	schema := configToMap(genai.GenerateContentConfig{})
+// curated pairs each reflected config schema with the overrides written for it.
+type curated struct {
+	schema    map[string]any
+	overrides internal.SchemaOverrides
+}
 
-	for _, hidden := range gccOverrides.hidden {
-		assertHidden(t, "Gemini", schema, hidden)
+func curatedConfigs() map[string]curated {
+	return map[string]curated{
+		"Gemini": {configToMap(genai.GenerateContentConfig{}), gccOverrides},
+		"Imagen": {configToMap(genai.GenerateImagesConfig{}), gicOverrides},
+		"Veo":    {configToMap(genai.GenerateVideosConfig{}), gvcOverrides},
 	}
+}
 
-	// Sanity: built-in API tools still surface in tools[]'s item shape so the
-	// dev UI can let users enable them. Only functionDeclarations should have
-	// been removed from there.
-	if toolItem := navigate(schema, "tools", "[]"); toolItem != nil {
-		if itemProps, ok := toolItem["properties"].(map[string]any); ok {
-			for _, expected := range []string{"googleSearch", "retrieval", "codeExecution"} {
-				if _, ok := itemProps[expected]; !ok {
-					t.Errorf("Gemini schema: tools[].%s should remain visible — got %v", expected, keys(itemProps))
-				}
+// TestConfigOverridePathsResolve is the guard that keeps the override maps
+// honest. Applying a path the genai SDK no longer has is a silent no-op, so an
+// entry left behind by a renamed field would quietly stop describing anything.
+func TestConfigOverridePathsResolve(t *testing.T) {
+	for name, c := range curatedConfigs() {
+		if stale := c.overrides.UnresolvedPaths(c.schema); len(stale) > 0 {
+			t.Errorf("%s: override paths no longer in the SDK schema: %v", name, stale)
+		}
+	}
+}
+
+// TestConfigDescriptionsApplied checks the curated text actually lands, at the
+// top level and inside an array's items.
+func TestConfigDescriptionsApplied(t *testing.T) {
+	for name, c := range curatedConfigs() {
+		for path, want := range c.overrides.Descriptions {
+			target, ok := internal.SchemaAt(c.schema, path).(map[string]any)
+			if !ok {
+				continue // reported by TestConfigOverridePathsResolve
 			}
-			if got := itemProps["functionDeclarations"]; got != true {
-				t.Errorf("Gemini schema: tools[].functionDeclarations = %v, want true (hidden)", got)
+			if got, _ := target["description"].(string); got != want {
+				t.Errorf("%s: description for %q\n got: %q\nwant: %q", name, path, got, want)
 			}
 		}
 	}
-
-	checkDescriptions(t, "Gemini", schema, gccOverrides.descriptions)
 }
 
-// TestConfigToMap_HidingKeepsObjectsClosed pins the reason a hidden property
-// is replaced rather than deleted: every object stays strict, including the
-// ones that hide something.
-//
-// Deleting the property would fail a caller's value as an unknown one, so it
-// would have to be paid for by forcing additionalProperties open on the
-// parent, and that gives up rejecting unknown fields for every other property
-// of that object too. The root and tools[] are exactly the objects that hide
-// something, so they are the ones that would have gone open.
-func TestConfigToMap_HidingKeepsObjectsClosed(t *testing.T) {
+// TestManagedFieldsHiddenButAccepted pins what hiding means here: the property
+// stays present and typeless, so the dev UI skips it while a caller's value
+// still survives input validation and reaches the plugin check that names the
+// Genkit option to use instead.
+func TestManagedFieldsHiddenButAccepted(t *testing.T) {
 	schema := configToMap(genai.GenerateContentConfig{})
+	for _, path := range gccOverrides.Hidden {
+		if got := internal.SchemaAt(schema, path); got != true {
+			t.Errorf("%q = %v, want true (typeless, so the dev UI skips it)", path, got)
+		}
+	}
 
-	if schema["additionalProperties"] != false {
-		t.Errorf("root additionalProperties = %v, want false (hiding must not open the object)", schema["additionalProperties"])
-	}
-	if toolItem := navigate(schema, "tools", "[]"); toolItem != nil {
-		if toolItem["additionalProperties"] != false {
-			t.Errorf("tools[] additionalProperties = %v, want false (hiding must not open the object)", toolItem["additionalProperties"])
-		}
-	}
-	if thinking := navigate(schema, "thinkingConfig"); thinking != nil {
-		if thinking["additionalProperties"] != false {
-			t.Errorf("thinkingConfig additionalProperties = %v, want false", thinking["additionalProperties"])
-		}
-	}
-	for _, name := range []string{"Imagen", "Veo"} {
-		var s map[string]any
-		if name == "Imagen" {
-			s = configToMap(genai.GenerateImagesConfig{})
-		} else {
-			s = configToMap(genai.GenerateVideosConfig{})
-		}
-		if s["additionalProperties"] != false {
-			t.Errorf("%s schema additionalProperties = %v, want false (it hides nothing)", name, s["additionalProperties"])
+	// Built-in API tools stay visible so the dev UI can offer them; only the
+	// function declarations Genkit owns are hidden from tools[].
+	item, _ := internal.SchemaAt(schema, "tools[]").(map[string]any)
+	itemProps, _ := item["properties"].(map[string]any)
+	for _, want := range []string{"googleSearch", "retrieval", "codeExecution"} {
+		if _, ok := itemProps[want]; !ok {
+			t.Errorf("tools[].%s should remain visible, got %v", want, keys(itemProps))
 		}
 	}
 }
 
-func TestConfigToMap_GenerateImagesConfig(t *testing.T) {
-	checkDescriptions(t, "Imagen", configToMap(genai.GenerateImagesConfig{}), gicOverrides.descriptions)
+// TestHidingKeepsObjectsClosed pins the reason a hidden property is replaced
+// rather than deleted: every object stays strict, including the ones that hide
+// something. Deleting would fail a caller's value as unknown, and reopening the
+// parent to let it through gives up rejecting real typos in that object.
+func TestHidingKeepsObjectsClosed(t *testing.T) {
+	for name, c := range curatedConfigs() {
+		if c.schema["additionalProperties"] != false {
+			t.Errorf("%s root additionalProperties = %v, want false", name, c.schema["additionalProperties"])
+		}
+	}
+	schema := configToMap(genai.GenerateContentConfig{})
+	for _, path := range []string{"tools[]", "thinkingConfig"} {
+		obj, ok := internal.SchemaAt(schema, path).(map[string]any)
+		if ok && obj["additionalProperties"] != false {
+			t.Errorf("%s additionalProperties = %v, want false", path, obj["additionalProperties"])
+		}
+	}
 }
 
-func TestConfigToMap_GenerateVideosConfig(t *testing.T) {
-	checkDescriptions(t, "Veo", configToMap(genai.GenerateVideosConfig{}), gvcOverrides.descriptions)
-}
-
-// TestConfigToMap_PointerVariant covers the &Config{} call sites (e.g.
-// model_type.DefaultConfig) to make sure overrides apply for pointer values
-// too, not just value receivers.
-func TestConfigToMap_PointerVariant(t *testing.T) {
+// TestConfigToMapPointerVariant covers the &Config{} call sites (e.g.
+// model_type.DefaultConfig), where overrides must apply just the same.
+func TestConfigToMapPointerVariant(t *testing.T) {
 	schema := configToMap(&genai.GenerateContentConfig{})
-	props, _ := schema["properties"].(map[string]any)
-	if got := props["systemInstruction"]; got != true {
-		t.Errorf("systemInstruction = %v, want true (hidden) for pointer config too", got)
+	if got := internal.SchemaAt(schema, "systemInstruction"); got != true {
+		t.Errorf("systemInstruction = %v, want true (hidden) for a pointer config too", got)
 	}
-	if prop, ok := props["temperature"].(map[string]any); !ok || prop["description"] == "" {
-		t.Errorf("temperature should carry a description for pointer config too: %#v", prop)
-	}
-}
-
-// TestApplyConfigOverrides_BestEffort exercises bogus paths that don't
-// resolve in the schema. They must silently no-op rather than panicking,
-// since this code runs during package init and a panic would prevent the
-// plugin from loading.
-func TestApplyConfigOverrides_BestEffort(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("applyConfigOverrides panicked on bogus paths: %v", r)
-		}
-	}()
-	r := jsonschema.Reflector{
-		DoNotReference: true,
-		ExpandedStruct: true,
-		IgnoredTypes:   []any{genai.Schema{}},
-	}
-	schema := r.Reflect(genai.GenerateContentConfig{})
-	applyConfigOverrides(schema, configOverrides{
-		descriptions: map[string]string{
-			"doesNotExist":              "x",
-			"alsoMissing.deeplyMissing": "x",
-			"tools[].notARealField":     "x",
-			"completely[].fake[].path":  "x",
-			"thinkingConfig.gone":       "x",
-		},
-		hidden: []string{
-			"doesNotExist",
-			"missing[].alsoMissing",
-			"tools[].notARealField",
-			"[]",
-		},
-	})
-}
-
-func checkDescriptions(t *testing.T, label string, schema map[string]any, want map[string]string) {
-	t.Helper()
-	for path, desc := range want {
-		target := navigate(schema, parsePath(path)...)
-		if target == nil {
-			// Stale entry: either upstream renamed the field or we removed it.
-			// Surface the mismatch loudly so the override map stays honest.
-			t.Errorf("%s schema: described field %q missing — update %s overrides", label, path, label)
-			continue
-		}
-		if got, _ := target["description"].(string); got != desc {
-			t.Errorf("%s schema: description for %q\n got: %q\nwant: %q", label, path, got, desc)
-		}
+	prop, ok := internal.SchemaAt(schema, "temperature").(map[string]any)
+	if !ok || prop["description"] == "" {
+		t.Errorf("temperature should carry a description for a pointer config too: %#v", prop)
 	}
 }
 
-// assertHidden checks that a top-level or nested property (per parsePath
-// notation) resolves to the permissive `true` schema.
-//
-// Hidden means typeless, not absent. The dev UI renders only properties whose
-// type it recognizes, so `true` is enough to keep the field out of the form,
-// while leaving it in properties is what lets a caller's value survive input
-// validation and reach the plugin check that names the primitive to use.
-func assertHidden(t *testing.T, label string, schema map[string]any, path string) {
-	t.Helper()
-	steps := parsePath(path)
-	leaf := steps[len(steps)-1]
-	parent := schema
-	if len(steps) > 1 {
-		parent = navigate(schema, steps[:len(steps)-1]...)
-	}
-	if parent == nil {
-		return // upstream removed the parent — nothing to assert
-	}
-	props, _ := parent["properties"].(map[string]any)
-	if props == nil && len(steps) == 1 {
-		t.Fatalf("%s schema missing top-level properties", label)
-	}
-	got, present := props[leaf]
-	if !present {
-		t.Errorf("%s schema: %q is absent, want the permissive true schema — properties %v", label, path, keys(props))
-		return
-	}
-	if got != true {
-		t.Errorf("%s schema: %q = %v, want true (typeless, so the dev UI skips it)", label, path, got)
-	}
-}
-
-// navigate descends a JSON Schema map by walking `properties` for ordinary
-// step names and `items` for "[]" steps. Returns nil if the path doesn't
-// resolve.
-func navigate(schema map[string]any, steps ...string) map[string]any {
-	cur := schema
-	for _, step := range steps {
-		if cur == nil {
-			return nil
+// TestModelSupportsNativeConstraints keeps the constrained-output claim honest:
+// only models whose schema advertises responseJsonSchema handling may set it.
+func TestGeminiHidesResponseSchemaFields(t *testing.T) {
+	schema := configToMap(genai.GenerateContentConfig{})
+	for _, path := range []string{"responseSchema", "responseMimeType", "responseJsonSchema"} {
+		if got := internal.SchemaAt(schema, path); got != true {
+			t.Errorf("%s = %v, want true; ai.WithOutputType owns it", path, got)
 		}
-		if step == "[]" {
-			next, _ := cur["items"].(map[string]any)
-			cur = next
-			continue
-		}
-		props, _ := cur["properties"].(map[string]any)
-		if props == nil {
-			return nil
-		}
-		next, _ := props[step].(map[string]any)
-		cur = next
 	}
-	return cur
+	if !strings.Contains(strings.Join(gccOverrides.Hidden, ","), "candidateCount") {
+		t.Error("candidateCount should stay hidden; the plugin pins it to 1")
+	}
 }
 
 func keys(m map[string]any) []string {

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -34,6 +34,7 @@ import (
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal"
 	"github.com/firebase/genkit/go/internal/base"
+	plugininternal "github.com/firebase/genkit/go/plugins/internal"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 )
 
@@ -57,10 +58,9 @@ func configToMap(config any) map[string]any {
 		},
 	}
 
-	schema := r.Reflect(config)
-	applyConfigOverrides(schema, overridesFor(config))
-	result := base.SchemaAsMap(schema)
-	return result
+	schema := base.SchemaAsMap(r.Reflect(config))
+	plugininternal.ApplySchemaOverrides(schema, overridesFor(config))
+	return schema
 }
 
 // newModel creates a model without registering it. The model's config type

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 
 	"cloud.google.com/go/auth"
@@ -20,6 +19,7 @@ import (
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/internal"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"google.golang.org/genai"
@@ -33,13 +33,12 @@ const (
 	vertexAILabelPrefix = "Vertex AI"
 )
 
-// trimProvider drops a leading provider prefix from a model or embedder ID.
-// Callers reach for the spelling ai.WithModelName takes
-// ("googleai/gemini-flash-latest"), but the prefix is applied downstream by
-// concatenation, so without the trim it would double up and name an action
-// that resolves nowhere. The bare ID is also what the genai API expects.
-func trimProvider(provider, id string) string {
-	return strings.TrimPrefix(id, provider+"/")
+// displayName is how a provider is spelled in a model's dev UI label.
+func displayName(provider string) string {
+	if provider == vertexAIProvider {
+		return vertexAILabelPrefix
+	}
+	return googleAILabelPrefix
 }
 
 // rejectBackgroundModel refuses IDs whose modality is served by a background
@@ -251,9 +250,6 @@ func (v *VertexAI) customEndpointOnly() bool {
 // After calling Init, you may call [DefineModel] and [DefineEmbedder] to create
 // and register any additional generative models and embedders
 func (ga *GoogleAI) Init(ctx context.Context) []api.Action {
-	if ga == nil {
-		ga = &GoogleAI{}
-	}
 	ga.mu.Lock()
 	defer ga.mu.Unlock()
 	if ga.initted {
@@ -299,9 +295,6 @@ func (ga *GoogleAI) Init(ctx context.Context) []api.Action {
 // After calling Init, you may call [DefineModel] and [DefineEmbedder] to create
 // and register any additional generative models and embedders
 func (v *VertexAI) Init(ctx context.Context) []api.Action {
-	if v == nil {
-		v = &VertexAI{}
-	}
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if v.initted {
@@ -450,7 +443,7 @@ func (ga *GoogleAI) DefineModel(g *genkit.Genkit, id string, opts *ai.ModelOptio
 	if !ga.initted {
 		return nil, errors.New("GoogleAI plugin not initialized")
 	}
-	id = trimProvider(googleAIProvider, id)
+	id = internal.TrimProvider(googleAIProvider, id)
 	if err := rejectBackgroundModel(googleAIProvider, id); err != nil {
 		return nil, err
 	}
@@ -487,7 +480,7 @@ func (v *VertexAI) DefineModel(g *genkit.Genkit, id string, opts *ai.ModelOption
 	if !v.initted {
 		return nil, errors.New("VertexAI plugin not initialized")
 	}
-	id = trimProvider(vertexAIProvider, id)
+	id = internal.TrimProvider(vertexAIProvider, id)
 	if err := rejectBackgroundModel(vertexAIProvider, id); err != nil {
 		return nil, err
 	}
@@ -521,7 +514,7 @@ func (ga *GoogleAI) DefineEmbedder(g *genkit.Genkit, id string, embedOpts *ai.Em
 	if !ga.initted {
 		return nil, errors.New("GoogleAI plugin not initialized")
 	}
-	id = trimProvider(googleAIProvider, id)
+	id = internal.TrimProvider(googleAIProvider, id)
 	if embedOpts == nil {
 		opts := ga.catalog().embedderOptions(id)
 		embedOpts = &opts
@@ -539,7 +532,7 @@ func (v *VertexAI) DefineEmbedder(g *genkit.Genkit, id string, embedOpts *ai.Emb
 	if !v.initted {
 		return nil, errors.New("VertexAI plugin not initialized")
 	}
-	id = trimProvider(vertexAIProvider, id)
+	id = internal.TrimProvider(vertexAIProvider, id)
 	if embedOpts == nil {
 		opts := v.catalog().embedderOptions(id)
 		embedOpts = &opts
@@ -553,7 +546,7 @@ func (v *VertexAI) DefineEmbedder(g *genkit.Genkit, id string, embedOpts *ai.Emb
 // would register the very action the caller is checking for and answer true
 // for any ID.
 func isDefined(g *genkit.Genkit, atype api.ActionType, provider, id string) bool {
-	return genkit.LookupAction(g, api.NewKey(atype, provider, trimProvider(provider, id))) != nil
+	return genkit.LookupAction(g, api.NewKey(atype, provider, internal.TrimProvider(provider, id))) != nil
 }
 
 // IsDefinedEmbedder reports whether the [Embedder] is defined by this plugin.

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/plugins/internal"
 	"google.golang.org/genai"
 )
 
@@ -507,15 +508,10 @@ func GetModelOptions(name, provider string) ai.ModelOptions {
 		opts.ConfigSchema = mt.configSchema()
 	}
 
-	// Set label with provider prefix
-	prefix := googleAILabelPrefix
-	if provider == vertexAIProvider {
-		prefix = vertexAILabelPrefix
-	}
 	if opts.Label == "" {
 		opts.Label = name
 	}
-	opts.Label = fmt.Sprintf("%s - %s", prefix, opts.Label)
+	opts.Label = internal.ProviderLabel(displayName(provider), opts.Label)
 
 	return opts
 }
@@ -527,14 +523,10 @@ func GetEmbedderOptions(name, provider string) ai.EmbedderOptions {
 		opts = defaultEmbedOpts
 	}
 
-	prefix := googleAILabelPrefix
-	if provider == vertexAIProvider {
-		prefix = vertexAILabelPrefix
-	}
 	if opts.Label == "" {
 		opts.Label = name
 	}
-	opts.Label = fmt.Sprintf("%s - %s", prefix, opts.Label)
+	opts.Label = internal.ProviderLabel(displayName(provider), opts.Label)
 
 	return opts
 }

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -30,6 +30,7 @@ import (
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/base"
+	"github.com/firebase/genkit/go/plugins/internal"
 	pluginjsonschema "github.com/firebase/genkit/go/plugins/internal/jsonschema"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 	"github.com/invopop/jsonschema"
@@ -92,25 +93,21 @@ func toAnthropicMediaBlock(p *ai.Part, kind string) (anthropic.ContentBlockParam
 	}
 }
 
-// NewModel creates a Claude model action without registering it. name is the
-// Genkit action name and apiModel is the model ID sent to the API, which
-// differ when the name is an alias for a dated release; an empty apiModel
-// falls back to name. opts is used as given, except that a nil ConfigSchema
-// defaults to the reflected [anthropic.MessageNewParams] schema and an empty
-// label is derived from the provider and the name.
+// NewModel creates a Claude model action without registering it. name is both
+// the Genkit action name and the model ID requests are sent to: Anthropic
+// resolves an alias like claude-opus-4-5 to its current dated release itself.
 //
-// The framework validates the request's config against the config schema and
-// deserializes it into [anthropic.MessageNewParams] before the model function
-// runs, so the request arrives with the config already typed.
-func NewModel(client anthropic.Client, provider, name, apiModel string, opts ai.ModelOptions) *ai.ModelAction {
+// opts is used as given, except that a nil ConfigSchema defaults to the
+// reflected [anthropic.MessageNewParams] schema and an empty Label is derived
+// from the provider and the name. The framework validates the request's config
+// against that schema and deserializes it into [anthropic.MessageNewParams]
+// before the model function runs.
+func NewModel(client anthropic.Client, provider, name string, opts ai.ModelOptions) *ai.ModelAction {
 	if opts.ConfigSchema == nil {
 		opts.ConfigSchema = defaultConfigSchema
 	}
 	if opts.Label == "" {
-		opts.Label = fmt.Sprintf("%s - %s", ProviderLabel(provider), name)
-	}
-	if apiModel == "" {
-		apiModel = name
+		opts.Label = internal.ProviderLabel(DisplayName(provider), name)
 	}
 
 	return ai.NewModelAction(api.NewName(provider, name), &opts, func(
@@ -119,15 +116,14 @@ func NewModel(client anthropic.Client, provider, name, apiModel string, opts ai.
 		config anthropic.MessageNewParams,
 		cb ai.ModelStreamCallback,
 	) (*ai.ModelResponse, error) {
-		return Generate(ctx, client, provider, apiModel, input, config, cb)
+		return Generate(ctx, client, provider, name, input, config, cb)
 	})
 }
 
-// ProviderLabel is the display name Claude models are labeled with when the
-// caller supplies no label of its own. Callers that curate their own labels
-// use it to prefix them, so every Claude model names its provider the same way
-// whichever plugin serves it.
-func ProviderLabel(provider string) string {
+// DisplayName is how a provider is spelled in a model's dev UI label. Plugins
+// that curate their own labels join it with [internal.ProviderLabel], so every Claude
+// model names its provider the same way whichever plugin serves it.
+func DisplayName(provider string) string {
 	if provider == "vertexai" {
 		return "Vertex AI"
 	}
@@ -168,12 +164,10 @@ func reflectConfigSchema(config any) map[string]any {
 		}
 		return nil
 	}
-	schema := r.Reflect(config)
+	schema := base.SchemaAsMap(r.Reflect(config))
 	stripParamObjArtifact(schema)
-	applyConfigOverrides(schema, mncOverrides)
-	result := base.SchemaAsMap(schema)
-
-	return result
+	internal.ApplySchemaOverrides(schema, mncOverrides)
+	return schema
 }
 
 // rejectManagedConfig reports a config field that a Genkit primitive owns.

--- a/go/plugins/internal/anthropic/anthropic_test.go
+++ b/go/plugins/internal/anthropic/anthropic_test.go
@@ -86,7 +86,7 @@ func validateConfig(t *testing.T, inputSchema map[string]any, config any) error 
 // The schema is enforced on every request, so a form that the two disagree on
 // is either a request rejected for no reason or a value silently dropped.
 func TestModelConfig(t *testing.T) {
-	desc := NewModel(anthropic.Client{}, "anthropic", "claude-opus-4-5", "", ai.ModelOptions{}).Desc()
+	desc := NewModel(anthropic.Client{}, "anthropic", "claude-opus-4-5", ai.ModelOptions{}).Desc()
 
 	sampled := anthropic.MessageNewParams{
 		Temperature: anthropic.Float(1.0),
@@ -181,7 +181,7 @@ func TestModelLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.provider+"/"+tt.name, func(t *testing.T) {
-			desc := NewModel(anthropic.Client{}, tt.provider, tt.name, "", tt.opts).Desc()
+			desc := NewModel(anthropic.Client{}, tt.provider, tt.name, tt.opts).Desc()
 			got := desc.Metadata["model"].(map[string]any)["label"]
 			if got != tt.want {
 				t.Errorf("label = %v, want %q", got, tt.want)

--- a/go/plugins/internal/anthropic/config_overrides.go
+++ b/go/plugins/internal/anthropic/config_overrides.go
@@ -4,39 +4,20 @@
 package anthropic
 
 import (
-	"strings"
-
-	"github.com/invopop/jsonschema"
+	"github.com/firebase/genkit/go/internal/base"
+	"github.com/firebase/genkit/go/plugins/internal"
 )
 
-// configOverrides describes per-property metadata layered onto the reflected
-// [anthropic.MessageNewParams] schema before it is exposed to the Genkit
-// Developer UI. The Anthropic SDK's params structs carry Go doc comments but
-// no JSON Schema descriptions, and a few of their fields are owned by Genkit
-// primitives and rejected when supplied directly, so we curate that here.
-//
-// All path application is best-effort: if the upstream SDK renames or removes
-// a field, the corresponding entry silently no-ops rather than panicking. The
-// cost is that stale entries quietly stop applying, which the schema tests
-// catch rather than anything at runtime.
-//
-// This mirrors the same mechanism in the googlegenai plugin. The two are
-// deliberately shaped alike so they can be lifted into one shared helper once
-// a third plugin needs it.
-type configOverrides struct {
-	// descriptions maps a JSON property path to the help text shown as the
-	// field's tooltip in the dev UI. Keys may be a top-level property name
-	// ("temperature") or a dotted path ("output_config.effort").
-	descriptions map[string]string
-	// hidden lists JSON property paths to remove from the schema. Same
-	// notation as descriptions. Use this for fields a Genkit primitive owns
-	// and the plugin rejects at runtime.
-	hidden []string
-}
+// The presentation layered onto the reflected [anthropic.MessageNewParams]
+// schema before it reaches the dev UI: the SDK's params structs carry Go doc
+// comments but no schema descriptions, and a few of their fields are owned by a
+// Genkit option and rejected when supplied directly. See [internal.SchemaOverrides]
+// for the path notation; a stale entry is a no-op, which
+// TestConfigOverridePathsResolve catches.
 
 // mncOverrides controls dev UI presentation of [anthropic.MessageNewParams].
-var mncOverrides = configOverrides{
-	descriptions: map[string]string{
+var mncOverrides = internal.SchemaOverrides{
+	Descriptions: map[string]string{
 		"max_tokens": "Maximum number of tokens to generate before stopping. The model may stop on its own before reaching it, and the ceiling differs by model. Defaults to 4096 when unset.",
 		// The parameter deprecation is worth stating here: the API rejects a
 		// non-default value on Claude 4.7 and later rather than ignoring it.
@@ -58,7 +39,7 @@ var mncOverrides = configOverrides{
 		"output_config":        "Controls the shape of the model's output.",
 		"output_config.effort": "How much effort the model spends producing the output: low, medium, high, or max.",
 	},
-	hidden: []string{
+	Hidden: []string{
 		// Owned by Genkit primitives; the plugin rejects each of these when
 		// set, pointing at the option to use instead.
 		"messages",             // ai.WithMessages / ai.WithPrompt
@@ -68,143 +49,21 @@ var mncOverrides = configOverrides{
 	},
 }
 
-// applyConfigOverrides mutates schema in place: hides the managed properties
-// and writes descriptions onto the rest. Best-effort, so a path that no longer
-// resolves silently no-ops.
-//
-// A hidden property is replaced by the permissive `true` schema rather than
-// deleted. Both hide it from the dev UI, which renders only properties whose
-// type it recognizes, but they differ on everything else. The config schema is
-// enforced by input validation on every request, and a hidden field must still
-// reach the plugin's own check, which names the Genkit option to use instead;
-// deleting it would instead fail validation as an unknown property. Deleting
-// also forces the parent open with additionalProperties: true to let the value
-// back through, which gives up rejecting genuinely unknown fields. Replacing
-// keeps additionalProperties: false intact, so a typo like maxTokens for
-// max_tokens is still caught.
-func applyConfigOverrides(schema *jsonschema.Schema, o configOverrides) {
-	if schema == nil || schema.Properties == nil {
-		return
-	}
-	hideTop := make(map[string]struct{})
-	for _, path := range o.hidden {
-		steps := parsePath(path)
-		if len(steps) == 1 {
-			hideTop[steps[0]] = struct{}{}
-		}
-		hideAtPath(schema, steps)
-	}
-	// A hidden property that the SDK marks required would otherwise leave the
-	// schema demanding a field the dev UI cannot show and the plugin refuses.
-	if len(hideTop) > 0 && len(schema.Required) > 0 {
-		kept := schema.Required[:0]
-		for _, r := range schema.Required {
-			if _, drop := hideTop[r]; !drop {
-				kept = append(kept, r)
-			}
-		}
-		schema.Required = kept
-	}
-	for path, desc := range o.descriptions {
-		if target := schemaAtPath(schema, parsePath(path)); target != nil {
-			target.Description = desc
-		}
-	}
-}
-
 // stripParamObjArtifact removes the "any" property the reflector emits for
 // every SDK params struct.
 //
 // The SDK embeds param.APIObject in each of them, which in turn embeds an
-// anonymous `any` used to carry the raw message a value was decoded from. It
-// is machinery rather than a request field, but it reflects as a property
-// named "any" on every object at every depth, so the dev UI renders a junk
-// field on each one. Nothing sends it and dropping it costs nothing.
-func stripParamObjArtifact(schema *jsonschema.Schema) {
-	if schema == nil {
-		return
-	}
-	if schema.Properties != nil {
-		schema.Properties.Delete("any")
-		for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
-			stripParamObjArtifact(pair.Value)
+// anonymous `any` used to carry the raw message a value was decoded from. It is
+// machinery rather than a request field, but it reflects as a property named
+// "any" on every object at every depth, so the dev UI would render a junk field
+// on each one.
+func stripParamObjArtifact(schema map[string]any) {
+	drop := func(s map[string]any) map[string]any {
+		if props, ok := s["properties"].(map[string]any); ok {
+			delete(props, "any")
 		}
+		return s
 	}
-	stripParamObjArtifact(schema.Items)
-	for _, s := range schema.AnyOf {
-		stripParamObjArtifact(s)
-	}
-	for _, s := range schema.OneOf {
-		stripParamObjArtifact(s)
-	}
-	for _, s := range schema.AllOf {
-		stripParamObjArtifact(s)
-	}
-}
-
-// parsePath splits an override path into navigation steps. Each step is either
-// a property name or the literal "[]" meaning "descend into an array's item
-// schema". Examples:
-//
-//	"temperature"           -> ["temperature"]
-//	"output_config.format"  -> ["output_config", "format"]
-//	"tools[].name"          -> ["tools", "[]", "name"]
-func parsePath(path string) []string {
-	var steps []string
-	for _, tok := range strings.Split(path, ".") {
-		if name := strings.TrimSuffix(tok, "[]"); name != tok {
-			steps = append(steps, name, "[]")
-		} else {
-			steps = append(steps, tok)
-		}
-	}
-	return steps
-}
-
-// schemaAtPath descends a schema, walking Items for "[]" steps and Properties
-// for named ones. Returns nil if any step does not resolve, which callers
-// treat as a no-op rather than an error.
-func schemaAtPath(schema *jsonschema.Schema, steps []string) *jsonschema.Schema {
-	cur := schema
-	for _, step := range steps {
-		if cur == nil {
-			return nil
-		}
-		if step == "[]" {
-			cur = cur.Items
-			continue
-		}
-		if cur.Properties == nil {
-			return nil
-		}
-		next, ok := cur.Properties.Get(step)
-		if !ok {
-			return nil
-		}
-		cur = next
-	}
-	return cur
-}
-
-// hideAtPath replaces the leaf property at the given path with the permissive
-// `true` schema, which accepts any value and declares no type. Reports whether
-// there was a property to replace, so a stale path is a no-op rather than an
-// error.
-func hideAtPath(schema *jsonschema.Schema, steps []string) bool {
-	if len(steps) == 0 {
-		return false
-	}
-	leaf := steps[len(steps)-1]
-	if leaf == "[]" {
-		return false
-	}
-	parent := schemaAtPath(schema, steps[:len(steps)-1])
-	if parent == nil || parent.Properties == nil {
-		return false
-	}
-	if _, ok := parent.Properties.Get(leaf); !ok {
-		return false
-	}
-	parent.Properties.Set(leaf, jsonschema.TrueSchema)
-	return true
+	drop(schema)
+	base.WalkSubschemas(schema, drop)
 }

--- a/go/plugins/internal/anthropic/config_overrides_test.go
+++ b/go/plugins/internal/anthropic/config_overrides_test.go
@@ -11,16 +11,30 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/plugins/internal"
 )
 
-// configProps returns the advertised config schema's property map.
-func configProps(t *testing.T) map[string]any {
-	t.Helper()
-	desc := NewModel(anthropic.Client{}, "anthropic", "claude-opus-4-8", "", ai.ModelOptions{}).Desc()
-	cfg := desc.InputSchema["properties"].(map[string]any)["config"].(map[string]any)
-	first := cfg["anyOf"].([]any)[0].(map[string]any)
-	return first["properties"].(map[string]any)
+// advertisedSchema is the config schema the dev UI reads, before the framework
+// widens a copy of it for enforcement.
+func advertisedSchema() map[string]any {
+	return reflectConfigSchema(anthropic.MessageNewParams{})
+}
+
+// modelDesc is the descriptor a Claude model advertises, whose input schema is
+// what requests are validated against.
+func modelDesc() api.ActionDesc {
+	return NewModel(anthropic.Client{}, "anthropic", "claude-opus-4-8", ai.ModelOptions{}).Desc()
+}
+
+// TestConfigOverridePathsResolve is the guard that keeps the override map
+// honest. Applying a path the SDK no longer has is a silent no-op, so an entry
+// left behind by a renamed field would quietly stop describing anything.
+func TestConfigOverridePathsResolve(t *testing.T) {
+	if stale := mncOverrides.UnresolvedPaths(advertisedSchema()); len(stale) > 0 {
+		t.Errorf("override paths no longer in the SDK schema: %v", stale)
+	}
 }
 
 // TestManagedFieldsAreHiddenButAccepted pins the two halves of hiding a field
@@ -34,31 +48,15 @@ func configProps(t *testing.T) map[string]any {
 // would force additionalProperties open on the parent to let the value back
 // through, which is what gives up the unknown-field rejection below.
 func TestManagedFieldsAreHiddenButAccepted(t *testing.T) {
-	props := configProps(t)
-
-	for _, path := range mncOverrides.hidden {
-		name, _, nested := strings.Cut(path, ".")
-		if nested {
-			continue // checked separately below
-		}
-		got, ok := props[name]
-		if !ok {
-			t.Errorf("%s is absent from the schema, want the permissive true schema", name)
-			continue
-		}
-		if got != true {
-			t.Errorf("%s = %v, want true (typeless, so the dev UI skips it)", name, got)
+	schema := advertisedSchema()
+	for _, path := range mncOverrides.Hidden {
+		if got := internal.SchemaAt(schema, path); got != true {
+			t.Errorf("%q = %v, want true (typeless, so the dev UI skips it)", path, got)
 		}
 	}
-
-	// output_config keeps effort and hides only format.
-	oc := props["output_config"].(map[string]any)
-	ocProps := oc["properties"].(map[string]any)
-	if got := ocProps["format"]; got != true {
-		t.Errorf("output_config.format = %v, want true", got)
-	}
-	if _, ok := ocProps["effort"].(map[string]any)["type"]; !ok {
-		t.Error("output_config.effort lost its type; it is not managed by Genkit")
+	// Hiding is per-field: output_config.format goes, effort stays usable.
+	if effort, ok := internal.SchemaAt(schema, "output_config.effort").(map[string]any); !ok || effort["type"] == nil {
+		t.Errorf("output_config.effort lost its type; it is not managed by Genkit: %#v", effort)
 	}
 }
 
@@ -66,7 +64,7 @@ func TestManagedFieldsAreHiddenButAccepted(t *testing.T) {
 // deleting exists to preserve. A misspelled field is the common mistake, and
 // the SDK's wire names are snake_case, so camelCase must not slip through.
 func TestUnknownFieldsStillRejected(t *testing.T) {
-	desc := NewModel(anthropic.Client{}, "anthropic", "claude-opus-4-8", "", ai.ModelOptions{}).Desc()
+	desc := modelDesc()
 	for _, cfg := range []map[string]any{
 		{"nope": 1},
 		{"maxTokens": 10},
@@ -119,7 +117,7 @@ func TestManagedConfigRejected(t *testing.T) {
 		},
 	}
 
-	desc := NewModel(anthropic.Client{}, "anthropic", "claude-opus-4-8", "", ai.ModelOptions{}).Desc()
+	desc := modelDesc()
 	req := &ai.ModelRequest{Messages: []*ai.Message{ai.NewUserMessage(ai.NewTextPart("hello"))}}
 
 	for _, tt := range tests {
@@ -152,34 +150,20 @@ func TestManagedConfigRejected(t *testing.T) {
 // schema. The SDK carries Go doc comments but no JSON Schema descriptions, so
 // without this the dev UI shows every field bare.
 func TestConfigDescriptionsApplied(t *testing.T) {
-	props := configProps(t)
-
-	if got := props["temperature"].(map[string]any)["description"]; got == nil {
-		t.Error("temperature has no description")
-	} else if !strings.Contains(got.(string), "4.7") {
-		// The deprecation is the part a caller most needs: the API rejects a
-		// value here rather than ignoring it.
-		t.Errorf("temperature description does not mention the 4.7 deprecation: %q", got)
-	}
-
-	// A nested path must apply too, not just top-level ones.
-	oc := props["output_config"].(map[string]any)["properties"].(map[string]any)
-	if got := oc["effort"].(map[string]any)["description"]; got == nil {
-		t.Error("output_config.effort has no description")
-	}
-
-	// Every description path must still resolve, or the entry is dead weight
-	// that silently stopped applying when the SDK renamed something.
-	desc := NewModel(anthropic.Client{}, "anthropic", "claude-opus-4-8", "", ai.ModelOptions{}).Desc()
-	full := desc.InputSchema["properties"].(map[string]any)["config"].(map[string]any)
-	blob, err := json.Marshal(full)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for path, text := range mncOverrides.descriptions {
-		if !strings.Contains(string(blob), text) {
-			t.Errorf("description for %q never landed; the path no longer resolves", path)
+	schema := advertisedSchema()
+	for path, want := range mncOverrides.Descriptions {
+		target, ok := internal.SchemaAt(schema, path).(map[string]any)
+		if !ok {
+			continue // reported by TestConfigOverridePathsResolve
 		}
+		if got, _ := target["description"].(string); got != want {
+			t.Errorf("description for %q\n got: %q\nwant: %q", path, got, want)
+		}
+	}
+	// The 4.7 deprecation is the part a caller most needs: the API rejects a
+	// value there rather than ignoring it.
+	if !strings.Contains(mncOverrides.Descriptions["temperature"], "4.7") {
+		t.Error("the temperature description no longer mentions the 4.7 deprecation")
 	}
 }
 
@@ -188,8 +172,7 @@ func TestConfigDescriptionsApplied(t *testing.T) {
 // object at every depth, which the dev UI would render as a junk field on each
 // one.
 func TestParamObjArtifactStripped(t *testing.T) {
-	desc := NewModel(anthropic.Client{}, "anthropic", "claude-opus-4-8", "", ai.ModelOptions{}).Desc()
-	blob, err := json.Marshal(desc.InputSchema)
+	blob, err := json.Marshal(modelDesc().InputSchema)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/plugins/internal/catalog.go
+++ b/go/plugins/internal/catalog.go
@@ -11,66 +11,49 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package internal
 
-import "github.com/firebase/genkit/go/ai"
+import (
+	"strings"
+
+	"github.com/firebase/genkit/go/core/api"
+)
 
 // A plugin's model catalog answers two questions that must agree: what
-// ListActions advertises, and what ResolveAction builds when a request names a
-// model. A caller who knows better than the catalog supplies an override
-// through plugin config, and both paths overlay it on what the plugin already
-// knows. Overlaying rather than replacing is what lets a caller pin one
-// capability without restating the label, the config schema and the rest,
-// which a plugin needs set for the model to work at all.
-//
-// A zero-value field means "not specified" and leaves the base value in place.
-// Every field of both options structs distinguishes its zero value from a
-// meaningful one: the maps and slices are nil when unset, Supports is a
-// pointer, and the string and int fields have no meaningful zero.
+// ListActions advertises, and what ResolveAction builds to serve a request. A
+// caller who knows better than the catalog supplies an override through plugin
+// config, and both paths lay it over what the plugin already knows with
+// [ai.ModelOptions.Overlay].
 
-// OverlayModelOptions returns base with every field set in override replacing
-// base's. Fields left at their zero value in override keep base's value.
-func OverlayModelOptions(base, override ai.ModelOptions) ai.ModelOptions {
-	if override.ConfigSchema != nil {
-		base.ConfigSchema = override.ConfigSchema
+// LookupOverride returns the caller's entry for id in a plugin's override map,
+// accepting the key bare or provider-prefixed since both name the same model
+// everywhere else. id may itself carry the prefix.
+func LookupOverride[T any](overrides map[string]T, provider, id string) (T, bool) {
+	id = TrimProvider(provider, id)
+	if o, ok := overrides[id]; ok {
+		return o, true
 	}
-	if override.Label != "" {
-		base.Label = override.Label
-	}
-	if override.Stage != "" {
-		base.Stage = override.Stage
-	}
-	if override.Supports != nil {
-		base.Supports = override.Supports
-	}
-	if override.Versions != nil {
-		base.Versions = override.Versions
-	}
-	if override.Metadata != nil {
-		base.Metadata = override.Metadata
-	}
-	return base
+	o, ok := overrides[api.NewName(provider, id)]
+	return o, ok
 }
 
-// OverlayEmbedderOptions returns base with every field set in override
-// replacing base's. Fields left at their zero value in override keep base's
-// value.
-func OverlayEmbedderOptions(base, override ai.EmbedderOptions) ai.EmbedderOptions {
-	if override.ConfigSchema != nil {
-		base.ConfigSchema = override.ConfigSchema
+// TrimProvider returns id without its leading "provider/" prefix, inverting
+// [api.NewName] and leaving an id that does not carry the prefix unchanged.
+// Prefer it to [api.ParseName] when the provider is already known: only the
+// prefix is removed, so an ID with slashes of its own (a tuned Vertex
+// endpoint, say) survives intact.
+func TrimProvider(provider, id string) string {
+	return strings.TrimPrefix(id, provider+"/")
+}
+
+// ProviderLabel joins a provider's display name and a model's into the label
+// the dev UI lists a model under, e.g. "Anthropic - Claude Opus 5".
+func ProviderLabel(provider, name string) string {
+	if provider == "" {
+		return name
 	}
-	if override.Label != "" {
-		base.Label = override.Label
-	}
-	if override.Supports != nil {
-		base.Supports = override.Supports
-	}
-	if override.Dimensions != 0 {
-		base.Dimensions = override.Dimensions
-	}
-	if override.Metadata != nil {
-		base.Metadata = override.Metadata
-	}
-	return base
+	return provider + " - " + name
 }

--- a/go/plugins/internal/catalog_test.go
+++ b/go/plugins/internal/catalog_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+// TestLookupOverride pins that a caller's entry is found under either spelling
+// of a model ID, keyed and looked up. Callers write the prefixed form
+// everywhere else, and an ignored key is a silent no-op.
+func TestLookupOverride(t *testing.T) {
+	overrides := map[string]ai.ModelOptions{
+		"bare":          {Label: "bare entry"},
+		"acme/prefixed": {Label: "prefixed entry"},
+	}
+	for _, tt := range []struct {
+		name, id, want string
+	}{
+		{"bare key, bare id", "bare", "bare entry"},
+		{"bare key, prefixed id", "acme/bare", "bare entry"},
+		{"prefixed key, bare id", "prefixed", "prefixed entry"},
+		{"prefixed key, prefixed id", "acme/prefixed", "prefixed entry"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := LookupOverride(overrides, "acme", tt.id)
+			if !ok {
+				t.Fatalf("LookupOverride(%q) found nothing", tt.id)
+			}
+			if got.Label != tt.want {
+				t.Errorf("LookupOverride(%q).Label = %q, want %q", tt.id, got.Label, tt.want)
+			}
+		})
+	}
+	if _, ok := LookupOverride(overrides, "acme", "absent"); ok {
+		t.Error("LookupOverride found an entry for an ID with none")
+	}
+}
+
+// TestTrimProvider pins that only the prefix is removed, so an ID carrying
+// slashes of its own (a tuned Vertex endpoint, say) survives intact.
+func TestTrimProvider(t *testing.T) {
+	for _, tt := range []struct{ provider, id, want string }{
+		{"acme", "acme/model", "model"},
+		{"acme", "model", "model"},
+		{"acme", "acme/projects/p/endpoints/123", "projects/p/endpoints/123"},
+		{"acme", "other/model", "other/model"},
+	} {
+		if got := TrimProvider(tt.provider, tt.id); got != tt.want {
+			t.Errorf("TrimProvider(%q, %q) = %q, want %q", tt.provider, tt.id, got, tt.want)
+		}
+	}
+}

--- a/go/plugins/internal/schema.go
+++ b/go/plugins/internal/schema.go
@@ -162,6 +162,15 @@ func hideSchemaAt(schema map[string]any, steps []string) {
 	}
 	props[leaf] = true
 	if required, ok := parent["required"].([]any); ok {
-		parent["required"] = slices.DeleteFunc(required, func(r any) bool { return r == any(leaf) })
+		required = slices.DeleteFunc(required, func(r any) bool { return r == any(leaf) })
+		// Hiding the last required property drops the key rather than leaving
+		// an empty list: it constrains nothing either way, and draft-04
+		// validators reject the empty one (its meta-schema puts minItems 1 on
+		// required, a constraint draft-06 removed).
+		if len(required) == 0 {
+			delete(parent, "required")
+		} else {
+			parent["required"] = required
+		}
 	}
 }

--- a/go/plugins/internal/schema.go
+++ b/go/plugins/internal/schema.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"slices"
+	"sort"
+	"strings"
+)
+
+// This file holds the config-schema curation plugins share. A provider plugin
+// reflects its SDK's params struct into a config schema, then curates the
+// result: SDK structs carry no schema descriptions, and some of their fields
+// are owned by a Genkit option and must not be offered. Doing that by hand per
+// plugin is how two plugins end up with the same field spelled two ways.
+
+// SchemaOverrides is the presentation a plugin layers onto a reflected config
+// schema: help text for the fields a caller may set, and hiding for the ones a
+// Genkit option owns.
+//
+// Paths are property names, dotted for nesting, with "[]" to enter an array's
+// items: "temperature", "thinking.budget_tokens", "tools[].name".
+type SchemaOverrides struct {
+	// Descriptions maps a path to the field's dev UI help text.
+	Descriptions map[string]string
+	// Hidden lists paths to keep out of the dev UI.
+	Hidden []string
+}
+
+// ApplySchemaOverrides applies o to schema in place.
+//
+// A hidden property is replaced by the permissive `true` schema rather than
+// deleted. Both keep it out of the dev UI, which renders only properties whose
+// type it recognizes, but the config schema is also enforced on every request:
+// a hidden field must still reach the plugin's own check, which names the
+// Genkit option to use instead. Deleting it would fail validation as an unknown
+// property, and forcing additionalProperties open to let it back through would
+// give up rejecting real typos anywhere in that object.
+//
+// A path that does not resolve is a no-op, so an entry left stale by a renamed
+// SDK field is not fatal. Plugins assert [SchemaOverrides.UnresolvedPaths] is
+// empty in a test to catch those.
+func ApplySchemaOverrides(schema map[string]any, o SchemaOverrides) {
+	if schema == nil {
+		return
+	}
+	for _, path := range o.Hidden {
+		hideSchemaAt(schema, parseSchemaPath(path))
+	}
+	for path, desc := range o.Descriptions {
+		if target, ok := schemaAt(schema, parseSchemaPath(path)).(map[string]any); ok {
+			target["description"] = desc
+		}
+	}
+}
+
+// UnresolvedPaths returns the paths in o that schema has no property for,
+// sorted. Applying one is a silent no-op, so it is dead weight that stopped
+// describing anything when the SDK it was written against changed.
+func (o SchemaOverrides) UnresolvedPaths(schema map[string]any) []string {
+	var stale []string
+	for path := range o.Descriptions {
+		if _, ok := schemaAt(schema, parseSchemaPath(path)).(map[string]any); !ok {
+			stale = append(stale, path)
+		}
+	}
+	for _, path := range o.Hidden {
+		// A hidden path resolves to the `true` schema once applied, so accept
+		// any present value rather than requiring a map.
+		if schemaAt(schema, parseSchemaPath(path)) == nil {
+			stale = append(stale, path)
+		}
+	}
+	sort.Strings(stale)
+	return stale
+}
+
+// SchemaAt returns what path addresses in schema: a subschema, the `true` of a
+// hidden property, or nil when a step does not resolve. Paths use the notation
+// in [SchemaOverrides].
+func SchemaAt(schema map[string]any, path string) any {
+	return schemaAt(schema, parseSchemaPath(path))
+}
+
+// parseSchemaPath splits a path into navigation steps, each a property name or
+// the literal "[]" meaning "descend into an array's item schema".
+//
+//	"temperature"          -> ["temperature"]
+//	"output_config.format" -> ["output_config", "format"]
+//	"tools[].name"         -> ["tools", "[]", "name"]
+func parseSchemaPath(path string) []string {
+	var steps []string
+	for _, tok := range strings.Split(path, ".") {
+		if name := strings.TrimSuffix(tok, "[]"); name != tok {
+			steps = append(steps, name, "[]")
+		} else {
+			steps = append(steps, tok)
+		}
+	}
+	return steps
+}
+
+// schemaAt descends a schema, walking items for "[]" steps and properties for
+// named ones, and returns what the path addresses: a subschema, a boolean
+// schema, or nil when a step does not resolve.
+func schemaAt(schema map[string]any, steps []string) any {
+	var cur any = schema
+	for _, step := range steps {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		if step == "[]" {
+			cur = m["items"]
+			continue
+		}
+		props, ok := m["properties"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		if cur, ok = props[step]; !ok {
+			return nil
+		}
+	}
+	return cur
+}
+
+// hideSchemaAt replaces the property at the given path with the permissive
+// `true` schema, and drops it from its parent's "required" list: a hidden
+// property the SDK marks required would otherwise leave the schema demanding a
+// field the dev UI cannot show and the plugin refuses. A path that does not
+// resolve is a no-op.
+func hideSchemaAt(schema map[string]any, steps []string) {
+	if len(steps) == 0 || steps[len(steps)-1] == "[]" {
+		return
+	}
+	parent, ok := schemaAt(schema, steps[:len(steps)-1]).(map[string]any)
+	if !ok {
+		return
+	}
+	props, ok := parent["properties"].(map[string]any)
+	if !ok {
+		return
+	}
+	leaf := steps[len(steps)-1]
+	if _, ok := props[leaf]; !ok {
+		return
+	}
+	props[leaf] = true
+	if required, ok := parent["required"].([]any); ok {
+		parent["required"] = slices.DeleteFunc(required, func(r any) bool { return r == any(leaf) })
+	}
+}

--- a/go/plugins/internal/schema_test.go
+++ b/go/plugins/internal/schema_test.go
@@ -94,9 +94,10 @@ func TestApplySchemaOverrides(t *testing.T) {
 		t.Errorf("required lost a property that is not hidden: %v", required)
 	}
 	// The same holds at depth: hiding a nested property prunes it from its own
-	// parent's required list, not just the root's.
-	if required := props["thinking"].(map[string]any)["required"].([]any); slices.Contains(required, any("budget")) {
-		t.Errorf("nested required still demands the hidden property: %v", required)
+	// parent's required list, not just the root's. "budget" was the only entry,
+	// so the key goes rather than being left empty.
+	if required, ok := props["thinking"].(map[string]any)["required"]; ok {
+		t.Errorf("nested required survived hiding its only entry: %v", required)
 	}
 }
 

--- a/go/plugins/internal/schema_test.go
+++ b/go/plugins/internal/schema_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/firebase/genkit/go/internal/base"
+)
+
+// testSchema is shaped like a reflected SDK params struct: nested objects, an
+// array of objects, and a branch schema.
+func testSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"model", "temperature"},
+		"properties": map[string]any{
+			"model":       map[string]any{"type": "string"},
+			"temperature": map[string]any{"type": "number"},
+			"thinking": map[string]any{
+				"type":     "object",
+				"required": []any{"budget"},
+				"properties": map[string]any{
+					"budget": map[string]any{"type": "integer"},
+				},
+			},
+			"tools": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestApplySchemaOverrides(t *testing.T) {
+	schema := testSchema()
+	ApplySchemaOverrides(schema, SchemaOverrides{
+		Descriptions: map[string]string{
+			"temperature":     "how random",
+			"thinking.budget": "how much thinking",
+			"tools[].name":    "what to call it",
+		},
+		Hidden: []string{"model", "thinking.budget"},
+	})
+
+	if got := mustNavigate(t, schema, "temperature")["description"]; got != "how random" {
+		t.Errorf("top-level description = %v", got)
+	}
+	if got := mustNavigate(t, schema, "tools", "[]", "name")["description"]; got != "what to call it" {
+		t.Errorf("description inside an array's items = %v", got)
+	}
+
+	props := schema["properties"].(map[string]any)
+	if props["model"] != true {
+		t.Errorf("hidden property = %v, want the permissive true schema", props["model"])
+	}
+	nested := props["thinking"].(map[string]any)["properties"].(map[string]any)
+	if nested["budget"] != true {
+		t.Errorf("hidden nested property = %v, want true", nested["budget"])
+	}
+
+	// Hiding must not open the object: an unknown property is still a typo
+	// worth rejecting, and a hidden one is present rather than absent.
+	if schema["additionalProperties"] != false {
+		t.Errorf("hiding opened the object: additionalProperties = %v", schema["additionalProperties"])
+	}
+	// A hidden property the SDK marked required would demand a field the dev UI
+	// cannot show and the plugin refuses.
+	if required := schema["required"].([]any); slices.Contains(required, any("model")) {
+		t.Errorf("required still demands the hidden property: %v", required)
+	} else if !slices.Contains(required, any("temperature")) {
+		t.Errorf("required lost a property that is not hidden: %v", required)
+	}
+	// The same holds at depth: hiding a nested property prunes it from its own
+	// parent's required list, not just the root's.
+	if required := props["thinking"].(map[string]any)["required"].([]any); slices.Contains(required, any("budget")) {
+		t.Errorf("nested required still demands the hidden property: %v", required)
+	}
+}
+
+// A path that no longer resolves must no-op: plugins build these schemas during
+// init, so a renamed SDK field would otherwise stop the plugin from loading.
+func TestApplySchemaOverridesIsBestEffort(t *testing.T) {
+	schema := testSchema()
+	before := base.CloneSchema(schema)
+	ApplySchemaOverrides(schema, SchemaOverrides{
+		Descriptions: map[string]string{
+			"doesNotExist":             "x",
+			"alsoMissing.deeper":       "x",
+			"tools[].notReal":          "x",
+			"completely[].fake[].path": "x",
+			"temperature.notAnObject":  "x",
+		},
+		Hidden: []string{"doesNotExist", "missing[].alsoMissing", "tools[].notReal", "[]"},
+	})
+	if !reflect.DeepEqual(before, schema) {
+		t.Error("bogus paths changed the schema")
+	}
+}
+
+func TestUnresolvedPaths(t *testing.T) {
+	schema := testSchema()
+	o := SchemaOverrides{
+		Descriptions: map[string]string{"temperature": "x", "tools[].name": "x", "renamedAway": "x"},
+		Hidden:       []string{"model", "alsoRenamed"},
+	}
+	got := o.UnresolvedPaths(schema)
+	if want := []string{"alsoRenamed", "renamedAway"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("UnresolvedPaths() = %v, want %v", got, want)
+	}
+
+	// Applying the overrides must not change the answer: a hidden path resolves
+	// to the `true` schema afterward, and that still counts as present.
+	ApplySchemaOverrides(schema, o)
+	if got := o.UnresolvedPaths(schema); slices.Contains(got, "model") {
+		t.Errorf("an applied hidden path was reported stale: %v", got)
+	}
+}
+
+func mustNavigate(t *testing.T, schema map[string]any, steps ...string) map[string]any {
+	t.Helper()
+	got, ok := schemaAt(schema, steps).(map[string]any)
+	if !ok {
+		t.Fatalf("path %v does not resolve to a schema", steps)
+	}
+	return got
+}

--- a/go/plugins/middleware/fallback.go
+++ b/go/plugins/middleware/fallback.go
@@ -67,8 +67,10 @@ type Fallback struct {
 	Statuses []status.Name `json:"statuses,omitempty"`
 }
 
+// Name implements [ai.Middleware].
 func (f *Fallback) Name() string { return provider + "/fallback" }
 
+// New implements [ai.Middleware], hooking the model stage.
 func (f *Fallback) New(ctx context.Context) (*ai.Hooks, error) {
 	return &ai.Hooks{
 		WrapModel: f.wrapModel,
@@ -120,7 +122,7 @@ func (f *Fallback) wrapModel(ctx context.Context, params *ai.ModelParams, next a
 // requires an explicit classification; without this, a deterministic bug in a
 // model plugin would silently reroute every request to the fallback.
 func isFallbackRetryable(err error, statuses []status.Name) bool {
-	if s, ok := classifiedStatus(err); ok {
+	if s, ok := status.Classified(err); ok {
 		return slices.Contains(statuses, s)
 	}
 	return false

--- a/go/plugins/middleware/filesystem.go
+++ b/go/plugins/middleware/filesystem.go
@@ -162,6 +162,7 @@ type Filesystem struct {
 	ToolNamePrefix string `json:"toolNamePrefix,omitempty"`
 }
 
+// Name implements [ai.Middleware].
 func (f *Filesystem) Name() string { return provider + "/filesystem" }
 
 // New initializes a per-call instance: opens the [os.Root], builds the tool

--- a/go/plugins/middleware/retry.go
+++ b/go/plugins/middleware/retry.go
@@ -20,7 +20,6 @@ package middleware
 
 import (
 	"context"
-	"errors"
 	"math"
 	"math/rand"
 	"slices"
@@ -88,8 +87,10 @@ type Retry struct {
 	NoJitter bool `json:"noJitter,omitempty"`
 }
 
+// Name implements [ai.Middleware].
 func (r *Retry) Name() string { return provider + "/retry" }
 
+// New implements [ai.Middleware], hooking the model stage.
 func (r *Retry) New(ctx context.Context) (*ai.Hooks, error) {
 	return &ai.Hooks{
 		WrapModel: r.wrapModel,
@@ -174,26 +175,8 @@ func (r *Retry) wrapModel(ctx context.Context, params *ai.ModelParams, next ai.M
 // preserving the v1 contract that non-GenkitError errors are retried
 // regardless of the Statuses setting.
 func isRetryable(err error, statuses []status.Name) bool {
-	if s, ok := classifiedStatus(err); ok {
+	if s, ok := status.Classified(err); ok {
 		return slices.Contains(statuses, s)
 	}
 	return true
-}
-
-// classifiedStatus returns the status err was explicitly classified with, or
-// false when nothing in err's chain carries one. The distinction keeps these
-// middlewares matching their v1 contracts: a classified error is checked
-// against the configured status list, while an unclassified one (a plain error
-// from a provider SDK or the network) keeps its v1 behavior instead of
-// silently inheriting INTERNAL's membership in the list. Cancellation and
-// deadline expiry count as classified, reporting CANCELLED and
-// DEADLINE_EXCEEDED per [status.Of].
-func classifiedStatus(err error) (status.Name, bool) {
-	var e *status.Error
-	var s *status.Sentinel
-	if errors.As(err, &e) || errors.As(err, &s) ||
-		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return status.Of(err), true
-	}
-	return "", false
 }

--- a/go/plugins/middleware/retry_test.go
+++ b/go/plugins/middleware/retry_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -313,3 +314,30 @@ func TestRetryStopsWhenContextCanceledDuringBackoff(t *testing.T) {
 }
 
 var ctx = context.Background()
+
+// TestUnclassifiedErrorsKeepTheirContract pins the distinction Classified
+// draws. An error chain can carry a typed-nil *status.Error without anything
+// having classified it, and reading that as a deliberate INTERNAL would retry
+// it here and fail over to a different billed model in the fallback middleware.
+func TestUnclassifiedErrorsKeepTheirContract(t *testing.T) {
+	var typedNil *status.Error
+	unclassified := fmt.Errorf("provider blew up: %w", typedNil)
+
+	// Retry's contract: an unclassified error is always retried, whatever the
+	// status list says.
+	if !isRetryable(unclassified, []status.Name{status.Unavailable}) {
+		t.Error("isRetryable = false for an unclassified error, want true regardless of the list")
+	}
+	// Fallback's contract: an unclassified error propagates instead.
+	if isFallbackRetryable(unclassified, defaultFallbackStatuses) {
+		t.Error("isFallbackRetryable = true for an unclassified error, want false")
+	}
+	// A deliberate INTERNAL is still honored on both sides.
+	classified := status.Errorf(status.ErrInternal, "the plugin said so")
+	if !isRetryable(classified, defaultRetryStatuses) {
+		t.Error("isRetryable = false for a deliberate INTERNAL")
+	}
+	if !isFallbackRetryable(classified, defaultFallbackStatuses) {
+		t.Error("isFallbackRetryable = false for a deliberate INTERNAL")
+	}
+}

--- a/go/plugins/middleware/tool_approval.go
+++ b/go/plugins/middleware/tool_approval.go
@@ -53,8 +53,10 @@ type ToolApproval struct {
 	AllowedTools []string `json:"allowedTools,omitempty"`
 }
 
+// Name implements [ai.Middleware].
 func (t *ToolApproval) Name() string { return provider + "/toolApproval" }
 
+// New implements [ai.Middleware], hooking tool execution.
 func (t *ToolApproval) New(ctx context.Context) (*ai.Hooks, error) {
 	return &ai.Hooks{
 		WrapTool: t.wrapTool,

--- a/go/plugins/middleware/tool_approval_test.go
+++ b/go/plugins/middleware/tool_approval_test.go
@@ -211,13 +211,15 @@ func TestToolApprovalInterruptIsTracedOnce(t *testing.T) {
 	if len(spans) != 1 {
 		t.Fatalf("got %d spans named %q, want exactly 1", len(spans), "dangerous")
 	}
+	// An approval interrupt resolves the call without running the tool, and
+	// must still look exactly like a tool call in the trace.
 	const subtypeKey = "genkit:metadata:subtype"
 	subtype, ok := spanAttr(spans[0], subtypeKey)
 	if !ok {
 		t.Fatalf("span %q: missing attribute %q", "dangerous", subtypeKey)
 	}
-	if subtype != "tool" {
-		t.Errorf("span %q: %s = %q, want %q", "dangerous", subtypeKey, subtype, "tool")
+	if want := string(api.ActionTypeToolV2); subtype != want {
+		t.Errorf("span %q: %s = %q, want %q", "dangerous", subtypeKey, subtype, want)
 	}
 }
 

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -27,6 +27,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/internal"
 )
 
 type EmbedOptions struct {
@@ -152,7 +153,7 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, 
 	}
 
 	if meta.Label == "" {
-		meta.Label = "Ollama Embedding - " + model
+		meta.Label = internal.ProviderLabel("Ollama Embedding", model)
 	}
 	if meta.Supports == nil {
 		meta.Supports = &ai.EmbedderSupports{}

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -36,6 +36,7 @@ import (
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/internal"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 	"github.com/invopop/jsonschema"
 )
@@ -189,15 +190,15 @@ func (o *Ollama) listLocalModels(ctx context.Context) ([]ollamaLocalModel, error
 	return tagsResp.Models, nil
 }
 
+// DefineModel registers an Ollama model with g. A nil opts takes the
+// capabilities discovery has already found for the model, or the static
+// fallback when it has not been asked about.
 func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.ModelOptions) ai.Model {
-	// Check the init guard under a separate brief lock. The lock must be
-	// released before cachedModelCapabilities below, which acquires it again.
 	o.mu.Lock()
+	defer o.mu.Unlock()
 	if !o.initted {
-		o.mu.Unlock()
 		panic("ollama.Init not called")
 	}
-	o.mu.Unlock()
 
 	var modelOpts ai.ModelOptions
 	if opts != nil {
@@ -208,8 +209,7 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		// when available without doing network I/O during registration.
 		supports := modelSupportsFromStaticLists(model.Name)
 		if cached, ok := o.cachedModelCapabilities(model.Name, ""); ok && cached.detected {
-			cachedSupports := cached.supports
-			supports = &cachedSupports
+			supports = cached.supportsCopy()
 		}
 		// Only chat models use /api/chat, which is the endpoint that accepts tools.
 		supports.Tools = model.Type == "chat" && supports.Tools
@@ -220,11 +220,8 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		}
 	}
 
-	// Re-acquire lock for the registration step.
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	meta := &ai.ModelOptions{
-		Label:        "Ollama - " + model.Name,
+		Label:        internal.ProviderLabel("Ollama", model.Name),
 		Supports:     modelOpts.Supports,
 		Versions:     []string{},
 		ConfigSchema: core.InferSchemaMap(GenerateContentConfig{}),
@@ -298,10 +295,12 @@ func (t *ThinkOption) IsEnabled() bool {
 	}
 }
 
+// MarshalJSON writes the option as the bool or string Ollama expects.
 func (t ThinkOption) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.value)
 }
 
+// UnmarshalJSON reads either the bool or the string form.
 func (t *ThinkOption) UnmarshalJSON(data []byte) error {
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
@@ -326,6 +325,9 @@ func (ThinkOption) JSONSchema() *jsonschema.Schema {
 	}
 }
 
+// GenerateContentConfig is the per-request configuration an Ollama model
+// accepts through [ai.WithConfig]. Every field is optional; an unset one takes
+// the model's own default.
 type GenerateContentConfig struct {
 	// Think controls thinking/reasoning mode.
 	// Use ThinkEnabled(true/false) for Ollama models, or
@@ -402,12 +404,21 @@ type Ollama struct {
 	ServerAddress string // Server address of oLLama.
 	Timeout       int    // Response timeout in seconds (defaulted to 30 seconds)
 
-	mu                sync.Mutex   // Mutex to control access.
-	initted           bool         // Whether the plugin has been initialized.
-	client            *http.Client // Shared HTTP client for API calls (e.g., /api/tags).
+	mu      sync.Mutex   // Guards the plugin's own state below.
+	initted bool         // Whether the plugin has been initialized.
+	client  *http.Client // Shared HTTP client for API calls (e.g., /api/tags).
+
+	// The capabilities cache has its own lock: the discovery goroutines write
+	// to it while DefineModel reads it holding mu, so sharing one lock would
+	// mean dropping and retaking mu mid-function.
+	capMu             sync.Mutex
 	capabilitiesCache map[string]modelCapabilitiesCacheEntry
 }
 
+// modelCapabilitiesCacheEntry is one model's detected capabilities. A
+// successful detection is kept for the process's life, keyed by the digest
+// /api/tags reports so a re-pulled model is re-detected; a failure is kept only
+// briefly, so a server that was down is retried.
 type modelCapabilitiesCacheEntry struct {
 	digest   string
 	supports ai.ModelSupports
@@ -415,6 +426,7 @@ type modelCapabilitiesCacheEntry struct {
 	expires  time.Time
 }
 
+// Name implements genkit.Plugin.
 func (o *Ollama) Name() string {
 	return provider
 }
@@ -440,10 +452,17 @@ func (o *Ollama) Init(ctx context.Context) []api.Action {
 	return []api.Action{}
 }
 
+// supportsCopy returns a copy of the entry's capabilities, so the model built
+// from it cannot reach the cache through the pointer.
+func (e modelCapabilitiesCacheEntry) supportsCopy() *ai.ModelSupports {
+	supports := e.supports
+	return &supports
+}
+
 func (o *Ollama) cachedModelCapabilities(name, digest string) (modelCapabilitiesCacheEntry, bool) {
 	key := normalizeModelName(name)
-	o.mu.Lock()
-	defer o.mu.Unlock()
+	o.capMu.Lock()
+	defer o.capMu.Unlock()
 	entry, ok := o.capabilitiesCache[key]
 	if !ok || (digest != "" && entry.digest != digest) {
 		return modelCapabilitiesCacheEntry{}, false
@@ -464,8 +483,8 @@ func (o *Ollama) cacheModelSupports(name, digest string, supports *ai.ModelSuppo
 		expires = time.Now().Add(capabilityFailureCacheLifetime)
 	}
 	key := normalizeModelName(name)
-	o.mu.Lock()
-	defer o.mu.Unlock()
+	o.capMu.Lock()
+	defer o.capMu.Unlock()
 	if o.capabilitiesCache == nil {
 		o.capabilitiesCache = make(map[string]modelCapabilitiesCacheEntry)
 	}
@@ -484,7 +503,7 @@ func normalizeModelName(name string) string {
 // It is used by ListActions (to generate ActionDesc) and ResolveAction (to return an Action).
 func (o *Ollama) newModel(name string, opts ai.ModelOptions) ai.Model {
 	meta := &ai.ModelOptions{
-		Label:        "Ollama - " + name,
+		Label:        internal.ProviderLabel("Ollama", name),
 		Supports:     opts.Supports,
 		Versions:     []string{},
 		ConfigSchema: core.InferSchemaMap(GenerateContentConfig{}),
@@ -521,8 +540,7 @@ func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 scheduleQueries:
 	for i, m := range filtered {
 		if cached, ok := o.cachedModelCapabilities(m.Name, m.Digest); ok {
-			cachedSupports := cached.supports
-			supports[i] = &cachedSupports
+			supports[i] = cached.supportsCopy()
 			continue
 		}
 		select {
@@ -574,8 +592,7 @@ func (o *Ollama) ResolveAction(atype api.ActionType, id string) api.Action {
 	}
 	supports := &defaultOllamaSupports
 	if cached, ok := o.cachedModelCapabilities(id, ""); ok {
-		cachedSupports := cached.supports
-		supports = &cachedSupports
+		supports = cached.supportsCopy()
 	}
 	model := o.newModel(id, ai.ModelOptions{Supports: supports})
 	if action, ok := model.(api.Action); ok {

--- a/go/plugins/ollama/ollama_test.go
+++ b/go/plugins/ollama/ollama_test.go
@@ -474,11 +474,11 @@ func TestDynamicPlugin(t *testing.T) {
 				t.Fatalf("/api/show calls before cache expiry = %d, want 1", got)
 			}
 
-			o.mu.Lock()
+			o.capMu.Lock()
 			entry := o.capabilitiesCache["recovering-model"]
 			entry.expires = time.Now().Add(-time.Second)
 			o.capabilitiesCache["recovering-model"] = entry
-			o.mu.Unlock()
+			o.capMu.Unlock()
 
 			actions := o.ListActions(t.Context())
 			if len(actions) != 1 {

--- a/go/plugins/vertexai/modelgarden/anthropic.go
+++ b/go/plugins/vertexai/modelgarden/anthropic.go
@@ -27,6 +27,7 @@ import (
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 
+	"github.com/firebase/genkit/go/plugins/internal"
 	ant "github.com/firebase/genkit/go/plugins/internal/anthropic"
 )
 
@@ -50,10 +51,6 @@ func (a *Anthropic) Name() string {
 // Init initializes the VertexAI Model Garden for Anthropic plugin and all its known models.
 // After calling Init, you may call [DefineModel] to create and register any additional models.
 func (a *Anthropic) Init(ctx context.Context) []api.Action {
-	if a == nil {
-		a = &Anthropic{}
-	}
-
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.initted {
@@ -75,8 +72,8 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 		// The catalog stores bare display names ("Claude Opus 4.6"). Prefix
 		// the provider so these sit alongside the other Vertex AI models in a
 		// picker instead of looking like they came from somewhere else.
-		opts.Label = fmt.Sprintf("%s - %s", ant.ProviderLabel(provider), opts.Label)
-		actions = append(actions, ant.NewModel(a.client, provider, name, name, opts))
+		opts.Label = internal.ProviderLabel(ant.DisplayName(provider), opts.Label)
+		actions = append(actions, ant.NewModel(a.client, provider, name, opts))
 	}
 
 	return actions
@@ -102,5 +99,5 @@ func (a *Anthropic) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, e
 	if opts == nil {
 		return nil, fmt.Errorf("DefineModel called with nil ai.ModelOptions")
 	}
-	return ant.NewModel(a.client, provider, name, name, *opts), nil
+	return ant.NewModel(a.client, provider, name, *opts), nil
 }

--- a/go/plugins/vertexai/modelgarden/models_test.go
+++ b/go/plugins/vertexai/modelgarden/models_test.go
@@ -135,7 +135,7 @@ func TestResolveVertexMaasEnv_PanicsWithoutLocation(t *testing.T) {
 // it the way the rest of the Vertex AI models do, which means an entry that
 // carried its own prefix would come out as "Vertex AI - Vertex AI - Claude".
 func TestAnthropicModelLabelsAreBare(t *testing.T) {
-	prefix := ant.ProviderLabel(provider)
+	prefix := ant.DisplayName(provider)
 	for name, opts := range AnthropicModels {
 		if opts.Label == "" {
 			t.Errorf("AnthropicModels[%q].Label is empty, want a display name", name)


### PR DESCRIPTION
googlegenai and `internal/anthropic` each carried the same walker for curating a reflected config schema, and provider naming, catalog overlays, and error classification were spelled several ways across the plugins. #5874 added `plugins/internal/catalog.go` for the overlay half of that.

Collapses the copies and migrates every plugin onto one spelling of each. Doing so is what surfaced the defects in the second half of this description: each was live in one copy of a mechanism and already fixed in another.

The shared code stays internal. Plugins are due to be sharded into their own modules, and that is when their common code needs a permanent home worth committing to; until then `plugins/internal` costs nothing to move.

## Where the shared code lives

`plugins/internal` gets the plugin-facing helpers: `SchemaOverrides` and `ApplySchemaOverrides`, `LookupOverride`, `TrimProvider`, and `ProviderLabel`.

The two schema primitives underneath, `WalkSubschemas` and `CloneSchema`, go to `internal/base` instead, because `ai/config.go` uses them for the null-tolerance and required-stripping work below and cannot import plugin code. `internal/base` is a leaf package with no genkit imports that `ai`, `core`, and five plugin packages already depend on.

**Before:** every plugin that curates a schema reimplements the navigation.

```go
func applyConfigOverrides(schema *jsonschema.Schema, o configOverrides)
func parsePath(path string) []string
func schemaAtPath(schema *jsonschema.Schema, steps []string) *jsonschema.Schema
func hideAtPath(schema *jsonschema.Schema, steps []string) bool
```

**After:** the plugin keeps only its data.

```go
var gccOverrides = internal.SchemaOverrides{
    Descriptions: map[string]string{"temperature": "Sampling temperature.", ...},
    Hidden:       []string{"tools", "responseSchema", ...},
}

schema := base.SchemaAsMap(r.Reflect(config))
internal.ApplySchemaOverrides(schema, overridesFor(config))
```

The shared version works on `map[string]any`, which is what `ModelOptions.ConfigSchema` already is, so a plugin reflecting with a different library converts once at the edge rather than being locked to invopop.

A hidden property is replaced by the permissive `true` schema rather than deleted, because the config schema is also enforced on every request: the field must still reach the plugin's own check, which names the Genkit option to use instead. Deleting it would fail validation as an unknown property.

`LookupOverride` also fixes a real inconsistency. Callers write `googleai/gemini-flash-latest` everywhere else, so a `Models` map keyed that way silently missed.

**Before:**

```go
if override, ok := c.models[id]; ok {
    return internal.OverlayModelOptions(base, override)
}
```

**After:**

```go
if override, ok := internal.LookupOverride(c.models, c.provider, id); ok {
    return base.Overlay(override)
}
```

`Overlay` is hand-written per struct rather than reflective, so a new field is a silent drop. `TestOverlayCoversEveryField` sets each field to a distinct value and fails naming the field Overlay ignored. It also rejects any `bool` field added to these structs, since `false` cannot mean "not specified". `TestCloneSupportsDetachesEveryField` is the same guard for the capability structs, which the constructors now copy.

## Defects the copies hid

**Short-circuited tool calls reported the wrong span subtype.** `recordToolShortCircuit` built its own span metadata with subtype `tool`, while real tool actions emit `tool.v2`. A tool answered by middleware was a different kind of span from the same tool answered normally. The googlecloud telemetry plugin matched the literal `"tool"`, so it now accepts both; that filter had already gone stale for real tool spans.

**The retry and fallback middleware misclassified unclassified errors.** Their local `classifiedStatus` treated `errors.As(err, &e)` as a hit even when it matched a typed-nil `*status.Error`, which `Convert` produces and the generated `AgentOutput.Error` field is whenever nothing failed. Such a chain read as a deliberate `INTERNAL` and was retried on that basis. `status.Classified` reports whether anything in the chain actually carries a status, and `Of` is now two lines on top of it rather than a second copy of the same walk.

**`Label` only defaulted when the whole options pointer was nil.** `NewModelAction("m", &ModelOptions{Versions: v}, fn)` shipped a blank dev UI label. All five constructors now default it whenever it is empty.

**The constructors kept the caller's `*ModelSupports`.** A plugin pointing a model table at one shared capabilities value had every action aliasing it. They now copy, slice fields included.

**A declared config schema was enforced verbatim while an inferred one was widened.** A partial config marshals its unset pointer and slice fields to `null`, so googlegenai rejected `{"temperature": 0.5, "stopSequences": null}` from the dev UI while an inferred schema accepted the equivalent. Enforcement now widens a clone, leaving the advertised schema exactly what the plugin declared.

`format.go` also loses 260 lines to a shared `baseHandler` embedded by all five output handlers, which were five copies of one streaming state machine.

## Not a breaking change

Nothing changes shape for an application. `internal.OverlayModelOptions`, `internal.OverlayEmbedderOptions`, `anthropic.ProviderLabel`, and the `apiModel` parameter on `anthropic.NewModel` (which every caller passed twice) are all under `plugins/internal`, which no external package can import.

The runtime changes are relaxations: a config that used to be rejected for an explicit `null` is now accepted, a label that used to be blank is now filled, and options that used to be aliased are now copied.

The one observable change is the tool short-circuit span subtype, `tool` to `tool.v2`. Custom telemetry matching the old value would stop seeing those spans, which is the point: it was matching a value real tool spans stopped emitting some time ago.

## New API

```go
// ai
func (ModelOptions) Overlay(override ModelOptions) ModelOptions
func (EmbedderOptions) Overlay(override EmbedderOptions) EmbedderOptions

// core/status
status.Classified(err error) (Name, bool)
```

That is the whole diff in exported surface across `ai`, `core`, `core/api`, `core/status`, and `genkit`, verified by diffing `go doc -short -all` against the merge base.

`SchemaOverrides.UnresolvedPaths` (internal) exists because an override path that stops resolving is a silent no-op. Both plugins assert it is empty in a test, so a renamed SDK field fails there instead of quietly dropping the curation.

## What this does not do

**Does not consolidate the two plugin generations.** The older `compat_oai` derivatives and the newer plugins still differ structurally. That is in flight separately, and it is why `zai`, `kimi`, and `dashscope` keep their triplicated test files here: rewriting them now would only create conflicts.

**Does not make the plugins independent.** Four cross-plugin packages remain, three of them pre-existing: `internal/anthropic` (used by `plugins/anthropic` and `vertexai/modelgarden`), `internal/jsonschema` (`compat_oai`, `internal/anthropic`), `internal/uri` (`googlegenai`, `ollama`, `internal/anthropic`), and now `plugins/internal` itself. Deliberate, per above.

**Does not touch the model catalogs.** `gemini-2.5-flash` is retired from the API but still listed in `supportedGeminiModels`, which breaks `TestGoogleAILive` on `main` today. Pruning it belongs with the catalog work.

## Verification

Go 1.26.3, from `go/`: `go test ./...` passes, 42 packages, no failures. `go test -race` on the 32 packages this touches is clean. `gofmt -l .` and `go vet ./...` are both clean.

Live, with real keys: `TestAnthropicLive` passes, 14 subtests, exercising prefixed override keys and partial typed configs through the changed paths. `TestGoogleAILive` fails on `models/gemini-2.5-flash is not found` (404), which reproduces identically on an unmodified worktree at the merge base `feb5f335`.

Each fix above has a test that fails without it. Two were verified by breaking the code deliberately: removing `Versions` from `Overlay` produces `ModelOptions.Versions: Overlay kept [value-1], want the override's [value-2]`, and adding a status without a sentinel produces `status "PROBE_ONLY" has no base sentinel`.
