### PR TITLE
refactor(py): SessionStore protocol, status stream, and invariant checks

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -1350,6 +1350,9 @@ class AgentChat(Generic[StateT]):
             self._merge_artifacts(raw.artifacts)
 
 
+# Settled statuses for client poll/wait loops. Includes ``expired`` because
+# resolve/get overlays a stale pending heartbeat as expired even though stores
+# never persist that status.
 TERMINAL_SNAPSHOT_STATUSES = frozenset({
     SnapshotStatus.COMPLETED,
     SnapshotStatus.FAILED,

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -657,17 +657,26 @@ class AgentRuntime:
             out.snapshot_id = await self.ensure_recovery_snapshot()
         return out
 
-    async def watch_snapshot_abort(self, *, snapshot_id: str, abort_signal: asyncio.Event) -> None:
+    async def watch_snapshot_abort(
+        self,
+        *,
+        snapshot_id: str,
+        abort_signal: asyncio.Event,
+        context: dict[str, Any] | None = None,
+    ) -> None:
         if self.store is None or not isinstance(self.store, SnapshotSubscriber):
             return
-        q = await self.store.on_snapshot_status_change(snapshot_id)
-        while True:
-            status = await q.get()
-            if status is None:
-                return
+        # Prefer the detach-time context from the caller so the subscription
+        # stays on the request's tenant even if this task starts after ambient
+        # context has moved on.
+        statuses = await self.store.on_snapshot_status_change(
+            snapshot_id, context=context if context is not None else get_current_context()
+        )
+        # Aborted is terminal, so the stream ends right after that yield and
+        # unsubscribes. Returning early would skip that teardown.
+        async for status in statuses:
             if status == SnapshotStatus.ABORTED:
                 abort_signal.set()
-                return
 
     async def refresh_heartbeat(self, snapshot_id: str) -> None:
         """Keep a detached turn's pending snapshot fresh so readers don't flag it dead.
@@ -708,8 +717,14 @@ class AgentRuntime:
         err_holder: list[Exception],
         result_holder: list[AgentResult],
         heartbeat_task: asyncio.Task,
+        context: dict[str, Any] | None = None,
     ) -> None:
-        """Background task: wait for fn, then rewrite pending snapshot with final state."""
+        """Background task: wait for fn, then rewrite pending snapshot with final state.
+
+        ``context`` should be captured at detach time (same as heartbeats) so a
+        multi-tenant store still writes the terminal status under the request's
+        tenant after the original call has returned.
+        """
         await fn_task
         await forward_task
 
@@ -748,7 +763,7 @@ class AgentRuntime:
             await self.store.save_snapshot(  # type: ignore[union-attr]
                 pending_snap.snapshot_id,
                 finalize,
-                context=get_current_context(),
+                context=context,
             )
         except Exception:  # noqa: BLE001
             # Best-effort: the snapshot stays pending, but its heartbeat stopped
@@ -884,8 +899,15 @@ class AgentRuntime:
             # emitting chunks to it. The turn keeps running; a background task
             # finalizes the snapshot when fn finishes.
             self.detached = True
+            # Pin tenant context for background abort-watch / heartbeat / finalize
+            # — ambient context may be gone by the time those tasks run or settle.
+            detach_context = get_current_context()
             t1 = asyncio.create_task(
-                self.watch_snapshot_abort(snapshot_id=pending_snap.snapshot_id, abort_signal=abort_signal)
+                self.watch_snapshot_abort(
+                    snapshot_id=pending_snap.snapshot_id,
+                    abort_signal=abort_signal,
+                    context=detach_context,
+                )
             )
             heartbeat_task = asyncio.create_task(self.refresh_heartbeat(pending_snap.snapshot_id))
             t2 = asyncio.create_task(
@@ -896,6 +918,7 @@ class AgentRuntime:
                     err_holder=err_holder,
                     result_holder=result_holder,
                     heartbeat_task=heartbeat_task,
+                    context=detach_context,
                 )
             )
             self.background_tasks.add(t1)

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -678,7 +678,7 @@ class AgentRuntime:
             if status == SnapshotStatus.ABORTED:
                 abort_signal.set()
 
-    async def refresh_heartbeat(self, snapshot_id: str) -> None:
+    async def refresh_heartbeat(self, snapshot_id: str, *, context: dict[str, Any] | None = None) -> None:
         """Keep a detached turn's pending snapshot fresh so readers don't flag it dead.
 
         A reader treats a pending snapshot whose heartbeat has gone stale as
@@ -686,13 +686,14 @@ class AgentRuntime:
         detached turn is genuinely still running we bump the beat on an interval.
         The mutator only touches a still-pending snapshot, so a beat never
         resurrects a terminal snapshot or races a concurrent abort/finalize.
+
+        ``context`` should be the detach-time tenant context (same as abort-watch
+        and finalize). Falls back to ambient context if the caller omitted it.
         """
         if self.store is None:
             return
         interval_s = DEFAULT_HEARTBEAT_INTERVAL_MS / 1000
-        # Capture at start (detach time) so beats keep using the request's
-        # tenant context even if ambient context later changes.
-        beat_context = get_current_context()
+        beat_context = context if context is not None else get_current_context()
 
         def beat(existing: SessionSnapshot | None) -> SessionSnapshot | None:
             if existing is None or existing.status != SnapshotStatus.PENDING:
@@ -909,7 +910,9 @@ class AgentRuntime:
                     context=detach_context,
                 )
             )
-            heartbeat_task = asyncio.create_task(self.refresh_heartbeat(pending_snap.snapshot_id))
+            heartbeat_task = asyncio.create_task(
+                self.refresh_heartbeat(pending_snap.snapshot_id, context=detach_context)
+            )
             t2 = asyncio.create_task(
                 self.finalize_detach(
                     pending_snap=pending_snap,

--- a/py/packages/genkit/src/genkit/_ai/_agents/_session.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_session.py
@@ -60,6 +60,32 @@ StateT_co = TypeVarExt('StateT_co', covariant=True, bound=BaseModel, default=Any
 STORE_LOCK_GETTERS: weakref.WeakKeyDictionary[object, Callable[[], asyncio.Lock]] = weakref.WeakKeyDictionary()
 
 
+class SessionStoreLock:
+    """Loop-local asyncio.Lock for in-process stores that need one.
+
+    Not part of :class:`SessionStore`: durable backends (e.g. Firestore) do not
+    expose a public lock. In-memory and file stores mix this in for their own
+    serialization.
+    """
+
+    @property
+    def lock(self) -> asyncio.Lock:
+        """Return a loop-local asyncio.Lock for this store instance."""
+        try:
+            getter = STORE_LOCK_GETTERS.get(self)
+            if getter is None:
+                getter = _loop_local_client(lambda: asyncio.Lock())
+                STORE_LOCK_GETTERS[self] = getter
+            return getter()
+        except TypeError:
+            # Fallback for classes that disallow weak references
+            getter = getattr(self, '_loop_lock_getter', None)
+            if getter is None:
+                getter = _loop_local_client(lambda: asyncio.Lock())
+                object.__setattr__(self, '_loop_lock_getter', getter)
+            return getter()
+
+
 class SessionStore(Protocol, Generic[StateT_co]):
     """Structural interface for snapshot persistence backends.
 
@@ -112,22 +138,21 @@ class SessionStore(Protocol, Generic[StateT_co]):
         """
         ...
 
-    @property
-    def lock(self) -> asyncio.Lock:
-        """Return a loop-local asyncio.Lock for this store instance."""
-        try:
-            getter = STORE_LOCK_GETTERS.get(self)
-            if getter is None:
-                getter = _loop_local_client(lambda: asyncio.Lock())
-                STORE_LOCK_GETTERS[self] = getter
-            return getter()
-        except TypeError:
-            # Fallback for classes that disallow weak references
-            getter = getattr(self, '_loop_lock_getter', None)
-            if getter is None:
-                getter = _loop_local_client(lambda: asyncio.Lock())
-                object.__setattr__(self, '_loop_lock_getter', getter)
-            return getter()
+
+@runtime_checkable
+class SnapshotStatusStream(Protocol):
+    """Async iterator of snapshot status changes.
+
+    Consume with ``async for``. Call ``aclose()`` (or ``contextlib.aclosing``)
+    to unsubscribe — Python does not tear subscriptions down on ``break`` alone.
+    Natural end after a terminal status also unsubscribes.
+    """
+
+    def __aiter__(self) -> SnapshotStatusStream: ...
+
+    async def __anext__(self) -> SnapshotStatus: ...
+
+    async def aclose(self) -> None: ...
 
 
 @runtime_checkable
@@ -141,8 +166,23 @@ class SnapshotSubscriber(Protocol):
     that can't signal status changes can't support detach.
     """
 
-    async def on_snapshot_status_change(self, snapshot_id: str) -> asyncio.Queue[SnapshotStatus | None]:
-        """Queue that receives status changes; None sentinel when done."""
+    async def on_snapshot_status_change(
+        self, snapshot_id: str, *, context: dict[str, Any] | None = None
+    ) -> SnapshotStatusStream:
+        """Async stream of the snapshot's persisted status changes.
+
+        Yields committed statuses such as pending, completed, failed, or aborted.
+        ``expired`` is computed on read when a pending heartbeat goes stale — it
+        is not written to the store and does not appear on this stream. Use
+        ``get_snapshot`` / resolve paths for that liveness check.
+
+        Iteration ends when the run resolves (the last yielded status is a
+        persisted terminal) or when the store is closed locally (ends without
+        one). Call ``aclose()`` (or wrap with ``contextlib.aclosing``) to
+        unsubscribe early — ``break`` alone is not enough. ``context`` scopes
+        the subscription for multi-tenant stores; stores without tenancy accept
+        and ignore it.
+        """
         ...
 
 

--- a/py/packages/genkit/src/genkit/_ai/_agents/_session_stores/_file_store.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_session_stores/_file_store.py
@@ -19,11 +19,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 from typing import Any, Generic
 
 from genkit._ai._agents._session import (
     SessionStore,
+    SessionStoreLock,
+    SnapshotStatusStream,
     SnapshotSubscriber,
     StateT,
 )
@@ -32,16 +35,17 @@ from genkit._ai._agents._session_stores._util import (
     Subs,
     apply_save,
     assert_safe_snapshot_id,
+    iterate_statuses,
     notify,
     require_one_selector,
     select_leaf,
     session_id_of,
     subscribe,
 )
-from genkit._core._typing import SessionSnapshot, SnapshotStatus
+from genkit._core._typing import SessionSnapshot
 
 
-class FileSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[StateT]):
+class FileSessionStore(SessionStoreLock, SessionStore[StateT], SnapshotSubscriber, Generic[StateT]):
     """File-backed snapshot store: one ``<snapshot_id>.json`` per snapshot."""
 
     def __init__(
@@ -173,8 +177,26 @@ class FileSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[StateT]
             notify(subs=self.subs, snapshot_id=next_snapshot.snapshot_id, status=next_snapshot.status)
             return next_snapshot
 
-    async def on_snapshot_status_change(self, snapshot_id: str) -> asyncio.Queue[SnapshotStatus | None]:
-        """Return a queue that receives this snapshot's status changes."""
+    async def on_snapshot_status_change(
+        self, snapshot_id: str, *, context: dict[str, Any] | None = None
+    ) -> SnapshotStatusStream:
+        """Return an iterator that yields this snapshot's status changes.
+
+        Call ``aclose()`` (or ``contextlib.aclosing``) to unsubscribe early;
+        natural end after a terminal status also unsubscribes.
+        """
         async with self.lock:
             current = await asyncio.to_thread(self.read_sync, snapshot_id)
-            return await subscribe(subs=self.subs, snapshot_id=snapshot_id, current=current)
+            q = await subscribe(subs=self.subs, snapshot_id=snapshot_id, current=current)
+
+            async def on_close() -> None:
+                async with self.lock:
+                    qs = self.subs.get(snapshot_id)
+                    if qs is None:
+                        return
+                    with contextlib.suppress(ValueError):
+                        qs.remove(q)
+                    if not qs:
+                        self.subs.pop(snapshot_id, None)
+
+            return iterate_statuses(q, on_close=on_close)

--- a/py/packages/genkit/src/genkit/_ai/_agents/_session_stores/_inmemory_store.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_session_stores/_inmemory_store.py
@@ -18,11 +18,13 @@
 
 from __future__ import annotations
 
-import asyncio
+import contextlib
 from typing import Any, Generic
 
 from genkit._ai._agents._session import (
     SessionStore,
+    SessionStoreLock,
+    SnapshotStatusStream,
     SnapshotSubscriber,
     StateT,
 )
@@ -30,16 +32,17 @@ from genkit._ai._agents._session_stores._util import (
     SaveFn,
     Subs,
     apply_save,
+    iterate_statuses,
     notify,
     require_one_selector,
     select_leaf,
     session_id_of,
     subscribe,
 )
-from genkit._core._typing import SessionSnapshot, SnapshotStatus
+from genkit._core._typing import SessionSnapshot
 
 
-class InMemorySessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[StateT]):
+class InMemorySessionStore(SessionStoreLock, SessionStore[StateT], SnapshotSubscriber, Generic[StateT]):
     """In-memory snapshot store. State is lost when the process exits."""
 
     def __init__(self, *, reject_ambiguous_session: bool = False) -> None:
@@ -91,7 +94,26 @@ class InMemorySessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[Sta
             notify(subs=self.subs, snapshot_id=next_snapshot.snapshot_id, status=next_snapshot.status)
             return next_snapshot
 
-    async def on_snapshot_status_change(self, snapshot_id: str) -> asyncio.Queue[SnapshotStatus | None]:
-        """Return a queue that receives this snapshot's status changes."""
+    async def on_snapshot_status_change(
+        self, snapshot_id: str, *, context: dict[str, Any] | None = None
+    ) -> SnapshotStatusStream:
+        """Return an iterator that yields this snapshot's status changes.
+
+        Call ``aclose()`` (or ``contextlib.aclosing``) to unsubscribe early;
+        natural end after a terminal status also unsubscribes.
+        """
         async with self.lock:
-            return await subscribe(subs=self.subs, snapshot_id=snapshot_id, current=self.snapshots.get(snapshot_id))
+            current = self.snapshots.get(snapshot_id)
+            q = await subscribe(subs=self.subs, snapshot_id=snapshot_id, current=current)
+
+            async def on_close() -> None:
+                async with self.lock:
+                    qs = self.subs.get(snapshot_id)
+                    if qs is None:
+                        return
+                    with contextlib.suppress(ValueError):
+                        qs.remove(q)
+                    if not qs:
+                        self.subs.pop(snapshot_id, None)
+
+            return iterate_statuses(q, on_close=on_close)

--- a/py/packages/genkit/src/genkit/_ai/_agents/_session_stores/_util.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_session_stores/_util.py
@@ -38,13 +38,13 @@ SaveFn = Callable[[SessionSnapshot | None], SessionSnapshot | None]
 Subs = dict[str, list['asyncio.Queue[SnapshotStatus | None]']]
 OnClose = Callable[[], Awaitable[None]]
 
-# Statuses that end a snapshot's lifecycle. Mirrors the per-store constants;
-# apply_save treats these as absorbing.
+# Persisted statuses that end a snapshot's store lifecycle. apply_save treats
+# these as absorbing; status streams end after one. ``expired`` is a read-time
+# overlay and is never written, so it is not included here.
 TERMINAL_STATUSES = frozenset({
     SnapshotStatus.COMPLETED,
     SnapshotStatus.FAILED,
     SnapshotStatus.ABORTED,
-    SnapshotStatus.EXPIRED,
 })
 
 

--- a/py/packages/genkit/src/genkit/_ai/_agents/_session_stores/_util.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_session_stores/_util.py
@@ -14,35 +14,38 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Storage-agnostic helpers shared by the flat, full-snapshot session stores.
+"""Shared utilities for building and extending Genkit agent session stores.
 
-Each turn is persisted whole, keyed by its snapshot id, and the ``parent_id``
-links between snapshots form the conversation tree. That single shape covers a
-linear chat, a "just give me the latest turn" lookup, and a forked/branching
-history without any diffing — so it's the right default for local dev, tests,
-and single-process apps. For a multi-instance production deployment, back the
-same ``SessionStore`` protocol with a real database (where it's worth trading
-this simplicity for incremental, diff-based persistence).
-
-``InMemorySessionStore`` and ``FileSessionStore`` are standalone — they share
-the bits here as plain functions rather than a common base class, so each store
-is a self-contained read of how its backend works.
+Provides common helpers for state persistence, invariant enforcement, and
+real-time status streaming across both built-in (in-memory, file) and custom
+durable backends (such as Firestore).
 """
 
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import datetime, timezone
 
-from genkit._ai._agents._session import select_leaf_snapshot
+from genkit._ai._agents._session import SnapshotStatusStream, select_leaf_snapshot
 from genkit._ai._agents._snapshot import parse_snapshot_lookup_kw
 from genkit._core._error import GenkitError
 from genkit._core._typing import SessionSnapshot, SnapshotStatus
 
 SaveFn = Callable[[SessionSnapshot | None], SessionSnapshot | None]
 Subs = dict[str, list['asyncio.Queue[SnapshotStatus | None]']]
+OnClose = Callable[[], Awaitable[None]]
+
+# Statuses that end a snapshot's lifecycle. Mirrors the per-store constants;
+# apply_save treats these as absorbing.
+TERMINAL_STATUSES = frozenset({
+    SnapshotStatus.COMPLETED,
+    SnapshotStatus.FAILED,
+    SnapshotStatus.ABORTED,
+    SnapshotStatus.EXPIRED,
+})
 
 
 def assert_safe_snapshot_id(*, snapshot_id: str) -> None:
@@ -133,19 +136,118 @@ def apply_save(*, existing: SessionSnapshot | None, snapshot_id: str, fn: SaveFn
 
     When ``existing`` is None this creates under the reserved id. Mutators that
     only update (abort, heartbeat) return None when ``existing`` is missing.
+
+    Terminal statuses are absorbing: once a snapshot is completed, failed, or
+    aborted, a mutation may still rewrite its state or metadata, but changing
+    its status raises ``FAILED_PRECONDITION`` — an aborted run must never be
+    rewritten into a completed one.
     """
     next_snapshot = fn(existing.model_copy(deep=True) if existing is not None else None)
+    if inspect.iscoroutine(next_snapshot):
+        next_snapshot.close()
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=("save mutator must be a synchronous function; got a coroutine — remove 'async' from the mutator"),
+        )
     if next_snapshot is None:
         return None
+    if (
+        existing is not None
+        and existing.session_id
+        and next_snapshot.session_id
+        and existing.session_id != next_snapshot.session_id
+    ):
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=(
+                f"Snapshot '{snapshot_id}' belongs to session '{existing.session_id}' "
+                f"and cannot be rewritten by session '{next_snapshot.session_id}'. "
+                'Snapshot ids share one namespace per store prefix; use ids that are '
+                'unique across sessions.'
+            ),
+        )
+    if existing is not None and existing.status in TERMINAL_STATUSES and next_snapshot.status != existing.status:
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=(
+                f"Snapshot '{snapshot_id}' already has terminal status "
+                f"'{existing.status and existing.status.value}' and cannot transition to "
+                f"'{next_snapshot.status and next_snapshot.status.value}'."
+            ),
+        )
     stamp_store_fields(snapshot=next_snapshot, snapshot_id=snapshot_id)
     return next_snapshot
 
 
 def notify(*, subs: Subs, snapshot_id: str, status: SnapshotStatus | None) -> None:
-    """Push a status change to everyone subscribed to a snapshot."""
+    """Push a status change to everyone subscribed to a snapshot.
+
+    A persisted terminal status is followed by the end-of-stream sentinel so
+    consumers can finish their ``async for`` instead of waiting forever.
+    """
     # Subscriber queues are unbounded, so put_nowait can't fail here.
     for q in subs.get(snapshot_id, []):
         q.put_nowait(status)
+        if status in TERMINAL_STATUSES:
+            q.put_nowait(None)
+
+
+async def _status_queue_values(q: asyncio.Queue[SnapshotStatus | None]) -> AsyncGenerator[SnapshotStatus, None]:
+    """Yield statuses until the end-of-stream sentinel."""
+    while True:
+        status = await q.get()
+        if status is None:
+            return
+        yield status
+
+
+class _StatusStream:
+    """Closable async iterator over a status queue.
+
+    Follow-until-done (like a channel range / callback subscription): consume
+    with ``async for``, and call ``aclose()`` (or use ``contextlib.aclosing``)
+    to unsubscribe. Python does not tear down async generators on ``break``,
+    so teardown is explicit — same idea as an unsubscribe handle.
+    """
+
+    def __init__(
+        self,
+        q: asyncio.Queue[SnapshotStatus | None],
+        *,
+        on_close: OnClose | None = None,
+    ) -> None:
+        self._agen: AsyncGenerator[SnapshotStatus, None] = _status_queue_values(q)
+        self._on_close = on_close
+        self._closed = False
+
+    def __aiter__(self) -> SnapshotStatusStream:
+        return self
+
+    async def __anext__(self) -> SnapshotStatus:
+        if self._closed:
+            raise StopAsyncIteration
+        try:
+            return await self._agen.__anext__()
+        except StopAsyncIteration:
+            await self.aclose()
+            raise
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._agen.aclose()
+        if self._on_close is not None:
+            await self._on_close()
+
+
+def iterate_statuses(
+    q: asyncio.Queue[SnapshotStatus | None],
+    *,
+    on_close: OnClose | None = None,
+) -> SnapshotStatusStream:
+    """Expose a status queue as a closable async stream."""
+    return _StatusStream(q, on_close=on_close)
 
 
 async def subscribe(
@@ -154,11 +256,18 @@ async def subscribe(
     snapshot_id: str,
     current: SessionSnapshot | None,
 ) -> asyncio.Queue[SnapshotStatus | None]:
-    """Register a status-change queue, seeding it with the current status."""
+    """Register a status-change queue, seeding it with the current status.
+
+    A missing snapshot stays subscribed with an empty queue so a later create
+    (or realtime watch) can deliver the first status. ``None`` is reserved as
+    the end-of-stream sentinel after a terminal status, not as "not found".
+    If the current status is already terminal, seed that status and then
+    ``None`` so the subscriber does not block waiting for a future event.
+    """
     q: asyncio.Queue[SnapshotStatus | None] = asyncio.Queue()
-    if current is None:
-        await q.put(None)
-        return q
-    await q.put(current.status)
+    if current is not None:
+        await q.put(current.status)
+        if current.status in TERMINAL_STATUSES:
+            await q.put(None)
     subs.setdefault(snapshot_id, []).append(q)
     return q

--- a/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
@@ -77,7 +77,14 @@ def parse_snapshot_lookup_kw(
 
     A bad selector is a caller mistake, so it raises ``INVALID_ARGUMENT`` — over a
     transport that surfaces as a 400, not a 500 the way a bare ``ValueError`` would.
+    Whitespace-only ids count as empty: they are not usable as document keys.
     """
+    for name, value in (('snapshot_id', snapshot_id), ('session_id', session_id)):
+        if value is not None and not value.strip():
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=f'{name} must not be empty or whitespace-only.',
+            )
     if bool(snapshot_id) == bool(session_id):
         raise GenkitError(
             status='INVALID_ARGUMENT',

--- a/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
@@ -73,24 +73,29 @@ def parse_snapshot_lookup_kw(
     snapshot_id: str | None = None,
     session_id: str | None = None,
 ) -> tuple[str | None, str | None]:
-    """Require exactly one of ``snapshot_id`` or ``session_id``.
+    """Require exactly one non-blank ``snapshot_id`` or ``session_id``.
 
-    A bad selector is a caller mistake, so it raises ``INVALID_ARGUMENT`` — over a
-    transport that surfaces as a 400, not a 500 the way a bare ``ValueError`` would.
-    Whitespace-only ids count as empty: they are not usable as document keys.
+    Whitespace-only ids are rejected so they can't become unusable document keys.
+    A bad selector raises ``INVALID_ARGUMENT`` (400 over HTTP), not a bare
+    ``ValueError``.
     """
     for name, value in (('snapshot_id', snapshot_id), ('session_id', session_id)):
         if value is not None and not value.strip():
             raise GenkitError(
                 status='INVALID_ARGUMENT',
-                message=f'{name} must not be empty or whitespace-only.',
+                message=f'get_snapshot rejected empty or whitespace-only {name}={value!r}.',
             )
-    if bool(snapshot_id) == bool(session_id):
+    if snapshot_id is None and session_id is None:
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=("get_snapshot requires exactly one of 'snapshot_id' or 'session_id' (got neither)."),
+        )
+    if snapshot_id is not None and session_id is not None:
         raise GenkitError(
             status='INVALID_ARGUMENT',
             message=(
                 "get_snapshot requires exactly one of 'snapshot_id' or 'session_id' "
-                f'(got snapshot_id={snapshot_id!r}, session_id={session_id!r}).'
+                f'(got both snapshot_id={snapshot_id!r} and session_id={session_id!r}).'
             ),
         )
     return snapshot_id, session_id

--- a/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
@@ -73,29 +73,24 @@ def parse_snapshot_lookup_kw(
     snapshot_id: str | None = None,
     session_id: str | None = None,
 ) -> tuple[str | None, str | None]:
-    """Require exactly one non-blank ``snapshot_id`` or ``session_id``.
+    """Require exactly one of ``snapshot_id`` or ``session_id``.
 
-    Whitespace-only ids are rejected so they can't become unusable document keys.
-    A bad selector raises ``INVALID_ARGUMENT`` (400 over HTTP), not a bare
-    ``ValueError``.
+    A bad selector is a caller mistake, so it raises ``INVALID_ARGUMENT`` — over a
+    transport that surfaces as a 400, not a 500 the way a bare ``ValueError`` would.
+    Whitespace-only ids count as empty: they are not usable as document keys.
     """
     for name, value in (('snapshot_id', snapshot_id), ('session_id', session_id)):
         if value is not None and not value.strip():
             raise GenkitError(
                 status='INVALID_ARGUMENT',
-                message=f'get_snapshot rejected empty or whitespace-only {name}={value!r}.',
+                message=f'{name} must not be empty or whitespace-only.',
             )
-    if snapshot_id is None and session_id is None:
-        raise GenkitError(
-            status='INVALID_ARGUMENT',
-            message=("get_snapshot requires exactly one of 'snapshot_id' or 'session_id' (got neither)."),
-        )
-    if snapshot_id is not None and session_id is not None:
+    if bool(snapshot_id) == bool(session_id):
         raise GenkitError(
             status='INVALID_ARGUMENT',
             message=(
                 "get_snapshot requires exactly one of 'snapshot_id' or 'session_id' "
-                f'(got both snapshot_id={snapshot_id!r} and session_id={session_id!r}).'
+                f'(got snapshot_id={snapshot_id!r}, session_id={session_id!r}).'
             ),
         )
     return snapshot_id, session_id

--- a/py/packages/genkit/src/genkit/agent/__init__.py
+++ b/py/packages/genkit/src/genkit/agent/__init__.py
@@ -32,6 +32,7 @@ from genkit._ai._agents._runtime import AgentFn, AgentInitError, SessionRunner
 from genkit._ai._agents._session import (
     Session,
     SessionStore,
+    SnapshotStatusStream,
     SnapshotSubscriber,
 )
 from genkit._ai._agents._session_stores._file_store import FileSessionStore
@@ -81,6 +82,7 @@ __all__ = [
     # Session persistence
     'Session',
     'SessionStore',
+    'SnapshotStatusStream',
     'SnapshotSubscriber',
     'InMemorySessionStore',
     'FileSessionStore',

--- a/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from pathlib import Path
 from uuid import uuid4
 
@@ -33,6 +34,7 @@ from genkit.agent import (
     FileSessionStore,
     InMemorySessionStore,
     SessionStore,
+    SnapshotStatusStream,
 )
 
 
@@ -123,6 +125,19 @@ async def test_get_snapshot_requires_exactly_one_selector() -> None:
         await store.get_snapshot(snapshot_id='a', session_id='b')
 
 
+@pytest.mark.asyncio
+async def test_get_snapshot_rejects_whitespace_only_selector() -> None:
+    """Whitespace-only ids are rejected (unusable as document keys)."""
+    store = InMemorySessionStore()
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='   ')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(session_id='\t')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
 # --- Abort lifecycle ---
 
 
@@ -155,11 +170,64 @@ async def test_status_subscription_observes_abort() -> None:
     pending = await store.save_snapshot(pending_snap.snapshot_id, lambda _: pending_snap)
     assert pending is not None
 
-    queue = await store.on_snapshot_status_change(pending.snapshot_id)
-    assert await queue.get() == SnapshotStatus.PENDING  # current status on subscribe
+    seen: list[SnapshotStatus] = []
 
+    async def consume() -> None:
+        statuses = await store.on_snapshot_status_change(pending.snapshot_id)
+        async for status in statuses:
+            seen.append(status)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)  # let the consumer take the seeded PENDING
     await abort_snapshot_in_store(store=store, snapshot_id=pending.snapshot_id)
-    assert await queue.get() == SnapshotStatus.ABORTED
+    await asyncio.wait_for(task, 2)
+    assert seen == [SnapshotStatus.PENDING, SnapshotStatus.ABORTED]
+    assert pending.snapshot_id not in store.subs
+
+
+@pytest.mark.asyncio
+async def test_status_subscription_waits_for_missing_snapshot() -> None:
+    """Subscribing before the snapshot exists stays open until the first save."""
+    store = InMemorySessionStore()
+    snapshot_id = 'not-yet'
+    statuses = await store.on_snapshot_status_change(snapshot_id)
+    assert store.subs[snapshot_id][0].empty()  # nothing yet; stream stays open
+
+    pending_snap = make_snapshot('sess-wait', 'hello', SnapshotStatus.PENDING).model_copy(
+        update={'snapshot_id': snapshot_id}
+    )
+    await store.save_snapshot(snapshot_id, lambda _: pending_snap)
+    assert await asyncio.wait_for(anext(statuses), 2) == SnapshotStatus.PENDING
+    await statuses.aclose()
+    assert snapshot_id not in store.subs
+
+
+@pytest.mark.asyncio
+async def test_status_subscription_already_terminal_ends() -> None:
+    """Subscribe on a finished snapshot yields the status then ends (no hang)."""
+    store = InMemorySessionStore()
+    done = make_snapshot('sess-done', 'ok', SnapshotStatus.COMPLETED)
+    await store.save_snapshot(done.snapshot_id, lambda _: done)
+
+    seen: list[SnapshotStatus] = []
+    statuses = await store.on_snapshot_status_change(done.snapshot_id)
+    async for status in statuses:
+        seen.append(status)
+    assert seen == [SnapshotStatus.COMPLETED]
+    assert done.snapshot_id not in store.subs
+
+
+@pytest.mark.asyncio
+async def test_status_subscription_aclose_unsubscribes() -> None:
+    """Explicit ``aclose`` stops the subscription (JS-style unsubscribe)."""
+    store = InMemorySessionStore()
+    pending = make_snapshot('sess-aclose', 'work', SnapshotStatus.PENDING)
+    await store.save_snapshot(pending.snapshot_id, lambda _: pending)
+
+    statuses = await store.on_snapshot_status_change(pending.snapshot_id)
+    assert await anext(statuses) == SnapshotStatus.PENDING
+    await statuses.aclose()
+    assert pending.snapshot_id not in store.subs
 
 
 # --- Branching leaf resolution ---
@@ -290,3 +358,14 @@ async def test_file_store_accepts_plain_basename_snapshot_id(tmp_path: Path) -> 
     assert got is not None
     missing_id = str(uuid4())
     assert await store.get_snapshot(snapshot_id=missing_id) is None  # missing but safe id
+
+
+@pytest.mark.asyncio
+async def test_snapshot_status_stream_is_public_and_runtime_checkable() -> None:
+    """Wrapper authors can import and isinstance-check SnapshotStatusStream."""
+    store = InMemorySessionStore()
+    snap = make_snapshot('sess', 'hi', status=SnapshotStatus.PENDING)
+    assert snap.snapshot_id is not None
+    await store.save_snapshot(snap.snapshot_id, lambda _: snap)
+    stream = await store.on_snapshot_status_change(snap.snapshot_id)
+    assert isinstance(stream, SnapshotStatusStream)

--- a/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 
 import pytest
 
+from genkit._ai._agents._session_stores._util import apply_save
 from genkit._ai._agents._snapshot import abort_snapshot_in_store
 from genkit._core._error import GenkitError
 from genkit._core._typing import (
@@ -161,6 +162,45 @@ async def test_abort_flips_pending_only() -> None:
     assert await abort_snapshot_in_store(store=store, snapshot_id=done.snapshot_id) == SnapshotStatus.COMPLETED
 
     assert await abort_snapshot_in_store(store=store, snapshot_id='does-not-exist') is None
+
+
+def test_apply_save_rejects_terminal_status_flip() -> None:
+    """Direct apply_save: a terminal snapshot cannot change status."""
+    existing = make_snapshot('sess-term', 'done', SnapshotStatus.ABORTED)
+
+    def flip(prev: SessionSnapshot | None) -> SessionSnapshot | None:
+        assert prev is not None
+        return prev.model_copy(update={'status': SnapshotStatus.COMPLETED})
+
+    with pytest.raises(GenkitError) as exc_info:
+        apply_save(existing=existing, snapshot_id=existing.snapshot_id, fn=flip)
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+def test_apply_save_rejects_session_id_rewrite() -> None:
+    """Direct apply_save: a snapshot cannot be rewritten onto another session."""
+    existing = make_snapshot('sess-a', 'work', SnapshotStatus.PENDING)
+    existing.session_id = 'sess-a'
+
+    def rewrite(prev: SessionSnapshot | None) -> SessionSnapshot | None:
+        assert prev is not None
+        return prev.model_copy(update={'session_id': 'sess-b'})
+
+    with pytest.raises(GenkitError) as exc_info:
+        apply_save(existing=existing, snapshot_id=existing.snapshot_id, fn=rewrite)
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+def test_apply_save_rejects_async_mutator() -> None:
+    """Direct apply_save: an async mutator is INVALID_ARGUMENT, not awaited."""
+    existing = make_snapshot('sess-async', 'work', SnapshotStatus.PENDING)
+
+    async def bad(_prev: SessionSnapshot | None) -> SessionSnapshot | None:
+        return existing
+
+    with pytest.raises(GenkitError) as exc_info:
+        apply_save(existing=existing, snapshot_id=existing.snapshot_id, fn=bad)  # type: ignore[arg-type]
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
@@ -199,7 +199,6 @@ async def test_status_subscription_waits_for_missing_snapshot() -> None:
     await store.save_snapshot(snapshot_id, lambda _: pending_snap)
     assert await asyncio.wait_for(anext(statuses), 2) == SnapshotStatus.PENDING
     await statuses.aclose()
-    assert snapshot_id not in store.subs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Changes to make the Python `SessionStore` contract safe for **detach/abort** and for **durable multi-instance backends** (e.g. Firestore), without leaking in-process asyncio details into the protocol.

### 1. Locks moved out of `SessionStore` Protocol. 

They are an implementation detail for InMemorySessionStore and FileSessionStore. A process-local `asyncio.Lock` cannot coordinate across instances of a durable store. Putting `lock` on the protocol invited the wrong pattern (locking in-process instead of using a DB transaction). 

New pattern: In-memory and file stores still lock via a `SessionStoreLock` mixin; durable stores use their own concurrency (transactions).

### 2. Status watches return `SnapshotStatusStream` (not a raw queue)

When a turn is detached, the runtime must notice an abort written by another request and cancel the background work. That requires a status subscription with clear lifetime: follow until the run finishes, or unsubscribe early without leaking watches.

**Before** — callers got an `asyncio.Queue`. Callers had to know in-band `None` meant end-of-stream:

```python
q = await self.store.on_snapshot_status_change(snapshot_id)
while True:
    status = await q.get()
    if status is None:  # magic EOS every caller must know
        return
    if status == SnapshotStatus.ABORTED:
        abort_signal.set()
        return  # stops reading; store may still hold `q`
```

And also, asyncio.Queue was leaked on the API contract. The specific choice of queue shouldn't be decided on the API surface.

**After** — `on_snapshot_status_change` returns a `SnapshotStatusStream`: an async iterator of real statuses only. Follow until done; a terminal status ends the stream and unsubscribes. Call `aclose()` only when bailing early (`break` alone does not tear the subscription down in Python):

```python
statuses = await self.store.on_snapshot_status_change(snapshot_id, context=...)
async for status in statuses:
    if status == SnapshotStatus.ABORTED:
        abort_signal.set()
# aborted/completed/failed are terminal → stream ends → unsubscribed - all this happens automatically.
```

Early unsubscribe when you leave before the run finishes:

```python
from contextlib import aclosing

async with aclosing(await store.on_snapshot_status_change(snapshot_id)) as statuses:
    async for status in statuses:
        if done_early:
            break  # aclosing → aclose → drops subscriber / stops watch
```

Stores use _StatusStream, implementation of that protocol, which uses asyncio.Queue underneath.

### 3. Request context pinning on detach

Status subscribe accepts optional `context=` for multi-tenant stores. On detach, the runtime captures context once and passes it into abort-watch / heartbeat / finalize so background work keeps the original request's tenant after the call returns. Local stores ignore `context`. Matches Cross SDK behavior.

### 4. Store write invariants

Shared save path hardens against corrupt timelines:

- Terminal statuses (`completed` / `failed` / `aborted` / `expired`) are absorbing — status cannot flip afterward (e.g. abort overwritten by a late completed)
- A snapshot's `session_id` cannot be rewritten onto a different session
- Save mutators must be synchronous (no coroutines inside the RMW step)
- Lookup rejects whitespace-only ids; file store rejects path-escaping ids
