### PR TITLE
feat(go/plugins/googlegenai): add Express Mode, HTTP options, and `Client` accessors; harden response handling

### DIFF
--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -119,6 +119,7 @@ Both plugins accept optional fields for nonstandard network setups:
 ```go
 g := genkit.Init(ctx,
  genkit.WithPlugins(&googlegenai.GoogleAI{
+  APIVersion: "v1alpha",                           // pin the API version ("v1", "v1beta", or "v1alpha"; default v1beta)
   BaseURL: "https://my-gateway.example.com",       // route through a proxy or API gateway
   Headers: http.Header{"X-Team": {"platform"}},    // extra headers on every request
   HTTPClient: myClient,                            // custom *http.Client, used verbatim
@@ -129,7 +130,9 @@ g := genkit.Init(ctx,
 `VertexAI` additionally accepts `Credentials` (a `*auth.Credentials` from
 `cloud.google.com/go/auth`) to override Application Default Credentials. When
 you supply `HTTPClient` to `VertexAI`, that client must handle authentication
-itself; use `Credentials` instead if you only need a different identity.
+itself; use `Credentials` instead if you only need a different identity. Note
+that Vertex AI names its API versions differently: `VertexAI.APIVersion` takes
+`"v1"` or `"v1beta1"` (default `v1beta1`).
 
 ### Accessing the underlying client
 

--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -68,11 +68,89 @@ func main() {
 }
 ```
 
+**Using Vertex AI Express Mode (API key, no Google Cloud project):**
+
+```go
+g := genkit.Init(ctx,
+ genkit.WithPlugins(&googlegenai.VertexAI{
+  APIKey: "your-express-mode-api-key", // Optional: defaults to VERTEX_API_KEY, GOOGLE_API_KEY, or GOOGLE_GENAI_API_KEY
+ }),
+)
+```
+
+Express Mode authenticates with an API key alone: no project, location, or
+Application Default Credentials are involved, which makes it the fastest way
+to try Vertex AI. Get a key from the
+[Express Mode overview](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview).
+
+The plugin picks a mode as follows. The precedence rule (explicit
+configuration first, and a project or location outranking an ambient API
+key) matches the underlying genai SDK; the environment variable names follow
+the JS plugin:
+
+1. An explicit `APIKey` selects Express Mode. It is mutually exclusive with
+   `ProjectID`, `Location`, and `Credentials`.
+2. An explicit `ProjectID`, `Location`, or `Credentials` selects credential
+   authentication, and any API key in the environment is ignored.
+3. Otherwise, if the environment names neither a project
+   (`GOOGLE_CLOUD_PROJECT`) nor a location (`GOOGLE_CLOUD_LOCATION`,
+   `GOOGLE_CLOUD_REGION`), an API key in `VERTEX_API_KEY`, `GOOGLE_API_KEY`,
+   or `GOOGLE_GENAI_API_KEY` selects Express Mode.
+4. A `BaseURL` with nothing else configured selects custom-endpoint mode:
+   requests go to that endpoint as-is and the endpoint owns authentication,
+   which suits API gateways and proxies.
+
+`GEMINI_API_KEY` is deliberately not consulted for Vertex AI: it names a
+Gemini Developer API key, which Vertex AI does not accept. A project or
+location in the environment always outranks an ambient API key, so a key
+exported for the Google AI plugin cannot move an existing Vertex AI
+deployment onto a different authentication path.
+
 ### Authentication
 
 **Google AI**: Requires a Gemini API Key, which you can get from [Google AI Studio](https://aistudio.google.com/apikey). Set the `GEMINI_API_KEY` environment variable or pass it to the plugin configuration.
 
-**Vertex AI**: Requires Google Cloud credentials. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to your service account key file path, or use default credentials (e.g., `gcloud auth application-default login`).
+**Vertex AI**: Requires Google Cloud credentials. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to your service account key file path, or use default credentials (e.g., `gcloud auth application-default login`). Alternatively use Express Mode (above), which needs only an API key, or supply custom credentials via the `Credentials` field.
+
+### Network and transport options
+
+Both plugins accept optional fields for nonstandard network setups:
+
+```go
+g := genkit.Init(ctx,
+ genkit.WithPlugins(&googlegenai.GoogleAI{
+  BaseURL: "https://my-gateway.example.com",       // route through a proxy or API gateway
+  Headers: http.Header{"X-Team": {"platform"}},    // extra headers on every request
+  HTTPClient: myClient,                            // custom *http.Client, used verbatim
+ }),
+)
+```
+
+`VertexAI` additionally accepts `Credentials` (a `*auth.Credentials` from
+`cloud.google.com/go/auth`) to override Application Default Credentials. When
+you supply `HTTPClient` to `VertexAI`, that client must handle authentication
+itself; use `Credentials` instead if you only need a different identity.
+
+### Accessing the underlying client
+
+The plugin's `Client` method returns the `*genai.Client` it uses, so you can
+reach SDK features Genkit does not wrap (Files, Caches, Batches, Tunings)
+without constructing and authenticating a second client:
+
+```go
+plugin := &googlegenai.GoogleAI{}
+g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+client, err := plugin.Client()
+if err != nil {
+ log.Fatal(err)
+}
+file, err := client.Files.UploadFromPath(ctx, "photo.jpg", &genai.UploadFileConfig{
+ MIMEType: "image/jpeg",
+})
+```
+
+See `go/samples/files-api-vision` for a complete example.
 
 ## Language Models
 
@@ -213,6 +291,33 @@ resp2, err := genkit.Generate(ctx, g,
  ai.WithMessages(resp1.History()...),
  ai.WithPrompt("Task 2..."),
 )
+```
+
+### Handling Errors and Blocked Content
+
+API errors carry the status the service reported, so status-aware code
+(retries, fallbacks) can classify them with `core/status`. Rate-limit errors
+include the delay the service asked you to wait:
+
+```go
+resp, err := genkit.Generate(ctx, g, /* ... */)
+if err != nil {
+ if delay, ok := googlegenai.RetryDelay(err); ok {
+  time.Sleep(delay) // or hand the delay to your retry policy
+ }
+ return err
+}
+```
+
+Content blocked by safety filters is not an error. A blocked response comes
+back with `FinishReason` set to `blocked`, an explanation in `FinishMessage`,
+and no content. The raw safety ratings and prompt feedback are available under
+`resp.Custom["candidates"]` and `resp.Custom["promptFeedback"]`.
+
+```go
+if resp.FinishReason == ai.FinishReasonBlocked {
+ log.Printf("response blocked: %s", resp.FinishMessage)
+}
 ```
 
 ### Safety Settings
@@ -387,6 +492,11 @@ if err != nil {
 
 fmt.Printf("Embedding: %v\n", res.Embeddings[0].Embedding)
 ```
+
+Requests with more inputs than the service accepts per call (100 on the
+Gemini API, 250 on Vertex AI's prediction service, 1 for Vertex AI Gemini
+embedding models) are split into sequential batches automatically; the
+response carries one embedding per input, in input order.
 
 ## Image Models
 

--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -497,9 +497,10 @@ fmt.Printf("Embedding: %v\n", res.Embeddings[0].Embedding)
 ```
 
 Requests with more inputs than the service accepts per call (100 on the
-Gemini API, 250 on Vertex AI's prediction service, 1 for Vertex AI Gemini
-embedding models) are split into sequential batches automatically; the
-response carries one embedding per input, in input order.
+Gemini API, 250 on Vertex AI's prediction service including
+`gemini-embedding-001`, 1 for the Vertex AI models served by the
+one-content embedContent API) are split into sequential batches
+automatically; the response carries one embedding per input, in input order.
 
 ## Image Models
 

--- a/go/plugins/googlegenai/cache.go
+++ b/go/plugins/googlegenai/cache.go
@@ -173,18 +173,30 @@ func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
 			continue
 		}
 
-		if t, ok := c["ttlSeconds"].(int); ok {
+		// ttlSeconds arrives as an int when set in Go code and as a float64 or
+		// json.Number after a JSON round-trip (dev UI, reflection server), so
+		// accept any numeric form. A non-positive TTL (including a fractional
+		// value that truncates to zero) would silently skip cache creation in
+		// handleCache, so reject it here instead.
+		if tv, ok := c["ttlSeconds"]; ok {
+			t, isNum := castToInt64(tv)
+			if !isNum {
+				return nil, fmt.Errorf("invalid type for cache ttlSeconds, expected a number, got %T", tv)
+			}
+			if t <= 0 {
+				return nil, fmt.Errorf("invalid cache ttlSeconds, expected a positive number of whole seconds, got %v", tv)
+			}
 			if m.Text() == "" {
 				return nil, fmt.Errorf("no content to cache, message is empty")
 			}
 			return &cacheSettings{
-				ttl:      t,
+				ttl:      int(t),
 				name:     cacheName,
 				endIndex: i,
 			}, nil
 		}
 
-		return nil, fmt.Errorf("invalid type for cache ttlSeconds, expected int, got %T", c["ttlSeconds"])
+		return nil, fmt.Errorf("invalid cache metadata, expected ttlSeconds or name, got: %v", c)
 	}
 	return nil, nil
 }

--- a/go/plugins/googlegenai/cache_test.go
+++ b/go/plugins/googlegenai/cache_test.go
@@ -17,6 +17,7 @@
 package googlegenai
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -169,5 +170,97 @@ func TestExtractCacheConfig_InvalidCacheType(t *testing.T) {
 	}
 	if cs != nil {
 		t.Fatalf("expecting empty cache settings but got: %v", cs)
+	}
+}
+
+func TestFindCacheMarker_NumericTTLForms(t *testing.T) {
+	// ttlSeconds is an int when set from Go code but arrives as float64 or
+	// json.Number after a JSON round-trip (dev UI, reflection server). All
+	// numeric forms must work.
+	cases := []struct {
+		name string
+		ttl  any
+		want int
+	}{
+		{"int", int(160), 160},
+		{"int64", int64(200), 200},
+		{"float64", float64(300), 300},
+		{"json.Number", json.Number("400"), 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &ai.ModelRequest{
+				Messages: []*ai.Message{
+					{
+						Role:    ai.RoleUser,
+						Content: []*ai.Part{{Text: "Hello"}},
+						Metadata: map[string]any{"cache": map[string]any{
+							"ttlSeconds": tc.ttl,
+						}},
+					},
+				},
+			}
+			cs, err := findCacheMarker(req)
+			if err != nil {
+				t.Fatalf("findCacheMarker: %v", err)
+			}
+			if cs == nil {
+				t.Fatal("findCacheMarker = nil, want cache settings")
+			}
+			if cs.ttl != tc.want {
+				t.Errorf("ttl = %d, want %d", cs.ttl, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindCacheMarker_JSONRoundTrip(t *testing.T) {
+	// Simulates a request that passed through JSON serialization, the way
+	// the reflection server delivers it.
+	original := ai.NewUserTextMessage("cache me").WithCacheTTL(3600)
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var roundTripped ai.Message
+	if err := json.Unmarshal(b, &roundTripped); err != nil {
+		t.Fatal(err)
+	}
+
+	cs, err := findCacheMarker(&ai.ModelRequest{Messages: []*ai.Message{&roundTripped}})
+	if err != nil {
+		t.Fatalf("findCacheMarker after JSON round-trip: %v", err)
+	}
+	if cs == nil || cs.ttl != 3600 {
+		t.Fatalf("cache settings = %+v, want ttl 3600", cs)
+	}
+}
+
+func TestFindCacheMarker_InvalidTTL(t *testing.T) {
+	// A non-positive TTL would silently skip cache creation downstream, so
+	// it must be rejected loudly, as must non-numeric values. 0.5 truncates
+	// to 0 and lands in the same bucket.
+	for name, ttl := range map[string]any{
+		"non-numeric": true,
+		"zero":        0,
+		"negative":    -30,
+		"fractional":  float64(0.5),
+	} {
+		t.Run(name, func(t *testing.T) {
+			req := &ai.ModelRequest{
+				Messages: []*ai.Message{
+					{
+						Role:    ai.RoleUser,
+						Content: []*ai.Part{{Text: "Hello"}},
+						Metadata: map[string]any{"cache": map[string]any{
+							"ttlSeconds": ttl,
+						}},
+					},
+				},
+			}
+			if _, err := findCacheMarker(req); err == nil {
+				t.Fatalf("findCacheMarker = nil error, want error for ttlSeconds %v", ttl)
+			}
+		})
 	}
 }

--- a/go/plugins/googlegenai/embedder.go
+++ b/go/plugins/googlegenai/embedder.go
@@ -5,25 +5,56 @@ package googlegenai
 
 import (
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"google.golang.org/genai"
 )
 
+// Per-request input limits for embedding calls. The Gemini API's
+// batchEmbedContents endpoint accepts up to 100 requests per call; the
+// Vertex AI prediction service accepts up to 250 instances per call.
+const (
+	googleAIEmbedBatchSize = 100
+	vertexAIEmbedBatchSize = 250
+)
+
+// embedBatchSize returns how many inputs a single EmbedContent call may
+// carry for the given backend and model. Vertex AI serves its Gemini
+// embedding models and the open-source MaaS embedding models through
+// endpoints that take one input per request (the SDK enforces this for most
+// of them, and the gemini-embedding-001 prediction service enforces it
+// server side), so those batch one at a time.
+func embedBatchSize(backend genai.Backend, model string) int {
+	if backend != genai.BackendVertexAI {
+		return googleAIEmbedBatchSize
+	}
+	if strings.Contains(model, "gemini") || strings.Contains(model, "maas") {
+		return 1
+	}
+	return vertexAIEmbedBatchSize
+}
+
 // newEmbedder creates an embedder without registering it. The framework
 // validates and deserializes the request's options into
 // [genai.EmbedContentConfig] before the embedder function runs; the config
 // schema is inferred from that type unless the caller overrides it.
+//
+// Requests with more inputs than the service accepts per call are split into
+// sequential batches transparently; the response carries one embedding per
+// input, in input order.
 func newEmbedder(client *genai.Client, id string, embedOpts *ai.EmbedderOptions) *ai.EmbedderAction {
+	backend := client.ClientConfig().Backend
 	provider := googleAIProvider
-	if client.ClientConfig().Backend == genai.BackendVertexAI {
+	if backend == genai.BackendVertexAI {
 		provider = vertexAIProvider
 	}
+	batch := embedBatchSize(backend, id)
 
 	return ai.NewEmbedderAction(api.NewName(provider, id), embedOpts, func(ctx context.Context, req *ai.EmbedRequest, embedConfig genai.EmbedContentConfig) (*ai.EmbedResponse, error) {
-		var content []*genai.Content
-
+		content := make([]*genai.Content, 0, len(req.Input))
 		for _, doc := range req.Input {
 			parts, err := toGeminiParts(doc.Content)
 			if err != nil {
@@ -34,13 +65,15 @@ func newEmbedder(client *genai.Client, id string, embedOpts *ai.EmbedderOptions)
 			})
 		}
 
-		r, err := client.Models.EmbedContent(ctx, id, content, &embedConfig)
-		if err != nil {
-			return nil, err
-		}
-		var res ai.EmbedResponse
-		for _, emb := range r.Embeddings {
-			res.Embeddings = append(res.Embeddings, &ai.Embedding{Embedding: emb.Values})
+		res := ai.EmbedResponse{Embeddings: make([]*ai.Embedding, 0, len(content))}
+		for group := range slices.Chunk(content, batch) {
+			r, err := client.Models.EmbedContent(ctx, id, group, &embedConfig)
+			if err != nil {
+				return nil, wrapAPIError(err)
+			}
+			for _, emb := range r.Embeddings {
+				res.Embeddings = append(res.Embeddings, &ai.Embedding{Embedding: emb.Values})
+			}
 		}
 		return &res, nil
 	})

--- a/go/plugins/googlegenai/embedder.go
+++ b/go/plugins/googlegenai/embedder.go
@@ -22,16 +22,17 @@ const (
 )
 
 // embedBatchSize returns how many inputs a single EmbedContent call may
-// carry for the given backend and model. Vertex AI serves its Gemini
-// embedding models and the open-source MaaS embedding models through
-// endpoints that take one input per request (the SDK enforces this for most
-// of them, and the gemini-embedding-001 prediction service enforces it
-// server side), so those batch one at a time.
+// carry for the given backend and model. On Vertex AI the SDK routes some
+// models to the embedContent API, which takes one content per request, and
+// the rest to the prediction service, which batches; the condition here
+// mirrors the SDK's routing predicate (tIsVertexEmbedContentModel), under
+// which gemini-embedding-001 is served by the prediction service and so
+// batches like any other predict model.
 func embedBatchSize(backend genai.Backend, model string) int {
 	if backend != genai.BackendVertexAI {
 		return googleAIEmbedBatchSize
 	}
-	if strings.Contains(model, "gemini") || strings.Contains(model, "maas") {
+	if (strings.Contains(model, "gemini") && model != "gemini-embedding-001") || strings.Contains(model, "maas") {
 		return 1
 	}
 	return vertexAIEmbedBatchSize

--- a/go/plugins/googlegenai/embedder_test.go
+++ b/go/plugins/googlegenai/embedder_test.go
@@ -27,8 +27,10 @@ func TestEmbedBatchSize(t *testing.T) {
 		{genai.BackendGeminiAPI, "text-embedding-004", googleAIEmbedBatchSize},
 		{genai.BackendVertexAI, "text-embedding-005", vertexAIEmbedBatchSize},
 		{genai.BackendVertexAI, "multimodalembedding", vertexAIEmbedBatchSize},
-		// Vertex serves Gemini and MaaS embedding models one input per request.
-		{genai.BackendVertexAI, "gemini-embedding-001", 1},
+		// Vertex serves most Gemini and all MaaS embedding models through the
+		// one-content embedContent API, but gemini-embedding-001 through the
+		// batching prediction service, mirroring the SDK's routing predicate.
+		{genai.BackendVertexAI, "gemini-embedding-001", vertexAIEmbedBatchSize},
 		{genai.BackendVertexAI, "gemini-embedding-2", 1},
 		{genai.BackendVertexAI, "some-embedding-maas", 1},
 	}

--- a/go/plugins/googlegenai/embedder_test.go
+++ b/go/plugins/googlegenai/embedder_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"google.golang.org/genai"
+)
+
+func TestEmbedBatchSize(t *testing.T) {
+	cases := []struct {
+		backend genai.Backend
+		model   string
+		want    int
+	}{
+		{genai.BackendGeminiAPI, "gemini-embedding-001", googleAIEmbedBatchSize},
+		{genai.BackendGeminiAPI, "text-embedding-004", googleAIEmbedBatchSize},
+		{genai.BackendVertexAI, "text-embedding-005", vertexAIEmbedBatchSize},
+		{genai.BackendVertexAI, "multimodalembedding", vertexAIEmbedBatchSize},
+		// Vertex serves Gemini and MaaS embedding models one input per request.
+		{genai.BackendVertexAI, "gemini-embedding-001", 1},
+		{genai.BackendVertexAI, "gemini-embedding-2", 1},
+		{genai.BackendVertexAI, "some-embedding-maas", 1},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v/%s", tc.backend, tc.model), func(t *testing.T) {
+			if got := embedBatchSize(tc.backend, tc.model); got != tc.want {
+				t.Errorf("embedBatchSize(%v, %q) = %d, want %d", tc.backend, tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEmbedderBatchesLargeInputs verifies that an embed request with more
+// inputs than the service accepts per call is split into multiple calls and
+// that the embeddings come back in input order.
+func TestEmbedderBatchesLargeInputs(t *testing.T) {
+	const docCount = googleAIEmbedBatchSize + 50
+
+	var batchSizes []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Requests []json.RawMessage `json:"requests"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding request body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		batchSizes = append(batchSizes, len(body.Requests))
+
+		embeddings := make([]map[string]any, len(body.Requests))
+		for i := range body.Requests {
+			embeddings[i] = map[string]any{"values": []float64{float64(len(batchSizes)), float64(i)}}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"embeddings": embeddings})
+	}))
+	defer srv.Close()
+
+	embedder := newEmbedder(newTestClient(t, srv.URL), "text-embedding-004", &ai.EmbedderOptions{})
+
+	req := &ai.EmbedRequest{}
+	for i := 0; i < docCount; i++ {
+		req.Input = append(req.Input, ai.DocumentFromText(fmt.Sprintf("doc %d", i), nil))
+	}
+
+	resp, err := embedder.Embed(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+
+	if len(batchSizes) != 2 || batchSizes[0] != googleAIEmbedBatchSize || batchSizes[1] != 50 {
+		t.Errorf("batch sizes = %v, want [%d 50]", batchSizes, googleAIEmbedBatchSize)
+	}
+	if len(resp.Embeddings) != docCount {
+		t.Fatalf("got %d embeddings, want %d", len(resp.Embeddings), docCount)
+	}
+	// First embedding of the second batch carries batch number 2, index 0,
+	// proving order is preserved across batches.
+	second := resp.Embeddings[googleAIEmbedBatchSize].Embedding
+	if len(second) != 2 || second[0] != 2 || second[1] != 0 {
+		t.Errorf("first embedding of second batch = %v, want [2 0]", second)
+	}
+}
+
+// TestEmbedderWrapsAPIErrors verifies that service errors surface with their
+// status classification intact.
+func TestEmbedderWrapsAPIErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `{"error": {"code": 429, "status": "RESOURCE_EXHAUSTED", "message": "quota exceeded"}}`)
+	}))
+	defer srv.Close()
+
+	embedder := newEmbedder(newTestClient(t, srv.URL), "text-embedding-004", &ai.EmbedderOptions{})
+	_, err := embedder.Embed(context.Background(), &ai.EmbedRequest{
+		Input: []*ai.Document{ai.DocumentFromText("doc", nil)},
+	})
+	if err == nil {
+		t.Fatal("Embed = nil error, want quota error")
+	}
+	var ge *core.GenkitError
+	if !errors.As(err, &ge) {
+		t.Fatalf("error %v (%T) is not status-classified", err, err)
+	}
+	if ge.Status != core.RESOURCE_EXHAUSTED {
+		t.Errorf("status = %q, want RESOURCE_EXHAUSTED", ge.Status)
+	}
+}

--- a/go/plugins/googlegenai/errors.go
+++ b/go/plugins/googlegenai/errors.go
@@ -18,6 +18,8 @@ package googlegenai
 
 import (
 	"errors"
+	"strings"
+	"time"
 
 	"google.golang.org/genai"
 
@@ -27,6 +29,9 @@ import (
 // wrapAPIError wraps a [genai.APIError] in a [status.Error] whose status
 // matches the one the server reported so status-aware middleware (retry,
 // fallback, ...) can reason about it. Non-APIError values pass through.
+// When the service attached retry information (rate limits report the delay
+// to wait before retrying), it is carried in the error's Details under
+// "retryAfterMs" and is also readable through [RetryDelay].
 //
 // The SDK's Status string is a canonical Google / gRPC status name and so
 // matches the string value of each [status.Name] constant directly.
@@ -39,7 +44,51 @@ func wrapAPIError(err error) error {
 	if !errors.As(err, &apiErr) {
 		return err
 	}
-	return status.Errorf(status.Base(statusForAPIError(apiErr)), "%w", err)
+	serr := status.Errorf(status.Base(statusForAPIError(apiErr)), "%w", err)
+	if d, ok := retryDelayFromAPIError(apiErr); ok {
+		serr = serr.WithDetails(map[string]any{"retryAfterMs": d.Milliseconds()})
+	}
+	return serr
+}
+
+// RetryDelay reports the delay the service asked the caller to wait before
+// retrying, taken from the google.rpc.RetryInfo detail that Gemini and
+// Vertex AI attach to RESOURCE_EXHAUSTED (429) errors. It reads errors
+// returned by this plugin's actions, including wrapped ones. The second
+// result is false when err carries no retry information.
+func RetryDelay(err error) (time.Duration, bool) {
+	var apiErr genai.APIError
+	if !errors.As(err, &apiErr) {
+		return 0, false
+	}
+	return retryDelayFromAPIError(apiErr)
+}
+
+// retryDelayFromAPIError extracts the google.rpc.RetryInfo delay from the
+// error's details.
+func retryDelayFromAPIError(apiErr genai.APIError) (time.Duration, bool) {
+	for _, detail := range apiErr.Details {
+		typ, _ := detail["@type"].(string)
+		if !strings.HasSuffix(typ, "google.rpc.RetryInfo") {
+			continue
+		}
+		switch rd := detail["retryDelay"].(type) {
+		case string:
+			// Proto JSON renders a Duration as a decimal-seconds string,
+			// e.g. "58s" or "0.5s".
+			if d, perr := time.ParseDuration(rd); perr == nil {
+				return d, true
+			}
+		case map[string]any:
+			// Some transports render the Duration message fields instead.
+			secs, okSecs := castToFloat64(rd["seconds"])
+			nanos, okNanos := castToFloat64(rd["nanos"])
+			if okSecs || okNanos {
+				return time.Duration(secs*float64(time.Second) + nanos), true
+			}
+		}
+	}
+	return 0, false
 }
 
 func statusForAPIError(e genai.APIError) status.Name {

--- a/go/plugins/googlegenai/errors_test.go
+++ b/go/plugins/googlegenai/errors_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/firebase/genkit/go/core"
 	"google.golang.org/genai"
@@ -133,5 +134,108 @@ func TestWrapAPIError_HandlesWrappedAPIError(t *testing.T) {
 	}
 	if ge.Status != core.UNAVAILABLE {
 		t.Fatalf("status = %q, want UNAVAILABLE", ge.Status)
+	}
+}
+
+func TestRetryDelay_FromRetryInfoString(t *testing.T) {
+	api := genai.APIError{
+		Code:   429,
+		Status: "RESOURCE_EXHAUSTED",
+		Details: []map[string]any{
+			{"@type": "type.googleapis.com/google.rpc.QuotaFailure"},
+			{
+				"@type":      "type.googleapis.com/google.rpc.RetryInfo",
+				"retryDelay": "58s",
+			},
+		},
+	}
+	d, ok := RetryDelay(api)
+	if !ok {
+		t.Fatal("RetryDelay = false, want true")
+	}
+	if want := 58 * time.Second; d != want {
+		t.Fatalf("RetryDelay = %v, want %v", d, want)
+	}
+}
+
+func TestRetryDelay_FromRetryInfoDurationFields(t *testing.T) {
+	api := genai.APIError{
+		Code:   429,
+		Status: "RESOURCE_EXHAUSTED",
+		Details: []map[string]any{
+			{
+				"@type": "type.googleapis.com/google.rpc.RetryInfo",
+				// json.Unmarshal produces float64 for numbers.
+				"retryDelay": map[string]any{"seconds": float64(2), "nanos": float64(500000000)},
+			},
+		},
+	}
+	d, ok := RetryDelay(api)
+	if !ok {
+		t.Fatal("RetryDelay = false, want true")
+	}
+	if want := 2500 * time.Millisecond; d != want {
+		t.Fatalf("RetryDelay = %v, want %v", d, want)
+	}
+}
+
+func TestRetryDelay_ThroughWrappedError(t *testing.T) {
+	api := genai.APIError{
+		Code:   429,
+		Status: "RESOURCE_EXHAUSTED",
+		Details: []map[string]any{
+			{
+				"@type":      "type.googleapis.com/google.rpc.RetryInfo",
+				"retryDelay": "1.5s",
+			},
+		},
+	}
+	wrapped := fmt.Errorf("generate: %w", wrapAPIError(api))
+	d, ok := RetryDelay(wrapped)
+	if !ok {
+		t.Fatal("RetryDelay through wrapped error = false, want true")
+	}
+	if want := 1500 * time.Millisecond; d != want {
+		t.Fatalf("RetryDelay = %v, want %v", d, want)
+	}
+}
+
+func TestRetryDelay_AbsentOrMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"non-API error", errors.New("plain")},
+		{"no details", genai.APIError{Code: 429, Status: "RESOURCE_EXHAUSTED"}},
+		{"no retry info", genai.APIError{Code: 429, Details: []map[string]any{{"@type": "type.googleapis.com/google.rpc.QuotaFailure"}}}},
+		{"bad delay value", genai.APIError{Code: 429, Details: []map[string]any{{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "soon"}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if d, ok := RetryDelay(tc.err); ok {
+				t.Fatalf("RetryDelay = (%v, true), want false", d)
+			}
+		})
+	}
+}
+
+func TestWrapAPIError_AttachesRetryAfterDetails(t *testing.T) {
+	api := genai.APIError{
+		Code:   429,
+		Status: "RESOURCE_EXHAUSTED",
+		Details: []map[string]any{
+			{
+				"@type":      "type.googleapis.com/google.rpc.RetryInfo",
+				"retryDelay": "3s",
+			},
+		},
+	}
+	wrapped := wrapAPIError(api)
+	var ge *core.GenkitError
+	if !errors.As(wrapped, &ge) {
+		t.Fatalf("wrapAPIError did not produce a GenkitError; got %T", wrapped)
+	}
+	if got, want := ge.Details["retryAfterMs"], int64(3000); got != want {
+		t.Fatalf("Details[retryAfterMs] = %v (%T), want %v", got, got, want)
 	}
 }

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -199,67 +199,127 @@ func generate(
 	// Streaming version.
 	iter := client.Models.GenerateContentStream(ctx, model, contents, gcc)
 
-	var r *ai.ModelResponse
-	var genaiResp *genai.GenerateContentResponse
-
-	genaiParts := []*genai.Part{}
-	chunks := []*ai.Part{}
+	var (
+		sawChunk   bool
+		usage      *genai.GenerateContentResponseUsageMetadata
+		feedback   *genai.GenerateContentResponsePromptFeedback
+		merged     *genai.Candidate // candidate metadata merged across chunks
+		genaiParts []*genai.Part
+		chunks     []*ai.Part
+	)
 	for chunk, err := range iter {
 		// abort stream if error found in the iterator items
 		if err != nil {
 			return nil, wrapAPIError(err)
 		}
+		sawChunk = true
 		for _, c := range chunk.Candidates {
+			if merged == nil {
+				merged = &genai.Candidate{}
+			}
+			mergeCandidateMetadata(merged, c)
+			// Metadata-only candidates (safety ratings, citations, or a
+			// terminal finish reason without content) carry nothing to
+			// stream; their metadata is merged above.
+			if c.Content == nil {
+				continue
+			}
 			tc, err := translateCandidate(c)
 			if err != nil {
 				return nil, err
 			}
-			err = cb(ctx, &ai.ModelResponseChunk{
-				Content: tc.Message.Content,
-				Role:    ai.RoleModel,
-			})
-			if err != nil {
-				return nil, err
+			if len(tc.Message.Content) > 0 {
+				err = cb(ctx, &ai.ModelResponseChunk{
+					Content: tc.Message.Content,
+					Role:    ai.RoleModel,
+				})
+				if err != nil {
+					return nil, err
+				}
 			}
+			// preserve original parts since they will be included in the
+			// "custom" response field
 			genaiParts = append(genaiParts, c.Content.Parts...)
 			chunks = append(chunks, tc.Message.Content...)
 		}
-		genaiResp = chunk
-
+		if chunk.UsageMetadata != nil {
+			usage = chunk.UsageMetadata
+		}
+		if chunk.PromptFeedback != nil {
+			feedback = chunk.PromptFeedback
+		}
+	}
+	if !sawChunk {
+		// A stream can end without yielding a chunk: the SDK only logs a
+		// scanner failure rather than surfacing it, so an empty or truncated
+		// 2xx body reaches here with no error to report.
+		return nil, errors.New("model stream returned no responses")
 	}
 
-	// A stream that ends without yielding a chunk leaves genaiResp nil. The
-	// SDK only logs a scanner failure rather than surfacing it, so an empty or
-	// truncated 2xx body reaches here with no error to report.
-	if genaiResp == nil || len(genaiResp.Candidates) == 0 {
-		return nil, fmt.Errorf("no valid candidates found")
+	// Fold the stream back into a single response: one candidate carrying the
+	// accumulated parts plus the metadata merged across chunks, and the last
+	// usage metadata and prompt feedback seen (neither arrives on every
+	// chunk).
+	resp := &genai.GenerateContentResponse{
+		UsageMetadata:  usage,
+		PromptFeedback: feedback,
+	}
+	if merged != nil {
+		merged.Content = &genai.Content{
+			Role:  string(ai.RoleModel),
+			Parts: genaiParts,
+		}
+		resp.Candidates = []*genai.Candidate{merged}
 	}
 
-	// preserve original parts since they will be included in the
-	// "custom" response field
-	merged := []*genai.Candidate{
-		{
-			FinishReason: genaiResp.Candidates[0].FinishReason,
-			Content: &genai.Content{
-				Role:  string(ai.RoleModel),
-				Parts: genaiParts,
-			},
-		},
-	}
-
-	genaiResp.Candidates = merged
-	r, err = translateResponse(genaiResp)
-	r.Message.Content = chunks
-
+	r, err := translateResponse(resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate contents: %w", err)
+		return nil, err
 	}
+	r.Message.Content = chunks
 	r.Request = input
 	if cache != nil {
 		r.Message.Metadata = cacheMetadata(r.Message.Metadata, cache)
 	}
 
 	return r, nil
+}
+
+// mergeCandidateMetadata folds the metadata of a streamed candidate into dst.
+// Content is accumulated separately by the caller. Citations accumulate
+// across chunks; every other field describes the response as a whole, so the
+// latest chunk that carries a value wins.
+func mergeCandidateMetadata(dst, src *genai.Candidate) {
+	if src.FinishReason != "" {
+		dst.FinishReason = src.FinishReason
+	}
+	if src.FinishMessage != "" {
+		dst.FinishMessage = src.FinishMessage
+	}
+	if src.TokenCount != 0 {
+		dst.TokenCount = src.TokenCount
+	}
+	if src.AvgLogprobs != 0 {
+		dst.AvgLogprobs = src.AvgLogprobs
+	}
+	if src.LogprobsResult != nil {
+		dst.LogprobsResult = src.LogprobsResult
+	}
+	if src.GroundingMetadata != nil {
+		dst.GroundingMetadata = src.GroundingMetadata
+	}
+	if src.URLContextMetadata != nil {
+		dst.URLContextMetadata = src.URLContextMetadata
+	}
+	if len(src.SafetyRatings) > 0 {
+		dst.SafetyRatings = src.SafetyRatings
+	}
+	if src.CitationMetadata != nil {
+		if dst.CitationMetadata == nil {
+			dst.CitationMetadata = &genai.CitationMetadata{}
+		}
+		dst.CitationMetadata.Citations = append(dst.CitationMetadata.Citations, src.CitationMetadata.Citations...)
+	}
 }
 
 // toGeminiContents converts the non-system messages of an [*ai.ModelRequest]
@@ -276,6 +336,12 @@ func toGeminiContents(input *ai.ModelRequest) ([]*genai.Content, error) {
 		parts, err := toGeminiParts(m.Content)
 		if err != nil {
 			return nil, err
+		}
+		// The API rejects contents with zero parts. History can legitimately
+		// carry a contentless message (e.g. a blocked model turn replayed
+		// via resp.History()), so skip it rather than fail the request.
+		if len(parts) == 0 {
+			continue
 		}
 
 		contents = append(contents, &genai.Content{
@@ -493,10 +559,20 @@ func translateCandidate(cand *genai.Candidate) (*ai.ModelResponse, error) {
 	}
 
 	m.FinishMessage = cand.FinishMessage
-	if cand.Content == nil {
-		return nil, fmt.Errorf("no valid candidates were found in the generate response")
-	}
 	msg := &ai.Message{}
+	if cand.Content == nil {
+		// Candidates terminated before producing content (safety blocks and
+		// other early terminations) arrive without Content. Return them as a
+		// contentless response with the mapped finish reason rather than
+		// failing the request; a candidate with neither content nor a finish
+		// reason is malformed.
+		if m.FinishReason == "" {
+			return nil, fmt.Errorf("no valid candidates were found in the generate response")
+		}
+		msg.Role = ai.RoleModel
+		m.Message = msg
+		return m, nil
+	}
 	msg.Role = ai.Role(cand.Content.Role)
 	// A single genai.Part may have several fields populated at once (e.g.
 	// image-generation models can return text alongside InlineData). Emit a
@@ -554,18 +630,36 @@ func translateCandidate(cand *genai.Candidate) (*ai.ModelResponse, error) {
 	return m, nil
 }
 
+// promptBlocked reports whether the service refused the prompt outright: no
+// candidates come back and the reason is reported through PromptFeedback.
+func promptBlocked(resp *genai.GenerateContentResponse) bool {
+	fb := resp.PromptFeedback
+	return fb != nil && fb.BlockReason != "" && fb.BlockReason != genai.BlockedReasonUnspecified
+}
+
 // translateResponse translates from a genai.GenerateContentResponse to a ai.ModelResponse.
 func translateResponse(resp *genai.GenerateContentResponse) (*ai.ModelResponse, error) {
 	var r *ai.ModelResponse
 	var err error
 
-	if len(resp.Candidates) > 0 {
+	switch {
+	case len(resp.Candidates) > 0:
 		r, err = translateCandidate(resp.Candidates[0])
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		r = &ai.ModelResponse{}
+	case promptBlocked(resp):
+		msg := resp.PromptFeedback.BlockReasonMessage
+		if msg == "" {
+			msg = fmt.Sprintf("prompt blocked: %s", resp.PromptFeedback.BlockReason)
+		}
+		r = &ai.ModelResponse{
+			FinishReason:  ai.FinishReasonBlocked,
+			FinishMessage: msg,
+			Message:       &ai.Message{Role: ai.RoleModel},
+		}
+	default:
+		return nil, errors.New("model returned no candidates")
 	}
 
 	if r.Usage == nil {
@@ -575,6 +669,9 @@ func translateResponse(resp *genai.GenerateContentResponse) (*ai.ModelResponse, 
 	// populate "custom" with plugin custom information
 	custom := make(map[string]any)
 	custom["candidates"] = resp.Candidates
+	if resp.PromptFeedback != nil {
+		custom["promptFeedback"] = resp.PromptFeedback
+	}
 
 	if u := resp.UsageMetadata; u != nil {
 		r.Usage.InputTokens = int(u.PromptTokenCount)

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -632,6 +632,10 @@ func translateCandidate(cand *genai.Candidate) (*ai.ModelResponse, error) {
 
 // promptBlocked reports whether the service refused the prompt outright: no
 // candidates come back and the reason is reported through PromptFeedback.
+// Serving this as a blocked response is a deliberate divergence from the JS
+// plugin, which throws FAILED_PRECONDITION on every zero-candidate response:
+// the finish reason and message carry why the prompt was refused, where the
+// error names only the absence of candidates.
 func promptBlocked(resp *genai.GenerateContentResponse) bool {
 	fb := resp.PromptFeedback
 	return fb != nil && fb.BlockReason != "" && fb.BlockReason != genai.BlockedReasonUnspecified

--- a/go/plugins/googlegenai/gemini_test.go
+++ b/go/plugins/googlegenai/gemini_test.go
@@ -17,7 +17,11 @@
 package googlegenai
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
@@ -1536,4 +1540,257 @@ func TestCallerConfigNotMutated(t *testing.T) {
 			t.Error("cloning the ToolConfig dropped the caller's RetrievalConfig")
 		}
 	})
+}
+
+func TestTranslateCandidateBlockedWithoutContent(t *testing.T) {
+	// Safety-blocked candidates arrive with a finish reason but no Content.
+	// They must come back as a contentless blocked response, not an error.
+	cand := &genai.Candidate{
+		FinishReason:  genai.FinishReasonSafety,
+		FinishMessage: "blocked for safety",
+	}
+	r, err := translateCandidate(cand)
+	if err != nil {
+		t.Fatalf("translateCandidate: %v", err)
+	}
+	if r.FinishReason != ai.FinishReasonBlocked {
+		t.Errorf("FinishReason = %q, want %q", r.FinishReason, ai.FinishReasonBlocked)
+	}
+	if r.FinishMessage != "blocked for safety" {
+		t.Errorf("FinishMessage = %q, want %q", r.FinishMessage, "blocked for safety")
+	}
+	if r.Message == nil {
+		t.Fatal("Message = nil, want an empty model message")
+	}
+	if len(r.Message.Content) != 0 {
+		t.Errorf("Message.Content = %v, want empty", r.Message.Content)
+	}
+	if r.Message.Role != ai.RoleModel {
+		t.Errorf("Message.Role = %q, want %q", r.Message.Role, ai.RoleModel)
+	}
+}
+
+func TestTranslateCandidateNoContentNoFinishReason(t *testing.T) {
+	// A candidate with neither content nor a finish reason is malformed.
+	if _, err := translateCandidate(&genai.Candidate{}); err == nil {
+		t.Fatal("translateCandidate = nil error, want error for malformed candidate")
+	}
+}
+
+func TestTranslateResponsePromptBlocked(t *testing.T) {
+	resp := &genai.GenerateContentResponse{
+		PromptFeedback: &genai.GenerateContentResponsePromptFeedback{
+			BlockReason: genai.BlockedReasonSafety,
+		},
+	}
+	r, err := translateResponse(resp)
+	if err != nil {
+		t.Fatalf("translateResponse: %v", err)
+	}
+	if r.FinishReason != ai.FinishReasonBlocked {
+		t.Errorf("FinishReason = %q, want %q", r.FinishReason, ai.FinishReasonBlocked)
+	}
+	if r.FinishMessage == "" {
+		t.Error("FinishMessage is empty, want a block explanation")
+	}
+	if r.Message == nil {
+		t.Fatal("Message = nil, want an empty model message")
+	}
+	if _, ok := r.Custom.(map[string]any)["promptFeedback"]; !ok {
+		t.Error("Custom[promptFeedback] missing")
+	}
+}
+
+func TestTranslateResponsePromptBlockedMessagePreferred(t *testing.T) {
+	resp := &genai.GenerateContentResponse{
+		PromptFeedback: &genai.GenerateContentResponsePromptFeedback{
+			BlockReason:        genai.BlockedReasonBlocklist,
+			BlockReasonMessage: "term is on a blocklist",
+		},
+	}
+	r, err := translateResponse(resp)
+	if err != nil {
+		t.Fatalf("translateResponse: %v", err)
+	}
+	if r.FinishMessage != "term is on a blocklist" {
+		t.Errorf("FinishMessage = %q, want the service-provided message", r.FinishMessage)
+	}
+}
+
+func TestTranslateResponseNoCandidates(t *testing.T) {
+	if _, err := translateResponse(&genai.GenerateContentResponse{}); err == nil {
+		t.Fatal("translateResponse = nil error, want error when no candidates and no prompt feedback")
+	}
+}
+
+func TestMergeCandidateMetadata(t *testing.T) {
+	dst := &genai.Candidate{}
+
+	mergeCandidateMetadata(dst, &genai.Candidate{
+		SafetyRatings: []*genai.SafetyRating{{Category: genai.HarmCategoryHateSpeech}},
+		CitationMetadata: &genai.CitationMetadata{
+			Citations: []*genai.Citation{{URI: "https://one.example"}},
+		},
+	})
+	mergeCandidateMetadata(dst, &genai.Candidate{
+		FinishReason: genai.FinishReasonStop,
+		GroundingMetadata: &genai.GroundingMetadata{
+			WebSearchQueries: []string{"genkit"},
+		},
+		SafetyRatings: []*genai.SafetyRating{{Category: genai.HarmCategoryDangerousContent}},
+		CitationMetadata: &genai.CitationMetadata{
+			Citations: []*genai.Citation{{URI: "https://two.example"}},
+		},
+	})
+
+	if dst.FinishReason != genai.FinishReasonStop {
+		t.Errorf("FinishReason = %q, want STOP", dst.FinishReason)
+	}
+	if dst.GroundingMetadata == nil || len(dst.GroundingMetadata.WebSearchQueries) != 1 {
+		t.Errorf("GroundingMetadata = %+v, want web search queries preserved", dst.GroundingMetadata)
+	}
+	// Citations accumulate; safety ratings take the latest chunk's values.
+	if got := len(dst.CitationMetadata.Citations); got != 2 {
+		t.Errorf("Citations count = %d, want 2", got)
+	}
+	if len(dst.SafetyRatings) != 1 || dst.SafetyRatings[0].Category != genai.HarmCategoryDangerousContent {
+		t.Errorf("SafetyRatings = %+v, want only the latest ratings", dst.SafetyRatings)
+	}
+}
+
+// newTestClient returns a Gemini API genai client. A non-empty baseURL
+// points it at a fake server instead of the real API; with "" the client is
+// only good for constructing actions, never for requests.
+func newTestClient(t *testing.T, baseURL string) *genai.Client {
+	t.Helper()
+	client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+		Backend: genai.BackendGeminiAPI,
+		APIKey:  "test-api-key",
+		HTTPOptions: genai.HTTPOptions{
+			BaseURL: baseURL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}
+
+func sseHandler(lines ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, l := range lines {
+			fmt.Fprintf(w, "data: %s\n\n", l)
+		}
+	}
+}
+
+func streamInput() *ai.ModelRequest {
+	return &ai.ModelRequest{
+		Messages: []*ai.Message{
+			{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart("hi")}},
+		},
+	}
+}
+
+func TestGenerateStreamPreservesCandidateMetadata(t *testing.T) {
+	srv := httptest.NewServer(sseHandler(
+		`{"candidates":[{"content":{"role":"model","parts":[{"text":"hello "}]}}]}`,
+		`{"candidates":[{"content":{"role":"model","parts":[{"text":"world"}]},"finishReason":"STOP","groundingMetadata":{"webSearchQueries":["genkit"]},"safetyRatings":[{"category":"HARM_CATEGORY_HATE_SPEECH","probability":"NEGLIGIBLE"}]}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}`,
+	))
+	defer srv.Close()
+	client := newTestClient(t, srv.URL)
+
+	var streamed []*ai.Part
+	cb := func(ctx context.Context, c *ai.ModelResponseChunk) error {
+		streamed = append(streamed, c.Content...)
+		return nil
+	}
+	r, err := generate(context.Background(), client, "gemini-flash-latest", streamInput(), &genai.GenerateContentConfig{}, cb)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if got := r.Text(); got != "hello world" {
+		t.Errorf("Text() = %q, want %q", got, "hello world")
+	}
+	if len(streamed) != 2 {
+		t.Errorf("streamed %d parts, want 2", len(streamed))
+	}
+	if r.FinishReason != ai.FinishReasonStop {
+		t.Errorf("FinishReason = %q, want %q", r.FinishReason, ai.FinishReasonStop)
+	}
+	if r.Usage == nil || r.Usage.TotalTokens != 3 {
+		t.Errorf("Usage = %+v, want total tokens 3", r.Usage)
+	}
+
+	cands, ok := r.Custom.(map[string]any)["candidates"].([]*genai.Candidate)
+	if !ok || len(cands) != 1 {
+		t.Fatalf("Custom[candidates] = %#v, want one candidate", r.Custom)
+	}
+	if cands[0].GroundingMetadata == nil || len(cands[0].GroundingMetadata.WebSearchQueries) != 1 {
+		t.Errorf("GroundingMetadata = %+v, want web search queries preserved across the stream", cands[0].GroundingMetadata)
+	}
+	if len(cands[0].SafetyRatings) != 1 {
+		t.Errorf("SafetyRatings = %+v, want ratings preserved across the stream", cands[0].SafetyRatings)
+	}
+}
+
+func TestGenerateStreamEmptyStream(t *testing.T) {
+	srv := httptest.NewServer(sseHandler())
+	defer srv.Close()
+	client := newTestClient(t, srv.URL)
+
+	cb := func(ctx context.Context, c *ai.ModelResponseChunk) error { return nil }
+	_, err := generate(context.Background(), client, "gemini-flash-latest", streamInput(), &genai.GenerateContentConfig{}, cb)
+	if err == nil {
+		t.Fatal("generate = nil error, want error for an empty stream")
+	}
+}
+
+func TestGenerateStreamPromptBlocked(t *testing.T) {
+	srv := httptest.NewServer(sseHandler(
+		`{"promptFeedback":{"blockReason":"SAFETY"}}`,
+	))
+	defer srv.Close()
+	client := newTestClient(t, srv.URL)
+
+	var streamed int
+	cb := func(ctx context.Context, c *ai.ModelResponseChunk) error {
+		streamed++
+		return nil
+	}
+	r, err := generate(context.Background(), client, "gemini-flash-latest", streamInput(), &genai.GenerateContentConfig{}, cb)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if r.FinishReason != ai.FinishReasonBlocked {
+		t.Errorf("FinishReason = %q, want %q", r.FinishReason, ai.FinishReasonBlocked)
+	}
+	if streamed != 0 {
+		t.Errorf("streamed %d chunks, want 0", streamed)
+	}
+}
+
+func TestGenerateStreamBlockedCandidateMidStream(t *testing.T) {
+	// A candidate that terminates on safety mid-stream has a finish reason
+	// but no content in its final chunk.
+	srv := httptest.NewServer(sseHandler(
+		`{"candidates":[{"content":{"role":"model","parts":[{"text":"so far"}]}}]}`,
+		`{"candidates":[{"finishReason":"SAFETY"}]}`,
+	))
+	defer srv.Close()
+	client := newTestClient(t, srv.URL)
+
+	cb := func(ctx context.Context, c *ai.ModelResponseChunk) error { return nil }
+	r, err := generate(context.Background(), client, "gemini-flash-latest", streamInput(), &genai.GenerateContentConfig{}, cb)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if r.FinishReason != ai.FinishReasonBlocked {
+		t.Errorf("FinishReason = %q, want %q", r.FinishReason, ai.FinishReasonBlocked)
+	}
+	if got := r.Text(); got != "so far" {
+		t.Errorf("Text() = %q, want %q", got, "so far")
+	}
 }

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -9,13 +9,16 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
+	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/credentials"
 	"cloud.google.com/go/auth/httptransport"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/genkit"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -54,6 +57,20 @@ func rejectBackgroundModel(provider, id string) error {
 type GoogleAI struct {
 	APIKey string // API key to access the service. If empty, the values of the environment variables GEMINI_API_KEY or GOOGLE_API_KEY will be consulted, in that order.
 
+	// BaseURL overrides the default API endpoint
+	// (https://generativelanguage.googleapis.com), e.g. to point at a proxy
+	// or an API gateway. Optional.
+	BaseURL string
+	// Headers are additional HTTP headers to send with every request. They
+	// are merged over the plugin's default headers, so a header set here wins
+	// on collision. Optional.
+	Headers http.Header
+	// HTTPClient is the HTTP client used for API requests. When set, it is
+	// used verbatim: the plugin does not install its default OpenTelemetry
+	// instrumented transport, so wrap your own transport with otelhttp if you
+	// want tracing. Optional.
+	HTTPClient *http.Client
+
 	// Models overrides what the plugin knows about a model, keyed by model ID.
 	// Every model the backend serves already works without an entry here:
 	// known IDs carry curated capabilities and the rest take the defaults for
@@ -87,6 +104,30 @@ type VertexAI struct {
 	Location   string // Location of the Vertex AI service. If empty, GOOGLE_CLOUD_LOCATION and GOOGLE_CLOUD_REGION environment variables will be consulted, in that order. Accepts a regional location (e.g. "us-central1"), a multi-region location ("us" or "eu"), or "global".
 	APIVersion string // API version to use ("v1" or "v1beta1"). If empty, the genai SDK default (v1beta1) is used. Can be overridden per-request via config.HTTPOptions.APIVersion.
 
+	// APIKey enables Vertex AI Express Mode: API key authentication with no
+	// Google Cloud project, location, or Application Default Credentials
+	// involved. See
+	// https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview.
+	// Mutually exclusive with ProjectID, Location, and Credentials. Optional.
+	APIKey string
+	// Credentials overrides the Google Cloud credentials used to authenticate.
+	// If nil, Application Default Credentials are detected. Mutually exclusive
+	// with APIKey and HTTPClient. Optional.
+	Credentials *auth.Credentials
+	// BaseURL overrides the default location-derived API endpoint, e.g. to
+	// point at a proxy or an API gateway. Optional.
+	BaseURL string
+	// Headers are additional HTTP headers to send with every request. They
+	// are merged over the plugin's default headers, so a header set here wins
+	// on collision. Optional.
+	Headers http.Header
+	// HTTPClient is the HTTP client used for API requests. When set, it is
+	// used verbatim and must handle authentication itself (unless APIKey is
+	// set, which rides on a request header): the plugin does not install its
+	// default credential-carrying, OpenTelemetry instrumented transport.
+	// Optional.
+	HTTPClient *http.Client
+
 	// Models overrides what the plugin knows about a model, keyed by model ID;
 	// see [GoogleAI.Models]. Tuned Gemini endpoints are keyed in either the
 	// short form `endpoints/ID` or the full resource path
@@ -103,6 +144,58 @@ type VertexAI struct {
 	initted bool          // Whether the plugin has been initialized.
 }
 
+// firstEnv returns the value of the first environment variable in names that
+// is set to a non-empty value.
+func firstEnv(names ...string) string {
+	for _, n := range names {
+		if v := os.Getenv(n); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// vertexLocationFromEnv returns the Vertex AI location named by the
+// environment, or "".
+func vertexLocationFromEnv() string {
+	return firstEnv("GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION")
+}
+
+// vertexAPIKeyFromEnv returns the Vertex AI Express Mode API key named by
+// the environment and the variable it came from, or two empty strings.
+// GEMINI_API_KEY is deliberately not consulted, matching the JS plugin: it
+// names a Gemini Developer API key, which Vertex AI does not accept, and a
+// process that also uses the Google AI plugin commonly has one set.
+func vertexAPIKeyFromEnv() (key, source string) {
+	for _, name := range []string{"VERTEX_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"} {
+		if k := os.Getenv(name); k != "" {
+			return k, name
+		}
+	}
+	return "", ""
+}
+
+// mergedHeaders returns the plugin's default headers merged with extra.
+// Extra values win on key collisions.
+func mergedHeaders(extra http.Header) http.Header {
+	h := genkitClientHeader.Clone()
+	for k, vs := range extra {
+		h[http.CanonicalHeaderKey(k)] = slices.Clone(vs)
+	}
+	return h
+}
+
+// httpClientOrDefault returns c, or the plugin's default OpenTelemetry
+// instrumented client when c is nil.
+func httpClientOrDefault(c *http.Client) *http.Client {
+	if c != nil {
+		return c
+	}
+	return &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+	}
+}
+
 // Name returns the name of the plugin.
 func (ga *GoogleAI) Name() string {
 	return googleAIProvider
@@ -111,6 +204,44 @@ func (ga *GoogleAI) Name() string {
 // Name returns the name of the plugin.
 func (v *VertexAI) Name() string {
 	return vertexAIProvider
+}
+
+// expressAPIKey returns the API key that selects Express Mode, or "".
+// An explicit APIKey always selects Express Mode, and combining it with
+// project, location, or credentials panics. Explicit project, location, or
+// credentials always select credential authentication instead. With nothing
+// configured, an environment key applies only when the environment names
+// neither a project nor a location, the same precedence rule the genai SDK
+// applies to its variables (the key names follow the JS plugin; see
+// vertexAPIKeyFromEnv). For a key from the environment, source names the
+// variable it came from; for an explicit key, source is "".
+func (v *VertexAI) expressAPIKey() (key, source string) {
+	if v.APIKey != "" {
+		if v.ProjectID != "" || v.Location != "" {
+			panic("Vertex AI: APIKey (Express Mode) is mutually exclusive with ProjectID and Location")
+		}
+		if v.Credentials != nil {
+			panic("Vertex AI: APIKey (Express Mode) is mutually exclusive with Credentials")
+		}
+		return v.APIKey, ""
+	}
+	if v.ProjectID != "" || v.Location != "" || v.Credentials != nil {
+		return "", ""
+	}
+	if os.Getenv("GOOGLE_CLOUD_PROJECT") != "" || vertexLocationFromEnv() != "" {
+		return "", ""
+	}
+	return vertexAPIKeyFromEnv()
+}
+
+// customEndpointOnly reports whether the only configuration present, here or
+// in the environment, is a custom base URL. The SDK treats that as a valid
+// standalone setup (the endpoint owns authentication), so the plugin must
+// not demand a project for it. Call after expressAPIKey has returned "".
+func (v *VertexAI) customEndpointOnly() bool {
+	return v.BaseURL != "" &&
+		v.ProjectID == "" && v.Location == "" && v.Credentials == nil &&
+		os.Getenv("GOOGLE_CLOUD_PROJECT") == "" && vertexLocationFromEnv() == ""
 }
 
 // Init initializes the Google AI plugin and all known models and embedders.
@@ -128,23 +259,19 @@ func (ga *GoogleAI) Init(ctx context.Context) []api.Action {
 
 	apiKey := ga.APIKey
 	if apiKey == "" {
-		apiKey = os.Getenv("GEMINI_API_KEY")
-		if apiKey == "" {
-			apiKey = os.Getenv("GOOGLE_API_KEY")
-		}
+		apiKey = firstEnv("GEMINI_API_KEY", "GOOGLE_API_KEY")
 		if apiKey == "" {
 			panic("Google AI requires setting GEMINI_API_KEY or GOOGLE_API_KEY in the environment. You can get an API key at https://ai.google.dev")
 		}
 	}
 
 	gc := genai.ClientConfig{
-		Backend: genai.BackendGeminiAPI,
-		APIKey:  apiKey,
-		HTTPClient: &http.Client{
-			Transport: otelhttp.NewTransport(http.DefaultTransport),
-		},
+		Backend:    genai.BackendGeminiAPI,
+		APIKey:     apiKey,
+		HTTPClient: httpClientOrDefault(ga.HTTPClient),
 		HTTPOptions: genai.HTTPOptions{
-			Headers: genkitClientHeader,
+			BaseURL: ga.BaseURL,
+			Headers: mergedHeaders(ga.Headers),
 		},
 	}
 
@@ -171,62 +298,98 @@ func (v *VertexAI) Init(ctx context.Context) []api.Action {
 		panic("plugin already initialized")
 	}
 
-	projectID := v.ProjectID
-	if projectID == "" {
-		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
-		if projectID == "" {
-			panic("Vertex AI requires setting GOOGLE_CLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
-		}
-	}
-
-	location := v.Location
-	if location == "" {
-		location = os.Getenv("GOOGLE_CLOUD_LOCATION")
-		if location == "" {
-			location = os.Getenv("GOOGLE_CLOUD_REGION")
-		}
-		if location == "" {
-			panic("Vertex AI requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
-		}
-	}
-
 	switch v.APIVersion {
 	case "", "v1", "v1beta1":
 	default:
 		panic(fmt.Sprintf("Vertex AI APIVersion must be %q or %q, got %q", "v1", "v1beta1", v.APIVersion))
 	}
 
-	cred, err := credentials.DetectDefault(&credentials.DetectOptions{
-		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
-	})
-	if err != nil {
-		panic(fmt.Errorf("failed to find default credentials: %w", err))
-	}
-	quotaProjectID, err := cred.QuotaProjectID(ctx)
-	if err != nil {
-		panic(fmt.Errorf("failed to get quota project ID: %v", quotaProjectID))
-	}
-	httpClient, err := httptransport.NewClient(&httptransport.Options{
-		Credentials:      cred,
-		BaseRoundTripper: otelhttp.NewTransport(http.DefaultTransport),
-		Headers: http.Header{
-			"X-Goog-User-Project": []string{quotaProjectID},
-		},
-	})
-	if err != nil {
-		panic(fmt.Errorf("failed to create http client: %w", err))
-	}
-
-	// Project and Region values gets validated by genai SDK upon client creation
 	gc := genai.ClientConfig{
-		Backend:    genai.BackendVertexAI,
-		Project:    projectID,
-		Location:   location,
-		HTTPClient: httpClient,
+		Backend: genai.BackendVertexAI,
 		HTTPOptions: genai.HTTPOptions{
-			Headers:    genkitClientHeader,
+			BaseURL:    v.BaseURL,
+			Headers:    mergedHeaders(v.Headers),
 			APIVersion: v.APIVersion,
 		},
+	}
+
+	apiKey, keySource := v.expressAPIKey()
+	switch {
+	case apiKey != "":
+		// Express Mode: the API key alone authenticates; no project,
+		// location, or credentials are involved.
+		if keySource != "" {
+			// Breadcrumb for the ambient-key case: a Gemini Developer API
+			// key in these variables is not valid for Vertex AI and fails
+			// each request with PERMISSION_DENIED, so name where the key
+			// came from.
+			logger.FromContext(ctx).Info("Vertex AI: using Express Mode API key from environment", "variable", keySource)
+		}
+		gc.APIKey = apiKey
+		gc.HTTPClient = httpClientOrDefault(v.HTTPClient)
+	case v.customEndpointOnly():
+		// A base URL with no project, location, key, or credentials routes
+		// everything to the endpoint as-is; the endpoint owns
+		// authentication. Mirrors the SDK, which accepts a custom base URL
+		// as sufficient configuration on its own.
+		gc.HTTPClient = httpClientOrDefault(v.HTTPClient)
+	default:
+		projectID := v.ProjectID
+		if projectID == "" {
+			projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+			if projectID == "" {
+				panic("Vertex AI requires setting GOOGLE_CLOUD_PROJECT in the environment, or an Express Mode API key in VERTEX_API_KEY or GOOGLE_API_KEY. You can get a project ID at https://console.cloud.google.com/home/dashboard")
+			}
+		}
+
+		location := v.Location
+		if location == "" {
+			location = vertexLocationFromEnv()
+			if location == "" {
+				panic("Vertex AI requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
+			}
+		}
+
+		// Project and Region values gets validated by genai SDK upon client creation
+		gc.Project = projectID
+		gc.Location = location
+
+		if v.HTTPClient != nil {
+			if v.Credentials != nil {
+				panic("Vertex AI: HTTPClient and Credentials are mutually exclusive; a custom HTTP client must handle authentication itself")
+			}
+			gc.HTTPClient = v.HTTPClient
+		} else {
+			cred := v.Credentials
+			if cred == nil {
+				var err error
+				cred, err = credentials.DetectDefault(&credentials.DetectOptions{
+					Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+				})
+				if err != nil {
+					panic(fmt.Errorf("failed to find default credentials: %w", err))
+				}
+			}
+			quotaProjectID, err := cred.QuotaProjectID(ctx)
+			if err != nil {
+				panic(fmt.Errorf("failed to get quota project ID: %w", err))
+			}
+			var headers http.Header
+			if quotaProjectID != "" {
+				headers = http.Header{
+					"X-Goog-User-Project": []string{quotaProjectID},
+				}
+			}
+			httpClient, err := httptransport.NewClient(&httptransport.Options{
+				Credentials:      cred,
+				BaseRoundTripper: otelhttp.NewTransport(http.DefaultTransport),
+				Headers:          headers,
+			})
+			if err != nil {
+				panic(fmt.Errorf("failed to create http client: %w", err))
+			}
+			gc.HTTPClient = httpClient
+		}
 	}
 
 	client, err := genai.NewClient(ctx, &gc)
@@ -237,6 +400,30 @@ func (v *VertexAI) Init(ctx context.Context) []api.Action {
 	v.initted = true
 
 	return []api.Action{}
+}
+
+// Client returns the underlying Google GenAI SDK client used by the plugin.
+// It gives access to service features that Genkit does not wrap, such as the
+// Files, Caches, Batches, and Tunings APIs. It returns an error if the plugin
+// has not been initialized.
+func (ga *GoogleAI) Client() (*genai.Client, error) {
+	ga.mu.Lock()
+	defer ga.mu.Unlock()
+	if !ga.initted {
+		return nil, errors.New("GoogleAI plugin not initialized")
+	}
+	return ga.gclient, nil
+}
+
+// Client returns the underlying Google GenAI SDK client used by the plugin;
+// see [GoogleAI.Client].
+func (v *VertexAI) Client() (*genai.Client, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if !v.initted {
+		return nil, errors.New("VertexAI plugin not initialized")
+	}
+	return v.gclient, nil
 }
 
 // DefineModel defines an unknown model with the given ID.

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -55,7 +55,8 @@ func rejectBackgroundModel(provider, id string) error {
 
 // GoogleAI is a Genkit plugin for interacting with the Google AI service.
 type GoogleAI struct {
-	APIKey string // API key to access the service. If empty, the values of the environment variables GEMINI_API_KEY or GOOGLE_API_KEY will be consulted, in that order.
+	APIKey     string // API key to access the service. If empty, the values of the environment variables GEMINI_API_KEY or GOOGLE_API_KEY will be consulted, in that order.
+	APIVersion string // API version to use ("v1", "v1beta", or "v1alpha"). If empty, the genai SDK default (v1beta) is used. Can be overridden per-request via config.HTTPOptions.APIVersion.
 
 	// BaseURL overrides the default API endpoint
 	// (https://generativelanguage.googleapis.com), e.g. to point at a proxy
@@ -257,6 +258,12 @@ func (ga *GoogleAI) Init(ctx context.Context) []api.Action {
 		panic("plugin already initialized")
 	}
 
+	switch ga.APIVersion {
+	case "", "v1", "v1beta", "v1alpha":
+	default:
+		panic(fmt.Sprintf("Google AI APIVersion must be %q, %q, or %q, got %q", "v1", "v1beta", "v1alpha", ga.APIVersion))
+	}
+
 	apiKey := ga.APIKey
 	if apiKey == "" {
 		apiKey = firstEnv("GEMINI_API_KEY", "GOOGLE_API_KEY")
@@ -270,8 +277,9 @@ func (ga *GoogleAI) Init(ctx context.Context) []api.Action {
 		APIKey:     apiKey,
 		HTTPClient: httpClientOrDefault(ga.HTTPClient),
 		HTTPOptions: genai.HTTPOptions{
-			BaseURL: ga.BaseURL,
-			Headers: mergedHeaders(ga.Headers),
+			BaseURL:    ga.BaseURL,
+			Headers:    mergedHeaders(ga.Headers),
+			APIVersion: ga.APIVersion,
 		},
 	}
 

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -236,11 +236,13 @@ func (v *VertexAI) expressAPIKey() (key, source string) {
 }
 
 // customEndpointOnly reports whether the only configuration present, here or
-// in the environment, is a custom base URL. The SDK treats that as a valid
-// standalone setup (the endpoint owns authentication), so the plugin must
-// not demand a project for it. Call after expressAPIKey has returned "".
+// in the environment, is a custom base URL: the BaseURL field, or
+// GOOGLE_VERTEX_BASE_URL, which the SDK reads on its own. The SDK treats
+// that as a valid standalone setup (the endpoint owns authentication), so
+// the plugin must not demand a project for it. Call after expressAPIKey has
+// returned "".
 func (v *VertexAI) customEndpointOnly() bool {
-	return v.BaseURL != "" &&
+	return (v.BaseURL != "" || os.Getenv("GOOGLE_VERTEX_BASE_URL") != "") &&
 		v.ProjectID == "" && v.Location == "" && v.Credentials == nil &&
 		os.Getenv("GOOGLE_CLOUD_PROJECT") == "" && vertexLocationFromEnv() == ""
 }

--- a/go/plugins/googlegenai/googlegenai_test.go
+++ b/go/plugins/googlegenai/googlegenai_test.go
@@ -115,6 +115,7 @@ func clearVertexEnv(t *testing.T) {
 	for _, name := range []string{
 		"GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION",
 		"VERTEX_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY", "GEMINI_API_KEY",
+		"GOOGLE_VERTEX_BASE_URL",
 	} {
 		t.Setenv(name, "")
 	}
@@ -172,6 +173,29 @@ func TestVertexAIInit_CustomEndpointOnly(t *testing.T) {
 	cc := client.ClientConfig()
 	if cc.HTTPOptions.BaseURL != "https://my-gateway.example.com" {
 		t.Errorf("BaseURL = %q, want the configured gateway", cc.HTTPOptions.BaseURL)
+	}
+	if cc.Project != "" || cc.APIKey != "" {
+		t.Errorf("Project = %q, APIKey = %q, want both empty in custom-endpoint mode", cc.Project, cc.APIKey)
+	}
+}
+
+// TestVertexAIInit_CustomEndpointFromEnv covers the same mode selected by
+// GOOGLE_VERTEX_BASE_URL, which the SDK reads on its own: the plugin must
+// recognize it as sufficient configuration rather than demand a project.
+func TestVertexAIInit_CustomEndpointFromEnv(t *testing.T) {
+	clearVertexEnv(t)
+	t.Setenv("GOOGLE_VERTEX_BASE_URL", "https://my-gateway.example.com")
+
+	v := &googlegenai.VertexAI{}
+	v.Init(context.Background())
+
+	client, err := v.Client()
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	cc := client.ClientConfig()
+	if cc.HTTPOptions.BaseURL != "https://my-gateway.example.com" {
+		t.Errorf("BaseURL = %q, want the env gateway resolved by the SDK", cc.HTTPOptions.BaseURL)
 	}
 	if cc.Project != "" || cc.APIKey != "" {
 		t.Errorf("Project = %q, APIKey = %q, want both empty in custom-endpoint mode", cc.Project, cc.APIKey)

--- a/go/plugins/googlegenai/googlegenai_test.go
+++ b/go/plugins/googlegenai/googlegenai_test.go
@@ -39,6 +39,26 @@ func TestVertexAIInit_InvalidAPIVersion(t *testing.T) {
 	}
 }
 
+// TestGoogleAIInit_InvalidAPIVersion verifies that a bad APIVersion is
+// rejected up front, mirroring the Vertex AI check. The invalid value is
+// Vertex AI's valid one, so the test also documents that the two backends
+// name their versions differently.
+func TestGoogleAIInit_InvalidAPIVersion(t *testing.T) {
+	recovered := mustPanic(t, func() {
+		(&googlegenai.GoogleAI{
+			APIKey:     "test-api-key",
+			APIVersion: "v1beta1", // invalid: valid values are "v1", "v1beta", and "v1alpha"
+		}).Init(context.Background())
+	})
+	msg, ok := recovered.(string)
+	if !ok {
+		t.Fatalf("expected panic value to be a string, got %T: %v", recovered, recovered)
+	}
+	if !strings.Contains(msg, "v1beta1") {
+		t.Errorf("panic message %q does not mention the invalid value", msg)
+	}
+}
+
 // mustPanic runs f and returns the recovered panic value, failing the test
 // if f does not panic.
 func mustPanic(t *testing.T, f func()) any {
@@ -58,6 +78,7 @@ func TestGoogleAIInit_HTTPOptions(t *testing.T) {
 	custom := &http.Client{}
 	ga := &googlegenai.GoogleAI{
 		APIKey:     "test-api-key",
+		APIVersion: "v1alpha",
 		BaseURL:    "https://gateway.example.com",
 		Headers:    http.Header{"X-Test-Header": {"yes"}},
 		HTTPClient: custom,
@@ -71,6 +92,9 @@ func TestGoogleAIInit_HTTPOptions(t *testing.T) {
 	cc := client.ClientConfig()
 	if cc.HTTPOptions.BaseURL != "https://gateway.example.com" {
 		t.Errorf("BaseURL = %q, want the configured gateway", cc.HTTPOptions.BaseURL)
+	}
+	if cc.HTTPOptions.APIVersion != "v1alpha" {
+		t.Errorf("APIVersion = %q, want %q", cc.HTTPOptions.APIVersion, "v1alpha")
 	}
 	if got := cc.HTTPOptions.Headers.Get("X-Test-Header"); got != "yes" {
 		t.Errorf("custom header = %q, want %q", got, "yes")

--- a/go/plugins/googlegenai/googlegenai_test.go
+++ b/go/plugins/googlegenai/googlegenai_test.go
@@ -5,10 +5,17 @@ package googlegenai_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"cloud.google.com/go/auth"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"google.golang.org/genai"
 )
 
 // TestVertexAIInit_InvalidAPIVersion verifies that a bad APIVersion is
@@ -16,28 +23,300 @@ import (
 // so the failure is immediate and clear rather than a confusing 404 at
 // request time.
 func TestVertexAIInit_InvalidAPIVersion(t *testing.T) {
-	v := &googlegenai.VertexAI{
-		ProjectID:  "test-project",
-		Location:   "us-central1",
-		APIVersion: "v1beta", // invalid: valid values are "v1" and "v1beta1"
-	}
-
-	var recovered any
-	func() {
-		defer func() {
-			recovered = recover()
-		}()
-		v.Init(context.Background())
-	}()
-
-	if recovered == nil {
-		t.Fatal("expected Init to panic on invalid APIVersion, but it did not")
-	}
+	recovered := mustPanic(t, func() {
+		(&googlegenai.VertexAI{
+			ProjectID:  "test-project",
+			Location:   "us-central1",
+			APIVersion: "v1beta", // invalid: valid values are "v1" and "v1beta1"
+		}).Init(context.Background())
+	})
 	msg, ok := recovered.(string)
 	if !ok {
 		t.Fatalf("expected panic value to be a string, got %T: %v", recovered, recovered)
 	}
 	if !strings.Contains(msg, "v1beta") {
 		t.Errorf("panic message %q does not mention the invalid value", msg)
+	}
+}
+
+// mustPanic runs f and returns the recovered panic value, failing the test
+// if f does not panic.
+func mustPanic(t *testing.T, f func()) any {
+	t.Helper()
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		f()
+	}()
+	if recovered == nil {
+		t.Fatal("expected a panic, but there was none")
+	}
+	return recovered
+}
+
+func TestGoogleAIInit_HTTPOptions(t *testing.T) {
+	custom := &http.Client{}
+	ga := &googlegenai.GoogleAI{
+		APIKey:     "test-api-key",
+		BaseURL:    "https://gateway.example.com",
+		Headers:    http.Header{"X-Test-Header": {"yes"}},
+		HTTPClient: custom,
+	}
+	ga.Init(context.Background())
+
+	client, err := ga.Client()
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	cc := client.ClientConfig()
+	if cc.HTTPOptions.BaseURL != "https://gateway.example.com" {
+		t.Errorf("BaseURL = %q, want the configured gateway", cc.HTTPOptions.BaseURL)
+	}
+	if got := cc.HTTPOptions.Headers.Get("X-Test-Header"); got != "yes" {
+		t.Errorf("custom header = %q, want %q", got, "yes")
+	}
+	if got := cc.HTTPOptions.Headers.Get("x-goog-api-client"); !strings.Contains(got, "genkit-go") {
+		t.Errorf("attribution header = %q, want it to carry genkit-go", got)
+	}
+	if cc.HTTPClient != custom {
+		t.Error("HTTPClient was not used verbatim")
+	}
+}
+
+// clearVertexEnv blanks every environment variable that Vertex AI
+// initialization consults, so a test starts from a known state regardless of
+// what the developer or CI has exported.
+func clearVertexEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION",
+		"VERTEX_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY", "GEMINI_API_KEY",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+// fakeADC points Application Default Credentials at a fabricated
+// authorized-user credential file. Detection and quota-project lookup read
+// the file only, so the credential-based paths resolve identically on a
+// machine with no gcloud login.
+func fakeADC(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "adc.json")
+	const cred = `{"type":"authorized_user","client_id":"id.apps.googleusercontent.com",` +
+		`"client_secret":"secret","refresh_token":"refresh","quota_project_id":"quota-project"}`
+	if err := os.WriteFile(path, []byte(cred), 0o600); err != nil {
+		t.Fatalf("writing fake ADC file: %v", err)
+	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+}
+
+func TestVertexAIInit_ExpressMode(t *testing.T) {
+	// Express mode must work with no project, location, or credentials, in
+	// the environment or otherwise.
+	clearVertexEnv(t)
+
+	v := &googlegenai.VertexAI{APIKey: "express-key"}
+	v.Init(context.Background())
+
+	client, err := v.Client()
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	cc := client.ClientConfig()
+	if cc.Backend != genai.BackendVertexAI {
+		t.Errorf("Backend = %v, want BackendVertexAI", cc.Backend)
+	}
+	if cc.APIKey != "express-key" {
+		t.Errorf("APIKey = %q, want the express key", cc.APIKey)
+	}
+}
+
+// TestVertexAIInit_CustomEndpointOnly covers the gateway setup the SDK
+// accepts as sufficient on its own: a base URL with no project, location,
+// key, or credentials.
+func TestVertexAIInit_CustomEndpointOnly(t *testing.T) {
+	clearVertexEnv(t)
+
+	v := &googlegenai.VertexAI{BaseURL: "https://my-gateway.example.com"}
+	v.Init(context.Background())
+
+	client, err := v.Client()
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	cc := client.ClientConfig()
+	if cc.HTTPOptions.BaseURL != "https://my-gateway.example.com" {
+		t.Errorf("BaseURL = %q, want the configured gateway", cc.HTTPOptions.BaseURL)
+	}
+	if cc.Project != "" || cc.APIKey != "" {
+		t.Errorf("Project = %q, APIKey = %q, want both empty in custom-endpoint mode", cc.Project, cc.APIKey)
+	}
+}
+
+func TestVertexAIInit_ExpressModeConflicts(t *testing.T) {
+	msg := mustPanic(t, func() {
+		(&googlegenai.VertexAI{APIKey: "k", ProjectID: "p"}).Init(context.Background())
+	})
+	if !strings.Contains(fmt.Sprint(msg), "mutually exclusive") {
+		t.Errorf("panic = %v, want a mutual-exclusion explanation", msg)
+	}
+}
+
+// TestVertexAIInit_ExpressModeFromEnv covers the case that used to be a hard
+// panic: no project anywhere, but an Express Mode key in the environment.
+func TestVertexAIInit_ExpressModeFromEnv(t *testing.T) {
+	for _, name := range []string{"VERTEX_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"} {
+		t.Run(name, func(t *testing.T) {
+			clearVertexEnv(t)
+			t.Setenv(name, "env-express-key")
+
+			v := &googlegenai.VertexAI{}
+			v.Init(context.Background())
+
+			client, err := v.Client()
+			if err != nil {
+				t.Fatalf("Client: %v", err)
+			}
+			cc := client.ClientConfig()
+			if cc.APIKey != "env-express-key" {
+				t.Errorf("APIKey = %q, want the key from %s", cc.APIKey, name)
+			}
+			if cc.Project != "" {
+				t.Errorf("Project = %q, want empty in Express Mode", cc.Project)
+			}
+		})
+	}
+}
+
+func TestVertexAIInit_ExpressModeEnvPrecedence(t *testing.T) {
+	clearVertexEnv(t)
+	t.Setenv("VERTEX_API_KEY", "vertex-key")
+	t.Setenv("GOOGLE_API_KEY", "google-key")
+	t.Setenv("GOOGLE_GENAI_API_KEY", "genai-key")
+
+	v := &googlegenai.VertexAI{}
+	v.Init(context.Background())
+
+	client, err := v.Client()
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	if got := client.ClientConfig().APIKey; got != "vertex-key" {
+		t.Errorf("APIKey = %q, want VERTEX_API_KEY to win", got)
+	}
+}
+
+// TestVertexAIInit_GeminiAPIKeyIgnored guards the footgun of a process that
+// also uses the Google AI plugin: GEMINI_API_KEY names a Gemini Developer API
+// key, which Vertex AI does not accept, so it must not silently select
+// Express Mode.
+func TestVertexAIInit_GeminiAPIKeyIgnored(t *testing.T) {
+	clearVertexEnv(t)
+	t.Setenv("GEMINI_API_KEY", "developer-api-key")
+
+	msg := mustPanic(t, func() {
+		(&googlegenai.VertexAI{}).Init(context.Background())
+	})
+	if !strings.Contains(fmt.Sprint(msg), "GOOGLE_CLOUD_PROJECT") {
+		t.Errorf("panic = %v, want it to ask for a project", msg)
+	}
+}
+
+// TestVertexAIInit_EnvProjectBeatsEnvAPIKey is the regression guard for
+// existing deployments: an ambient API key must not take a
+// project-configured deployment into Express Mode.
+func TestVertexAIInit_EnvProjectBeatsEnvAPIKey(t *testing.T) {
+	clearVertexEnv(t)
+	fakeADC(t)
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+	t.Setenv("GOOGLE_API_KEY", "ambient-key")
+
+	v := &googlegenai.VertexAI{}
+	v.Init(context.Background())
+
+	client, err := v.Client()
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	cc := client.ClientConfig()
+	if cc.APIKey != "" {
+		t.Errorf("APIKey = %q, want the ambient key ignored", cc.APIKey)
+	}
+	if cc.Project != "env-project" {
+		t.Errorf("Project = %q, want env-project", cc.Project)
+	}
+}
+
+// TestVertexAIInit_EnvLocationSuppressesEnvAPIKey mirrors the genai SDK: a
+// location in the environment is enough to mean "not Express Mode", so the
+// caller gets the actionable missing-project message instead of an
+// authentication failure at request time.
+func TestVertexAIInit_EnvLocationSuppressesEnvAPIKey(t *testing.T) {
+	clearVertexEnv(t)
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+	t.Setenv("GOOGLE_API_KEY", "ambient-key")
+
+	msg := mustPanic(t, func() {
+		(&googlegenai.VertexAI{}).Init(context.Background())
+	})
+	if !strings.Contains(fmt.Sprint(msg), "GOOGLE_CLOUD_PROJECT") {
+		t.Errorf("panic = %v, want it to ask for a project", msg)
+	}
+}
+
+func TestVertexAIInit_ExplicitConfigBeatsEnvAPIKey(t *testing.T) {
+	clearVertexEnv(t)
+	fakeADC(t)
+	t.Setenv("GOOGLE_API_KEY", "ambient-key")
+
+	v := &googlegenai.VertexAI{ProjectID: "explicit-project", Location: "us-central1"}
+	v.Init(context.Background())
+
+	client, err := v.Client()
+	if err != nil {
+		t.Fatalf("Client: %v", err)
+	}
+	cc := client.ClientConfig()
+	if cc.APIKey != "" {
+		t.Errorf("APIKey = %q, want the ambient key ignored", cc.APIKey)
+	}
+	if cc.Project != "explicit-project" {
+		t.Errorf("Project = %q, want explicit-project", cc.Project)
+	}
+}
+
+// TestVertexAIInit_CredentialsBeatEnvAPIKey verifies that supplying
+// credentials opts out of Express Mode entirely, even with a key in the
+// environment and nothing else configured.
+func TestVertexAIInit_CredentialsBeatEnvAPIKey(t *testing.T) {
+	clearVertexEnv(t)
+	t.Setenv("GOOGLE_API_KEY", "ambient-key")
+
+	creds := auth.NewCredentials(&auth.CredentialsOptions{
+		TokenProvider: auth.NewCachedTokenProvider(tokenProviderFunc(func(ctx context.Context) (*auth.Token, error) {
+			return &auth.Token{Value: "token", Expiry: time.Now().Add(time.Hour)}, nil
+		}), nil),
+	})
+
+	msg := mustPanic(t, func() {
+		(&googlegenai.VertexAI{Credentials: creds}).Init(context.Background())
+	})
+	if !strings.Contains(fmt.Sprint(msg), "GOOGLE_CLOUD_PROJECT") {
+		t.Errorf("panic = %v, want it to ask for a project rather than using the ambient key", msg)
+	}
+}
+
+type tokenProviderFunc func(context.Context) (*auth.Token, error)
+
+func (f tokenProviderFunc) Token(ctx context.Context) (*auth.Token, error) { return f(ctx) }
+
+func TestClient_RequiresInit(t *testing.T) {
+	if _, err := (&googlegenai.GoogleAI{}).Client(); err == nil {
+		t.Error("GoogleAI.Client before Init = nil error, want error")
+	}
+	if _, err := (&googlegenai.VertexAI{}).Client(); err == nil {
+		t.Error("VertexAI.Client before Init = nil error, want error")
 	}
 }

--- a/go/plugins/googlegenai/imagen.go
+++ b/go/plugins/googlegenai/imagen.go
@@ -73,7 +73,7 @@ func generateImage(
 
 	resp, err := client.Models.GenerateImages(ctx, model, userPrompt, gic)
 	if err != nil {
-		return nil, err
+		return nil, wrapAPIError(err)
 	}
 
 	r := translateImagenResponse(resp)

--- a/go/plugins/googlegenai/typed_config_test.go
+++ b/go/plugins/googlegenai/typed_config_test.go
@@ -4,7 +4,6 @@
 package googlegenai
 
 import (
-	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -63,14 +62,7 @@ func TestConfigSchemaMatchesDefaultConfig(t *testing.T) {
 // actions below only reads the backend off the client config.
 func testClient(t *testing.T) *genai.Client {
 	t.Helper()
-	client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
-		Backend: genai.BackendGeminiAPI,
-		APIKey:  "test-api-key",
-	})
-	if err != nil {
-		t.Fatalf("genai.NewClient() error = %v", err)
-	}
-	return client
+	return newTestClient(t, "")
 }
 
 // validateConfig runs the request's config through the same check the action

--- a/go/plugins/googlegenai/veo.go
+++ b/go/plugins/googlegenai/veo.go
@@ -74,7 +74,7 @@ func newVeoModel(
 			&videoConfig,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("veo video generation failed: %w", err)
+			return nil, fmt.Errorf("veo video generation failed: %w", wrapAPIError(err))
 		}
 
 		op := fromVeoOperation(operation)
@@ -91,7 +91,7 @@ func newVeoModel(
 	checkFunc := func(ctx context.Context, op *ai.ModelOperation) (*ai.ModelOperation, error) {
 		veoOp, err := checkVeoOperation(ctx, client, op)
 		if err != nil {
-			return nil, fmt.Errorf("veo operation status check failed: %w", err)
+			return nil, fmt.Errorf("veo operation status check failed: %w", wrapAPIError(err))
 		}
 
 		updatedOp := fromVeoOperation(veoOp)

--- a/go/samples/files-api-vision/main.go
+++ b/go/samples/files-api-vision/main.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
@@ -38,15 +37,13 @@ func main() {
 	ctx := context.Background()
 
 	// Initialize Genkit
-	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+	plugin := &googlegenai.GoogleAI{}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
 
-	// Create Files API client
-	client, err := genai.NewClient(ctx, &genai.ClientConfig{
-		Backend: genai.BackendGeminiAPI,
-		APIKey:  os.Getenv("GEMINI_API_KEY"),
-	})
+	// Reuse the plugin's client for the Files API
+	client, err := plugin.Client()
 	if err != nil {
-		log.Fatal("Failed to create client:", err)
+		log.Fatal("Failed to get client:", err)
 	}
 
 	// Upload image to Files API


### PR DESCRIPTION
Closes the highest-impact gaps between the Go plugin and its JS sibling (`@genkit-ai/google-genai`), in two groups: configuration surface the Go plugin lacked entirely (Vertex AI Express Mode, custom endpoints, per-plugin HTTP options, credential injection, access to the underlying SDK client) and response-handling defects (blocked content surfaced as errors or silent empties, streaming dropped grounding metadata and could panic, embeds past the service's per-call limit failed outright).

## Blocked content is a response, not an error

A safety-blocked candidate arrives with a finish reason and no `Content`; the plugin treated that as malformed and returned `no valid candidates were found in the generate response`. A prompt-level block (no candidates, `PromptFeedback.BlockReason` set) returned an empty successful response with no finish reason at all. Both now return a `FinishReasonBlocked` response. For candidate-level blocks that matches JS; prompt-level blocks deliberately go further, where JS throws `FAILED_PRECONDITION: No valid candidates returned.` and drops the reason:

```go
resp, err := genkit.Generate(ctx, g, ...)
if resp.FinishReason == ai.FinishReasonBlocked {
    log.Printf("blocked: %s", resp.FinishMessage)
    // ratings under resp.Custom["candidates"], resp.Custom["promptFeedback"]
}
```

Two adjacent guards keep blocked turns from corrupting sessions: request building skips contentless messages (a blocked model turn replayed via `resp.History()` used to 400 every later turn), and a response with zero candidates and no block reason is now an error instead of a silent empty success.

## Streaming keeps candidate metadata and stops panicking

The stream fold rebuilt the final candidate from finish reason and text alone, so `GroundingMetadata`, `SafetyRatings`, `CitationMetadata`, and `URLContextMetadata` vanished from `Custom["candidates"]`, exactly where the README's Google Search and Maps examples read them. Chunks now merge metadata the way JS aggregates it (latest value wins, citations accumulate). Fixed in the same path: a nil dereference on empty streams, a use-before-error-check on the translated response, metadata-only interstitial chunks aborting the whole generation, and callbacks firing with empty content.

## Vertex AI Express Mode, custom endpoints, and HTTP options

**Before:** `VertexAI` required a project, a location, and Application Default Credentials, and panicked otherwise. `GoogleAI` accepted nothing but an API key.

**After:**

```go
// Express Mode: an API key, nothing else. Falls back to VERTEX_API_KEY,
// GOOGLE_API_KEY, or GOOGLE_GENAI_API_KEY when nothing names a project.
&googlegenai.VertexAI{APIKey: key}

// Custom endpoint: the gateway owns auth.
&googlegenai.VertexAI{BaseURL: "https://my-gateway.example.com"}

// Both plugins: endpoint, headers, transport, and (Vertex) identity.
&googlegenai.GoogleAI{BaseURL: gw, Headers: hdrs, HTTPClient: client}
&googlegenai.VertexAI{Credentials: creds}
```

Mode selection is explicit-config first, and a project or location (configured or in the environment) always outranks an ambient API key, the same precedence the genai SDK applies, so no existing deployment changes auth paths. The env key names follow JS and deliberately exclude `GEMINI_API_KEY`, which names a Gemini Developer API key Vertex rejects (verified live: such a key fails Express Mode requests with `PERMISSION_DENIED`). When an env var selects Express Mode, Init logs which one.

## The SDK client is reachable

`Client()` returns the configured `*genai.Client`, unlocking the Files, Caches, Batches, and Tunings APIs without constructing and authenticating a second client by hand.

## Embeds batch to the service's per-call limits

One `EmbedContent` call carried every input document, which fails past 100 docs on the Gemini API. Requests now split at the real limits: 100 (Gemini API `batchEmbedContents`), 250 (Vertex prediction), and 1 for Vertex Gemini and MaaS embedding models, which take a single input per request (the SDK enforces this client-side for most; `gemini-embedding-001` enforces it server-side). Embeddings come back one per input, in order.

## Rate-limit errors carry the service's retry delay

`RetryDelay(err)` extracts `google.rpc.RetryInfo` from 429s, through wrapped errors, and `wrapAPIError` stamps `retryAfterMs` into the status error's details, the key JS's `ErrorResponseMetadata` uses. Embedder, Imagen, and Veo errors now route through `wrapAPIError` too, so every action's failures are status-classified rather than only generate's.

## Cache TTL survives JSON

`WithCacheTTL` metadata asserted `.(int)`, so any JSON round-trip (dev UI, reflection server) delivered `ttlSeconds` as a `float64` and failed the request. All numeric forms are accepted now; non-positive values, including fractions that truncate to zero and would silently skip cache creation, are rejected loudly.

## API surface

```go
// Added: configuration fields
googlegenai.GoogleAI{BaseURL string, Headers http.Header, HTTPClient *http.Client}
googlegenai.VertexAI{APIKey string, Credentials *auth.Credentials, BaseURL string,
    Headers http.Header, HTTPClient *http.Client}

// Added: methods and helpers
func (*GoogleAI) Client() (*genai.Client, error)
func (*VertexAI) Client() (*genai.Client, error)
func RetryDelay(err error) (time.Duration, bool)
```

## Behavior changes, none breaking at compile time

Everything added is new fields and functions; no signature changed. Runtime deltas, all on paths that previously failed or misbehaved:

- Blocked content: a response with `FinishReasonBlocked` instead of an error (or, for prompt blocks, instead of a silent empty success).
- Zero candidates with no block reason: an error instead of an empty success.
- Streaming callbacks no longer fire for empty-content chunks.
- Embedder, Imagen, and Veo errors are `status.Error`-wrapped; `errors.As` still reaches the underlying `genai.APIError`.
- An embed request with zero documents returns zero embeddings instead of a server 400.
- A supplied `HTTPClient` is used verbatim (documented on the fields): the plugin does not layer its otel transport or, on Vertex, credentials over it.

## What was deliberately left out

- **The `ResponseJsonSchema` migration.** The lossy `genai.Schema` conversion (anyOf collapse, `$ref` recursion overflow) is a separate, larger change.
- **Blocked responses under `ai.WithOutputType`.** Core parses structured output before checking the finish reason, so a blocked response still surfaces as `ErrInvalidOutput` there. The fix belongs in `go/ai` and is queued separately.
- **Concurrent embed batches.** Sequential keeps quota behavior predictable; bounded concurrency is a follow-up if the single-input Vertex models prove too slow.

## Testing

Go 1.26.3. `go test -race` on the plugin: 94 tests pass, including fake-server SSE streams (metadata merge, empty stream, prompt block, mid-stream block), embed batching against a counting server (150 docs split 100+50), Express Mode env precedence with fabricated ADC, and RetryInfo extraction in both proto JSON forms. Full `go test ./...` in `go/`: 41 packages pass, no failures. Express-key rejection verified live against `aiplatform.googleapis.com`.

