### PR TITLE
feat(go/plugins/compat_oai/anthropic): migrate to a typed config and the shared catalog

### DIFF
--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -186,9 +186,10 @@ providers disagree about which ones exist and what they are called: DeepSeek
 dropped the frequency and presence penalties, Z.ai caps `temperature` at 1,
 Kimi's K-series takes neither, and `maxOutputTokens` is `max_tokens` on some
 providers and `max_completion_tokens` on others. Use the same camelCase name
-other plugins use for the same setting.
+other plugins use for the same setting; `conformance_test.go` enforces that
+across the package.
 
-See the `openai` directory for a complete implementation.
+See the `openai` and `anthropic` directories for complete implementations.
 
 ## Running Tests
 

--- a/go/plugins/compat_oai/anthropic/README.md
+++ b/go/plugins/compat_oai/anthropic/README.md
@@ -36,8 +36,7 @@ import (
 
 ctx := context.Background()
 plugin := &anthropic.Anthropic{}
-g := genkit.Init(
-    ctx,
+g := genkit.Init(ctx,
     genkit.WithPlugins(plugin),
     genkit.WithDefaultModel("anthropic/claude-haiku-4-5-20251001"),
 )

--- a/go/plugins/compat_oai/anthropic/README.md
+++ b/go/plugins/compat_oai/anthropic/README.md
@@ -1,59 +1,99 @@
 # Anthropic Plugin
 
-This plugin provides a simple interface for using Anthropic's services.
+This plugin provides Genkit support for Claude models through Anthropic's
+OpenAI-compatible Chat Completions endpoint.
 
-## Prerequisites
+Anthropic positions that endpoint as a compatibility layer for testing and
+comparing Claude rather than a long-term integration surface: it does not
+return thinking content, ignores `response_format`, and hoists system
+messages to the start of the conversation. The full support matrix is at
+https://platform.claude.com/docs/en/cli-sdks-libraries/libraries/openai-sdk.
+For the native Messages API surface (thinking output, prompt caching,
+citations, structured outputs), use the `go/plugins/anthropic` plugin
+instead; this one is for code that must speak the OpenAI shape.
 
-- Go installed on your system
-- An Anthropic API key
+## Setup
 
-## Running Tests
-
-First, set your Anthropic API key as an environment variable:
+Set an Anthropic API key:
 
 ```bash
 export ANTHROPIC_API_KEY=<your-api-key>
 ```
-By default, `baseURL` is set to "https://api.anthropic.com/v1". However, if you
-want to use a custom value, you can set `ANTHROPIC_BASE_URL` environment variable:
 
-```bash
-export ANTHROPIC_BASE_URL=<your-custom-base-url>
+The plugin's `APIKey` field overrides the environment. The plugin uses
+`https://api.anthropic.com/v1` by default; set `ANTHROPIC_BASE_URL` or pass
+`option.WithBaseURL` through the plugin's `Opts` to use another compatible
+endpoint.
+
+```go
+import (
+    "context"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
+)
+
+ctx := context.Background()
+plugin := &anthropic.Anthropic{}
+g := genkit.Init(
+    ctx,
+    genkit.WithPlugins(plugin),
+    genkit.WithDefaultModel("anthropic/claude-haiku-4-5-20251001"),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain constitutional AI."))
 ```
 
-### Running All Tests
-To run all tests in the directory:
-```bash
-go test -v .
+## Models
+
+A catalog of dated Claude releases is registered at Init, and the catalog is
+not a ceiling: any Claude model ID resolves on demand, and the plugin lists
+what Anthropic's native models API reports (paged, authenticated with
+`x-api-key`, since listing is not part of the compatible surface). Use the
+`Models` field to describe or correct any model, most often one released
+after this plugin:
+
+```go
+plugin := &anthropic.Anthropic{Models: map[string]ai.ModelOptions{
+    "claude-opus-5": {Label: "Claude Opus 5", Supports: &compat_oai.Multimodal},
+}}
 ```
 
-### Running Tests from Specific Files
-To run tests from a specific file:
-```bash
-# Run only generate_live_test.go tests
-go test -run "^TestGenerator"
+The current model list is at
+https://platform.claude.com/docs/en/about-claude/models/overview.
 
-# Run only anthropic_live_test.go tests
-go test -run "^TestPlugin"
+## Config
+
+Models take a typed `anthropic.ChatConfig`: the fields the compatible
+endpoint honors, and none of the OpenAI fields it documents as ignored (the
+penalties, `logprobs`, `seed`). `temperature` runs 0 to 1, where the endpoint
+caps it. `anthropic.ModelRef` carries the config with the model ID:
+
+```go
+response, err := genkit.Generate(ctx, g,
+    ai.WithModel(anthropic.ModelRef("claude-sonnet-4-5-20250929", &anthropic.ChatConfig{
+        MaxOutputTokens: 2048,
+        Thinking:        &anthropic.ThinkingConfig{Type: "enabled", BudgetTokens: 2000},
+    })),
+    ai.WithPrompt("Work through this carefully."),
+)
 ```
 
-### Running Individual Tests
-To run a specific test case:
+`thinking` spends a reasoning budget, but the compatible endpoint does not
+return the thinking content itself; only the native API does. On Claude 5
+models thinking is adaptive and on by default, which makes the manual control
+a legacy mode.
+
+Every config also carries the settings Genkit owns: `version` pins the exact
+model version a request is served by, `apiKey` (settable only from Go code)
+serves one request with a different credential, and `extra` forwards request
+body fields the config does not declare, keyed by Anthropic's wire names.
+
+## Live tests
+
+Live tests are skipped unless `ANTHROPIC_API_KEY` is set:
+
 ```bash
-# Run only the streaming test from anthropic_live_test.go
-go test -run "TestPlugin/streaming"
-
-# Run only the Complete test from generate_live_test.go
-go test -run "TestGenerator_Complete"
-
-# Run only the Stream test from generate_live_test.go
-go test -run "TestGenerator_Stream"
+go test -v ./plugins/compat_oai/anthropic
 ```
-
-### Test Output Verbosity
-Add the `-v` flag for verbose output:
-```bash
-go test -v -run "TestPlugin/streaming"
-```
-
-Note: All live tests require the ANTHROPIC_API_KEY environment variable to be set. Tests will be skipped if the API key is not provided.

--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -72,8 +72,9 @@ type ThinkingConfig struct {
 	// reject a value Anthropic accepts.
 	Type string `json:"type,omitempty" jsonschema_description:"Turns thinking enabled or disabled."`
 	// BudgetTokens is the maximum number of tokens Claude may think with,
-	// sent as the API's budget_tokens.
-	BudgetTokens int `json:"budgetTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens Claude may think with, sent as the API's budget_tokens."`
+	// sent as the API's budget_tokens. Anthropic rejects budgets under 1,024
+	// tokens, and the budget must stay below the request's max_tokens.
+	BudgetTokens int `json:"budgetTokens,omitempty" jsonschema:"minimum=1024" jsonschema_description:"Maximum number of tokens Claude may think with, sent as the API's budget_tokens; at least 1,024, and less than maxOutputTokens."`
 }
 
 // ApplyToChatCompletion implements [compat_oai.ChatConfig]: the endpoint's

--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -12,16 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package anthropic provides a Genkit plugin for Claude models through
+// Anthropic's OpenAI-compatible endpoint. Anthropic positions that endpoint
+// for testing and comparison; the plugins/anthropic package speaks the native
+// Anthropic API and is the primary way to use Claude models with Genkit.
 package anthropic
 
 import (
 	"context"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 )
 
@@ -30,92 +37,249 @@ const (
 	baseURL  = "https://api.anthropic.com/v1"
 )
 
-// Supported models: https://docs.anthropic.com/en/docs/about-claude/models/all-models
+// ChatConfig is the per-request config for Claude models served through
+// Anthropic's OpenAI-compatible endpoint. It carries the fields that endpoint
+// honors; OpenAI fields Anthropic documents as ignored (penalties, log
+// probabilities, seed, response_format) are deliberately absent. See
+// https://platform.claude.com/docs/en/api/openai-sdk.
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// Temperature controls the degree of randomness, from 0 to 1; the
+	// endpoint caps greater values at 1, so the schema stops where the
+	// behavior does.
+	Temperature *float64 `json:"temperature,omitempty" jsonschema:"minimum=0,maximum=1" jsonschema_description:"Controls the degree of randomness in token selection, from 0 to 1. The endpoint would cap greater values at 1 rather than honor them."`
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as
+	// the API's max_tokens.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_tokens."`
+	// TopP is the nucleus sampling threshold. The endpoint documents no
+	// range for it, so the schema declares none.
+	TopP *float64 `json:"topP,omitempty" jsonschema_description:"Nucleus sampling threshold: only the tokens comprising the top P probability mass are considered."`
+	// StopSequences stop generation when produced by the model; whitespace
+	// stop sequences are not supported by the endpoint.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema_description:"Stop generation when produced by the model. Whitespace-only stop sequences are not supported by the endpoint."`
+	// Thinking controls Claude's extended thinking.
+	Thinking *ThinkingConfig `json:"thinking,omitempty" jsonschema_description:"Extended thinking controls. The OpenAI-compatible endpoint does not return the thinking content itself."`
+}
+
+// ThinkingConfig configures Claude's extended thinking through the
+// OpenAI-compatible endpoint. The endpoint does not return the thinking
+// content; the plugins/anthropic package does.
+type ThinkingConfig struct {
+	// Type turns thinking "enabled" or "disabled". It is not an enum in the
+	// schema: the endpoint documents no closed set, and the native API's set
+	// has grown (Claude 5 added adaptive thinking), so a list here would
+	// reject a value Anthropic accepts.
+	Type string `json:"type,omitempty" jsonschema_description:"Turns thinking enabled or disabled."`
+	// BudgetTokens is the maximum number of tokens Claude may think with,
+	// sent as the API's budget_tokens.
+	BudgetTokens int `json:"budgetTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens Claude may think with, sent as the API's budget_tokens."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the endpoint's
+// generation fields land on their chat completion counterparts and thinking
+// rides as the endpoint's thinking extra field.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.Temperature != nil {
+		params.Temperature = openai.Float(*c.Temperature)
+	}
+	if c.MaxOutputTokens > 0 {
+		params.MaxTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if c.TopP != nil {
+		params.TopP = openai.Float(*c.TopP)
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+
+	if c.Thinking != nil {
+		thinking := map[string]any{}
+		if c.Thinking.Type != "" {
+			thinking["type"] = c.Thinking.Type
+		}
+		if c.Thinking.BudgetTokens > 0 {
+			thinking["budget_tokens"] = c.Thinking.BudgetTokens
+		}
+		// An all-zero ThinkingConfig adds nothing rather than sending an
+		// empty thinking object the endpoint could reject.
+		if len(thinking) > 0 {
+			compat_oai.AddExtraFields(params, map[string]any{"thinking": thinking})
+		}
+	}
+}
+
+// Capability sets shared by the entries below. The Claude 3 generation
+// predates Anthropic's system-role support on the compatible endpoint.
+// Models from the 4.5 generation on support structured outputs natively:
+// the compatible endpoint takes response_format in its json_schema form and
+// rejects every other form with a 400, so no set lists "json" among its
+// native output formats and a schema-less JSON request rides the injected
+// format instructions. See https://platform.claude.com/docs/en/api/openai-sdk.
+var (
+	multimodal = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		ToolChoice: true,
+		SystemRole: true,
+		Media:      true,
+		Output:     []string{"text"},
+	}
+	multimodalConstrained = ai.ModelSupports{
+		Multiturn:   true,
+		Tools:       true,
+		ToolChoice:  true,
+		SystemRole:  true,
+		Media:       true,
+		Output:      []string{"text"},
+		Constrained: ai.ConstrainedSupportAll,
+	}
+	multimodalNoSystemRole = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		ToolChoice: true,
+		SystemRole: false,
+		Media:      true,
+		Output:     []string{"text"},
+	}
+)
+
+// supportedModels curates capabilities for well-known Claude models. It is not
+// the set of usable models: any Claude model resolves on demand and takes
+// [dynamicModelOptions], so an ID absent here still works. Dated snapshots are
+// folded into Versions rather than registered as separate models. The Claude 4
+// generations alias by bare name (claude-sonnet-4-5, never -latest), and IDs
+// from the 4.6 generation on are dateless pinned snapshots.
+//
+// Catalog: https://platform.claude.com/docs/en/about-claude/models/overview
 var supportedModels = map[string]ai.ModelOptions{
-	"claude-opus-4-1-20250805": {
-		Label: "Claude 4.1 Opus",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
-			SystemRole: true,
-			Media:      true,
-		},
-		Versions: []string{"claude-opus-4-1-latest", "claude-opus-4-1-20250805"},
+	"claude-fable-5": {
+		Label:    "Claude Fable 5",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-fable-5"},
+	},
+	"claude-opus-5": {
+		Label:    "Claude Opus 5",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-opus-5"},
+	},
+	"claude-sonnet-5": {
+		Label:    "Claude Sonnet 5",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-sonnet-5"},
+	},
+	"claude-opus-4-8": {
+		Label:    "Claude Opus 4.8",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-opus-4-8"},
+	},
+	"claude-opus-4-7": {
+		Label:    "Claude Opus 4.7",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-opus-4-7"},
+	},
+	"claude-opus-4-6": {
+		Label:    "Claude Opus 4.6",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-opus-4-6"},
+	},
+	"claude-sonnet-4-6": {
+		Label:    "Claude Sonnet 4.6",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-sonnet-4-6"},
+	},
+	"claude-opus-4-5-20251101": {
+		Label:    "Claude Opus 4.5",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-opus-4-5", "claude-opus-4-5-20251101"},
 	},
 	"claude-sonnet-4-5-20250929": {
-		Label: "Claude 4.5 Sonnet",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
-			SystemRole: true,
-			Media:      true,
-		},
-		Versions: []string{"claude-sonnet-4-5-latest", "claude-sonnet-4-5-20250929"},
+		Label:    "Claude Sonnet 4.5",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-sonnet-4-5", "claude-sonnet-4-5-20250929"},
 	},
 	"claude-haiku-4-5-20251001": {
-		Label: "Claude 4.5 Haiku",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
-			SystemRole: true,
-			Media:      true,
-		},
-		Versions: []string{"claude-haiku-4-5-latest", "claude-haiku-4-5-20251001"},
+		Label:    "Claude Haiku 4.5",
+		Supports: &multimodalConstrained,
+		Versions: []string{"claude-haiku-4-5", "claude-haiku-4-5-20251001"},
+	},
+	"claude-opus-4-1-20250805": {
+		Label:    "Claude Opus 4.1",
+		Supports: &multimodal,
+		Versions: []string{"claude-opus-4-1", "claude-opus-4-1-20250805"},
 	},
 	"claude-3-7-sonnet-20250219": {
-		Label: "Claude 3.7 Sonnet",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
-			SystemRole: true,
-			Media:      true,
-		},
+		Label:    "Claude 3.7 Sonnet",
+		Supports: &multimodal,
 		Versions: []string{"claude-3-7-sonnet-latest", "claude-3-7-sonnet-20250219"},
 	},
 	"claude-3-5-haiku-20241022": {
-		Label: "Claude 3.5 Haiku",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
-			SystemRole: true,
-			Media:      true,
-		},
+		Label:    "Claude 3.5 Haiku",
+		Supports: &multimodal,
 		Versions: []string{"claude-3-5-haiku-latest", "claude-3-5-haiku-20241022"},
 	},
 	"claude-3-5-sonnet-20240620": {
-		Label: "Claude 3.5 Sonnet",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
-			SystemRole: false, // NOTE: This model does not support system role
-			Media:      true,
-		},
+		Label:    "Claude 3.5 Sonnet",
+		Supports: &multimodalNoSystemRole,
 		Versions: []string{"claude-3-5-sonnet-20240620"},
 	},
 	"claude-3-opus-20240229": {
-		Label: "Claude 3 Opus",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
-			SystemRole: false, // NOTE: This model does not support system role
-			Media:      true,
-		},
+		Label:    "Claude 3 Opus",
+		Supports: &multimodalNoSystemRole,
 		Versions: []string{"claude-3-opus-latest", "claude-3-opus-20240229"},
 	},
 	"claude-3-haiku-20240307": {
-		Label: "Claude 3 Haiku",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
-			SystemRole: false, // NOTE: This model does not support system role
-			Media:      true,
-		},
+		Label:    "Claude 3 Haiku",
+		Supports: &multimodalNoSystemRole,
 		Versions: []string{"claude-3-haiku-20240307"},
 	},
 }
 
+// dynamicModelOptions is advertised for Claude models that resolve dynamically
+// rather than appearing in supportedModels.
+var dynamicModelOptions = ai.ModelOptions{
+	Supports: &multimodal,
+	Versions: []string{},
+	Stage:    ai.ModelStageStable,
+}
+
 type Anthropic struct {
-	Opts             []option.RequestOption
+	// APIKey is the key requests are authenticated with. When empty, the
+	// ANTHROPIC_API_KEY environment variable is used. A key set here or in
+	// the environment authenticates both surfaces the plugin speaks to: the
+	// chat endpoint as the bearer token and the native models list as
+	// x-api-key.
+	APIKey string
+
+	// Opts are additional options for the underlying client, such as
+	// [option.WithBaseURL] for a different endpoint; they are applied after
+	// what the plugin composes, so they win on overlap. The credential
+	// belongs in APIKey or the environment rather than here: a key inside
+	// Opts is opaque to the plugin, so model listing cannot be authenticated
+	// with it.
+	Opts []option.RequestOption
+
+	// Models overrides what the plugin knows about a Claude model, keyed by
+	// model ID, bare or provider-prefixed. Every Claude model already works
+	// without an entry: known IDs carry curated capabilities and the rest take
+	// the Claude defaults. Supply an entry only to correct or extend what the
+	// plugin resolves, most often for a model released after this version of
+	// the plugin.
+	//
+	//	&anthropic.Anthropic{Models: map[string]ai.ModelOptions{
+	//		"claude-sonnet-4-5-20250929": {Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+	//	}}
+	//
+	// Fields left at their zero value keep what the plugin resolves, so an
+	// entry can pin one capability without restating the label or the
+	// versions. Entries apply to the models Init registers as well as the
+	// ones [Anthropic.ListActions] advertises and [Anthropic.ResolveAction] builds,
+	// which is the way to describe a curated model differently: Init has
+	// already registered those and nothing can re-register them.
+	Models map[string]ai.ModelOptions
+
 	openAICompatible compat_oai.OpenAICompatible
 }
 
@@ -129,32 +293,136 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 	if url == "" {
 		url = baseURL
 	}
+	// ANTHROPIC_BASE_URL conventionally names the API origin without the
+	// version segment: the native SDKs append v1 to every path themselves,
+	// and environments like Claude Code export exactly that form. The OpenAI
+	// SDK's paths carry no version, so restore the segment unless the value
+	// already ends with it.
+	url = strings.TrimSuffix(url, "/")
+	if !strings.HasSuffix(url, "/v1") {
+		url += "/v1"
+	}
 	a.Opts = append([]option.RequestOption{option.WithBaseURL(url)}, a.Opts...)
 
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	apiKey := a.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
 	if apiKey != "" {
-		a.Opts = append([]option.RequestOption{option.WithAPIKey(apiKey)}, a.Opts...)
+		// The chat endpoint takes the OpenAI-style bearer token; the models
+		// list is a native Anthropic endpoint on the same base URL and takes
+		// x-api-key, so both ride along for listing to work.
+		a.Opts = append([]option.RequestOption{
+			option.WithAPIKey(apiKey),
+			option.WithHeader("x-api-key", apiKey),
+		}, a.Opts...)
 	}
 
 	// initialize OpenAICompatible
+	a.openAICompatible.Provider = provider
 	a.openAICompatible.Opts = a.Opts
-	compatActions := a.openAICompatible.Init(ctx)
-
-	var actions []api.Action
-	actions = append(actions, compatActions...)
+	a.openAICompatible.ListModels = listClaudeModels
+	actions := a.openAICompatible.Init(ctx)
 
 	// define default models
-	for model, opts := range supportedModels {
-		actions = append(actions, a.DefineModel(model, opts).(api.Action))
+	for model := range supportedModels {
+		actions = append(actions, a.newModel(model, a.modelOptions(model)))
 	}
 
 	return actions
 }
 
-func (a *Anthropic) Model(g *genkit.Genkit, id string) ai.Model {
-	return a.openAICompatible.Model(g, api.NewName(provider, id))
+// newModel creates a Claude model without registering it.
+func (a *Anthropic) newModel(id string, opts ai.ModelOptions) *ai.ModelAction {
+	return compat_oai.NewChatModel[ChatConfig](&a.openAICompatible, id, opts)
 }
 
+// modelOptions returns the ModelOptions for a Claude model ID: curated
+// capabilities for a known model and the Claude defaults for the rest, with
+// an entry from [Anthropic.Models] overlaid on whichever applies.
+//
+// Every path that describes a model goes through this one, which is what
+// makes a caller's entry authoritative whether Init, ListActions or
+// ResolveAction gets there first.
+func (a *Anthropic) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, supportedModels, dynamicModelOptions, a.Models)
+}
+
+// ModelRef names a Claude model and carries the config to generate with, so
+// the config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(anthropic.ModelRef("claude-3-5-haiku-20241022", &anthropic.ChatConfig{
+//		MaxOutputTokens: 1024,
+//	}))
+//
+// id is the model ID, with or without the provider prefix.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// DefineModel builds a Claude model and returns it, without registering it.
+//
+// Deprecated: describe the model through [Anthropic.Models] instead. This
+// method builds the model and registers nothing, so the result carries only
+// the model's name: generation resolves a model from that name and serves the
+// request with the capabilities the plugin resolves, not the ones passed
+// here. An entry in Models reaches both paths.
 func (a *Anthropic) DefineModel(id string, opts ai.ModelOptions) ai.Model {
-	return a.openAICompatible.DefineModel(provider, id, opts)
+	return a.newModel(id, opts)
+}
+
+// Model returns a previously registered model.
+//
+// Deprecated: Generation resolves a model from its name, so looking one up
+// first is rarely necessary: pass ai.WithModelName("anthropic/claude-3-5-haiku-20241022")
+// or, to carry config with it, [ModelRef]. Use [genkit.LookupModel] when the
+// action itself is what you need.
+func (a *Anthropic) Model(g *genkit.Genkit, id string) ai.Model {
+	return genkit.LookupModel(g, compat_oai.ActionName(provider, id))
+}
+
+// listClaudeModels pages through the models list. It is a native Anthropic
+// endpoint with its own cursoring, which the OpenAI-style lister does not
+// follow: it would stop after the first page and silently list a fraction of
+// the models. A page that fails to advance the cursor ends the walk, so an
+// endpoint that misbehaves and repeats itself cannot loop the pager forever.
+func listClaudeModels(ctx context.Context, client *openai.Client) ([]string, error) {
+	var models []string
+	after := ""
+	for {
+		var page struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+			HasMore bool   `json:"has_more"`
+			LastID  string `json:"last_id"`
+		}
+		path := "models?limit=1000"
+		if after != "" {
+			path += "&after_id=" + url.QueryEscape(after)
+		}
+		if err := client.Get(ctx, path, nil, &page); err != nil {
+			return nil, err
+		}
+		for _, m := range page.Data {
+			models = append(models, m.ID)
+		}
+		if !page.HasMore || page.LastID == "" || page.LastID == after {
+			return models, nil
+		}
+		after = page.LastID
+	}
+}
+
+// ListActions lists the Claude models the configured endpoint exposes,
+// described by the plugin's config schema and capabilities.
+func (a *Anthropic) ListActions(ctx context.Context) []api.ActionDesc {
+	return compat_oai.ListChatActions[ChatConfig](ctx, &a.openAICompatible, a.modelOptions)
+}
+
+// ResolveAction dynamically builds a Claude model, described by the plugin's
+// config schema and capabilities.
+func (a *Anthropic) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&a.openAICompatible, atype, id, a.modelOptions)
 }

--- a/go/plugins/compat_oai/anthropic/anthropic_live_test.go
+++ b/go/plugins/compat_oai/anthropic/anthropic_live_test.go
@@ -17,105 +17,36 @@ package anthropic_test
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
-	"github.com/openai/openai-go/option"
+	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
 )
 
-func TestPlugin(t *testing.T) {
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		t.Skip("Skipping test: ANTHROPIC_API_KEY environment variable not set")
+func TestPluginLive(t *testing.T) {
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY is not set")
 	}
 
 	ctx := context.Background()
-
-	// Initialize genkit with claude-4-5-sonnet as default model
-	g := genkit.Init(
-		ctx,
-		genkit.WithDefaultModel("anthropic/claude-sonnet-4-5-20250929"),
-		genkit.WithPlugins(&anthropic.Anthropic{
-			Opts: []option.RequestOption{
-				option.WithAPIKey(apiKey),
-			},
-		}),
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&anthropic.Anthropic{}),
+		genkit.WithDefaultModel("anthropic/claude-haiku-4-5-20251001"),
 	)
-	t.Log("genkit initialized")
 
-	t.Run("basic completion", func(t *testing.T) {
-		t.Log("generating basic completion response")
-		resp, err := genkit.Generate(ctx, g,
-			ai.WithPrompt("What is the capital of France?"),
-		)
-		if err != nil {
-			t.Fatal("error generating basic completion response: ", err)
-		}
-		t.Logf("basic completion response: %+v", resp)
-
-		out := resp.Message.Content[0].Text
-		if !strings.Contains(strings.ToLower(out), "paris") {
-			t.Errorf("got %q, expecting it to contain 'Paris'", out)
-		}
-
-		// Verify usage statistics are present
-		if resp.Usage == nil || resp.Usage.TotalTokens == 0 {
-			t.Error("Expected non-zero usage statistics")
-		}
-	})
-
-	t.Run("streaming", func(t *testing.T) {
-		var streamedOutput string
-		chunks := 0
-
-		final, err := genkit.Generate(ctx, g,
-			ai.WithPrompt("Write a short paragraph about artificial intelligence."),
-			ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
-				chunks++
-				for _, content := range chunk.Content {
-					streamedOutput += content.Text
-				}
-				return nil
-			}))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Verify streaming worked
-		if chunks <= 1 {
-			t.Error("Expected multiple chunks for streaming")
-		}
-
-		// Verify final output matches streamed content
-		finalOutput := ""
-		for _, content := range final.Message.Content {
-			finalOutput += content.Text
-		}
-		if streamedOutput != finalOutput {
-			t.Errorf("Streaming output doesn't match final output\nStreamed: %s\nFinal: %s",
-				streamedOutput, finalOutput)
-		}
-
-		t.Logf("streaming response: %+v", finalOutput)
-	})
-
-	t.Run("system message", func(t *testing.T) {
-		resp, err := genkit.Generate(ctx, g,
-			ai.WithPrompt("What are you?"),
-			ai.WithSystem("You are a helpful math tutor who loves numbers."),
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		out := resp.Message.Content[0].Text
-		if !strings.Contains(strings.ToLower(out), "math") {
-			t.Errorf("got %q, expecting response to mention being a math tutor", out)
-		}
-
-		t.Logf("system message response: %+v", out)
+	livetest.Run(t, g, livetest.Suite{
+		Model: anthropic.ModelRef("claude-haiku-4-5-20251001", nil),
+		// The OpenAI-compatible endpoint takes the thinking knob but never
+		// returns the thinking content itself.
+		ReasoningModel: anthropic.ModelRef("claude-haiku-4-5-20251001", &anthropic.ChatConfig{
+			MaxOutputTokens: 4096,
+			Thinking:        &anthropic.ThinkingConfig{Type: "enabled", BudgetTokens: 2048},
+		}),
+		VisionModel: anthropic.ModelRef("claude-haiku-4-5-20251001", nil),
+		ToolChoice:  true,
+		ExtraConfig: map[string]any{
+			"extra": map[string]any{"thinking": map[string]any{"type": "disabled"}},
+		},
 	})
 }

--- a/go/plugins/compat_oai/anthropic/anthropic_test.go
+++ b/go/plugins/compat_oai/anthropic/anthropic_test.go
@@ -1,0 +1,402 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/openai/openai-go"
+)
+
+// TestChatConfigApply pins the wire contract of the Claude compat config: the
+// camelCase fields land on their snake_case counterparts and thinking rides
+// as the endpoint's extra field.
+func TestChatConfigApply(t *testing.T) {
+	cfg := ChatConfig{
+		Temperature:     openai.Ptr(0.5),
+		MaxOutputTokens: 1024,
+		StopSequences:   []string{"END"},
+		Thinking:        &ThinkingConfig{Type: "enabled", BudgetTokens: 2000},
+	}
+
+	var params openai.ChatCompletionNewParams
+	cfg.ApplyToChatCompletion(&params)
+
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(data, &request); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if got := request["temperature"]; got != 0.5 {
+		t.Errorf("temperature = %v, want 0.5", got)
+	}
+	if got := request["max_tokens"]; got != float64(1024) {
+		t.Errorf("max_tokens = %v, want 1024", got)
+	}
+	thinking, ok := request["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking = %#v, want object", request["thinking"])
+	}
+	if got := thinking["type"]; got != "enabled" {
+		t.Errorf("thinking.type = %v, want enabled", got)
+	}
+	if got := thinking["budget_tokens"]; got != float64(2000) {
+		t.Errorf("thinking.budget_tokens = %v, want 2000", got)
+	}
+}
+
+// TestModelConfigSchema pins what the models advertise: the curated camelCase
+// config contract, without the OpenAI fields Anthropic documents as ignored.
+func TestModelConfigSchema(t *testing.T) {
+	a := &Anthropic{}
+	g := genkit.Init(context.Background(), genkit.WithPlugins(a))
+
+	m := genkit.LookupModel(g, "anthropic/claude-3-5-haiku-20241022")
+	if m == nil {
+		t.Fatal("claude-3-5-haiku-20241022 not registered by Init")
+	}
+	model, ok := m.(*ai.ModelAction).Desc().Metadata["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("model metadata missing")
+	}
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions missing, got %v", model["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions has no properties: %v", schema)
+	}
+	for _, key := range []string{"temperature", "maxOutputTokens", "topP", "stopSequences", "thinking", "version", "extra"} {
+		if props[key] == nil {
+			t.Errorf("config schema is missing the %q property", key)
+		}
+	}
+	for _, key := range []string{"frequencyPenalty", "presencePenalty", "logProbs", "topLogProbs"} {
+		if props[key] != nil {
+			t.Errorf("config schema advertises %q, which the endpoint ignores", key)
+		}
+	}
+
+	// The constraints the endpoint documents ride on the schema, where the
+	// framework enforces them: temperature runs 0 to 1, not OpenAI's 2, since
+	// the endpoint caps greater values rather than honoring them.
+	temp, _ := props["temperature"].(map[string]any)
+	if got := temp["minimum"]; got != 0.0 {
+		t.Errorf("temperature minimum = %#v, want 0", got)
+	}
+	if got := temp["maximum"]; got != 1.0 {
+		t.Errorf("temperature maximum = %#v, want the endpoint's 1", got)
+	}
+	// topP carries no range and thinking.type no enum: the endpoint documents
+	// neither a range nor a closed set, and Anthropic's thinking types have
+	// grown before, so a list here would reject a value the endpoint accepts.
+	topP, _ := props["topP"].(map[string]any)
+	for _, key := range []string{"minimum", "maximum"} {
+		if got, has := topP[key]; has {
+			t.Errorf("topP %s = %v, want none since the endpoint documents no range", key, got)
+		}
+	}
+	thinking, _ := props["thinking"].(map[string]any)
+	thinkingProps, _ := thinking["properties"].(map[string]any)
+	thinkingType, _ := thinkingProps["type"].(map[string]any)
+	if got, has := thinkingType["enum"]; has {
+		t.Errorf("thinking.type enum = %v, want none since the set is Anthropic's to grow", got)
+	}
+}
+
+// TestModelRef pins the name a ref carries and that the typed config rides
+// along.
+func TestModelRef(t *testing.T) {
+	cfg := &ChatConfig{MaxOutputTokens: 1024}
+
+	for _, name := range []string{"claude-3-5-haiku-20241022", "anthropic/claude-3-5-haiku-20241022"} {
+		ref := ModelRef(name, cfg)
+		if want := "anthropic/claude-3-5-haiku-20241022"; ref.Name() != want {
+			t.Errorf("ModelRef(%q).Name() = %q, want %q", name, ref.Name(), want)
+		}
+		if ref.Config() != cfg {
+			t.Errorf("ModelRef(%q).Config() = %v, want the config it was built with", name, ref.Config())
+		}
+	}
+}
+
+// TestUncuratedModelResolves covers a model outside the curated list: it
+// resolves on demand under either name form, and a [Anthropic.Models] entry
+// describes it without anything having to register it first.
+func TestUncuratedModelResolves(t *testing.T) {
+	a := &Anthropic{Models: map[string]ai.ModelOptions{
+		"claude-something-new": {Label: "Something New"},
+	}}
+	g := genkit.Init(context.Background(), genkit.WithPlugins(a))
+
+	for _, name := range []string{"claude-something-new", "anthropic/claude-something-new"} {
+		m := genkit.LookupModel(g, "anthropic/"+strings.TrimPrefix(name, "anthropic/"))
+		if m == nil {
+			t.Fatalf("LookupModel(%q) = nil, want the model resolved on demand", name)
+		}
+		if got := m.(*ai.ModelAction).Desc().Metadata["model"].(map[string]any)["label"]; got != "Something New" {
+			t.Errorf("%s label = %v, want the Models entry's", name, got)
+		}
+	}
+}
+
+// TestDynamicListingAndResolution pins the on-demand surface: the full,
+// cursor-paged models list is returned (the models list is a native
+// Anthropic endpoint, so requests carry x-api-key alongside the bearer token
+// and page through has_more/last_id rather than OpenAI-style), models are
+// described with the plugin's config schema, and generating with an
+// uncurated name resolves it instead of failing with model-not-found. The
+// server answers only version-prefixed paths, pinning that an origin-form
+// ANTHROPIC_BASE_URL gains the /v1 segment.
+func TestDynamicListingAndResolution(t *testing.T) {
+	var mu sync.Mutex
+	var modelsAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/models" {
+			mu.Lock()
+			modelsAuth = r.Header.Get("x-api-key")
+			mu.Unlock()
+			switch r.URL.Query().Get("after_id") {
+			case "":
+				_, _ = io.WriteString(w, `{"data":[{"id":"claude-brand-new","type":"model"}],"has_more":true,"last_id":"claude-brand-new"}`)
+			case "claude-brand-new":
+				_, _ = io.WriteString(w, `{"data":[{"id":"claude-second-page","type":"model"}],"has_more":false,"last_id":"claude-second-page"}`)
+			default:
+				t.Errorf("unexpected after_id %q", r.URL.Query().Get("after_id"))
+				_, _ = io.WriteString(w, `{"data":[],"has_more":false}`)
+			}
+			return
+		}
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"claude-brand-new",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"resolved"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", server.URL)
+
+	ctx := context.Background()
+	plugin := &Anthropic{}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	listed := map[string]bool{}
+	for _, desc := range plugin.ListActions(ctx) {
+		listed[desc.Name] = true
+		if desc.Name == "anthropic/claude-brand-new" {
+			model := desc.Metadata["model"].(map[string]any)
+			schema, ok := model["customOptions"].(map[string]any)
+			if !ok {
+				t.Fatalf("listed model has no customOptions: %v", model)
+			}
+			props, _ := schema["properties"].(map[string]any)
+			if props["thinking"] == nil {
+				t.Error("listed model schema is missing the plugin's thinking property")
+			}
+		}
+	}
+	if !listed["anthropic/claude-brand-new"] || !listed["anthropic/claude-second-page"] {
+		t.Fatalf("ListActions() = %v, want every page of the endpoint's models", listed)
+	}
+	mu.Lock()
+	if modelsAuth != "test-key" {
+		t.Errorf("models request x-api-key = %q, want the API key", modelsAuth)
+	}
+	mu.Unlock()
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("anthropic/claude-brand-new"),
+		ai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() with an uncurated model error = %v", err)
+	}
+	if got := resp.Text(); got != "resolved" {
+		t.Fatalf("Text() = %q, want %q", got, "resolved")
+	}
+}
+
+// TestPluginConfigPrecedence pins the credential contract: the struct field
+// wins over the environment, and either authenticates both surfaces the
+// plugin speaks to, the chat endpoint as the bearer token and the native
+// models list as x-api-key. A key arriving only through Opts is opaque to
+// the plugin and not part of this contract.
+func TestPluginConfigPrecedence(t *testing.T) {
+	var mu sync.Mutex
+	var chatAuth, modelsKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/models" {
+			mu.Lock()
+			modelsKey = r.Header.Get("x-api-key")
+			mu.Unlock()
+			_, _ = io.WriteString(w, `{"data":[],"has_more":false}`)
+			return
+		}
+		mu.Lock()
+		chatAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"claude-3-5-haiku-20241022",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("ANTHROPIC_API_KEY", "env-key")
+	t.Setenv("ANTHROPIC_BASE_URL", server.URL)
+
+	ctx := context.Background()
+	plugin := &Anthropic{APIKey: "struct-key"}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	plugin.ListActions(ctx)
+	if _, err := genkit.Generate(ctx, g,
+		ai.WithModelName("anthropic/claude-3-5-haiku-20241022"),
+		ai.WithPrompt("hi"),
+	); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if chatAuth != "Bearer struct-key" {
+		t.Errorf("chat Authorization = %q, want the struct key as the bearer token", chatAuth)
+	}
+	if modelsKey != "struct-key" {
+		t.Errorf("models x-api-key = %q, want the struct key over the environment's", modelsKey)
+	}
+}
+
+// TestExtraPassthroughRidesTheWire pins the inherited passthrough on this
+// plugin's own config: an undeclared field lands at the top level of the
+// request, and a collision with the extra the plugin itself writes (thinking)
+// resolves toward the caller's.
+func TestExtraPassthroughRidesTheWire(t *testing.T) {
+	var mu sync.Mutex
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"claude-3-5-haiku-20241022",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", server.URL)
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&Anthropic{}))
+
+	_, err := genkit.Generate(ctx, g,
+		ai.WithModelName("anthropic/claude-3-5-haiku-20241022"),
+		ai.WithPrompt("hi"),
+		ai.WithConfig(map[string]any{
+			"thinking": map[string]any{"type": "enabled", "budgetTokens": 2048},
+			"extra": map[string]any{
+				"thinking":       map[string]any{"type": "disabled"},
+				"context_window": "long",
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := body["context_window"]; got != "long" {
+		t.Errorf("context_window = %v, want the undeclared field on the wire", got)
+	}
+	thinking, _ := body["thinking"].(map[string]any)
+	if got := thinking["type"]; got != "disabled" {
+		t.Errorf("thinking.type = %v, want the caller's extra winning over the config's own thinking", got)
+	}
+}
+
+// TestListingStopsOnStuckCursor pins the pager's exit on a misbehaving
+// endpoint: a page that reports has_more but repeats the same last_id would
+// otherwise be fetched forever.
+func TestListingStopsOnStuckCursor(t *testing.T) {
+	var mu sync.Mutex
+	pages := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		pages++
+		n := pages
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if n > 2 {
+			t.Errorf("page request %d, want the walk to stop once the cursor fails to advance", n)
+			_, _ = io.WriteString(w, `{"data":[],"has_more":false}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[{"id":"claude-stuck","type":"model"}],"has_more":true,"last_id":"claude-stuck"}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", server.URL)
+
+	ctx := context.Background()
+	plugin := &Anthropic{}
+	genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	listed := false
+	for _, desc := range plugin.ListActions(ctx) {
+		if desc.Name == "anthropic/claude-stuck" {
+			listed = true
+		}
+	}
+	if !listed {
+		t.Error("ListActions() dropped the stuck page's model")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if pages != 2 {
+		t.Errorf("page requests = %d, want the first page and the one that proves the cursor is stuck", pages)
+	}
+}

--- a/go/plugins/compat_oai/anthropic/anthropic_test.go
+++ b/go/plugins/compat_oai/anthropic/anthropic_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 )
 
 // TestChatConfigApply pins the wire contract of the Claude compat config: the
@@ -129,6 +130,39 @@ func TestModelConfigSchema(t *testing.T) {
 	thinkingType, _ := thinkingProps["type"].(map[string]any)
 	if got, has := thinkingType["enum"]; has {
 		t.Errorf("thinking.type enum = %v, want none since the set is Anthropic's to grow", got)
+	}
+	// The API rejects thinking budgets under 1,024 tokens, so the schema
+	// carries the floor.
+	budget, _ := thinkingProps["budgetTokens"].(map[string]any)
+	if got := budget["minimum"]; got != 1024.0 {
+		t.Errorf("thinking.budgetTokens minimum = %#v, want Anthropic's 1024 floor", got)
+	}
+}
+
+// TestThinkingBudgetFloorRejected pins the floor end to end: the API rejects
+// budgets under 1,024 ("Input should be greater than or equal to 1024"), so
+// boundary validation catches one before the wire.
+func TestThinkingBudgetFloorRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("request reached the server, want boundary validation to reject the config")
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &Anthropic{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	_, err := genkit.Generate(ctx, g,
+		ai.WithModel(ModelRef("claude-3-5-haiku-20241022", &ChatConfig{
+			Thinking: &ThinkingConfig{Type: "enabled", BudgetTokens: 512},
+		})),
+		ai.WithPrompt("hi"),
+	)
+	if err == nil {
+		t.Fatal("Generate() error = nil, want the 512-token budget rejected")
+	}
+	if !strings.Contains(err.Error(), "budgetTokens") {
+		t.Errorf("error = %v, want it to name budgetTokens", err)
 	}
 }
 

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compat_oai_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
+)
+
+// canonicalTypes is the JSON type each shared config field must have wherever
+// a plugin declares it. Plugins declare their own fields rather than inheriting
+// them, so this is what keeps one config JSON meaning the same thing across
+// providers and runtimes. A field a provider does not accept is simply absent.
+var canonicalTypes = map[string]string{
+	"version":          "string",
+	"temperature":      "number",
+	"topP":             "number",
+	"maxOutputTokens":  "integer",
+	"stopSequences":    "array",
+	"frequencyPenalty": "number",
+	"presencePenalty":  "number",
+	"logProbs":         "boolean",
+	"topLogProbs":      "integer",
+	"seed":             "integer",
+	"reasoningEffort":  "string",
+}
+
+// TestConfigSchemaConformance pins the contract every plugin config in this
+// package shares: canonical camelCase names with canonical types, a version
+// key, and no credential or wire-name key. The openai plugin is deliberately
+// absent: its config is the OpenAI SDK request type, so it speaks the SDK's
+// own snake_case names by design.
+func TestConfigSchemaConformance(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	g := genkit.Init(context.Background(), genkit.WithPlugins(
+		&anthropic.Anthropic{},
+	))
+
+	models := []string{
+		"anthropic/claude-sonnet-4-5-20250929",
+	}
+
+	for _, name := range models {
+		t.Run(name, func(t *testing.T) {
+			m := genkit.LookupModel(g, name)
+			if m == nil {
+				t.Fatalf("%s not registered by Init", name)
+			}
+			model, ok := m.(api.Action).Desc().Metadata["model"].(map[string]any)
+			if !ok {
+				t.Fatalf("model metadata missing for %s", name)
+			}
+			schema, ok := model["customOptions"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s advertises no config schema", name)
+			}
+			props, ok := schema["properties"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s config schema has no properties: %v", name, schema)
+			}
+
+			if props["version"] == nil {
+				t.Error("config schema is missing the version property")
+			}
+			if props["apiKey"] != nil {
+				t.Error("config schema advertises apiKey, want the credential kept out of serialized configs")
+			}
+
+			for key, prop := range props {
+				if strings.ContainsAny(key, "_-") {
+					t.Errorf("config schema advertises %q, want the camelCase contract", key)
+				}
+				want, canonical := canonicalTypes[key]
+				if !canonical {
+					continue // A provider-specific field defines its own shape.
+				}
+				field, ok := prop.(map[string]any)
+				if !ok {
+					t.Errorf("%s property is %#v, want an object schema", key, prop)
+					continue
+				}
+				if got := field["type"]; got != want {
+					t.Errorf("%s type = %v, want %q to match every other plugin", key, got, want)
+				}
+			}
+
+			requireDescriptions(t, "", props)
+		})
+	}
+}
+
+// requireDescriptions walks a schema's properties, recursively through nested
+// objects, and fails for any that carries no description. The description is
+// the help text the Dev UI shows for the field, so a bare property is a knob
+// users see and get no explanation of.
+func requireDescriptions(t *testing.T, path string, props map[string]any) {
+	t.Helper()
+	for key, prop := range props {
+		field, ok := prop.(map[string]any)
+		if !ok {
+			continue // Reported as a malformed property by the caller's checks.
+		}
+		name := path + key
+		if desc, _ := field["description"].(string); desc == "" {
+			t.Errorf("%s has no description, want Dev UI help text on every config field", name)
+		}
+		if nested, ok := field["properties"].(map[string]any); ok {
+			requireDescriptions(t, name+".", nested)
+		}
+	}
+}
+
+// TestModelsOverrideConformance pins that a caller's Models entry reaches a
+// curated model, on every plugin. This is the answer to a catalog that
+// describes a model wrongly: Init registers the curated models and nothing can
+// re-register them, so the override has to be read before Init registers, not
+// applied afterwards.
+func TestModelsOverrideConformance(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	// Keyed provider-prefixed on half of them, bare on the rest: both forms
+	// name the same model.
+	pinned := ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, Media: false}}
+
+	g := genkit.Init(context.Background(), genkit.WithPlugins(
+		&anthropic.Anthropic{Models: map[string]ai.ModelOptions{
+			"anthropic/claude-sonnet-4-5-20250929": pinned}},
+	))
+
+	for _, name := range []string{
+		"anthropic/claude-sonnet-4-5-20250929",
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := genkit.LookupModel(g, name)
+			if m == nil {
+				t.Fatalf("%s not registered by Init", name)
+			}
+			model, ok := m.(api.Action).Desc().Metadata["model"].(map[string]any)
+			if !ok {
+				t.Fatalf("model metadata missing for %s", name)
+			}
+			supports, ok := model["supports"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s advertises no supports", name)
+			}
+			if supports["media"] != false {
+				t.Errorf("media = %v, want the override's false", supports["media"])
+			}
+			// Overlaid, not replaced: the curated label survives an entry that
+			// says nothing about it.
+			if label, _ := model["label"].(string); label == "" {
+				t.Error("label is empty, want the curated one kept by the overlay")
+			}
+		})
+	}
+}

--- a/go/samples/compat_oai/anthropic/main.go
+++ b/go/samples/compat_oai/anthropic/main.go
@@ -1,50 +1,67 @@
-// Copyright 2024 Google LLC
-// SPDX-License-Identifier: Apache-2.0
-
-// This program can be manually tested like so:
-// Start the server listening on port 3100:
+// Copyright 2026 Google LLC
 //
-//	genkit start -o -- go run .
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+// This sample demonstrates the Anthropic plugin: a flow that generates a joke
+// with a model pinned through anthropic.ModelRef and its typed config.
+//
+// To run:
+//
+//	export ANTHROPIC_API_KEY=...
+//	go run .
+//
+// In another terminal:
+//
+//	curl -X POST http://localhost:8080/jokesFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": "bananas"}'
 package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
 	"github.com/firebase/genkit/go/plugins/server"
-	"github.com/openai/openai-go/option"
 )
 
 func main() {
 	ctx := context.Background()
 
-	plugin := anthropic.Anthropic{
-		Opts: []option.RequestOption{
-			option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
-		},
-	}
-	g := genkit.Init(ctx, genkit.WithPlugins(&plugin))
+	// The plugin reads the API key from the ANTHROPIC_API_KEY environment variable.
+	g := genkit.Init(ctx, genkit.WithPlugins(&anthropic.Anthropic{}))
 
-	genkit.DefineFlow(g, "anthropic", func(ctx context.Context, subject string) (string, error) {
-		sonnet37 := anthropic.ModelRef("claude-3-7-sonnet-20250219", &anthropic.ChatConfig{
-			MaxOutputTokens: 1024,
-		})
-
-		prompt := fmt.Sprintf("tell me a joke about %s", subject)
-		foo, err := genkit.Generate(ctx, g, ai.WithModel(sonnet37), ai.WithPrompt(prompt))
-		if err != nil {
-			return "", err
+	// Define a flow that generates a joke about a given topic. The thinking
+	// config spends a reasoning budget before answering; the compatible
+	// endpoint keeps the thinking content itself server-side.
+	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		if topic == "" {
+			topic = "airplane food"
 		}
-		return fmt.Sprintf("foo: %s", foo.Text()), nil
+
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(anthropic.ModelRef("claude-sonnet-4-5-20250929", &anthropic.ChatConfig{
+				MaxOutputTokens: 2048,
+				Thinking:        &anthropic.ThinkingConfig{Type: "enabled", BudgetTokens: 2000},
+			})),
+			ai.WithPrompt("Share a joke about %s.", topic),
+		)
 	})
 
+	// Optionally, start a web server to make the flow callable via HTTP.
 	mux := http.NewServeMux()
 	for _, a := range genkit.ListFlows(g) {
 		mux.HandleFunc("POST /"+a.Name(), genkit.Handler(a))

--- a/go/samples/compat_oai/anthropic/main.go
+++ b/go/samples/compat_oai/anthropic/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
-	oai "github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
+	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
 	"github.com/firebase/genkit/go/plugins/server"
 	"github.com/openai/openai-go/option"
 )
@@ -25,15 +25,17 @@ import (
 func main() {
 	ctx := context.Background()
 
-	oai := oai.Anthropic{
+	plugin := anthropic.Anthropic{
 		Opts: []option.RequestOption{
 			option.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
 		},
 	}
-	g := genkit.Init(ctx, genkit.WithPlugins(&oai))
+	g := genkit.Init(ctx, genkit.WithPlugins(&plugin))
 
 	genkit.DefineFlow(g, "anthropic", func(ctx context.Context, subject string) (string, error) {
-		sonnet37 := oai.Model(g, "claude-3-7-sonnet-20250219")
+		sonnet37 := anthropic.ModelRef("claude-3-7-sonnet-20250219", &anthropic.ChatConfig{
+			MaxOutputTokens: 1024,
+		})
 
 		prompt := fmt.Sprintf("tell me a joke about %s", subject)
 		foo, err := genkit.Generate(ctx, g, ai.WithModel(sonnet37), ai.WithPrompt(prompt))


### PR DESCRIPTION
Migrates the compat `anthropic` plugin onto the typed-config base (#5976), the first sub-plugin PR of that train.

## The plugin and its config, at a glance

```go
type Anthropic struct {
	APIKey string
	Opts   []option.RequestOption
	Models map[string]ai.ModelOptions
}

type ChatConfig struct {
	compat_oai.RequestConfig
	Temperature     *float64        `json:"temperature,omitempty"`
	MaxOutputTokens int             `json:"maxOutputTokens,omitempty"`
	TopP            *float64        `json:"topP,omitempty"`
	StopSequences   []string        `json:"stopSequences,omitempty"`
	Thinking        *ThinkingConfig `json:"thinking,omitempty"`
}

type ThinkingConfig struct {
	Type         string `json:"type,omitempty"`
	BudgetTokens int    `json:"budgetTokens,omitempty"`
}
```

The released plugin took its credential from the environment alone; `APIKey` is additive, field-then-env. Either source derives both wire credentials (the bearer token for chat, `x-api-key` for the native models list); a key supplied only through `Opts` is opaque to the plugin, which is why the field exists, pinned by a precedence test.

The schema enforces the endpoint's documented limits: `temperature` runs 0 to 1 because that is where this endpoint caps it, and `thinking.budgetTokens` carries Anthropic's 1,024 floor (the API rejects smaller budgets, verified live), so an undersized budget fails boundary validation instead of at the endpoint. Two absences are deliberate and pinned by tests: `topP` declares no range (the endpoint documents none), and `thinking.type` no enum (the native set has grown before, so a list would reject values Anthropic accepts).

The catalog moves to the shared `ModelOptionsFor` overlay with a `Models` field, listing pages through the full models list, and the sample pins its config through `anthropic.ModelRef`. The package conformance sweep lands here with its first plugin (canonical camelCase names, a `version` key, no credential key, a description on every property); each later PR adds its own.

## Released surface

`compat_oai/anthropic` shipped in `go/v1.11.0`: `DefineModel` and `Model` are deprecated in place with signatures kept. Runtime tightens the way the base PR's `openai` does: an undeclared config field is rejected instead of riding along as an extra key, and a `temperature` above 1 fails instead of being sent and silently capped by the endpoint.

```go
// Added
type ChatConfig struct { compat_oai.RequestConfig; Temperature *float64; MaxOutputTokens int; TopP *float64; StopSequences []string; Thinking *ThinkingConfig }
type ThinkingConfig struct { Type string; BudgetTokens int }
Anthropic.Models map[string]ai.ModelOptions
func ModelRef(id string, config *ChatConfig) ai.ModelRef

// Deprecated, kept
anthropic.DefineModel, anthropic.Model
```

## The first live run fixed three things

**ANTHROPIC_BASE_URL now names the API origin.** The native SDKs treat the variable as the origin and add the version segment themselves, and environments export it in that form (Claude Code sets `https://api.anthropic.com`). Passed verbatim to the OpenAI SDK, whose paths carry no version, every request went to `/chat/completions` and answered 404. Init restores the `/v1` unless already present; the listing test's server answers only version-prefixed paths.

**Structured outputs are native from the 4.5 generation on.** The endpoint takes `response_format` in its `json_schema` form and rejects every other form with a 400. Models from 4.5 on declare `ConstrainedSupportAll`, and every capability set declares its output formats without `"json"`, so a schema-less JSON request sends no `response_format` at all (mechanism in the base PR).

**The 4.x `-latest` aliases never existed.** The wire answers `claude-haiku-4-5-latest` with model-not-found: from Claude 4 on the alias is the bare name, and from 4.6 on IDs are dateless pinned snapshots. Versions now carry the real aliases, and the catalog gains Fable 5, Opus 5, Sonnet 5, Opus 4.6 through 4.8, and Sonnet 4.6.

## Testing

Go 1.26.3: `go build ./...` and `go test ./plugins/compat_oai/...` pass at this level of the stack; the package is 10 cases counting subtests, the live one skipping without `ANTHROPIC_API_KEY`. The schema test pins the constraint values including the budget floor and both deliberate absences, a regression drives a 512-token budget into boundary validation, and the conformance sweep walks the advertised schema. The live test runs the shared checklist from the base PR's `internal/livetest` harness: Haiku 4.5 carries the whole list, thinking included (the endpoint accepts the knob but never returns the content), and a `thinking` key rides the `extra` passthrough. Against the real API: 15/15 pass, native structured output and vision included.

