### PR TITLE
fix(go/ai): surface abnormal finish reasons instead of failing output parsing

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -583,11 +583,19 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 
 			if formatHandler != nil {
 				resp.formatHandler = streamingHandler
-				// This is legacy behavior. New format handlers should implement ParseMessage as a passthrough.
-				resp.Message, err = formatHandler.ParseMessage(resp.Message)
-				if err != nil {
-					logger.FromContext(ctx).Debug("model failed to generate output matching expected schema", "error", err.Error())
-					return nil, status.Errorf(status.ErrInvalidOutput, "model failed to generate output matching expected schema: %w", err)
+				// Only parse output when the model delivered it: a natural
+				// stop, a length-capped response, or a model that reports no
+				// finish reason. An abnormal termination (blocked, aborted,
+				// ...) carries no conforming output, and a schema error here
+				// would mask the FinishReason and FinishMessage the caller
+				// needs to handle it, so those responses pass through as-is.
+				if resp.FinishReason == FinishReasonStop || resp.FinishReason == FinishReasonLength || resp.FinishReason == "" {
+					// This is legacy behavior. New format handlers should implement ParseMessage as a passthrough.
+					resp.Message, err = formatHandler.ParseMessage(resp.Message)
+					if err != nil {
+						logger.FromContext(ctx).Debug("model failed to generate output matching expected schema", "error", err.Error())
+						return nil, status.Errorf(status.ErrInvalidOutput, "model failed to generate output matching expected schema: %w", err)
+					}
 				}
 			}
 

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -583,13 +583,19 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 
 			if formatHandler != nil {
 				resp.formatHandler = streamingHandler
-				// Only parse output when the model delivered it: a natural
-				// stop, a length-capped response, or a model that reports no
-				// finish reason. An abnormal termination (blocked, aborted,
-				// ...) carries no conforming output, and a schema error here
-				// would mask the FinishReason and FinishMessage the caller
-				// needs to handle it, so those responses pass through as-is.
-				if resp.FinishReason == FinishReasonStop || resp.FinishReason == FinishReasonLength || resp.FinishReason == "" {
+				switch resp.FinishReason {
+				case FinishReasonBlocked, FinishReasonAborted, FinishReasonInterrupted, FinishReasonOther:
+					// A termination known to be abnormal carries no conforming
+					// output, and a schema error here would mask the
+					// FinishReason and FinishMessage the caller needs to
+					// handle it, so the response passes through as-is.
+					// FinishReasonUnknown is not in this set on purpose:
+					// plugins map unrecognized provider reasons to it, and
+					// ParseMessage is the only place the output schema is
+					// enforced, so skipping it on an unclassified reason would
+					// silently drop validation for output the model may well
+					// have completed.
+				default:
 					// This is legacy behavior. New format handlers should implement ParseMessage as a passthrough.
 					resp.Message, err = formatHandler.ParseMessage(resp.Message)
 					if err != nil {

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2815,6 +2815,18 @@ func TestGenerateAbnormalFinishSkipsOutputParsing(t *testing.T) {
 			opts:    []GenerateOption{WithOutputType(OutputData{})},
 			wantErr: status.ErrInvalidOutput,
 		},
+		{
+			// Plugins map unrecognized provider finish reasons to unknown, so
+			// it keeps the parse path: only reasons known to be abnormal skip
+			// output validation.
+			name: "unknown with non-conforming text still fails parsing",
+			response: &ModelResponse{
+				FinishReason: FinishReasonUnknown,
+				Message:      NewModelTextMessage("not json at all"),
+			},
+			opts:    []GenerateOption{WithOutputType(OutputData{})},
+			wantErr: status.ErrInvalidOutput,
+		},
 	}
 
 	for i, tt := range tests {

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/registry"
 	test_utils "github.com/firebase/genkit/go/tests/utils"
 	"github.com/google/go-cmp/cmp"
@@ -2750,6 +2751,106 @@ func TestGenerateWithMarkdownJSON(t *testing.T) {
 			t.Errorf("Unexpected output: %+v", out)
 		}
 	})
+}
+
+// TestGenerateAbnormalFinishSkipsOutputParsing verifies that a response that
+// did not run to a normal completion (e.g. safety-blocked) is returned as-is
+// when structured output is requested, instead of failing output parsing and
+// masking the finish reason with a schema error.
+func TestGenerateAbnormalFinishSkipsOutputParsing(t *testing.T) {
+	r := childRegistry(t)
+
+	type OutputData struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	tests := []struct {
+		name     string
+		response *ModelResponse
+		opts     []GenerateOption
+		wantErr  error
+	}{
+		{
+			name: "blocked contentless message with output type",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonBlocked,
+				FinishMessage: "blocked by safety settings",
+				Message:       &Message{Role: RoleModel},
+			},
+			opts: []GenerateOption{WithOutputType(OutputData{})},
+		},
+		{
+			name: "blocked nil message with output type",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonBlocked,
+				FinishMessage: "blocked by safety settings",
+			},
+			opts: []GenerateOption{WithOutputType(OutputData{})},
+		},
+		{
+			name: "blocked contentless message with enum output",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonBlocked,
+				FinishMessage: "blocked by safety settings",
+				Message:       &Message{Role: RoleModel},
+			},
+			opts: []GenerateOption{WithOutputEnums("YES", "NO")},
+		},
+		{
+			name: "other finish reason keeps unparsed text",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonOther,
+				FinishMessage: "malformed function call",
+				Message:       NewModelTextMessage("filter details, not JSON"),
+			},
+			opts: []GenerateOption{WithOutputType(OutputData{})},
+		},
+		{
+			name: "stop with non-conforming text still fails parsing",
+			response: &ModelResponse{
+				FinishReason: FinishReasonStop,
+				Message:      NewModelTextMessage("not json at all"),
+			},
+			opts:    []GenerateOption{WithOutputType(OutputData{})},
+			wantErr: status.ErrInvalidOutput,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := defineModel(r, fmt.Sprintf("test/abnormal-finish-%d", i), &ModelOptions{Supports: defaultModelSupports()},
+				func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+					resp := *tt.response
+					resp.Request = req
+					return &resp, nil
+				})
+			wantText := tt.response.Text()
+
+			resp, err := Generate(context.Background(), r, append([]GenerateOption{
+				WithModel(model),
+				WithPrompt("please respond"),
+			}, tt.opts...)...)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("Generate() err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Generate() returned error for %q response: %v", tt.response.FinishReason, err)
+			}
+			if resp.FinishReason != tt.response.FinishReason {
+				t.Errorf("FinishReason = %q, want %q", resp.FinishReason, tt.response.FinishReason)
+			}
+			if resp.FinishMessage != tt.response.FinishMessage {
+				t.Errorf("FinishMessage = %q, want %q", resp.FinishMessage, tt.response.FinishMessage)
+			}
+			if got := resp.Text(); got != wantText {
+				t.Errorf("Text() = %q, want %q", got, wantText)
+			}
+		})
+	}
 }
 
 func TestGenerateNoGoroutineLeak(t *testing.T) {


### PR DESCRIPTION
Skips output parsing when a response did not run to a normal completion, so blocked and filtered responses reach the caller with their `FinishReason` and `FinishMessage` for every plugin and every format.

`GenerateWithRequest` ran `ParseMessage` on every response whenever an output format was set. A safety-blocked response has no content, so parsing failed and `Generate` returned `status.ErrInvalidOutput` ("model failed to generate output matching expected schema") instead of the response: the documented `resp.FinishReason == ai.FinishReasonBlocked` check could never fire when `WithOutputType` or `WithOutputSchema` was in play, and a blocked response that does carry text (Veo attaches filter explanations) surfaced as a bogus schema mismatch.

Parsing is now skipped only for finish reasons known to be abnormal (`blocked`, `aborted`, `interrupted`, `other`), at the single call site, which covers the json and enum handlers alike (both reject contentless messages). `unknown`, where plugin mappers land unrecognized provider reasons, keeps the parse path: `ParseMessage` is the only place the output schema is enforced (`Output()` extracts without validating), so skipping an unclassified reason would silently drop validation. Skipped responses still carry their format handler, so `resp.Output(&v)` works on demand when content exists. `length` output still parses and still fails on truncation, matching JS, which validates length-capped output but raises `GenerationBlockedError` before any schema validation. Callers could not have keyed on the old error to detect blocking (its status never identified it), so the visible change is contentless abnormal responses returning instead of erroring.

New `TestGenerateAbnormalFinishSkipsOutputParsing` covers blocked with a contentless message, blocked with a nil message, blocked with enum output, `other` with non-JSON text surviving untouched, and `stop` with non-conforming text still failing with `ErrInvalidOutput`. Go 1.26.3, full `go test ./...` in `go/`: 41 packages pass, plus a `-race` run on `go/ai`.
