### PR TITLE
feat(go/plugins/compat_oai/dashscope): migrate to a typed config and the shared catalog

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1128,7 +1128,7 @@ Genkit provides a unified interface across all major AI providers. Use whichever
 | **Vertex AI** | `vertexai.VertexAI` | Gemini 3.5 Flash, Gemini 3.1 Pro via Google Cloud |
 | **Anthropic** | `anthropic.Anthropic` | Claude Opus 4.8, Claude Sonnet 4.6, Claude Haiku 4.5 |
 | **Ollama** | `ollama.Ollama` | Llama 4, Qwen 3, DeepSeek, and other local models |
-| **OpenAI Compatible** | `compat_oai` | GPT-5.6, and any OpenAI-compatible API |
+| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Qwen, and any OpenAI-compatible API |
 
 ```go
 // Google AI

--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -189,7 +189,8 @@ providers and `max_completion_tokens` on others. Use the same camelCase name
 other plugins use for the same setting; `conformance_test.go` enforces that
 across the package.
 
-See the `openai` and `anthropic` directories for complete implementations.
+See the `openai`, `anthropic`, and `dashscope` directories for complete
+implementations.
 
 ## Running Tests
 

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
+	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
 )
 
 // canonicalTypes is the JSON type each shared config field must have wherever
@@ -50,13 +51,16 @@ var canonicalTypes = map[string]string{
 // own snake_case names by design.
 func TestConfigSchemaConformance(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("DASHSCOPE_API_KEY", "test-key")
 
 	g := genkit.Init(context.Background(), genkit.WithPlugins(
 		&anthropic.Anthropic{},
+		&dashscope.DashScope{},
 	))
 
 	models := []string{
 		"anthropic/claude-sonnet-4-5-20250929",
+		"dashscope/qwen-plus",
 	}
 
 	for _, name := range models {
@@ -136,6 +140,7 @@ func requireDescriptions(t *testing.T, path string, props map[string]any) {
 // applied afterwards.
 func TestModelsOverrideConformance(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("DASHSCOPE_API_KEY", "test-key")
 
 	// Keyed provider-prefixed on half of them, bare on the rest: both forms
 	// name the same model.
@@ -144,10 +149,12 @@ func TestModelsOverrideConformance(t *testing.T) {
 	g := genkit.Init(context.Background(), genkit.WithPlugins(
 		&anthropic.Anthropic{Models: map[string]ai.ModelOptions{
 			"anthropic/claude-sonnet-4-5-20250929": pinned}},
+		&dashscope.DashScope{Models: map[string]ai.ModelOptions{"qwen-plus": pinned}},
 	))
 
 	for _, name := range []string{
 		"anthropic/claude-sonnet-4-5-20250929",
+		"dashscope/qwen-plus",
 	} {
 		t.Run(name, func(t *testing.T) {
 			m := genkit.LookupModel(g, name)

--- a/go/plugins/compat_oai/dashscope/README.md
+++ b/go/plugins/compat_oai/dashscope/README.md
@@ -30,8 +30,7 @@ import (
 
 ctx := context.Background()
 plugin := &dashscope.DashScope{}
-g := genkit.Init(
-    ctx,
+g := genkit.Init(ctx,
     genkit.WithPlugins(plugin),
     genkit.WithDefaultModel("dashscope/qwen-plus"),
 )

--- a/go/plugins/compat_oai/dashscope/README.md
+++ b/go/plugins/compat_oai/dashscope/README.md
@@ -1,38 +1,93 @@
 # DashScope Plugin
 
-This plugin provides a simple interface for using Alibaba Cloud Model Studio's
-DashScope service to call Qwen models through its OpenAI-compatible endpoint.
+This plugin provides Genkit support for Qwen models through Alibaba Cloud
+Model Studio's OpenAI-compatible DashScope endpoint.
 
-## Prerequisites
+## Setup
 
-- Go installed on your system
-- A DashScope API key
-
-## Base URL
-
-By default the plugin points at the shared international endpoint,
-`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`, which works out of the box for
-standard API keys. If you're on a mainland-China account, use
-`https://dashscope.aliyuncs.com/compatible-mode/v1` instead via `DASHSCOPE_BASE_URL`:
+Set a Model Studio API key:
 
 ```bash
-export DASHSCOPE_BASE_URL=<your-base-url>
+export DASHSCOPE_API_KEY=<your-api-key>
 ```
 
-Alibaba also offers a **workspace-dedicated domain**
-(`https://<workspace-id>.<region>.maas.aliyuncs.com/compatible-mode/v1`), which they
-recommend for production use (higher throughput, lower latency, workspace-level
-isolation) — get this from the Model Studio console's API-key popup or Workspace
-Management page if you want it. It's an optional upgrade, not a requirement: the shared
-default endpoint above works fine for standard usage too.
+By default the plugin points at the international endpoint,
+`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`. Mainland-China
+accounts use `https://dashscope.aliyuncs.com/compatible-mode/v1` instead, and
+Alibaba recommends a workspace-dedicated domain for production; set either
+through `DASHSCOPE_BASE_URL`, or pass `option.WithBaseURL` through the
+plugin's `Opts`. See https://help.aliyun.com/en/model-studio/base-url for the
+endpoint reference.
 
-See https://help.aliyun.com/en/model-studio/base-url for the full reference.
+```go
+import (
+    "context"
 
-## Tool Choice
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
+)
 
-Qwen models support tool calling, but forced tool-choice modes (`required`/`none`)
-carry model- and thinking-mode-specific restrictions. This plugin does not
-advertise `ToolChoice` support and always uses automatic tool selection.
+ctx := context.Background()
+plugin := &dashscope.DashScope{}
+g := genkit.Init(
+    ctx,
+    genkit.WithPlugins(plugin),
+    genkit.WithDefaultModel("dashscope/qwen-plus"),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain mixture-of-experts models."))
+```
+
+Qwen's `reasoning_content` output is returned as Genkit reasoning parts and
+is available through `response.Reasoning()`.
+
+## Models
+
+The registered catalog spans the commercial Qwen line (`qwen-flash`,
+`qwen-plus`, the `qwen3.5` through `qwen3.7` series, `qwen3-max`), vision
+(`qwen3-vl-plus`), and coding (`qwen3-coder-plus`) models. The catalog is not a ceiling: any model ID Model Studio serves
+resolves on demand, and the `Models` field describes or corrects any model,
+curated or not:
+
+```go
+plugin := &dashscope.DashScope{Models: map[string]ai.ModelOptions{
+    "qwen4-max": {Label: "Qwen4 Max", Supports: &compat_oai.Multimodal},
+}}
+```
+
+The current model list is at
+https://www.alibabacloud.com/help/en/model-studio/models.
+
+## Config
+
+Models take a typed `dashscope.ChatConfig`: the generation fields the
+compatible mode accepts plus the DashScope-specific controls (`seed`,
+`enableThinking`, `thinkingBudget`, `enableSearch`). `dashscope.ModelRef`
+carries the config with the model ID:
+
+```go
+response, err := genkit.Generate(ctx, g,
+    ai.WithModel(dashscope.ModelRef("qwen-plus", &dashscope.ChatConfig{
+        EnableThinking: openai.Ptr(true),
+        ThinkingBudget: openai.Ptr(2048),
+    })),
+    ai.WithPrompt("Explain mixture-of-experts models."),
+)
+```
+
+Every config also carries the settings Genkit owns: `version` pins the exact
+model version a request is served by, `apiKey` (settable only from Go code)
+serves one request with a different credential, and `extra` forwards request
+body fields the config does not declare, keyed by DashScope's wire names
+(for example `search_options`).
+
+## Tool choice
+
+Qwen models support tool calling, but forced tool-choice modes
+(`required`/`none`) carry model- and thinking-mode-specific restrictions.
+This plugin does not advertise `ToolChoice` support and always uses automatic
+tool selection.
 
 ## Live tests
 

--- a/go/plugins/compat_oai/dashscope/dashscope.go
+++ b/go/plugins/compat_oai/dashscope/dashscope.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package dashscope provides a Genkit plugin for Alibaba Cloud DashScope's Qwen models.
+// Package dashscope provides a Genkit plugin for Alibaba Cloud's Qwen models,
+// served through DashScope's OpenAI-compatible mode.
 package dashscope
 
 import (
@@ -21,162 +22,223 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
-	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 )
 
 const (
 	provider = "dashscope"
 	// defaultBaseURL is the shared international endpoint, used as a fallback
-	// when neither BaseURL nor DASHSCOPE_BASE_URL is set. Works for standard
-	// API keys; mainland-China accounts or workspace-dedicated domains
-	// (Alibaba's recommended production setup) should override via BaseURL or
-	// DASHSCOPE_BASE_URL. See https://help.aliyun.com/en/model-studio/base-url
+	// when DASHSCOPE_BASE_URL is not set. Works for standard API keys;
+	// mainland-China accounts or workspace-dedicated domains (Alibaba's
+	// recommended production setup) should override via DASHSCOPE_BASE_URL or
+	// [option.WithBaseURL]. See https://help.aliyun.com/en/model-studio/base-url
 	// and the package README.
 	defaultBaseURL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 )
 
-// Supported models: https://www.alibabacloud.com/help/en/model-studio/models
-// Confirmed against the live GET /compatible-mode/v1/models response for this workspace.
-// Dated snapshots are folded into Versions rather than registered as separate models,
-// mirroring the anthropic and openai subplugins.
+// ChatConfig is the per-request config for Qwen models served through
+// DashScope's OpenAI-compatible mode: the common generation fields plus the
+// DashScope-specific controls the mode accepts as extra request fields. See
+// https://www.alibabacloud.com/help/en/model-studio/use-qwen-by-calling-api.
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// Temperature controls the degree of randomness in token selection, from
+	// 0 inclusive up to but not including 2.
+	Temperature *float64 `json:"temperature,omitempty" jsonschema:"minimum=0,exclusiveMaximum=2" jsonschema_description:"Controls the degree of randomness in token selection, from 0 inclusive up to but not including 2."`
+	// TopP is the nucleus sampling threshold, above 0 and up to 1 inclusive.
+	TopP *float64 `json:"topP,omitempty" jsonschema:"exclusiveMinimum=0,maximum=1" jsonschema_description:"Nucleus sampling threshold, above 0 and up to 1 inclusive."`
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as the
+	// API's max_tokens; the default and the ceiling are both the model's
+	// maximum output length.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_tokens. The default and the ceiling are both the model's maximum output length."`
+	// StopSequences stop generation when produced by the model.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema_description:"Stop generation when produced by the model."`
+	// PresencePenalty penalizes tokens that have appeared at all, from -2.0 to
+	// 2.0. DashScope's compatible mode documents no frequency penalty.
+	PresencePenalty *float64 `json:"presencePenalty,omitempty" jsonschema:"minimum=-2,maximum=2" jsonschema_description:"Penalizes tokens that have appeared at all, from -2.0 to 2.0."`
+	// Seed makes generation reproducible across calls when set, from 0 to
+	// 2^31-1.
+	Seed *int `json:"seed,omitempty" jsonschema:"minimum=0,maximum=2147483647" jsonschema_description:"Makes generation reproducible across calls when set, from 0 to 2^31-1."`
+	// EnableThinking turns the thinking mode of hybrid Qwen models on or off,
+	// sent as the API's enable_thinking.
+	EnableThinking *bool `json:"enableThinking,omitempty" jsonschema_description:"Turns the thinking mode of hybrid Qwen models on or off, sent as the API's enable_thinking."`
+	// ThinkingBudget is the maximum number of tokens the model may think
+	// with, sent as the API's thinking_budget; it requires EnableThinking.
+	// The default is the model's maximum chain-of-thought length.
+	ThinkingBudget *int `json:"thinkingBudget,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens the model may think with, sent as the API's thinking_budget; requires enableThinking. Defaults to the model's maximum chain-of-thought length."`
+	// EnableSearch lets the model consult web search, sent as the API's
+	// enable_search.
+	EnableSearch *bool `json:"enableSearch,omitempty" jsonschema_description:"Lets the model consult web search, sent as the API's enable_search."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the generation
+// fields land on their chat completion counterparts and the DashScope controls
+// ride as the mode's extra request fields.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.Temperature != nil {
+		params.Temperature = openai.Float(*c.Temperature)
+	}
+	if c.TopP != nil {
+		params.TopP = openai.Float(*c.TopP)
+	}
+	if c.MaxOutputTokens > 0 {
+		params.MaxTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+	if c.PresencePenalty != nil {
+		params.PresencePenalty = openai.Float(*c.PresencePenalty)
+	}
+	if c.Seed != nil {
+		params.Seed = openai.Int(int64(*c.Seed))
+	}
+
+	extra := map[string]any{}
+	if c.EnableThinking != nil {
+		extra["enable_thinking"] = *c.EnableThinking
+	}
+	if c.ThinkingBudget != nil {
+		extra["thinking_budget"] = *c.ThinkingBudget
+	}
+	if c.EnableSearch != nil {
+		extra["enable_search"] = *c.EnableSearch
+	}
+	compat_oai.AddExtraFields(params, extra)
+}
+
+// Capability sets shared by the entries below. Forced tool-choice modes carry
+// model- and thinking-mode-specific restrictions on Qwen, so no model
+// advertises ToolChoice and tool selection is always automatic. Constrained
+// generation is likewise absent: DashScope's response_format takes
+// json_object only, not json_schema, so a schema reaches the model as prompt
+// instructions. See https://www.alibabacloud.com/help/en/model-studio/json-mode.
+var (
+	textOnly = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		SystemRole: true,
+		Media:      false,
+		Output:     []string{"text", "json"},
+	}
+	multimodal = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		SystemRole: true,
+		Media:      true,
+		Output:     []string{"text", "json"},
+	}
+)
+
+// supportedModels curates capabilities for well-known Qwen models. It is not
+// the set of usable models: any Qwen model resolves on demand and takes
+// [dynamicModelOptions], so an ID absent here still works. Dated snapshots are
+// folded into Versions rather than registered as separate models, matching the
+// anthropic and openai subplugins.
+//
+// Catalog: https://www.alibabacloud.com/help/en/model-studio/models
+// Confirmed against the live GET /compatible-mode/v1/models response.
 var supportedModels = map[string]ai.ModelOptions{
 	"qwen-flash": {
-		Label: "Qwen Flash",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      false,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen Flash",
+		Supports: &textOnly,
 		Versions: []string{"qwen-flash", "qwen-flash-2025-07-28"},
 	},
 	"qwen-plus": {
-		Label: "Qwen Plus",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      false,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen Plus",
+		Supports: &textOnly,
 		Versions: []string{"qwen-plus", "qwen-plus-2025-07-28", "qwen-plus-2025-09-11", "qwen-plus-2025-12-01"},
 	},
 	"qwen3.5-flash": {
-		Label: "Qwen 3.5 Flash",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3.5 Flash",
+		Supports: &multimodal,
 		Versions: []string{"qwen3.5-flash", "qwen3.5-flash-2026-02-23"},
 	},
 	"qwen3.5-plus": {
-		Label: "Qwen 3.5 Plus",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3.5 Plus",
+		Supports: &multimodal,
 		Versions: []string{"qwen3.5-plus", "qwen3.5-plus-2026-02-15"},
 	},
 	"qwen3.6-flash": {
-		Label: "Qwen 3.6 Flash",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3.6 Flash",
+		Supports: &multimodal,
 		Versions: []string{"qwen3.6-flash", "qwen3.6-flash-2026-04-16"},
 	},
 	"qwen3.6-plus": {
-		Label: "Qwen 3.6 Plus",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3.6 Plus",
+		Supports: &multimodal,
 		Versions: []string{"qwen3.6-plus", "qwen3.6-plus-2026-04-02"},
 	},
 	"qwen3.7-plus": {
-		Label: "Qwen 3.7 Plus",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3.7 Plus",
+		Supports: &multimodal,
 		Versions: []string{"qwen3.7-plus", "qwen3.7-plus-2026-05-26"},
 	},
 	"qwen3.7-max": {
-		Label: "Qwen 3.7 Max",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      false,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3.7 Max",
+		Supports: &textOnly,
 		Versions: []string{"qwen3.7-max", "qwen3.7-max-2026-06-08", "qwen3.7-max-2026-05-20"},
 	},
 	"qwen3-max": {
-		Label: "Qwen 3 Max",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      false,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3 Max",
+		Supports: &textOnly,
 		Versions: []string{"qwen3-max", "qwen3-max-2026-01-23", "qwen3-max-2025-09-23", "qwen3-max-preview"},
 	},
 	"qwen3-vl-plus": {
-		Label: "Qwen 3 VL Plus",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3 VL Plus",
+		Supports: &multimodal,
 		Versions: []string{"qwen3-vl-plus", "qwen3-vl-plus-2025-12-19", "qwen3-vl-plus-2025-09-23"},
 	},
 	"qwen3-coder-plus": {
-		Label: "Qwen 3 Coder Plus",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      false,
-			Output:     []string{"text", "json"},
-		},
+		Label:    "Qwen 3 Coder Plus",
+		Supports: &textOnly,
 		Versions: []string{"qwen3-coder-plus", "qwen3-coder-plus-2025-07-22", "qwen3-coder-plus-2025-09-23"},
 	},
+}
+
+// dynamicModelOptions is advertised for Qwen models that resolve dynamically
+// rather than appearing in supportedModels.
+var dynamicModelOptions = ai.ModelOptions{
+	Supports: &textOnly,
+	Versions: []string{},
+	Stage:    ai.ModelStageStable,
 }
 
 // DashScope configures the Alibaba Cloud DashScope (Qwen) plugin.
 type DashScope struct {
 	// APIKey is the DashScope API key. If empty, DASHSCOPE_API_KEY is consulted.
 	APIKey string
-	// BaseURL overrides the DashScope API endpoint. If empty, DASHSCOPE_BASE_URL,
-	// and then the default international endpoint are used.
-	BaseURL string
-	// Opts contains additional OpenAI client request options. Options supplied
-	// here are applied after the plugin defaults.
+	// Opts contains additional OpenAI client request options, such as
+	// [option.WithBaseURL] for a different endpoint (DASHSCOPE_BASE_URL works
+	// too). Options supplied here are applied after the plugin defaults, so
+	// they win on overlap.
 	Opts []option.RequestOption
 
-	openAICompatible *compat_oai.OpenAICompatible
+	// Models overrides what the plugin knows about a Qwen model, keyed by
+	// model ID, bare or provider-prefixed. Every Qwen model already works
+	// without an entry: known IDs carry curated capabilities and the rest take
+	// the Qwen defaults. Supply an entry only to correct or extend what the
+	// plugin resolves, most often for a model released after this version of
+	// the plugin.
+	//
+	//	&dashscope.DashScope{Models: map[string]ai.ModelOptions{
+	//		"qwen-plus": {Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+	//	}}
+	//
+	// Fields left at their zero value keep what the plugin resolves, so an
+	// entry can pin one capability without restating the label or the
+	// versions. Entries apply to the models Init registers as well as the
+	// ones [DashScope.ListActions] advertises and [DashScope.ResolveAction] builds,
+	// which is the way to describe a curated model differently: Init has
+	// already registered those and nothing can re-register them.
+	Models map[string]ai.ModelOptions
+
+	openAICompatible compat_oai.OpenAICompatible
 }
 
 // Name implements genkit.Plugin.
@@ -186,10 +248,7 @@ func (d *DashScope) Name() string {
 
 // Init implements genkit.Plugin.
 func (d *DashScope) Init(ctx context.Context) []api.Action {
-	baseURL := d.BaseURL
-	if baseURL == "" {
-		baseURL = os.Getenv("DASHSCOPE_BASE_URL")
-	}
+	baseURL := os.Getenv("DASHSCOPE_BASE_URL")
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
@@ -208,10 +267,6 @@ func (d *DashScope) Init(ctx context.Context) []api.Action {
 	}
 	opts = append(opts, d.Opts...)
 
-	if d.openAICompatible == nil {
-		d.openAICompatible = &compat_oai.OpenAICompatible{}
-	}
-
 	d.openAICompatible.Provider = provider
 	d.openAICompatible.Opts = opts
 	compatActions := d.openAICompatible.Init(ctx)
@@ -220,20 +275,50 @@ func (d *DashScope) Init(ctx context.Context) []api.Action {
 	actions = append(actions, compatActions...)
 
 	// define default models
-	for model, modelOpts := range supportedModels {
-		actions = append(actions, d.DefineModel(model, modelOpts).(api.Action))
+	for model := range supportedModels {
+		actions = append(actions, d.newModel(model, d.modelOptions(model)))
 	}
 
 	return actions
 }
 
-// Model returns a registered DashScope model.
-func (d *DashScope) Model(g *genkit.Genkit, id string) ai.Model {
-	return d.openAICompatible.Model(g, api.NewName(provider, id))
+// newModel creates a Qwen model without registering it.
+func (d *DashScope) newModel(id string, opts ai.ModelOptions) *ai.ModelAction {
+	return compat_oai.NewChatModel[ChatConfig](&d.openAICompatible, id, opts)
 }
 
-// DefineModel registers a DashScope model, including models not in the
-// built-in list.
-func (d *DashScope) DefineModel(id string, opts ai.ModelOptions) ai.Model {
-	return d.openAICompatible.DefineModel(provider, id, opts)
+// modelOptions returns the ModelOptions for a Qwen model ID: curated
+// capabilities for a known model and the Qwen defaults for the rest, with
+// an entry from [DashScope.Models] overlaid on whichever applies.
+//
+// Every path that describes a model goes through this one, which is what
+// makes a caller's entry authoritative whether Init, ListActions or
+// ResolveAction gets there first.
+func (d *DashScope) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, supportedModels, dynamicModelOptions, d.Models)
+}
+
+// ModelRef names a Qwen model and carries the config to generate with, so the
+// config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(dashscope.ModelRef("qwen-plus", &dashscope.ChatConfig{
+//		EnableThinking: openai.Ptr(true),
+//	}))
+//
+// id is the model ID, with or without the provider prefix.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// ListActions lists the models the configured DashScope endpoint exposes,
+// described by the plugin's config schema and capabilities.
+func (d *DashScope) ListActions(ctx context.Context) []api.ActionDesc {
+	return compat_oai.ListChatActions[ChatConfig](ctx, &d.openAICompatible, d.modelOptions)
+}
+
+// ResolveAction dynamically builds a model exposed by the DashScope endpoint,
+// described by the plugin's config schema and capabilities.
+func (d *DashScope) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&d.openAICompatible, atype, id, d.modelOptions)
 }

--- a/go/plugins/compat_oai/dashscope/dashscope.go
+++ b/go/plugins/compat_oai/dashscope/dashscope.go
@@ -118,6 +118,11 @@ func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams
 // generation is likewise absent: DashScope's response_format takes
 // json_object only, not json_schema, so a schema reaches the model as prompt
 // instructions. See https://www.alibabacloud.com/help/en/model-studio/json-mode.
+//
+// The NoJSON sets serve the models whose capability tables say "Structured
+// Outputs: Unsupported": response_format fails there, so they advertise text
+// output only, the base sends no response_format, and the format instructions
+// the framework injects carry a JSON request instead.
 var (
 	textOnly = ai.ModelSupports{
 		Multiturn:  true,
@@ -132,6 +137,20 @@ var (
 		SystemRole: true,
 		Media:      true,
 		Output:     []string{"text", "json"},
+	}
+	textOnlyNoJSON = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		SystemRole: true,
+		Media:      false,
+		Output:     []string{"text"},
+	}
+	multimodalNoJSON = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		SystemRole: true,
+		Media:      true,
+		Output:     []string{"text"},
 	}
 )
 
@@ -181,8 +200,17 @@ var supportedModels = map[string]ai.ModelOptions{
 	},
 	"qwen3.7-max": {
 		Label:    "Qwen 3.7 Max",
-		Supports: &textOnly,
+		Supports: &textOnlyNoJSON,
 		Versions: []string{"qwen3.7-max", "qwen3.7-max-2026-06-08", "qwen3.7-max-2026-05-20"},
+	},
+	// The 2026-06-08 snapshot has capabilities of its own: DashScope documents
+	// image and video input for it, which the floating qwen3.7-max and the May
+	// snapshot do not take. It is registered standalone so media requests pass
+	// validation, and stays in the base entry's Versions so pinning it there
+	// keeps working.
+	"qwen3.7-max-2026-06-08": {
+		Label:    "Qwen 3.7 Max (2026-06-08)",
+		Supports: &multimodalNoJSON,
 	},
 	"qwen3-max": {
 		Label:    "Qwen 3 Max",
@@ -196,7 +224,7 @@ var supportedModels = map[string]ai.ModelOptions{
 	},
 	"qwen3-coder-plus": {
 		Label:    "Qwen 3 Coder Plus",
-		Supports: &textOnly,
+		Supports: &textOnlyNoJSON,
 		Versions: []string{"qwen3-coder-plus", "qwen3-coder-plus-2025-07-22", "qwen3-coder-plus-2025-09-23"},
 	},
 }

--- a/go/plugins/compat_oai/dashscope/dashscope_live_test.go
+++ b/go/plugins/compat_oai/dashscope/dashscope_live_test.go
@@ -17,103 +17,36 @@ package dashscope_test
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
+	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
 )
 
 func TestPluginLive(t *testing.T) {
-	apiKey := os.Getenv("DASHSCOPE_API_KEY")
-	if apiKey == "" {
-		t.Skip("Skipping test: DASHSCOPE_API_KEY environment variable not set")
+	if os.Getenv("DASHSCOPE_API_KEY") == "" {
+		t.Skip("DASHSCOPE_API_KEY is not set")
 	}
 
 	ctx := context.Background()
-
-	g := genkit.Init(
-		ctx,
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&dashscope.DashScope{}),
 		genkit.WithDefaultModel("dashscope/qwen-plus"),
-		genkit.WithPlugins(&dashscope.DashScope{
-			APIKey: apiKey,
-		}),
 	)
-	t.Log("genkit initialized")
 
-	t.Run("basic completion", func(t *testing.T) {
-		t.Log("generating basic completion response")
-		resp, err := genkit.Generate(
-			ctx, g,
-			ai.WithPrompt("What is the capital of France?"),
-		)
-		if err != nil {
-			t.Fatal("error generating basic completion response: ", err)
-		}
-		t.Logf("basic completion response: %+v", resp)
-
-		out := resp.Message.Content[0].Text
-		if !strings.Contains(strings.ToLower(out), "paris") {
-			t.Errorf("got %q, expecting it to contain 'Paris'", out)
-		}
-
-		// Verify usage statistics are present
-		if resp.Usage == nil || resp.Usage.TotalTokens == 0 {
-			t.Error("Expected non-zero usage statistics")
-		}
-	})
-
-	t.Run("streaming", func(t *testing.T) {
-		var streamedOutput string
-		chunks := 0
-
-		final, err := genkit.Generate(ctx, g,
-			ai.WithPrompt("Write a short paragraph about artificial intelligence."),
-			ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
-				chunks++
-				for _, content := range chunk.Content {
-					streamedOutput += content.Text
-				}
-				return nil
-			}))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Verify streaming worked
-		if chunks <= 1 {
-			t.Error("Expected multiple chunks for streaming")
-		}
-
-		// Verify final output matches streamed content
-		finalOutput := ""
-		for _, content := range final.Message.Content {
-			finalOutput += content.Text
-		}
-		if streamedOutput != finalOutput {
-			t.Errorf("Streaming output doesn't match final output\nStreamed: %s\nFinal: %s",
-				streamedOutput, finalOutput)
-		}
-
-		t.Logf("streaming response: %+v", finalOutput)
-	})
-
-	t.Run("system message", func(t *testing.T) {
-		resp, err := genkit.Generate(
-			ctx, g,
-			ai.WithPrompt("What are you?"),
-			ai.WithSystem("You are a helpful math tutor who loves numbers."),
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		out := resp.Message.Content[0].Text
-		if !strings.Contains(strings.ToLower(out), "math") {
-			t.Errorf("got %q, expecting response to mention being a math tutor", out)
-		}
-
-		t.Logf("system message response: %+v", out)
+	thinking := true
+	livetest.Run(t, g, livetest.Suite{
+		Model: dashscope.ModelRef("qwen-plus", nil),
+		ReasoningModel: dashscope.ModelRef("qwen-plus", &dashscope.ChatConfig{
+			EnableThinking: &thinking,
+		}),
+		ReasoningContent: true,
+		// DashScope only serves thinking on streaming calls.
+		StreamOnlyReasoning: true,
+		VisionModel:         dashscope.ModelRef("qwen3-vl-plus", nil),
+		ExtraConfig: map[string]any{
+			"extra": map[string]any{"enable_thinking": false},
+		},
 	})
 }

--- a/go/plugins/compat_oai/dashscope/dashscope_test.go
+++ b/go/plugins/compat_oai/dashscope/dashscope_test.go
@@ -20,14 +20,18 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 )
 
 func TestPluginRequiresAPIKey(t *testing.T) {
@@ -47,12 +51,15 @@ func TestPluginRequiresAPIKey(t *testing.T) {
 }
 
 func TestPluginConfigPrecedence(t *testing.T) {
+	var mu sync.Mutex
 	var rightHit, wrongHit bool
 	var gotAuth string
 
 	right := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		rightHit = true
 		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"id":"c1","object":"chat.completion","created":1,"model":"qwen-plus",
@@ -63,27 +70,33 @@ func TestPluginConfigPrecedence(t *testing.T) {
 	defer right.Close()
 
 	wrong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		wrongHit = true
+		mu.Unlock()
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer wrong.Close()
 
-	// Struct fields must win over env vars for both APIKey and BaseURL.
+	// Explicit configuration must win over env vars: the struct field for the
+	// key, and an Opts [option.WithBaseURL] for the endpoint, which the
+	// plugin applies after its own defaults.
 	t.Setenv("DASHSCOPE_API_KEY", "env-key")
 	t.Setenv("DASHSCOPE_BASE_URL", wrong.URL+"/compatible-mode/v1")
 
 	ctx := context.Background()
 	plugin := &dashscope.DashScope{
-		APIKey:  "struct-key",
-		BaseURL: right.URL + "/compatible-mode/v1",
+		APIKey: "struct-key",
+		Opts:   []option.RequestOption{option.WithBaseURL(right.URL + "/compatible-mode/v1")},
 	}
 	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("dashscope/qwen-plus"))
 
 	if _, err := genkit.Generate(ctx, g, ai.WithPrompt("hi")); err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if !rightHit || wrongHit {
-		t.Fatalf("rightHit = %v, wrongHit = %v, want struct fields to take precedence over env vars", rightHit, wrongHit)
+		t.Fatalf("rightHit = %v, wrongHit = %v, want explicit configuration to take precedence over env vars", rightHit, wrongHit)
 	}
 	if gotAuth != "Bearer struct-key" {
 		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer struct-key")
@@ -91,9 +104,12 @@ func TestPluginConfigPrecedence(t *testing.T) {
 }
 
 func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
+	var mu sync.Mutex
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requests++
+		mu.Unlock()
 		if r.URL.Path != "/compatible-mode/v1/chat/completions" {
 			t.Errorf("path = %q, want %q", r.URL.Path, "/compatible-mode/v1/chat/completions")
 		}
@@ -139,7 +155,7 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 	}))
 	defer server.Close()
 
-	plugin := &dashscope.DashScope{APIKey: "test-key", BaseURL: server.URL + "/compatible-mode/v1"}
+	plugin := &dashscope.DashScope{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/compatible-mode/v1")}}
 	ctx := context.Background()
 	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("dashscope/qwen-plus"))
 
@@ -158,9 +174,9 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 		{models: mediaModels, wantMedia: true},
 	} {
 		for _, modelID := range group.models {
-			model := plugin.Model(g, modelID)
+			model := genkit.LookupModel(g, "dashscope/"+modelID)
 			if model == nil {
-				t.Errorf("Model(%q) = nil", modelID)
+				t.Errorf("LookupModel(%q) = nil", modelID)
 				continue
 			}
 			desc := model.(api.Action).Desc()
@@ -185,7 +201,9 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 		}
 	}
 
-	config := map[string]any{"enable_thinking": true}
+	// The Genkit config speaks the plugin's camelCase contract; the handler
+	// above asserts it reaches the wire as enable_thinking.
+	config := map[string]any{"enableThinking": true}
 	t.Run("complete", func(t *testing.T) {
 		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Say hi."), ai.WithConfig(config))
 		if err != nil {
@@ -227,15 +245,21 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 		}
 	})
 
+	mu.Lock()
+	defer mu.Unlock()
 	if requests != 2 {
 		t.Fatalf("requests = %d, want 2", requests)
 	}
 }
 
 func TestPluginHandlesToolCalls(t *testing.T) {
+	var mu sync.Mutex
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requests++
+		reqNum := requests
+		mu.Unlock()
 		var body struct {
 			Messages []map[string]any `json:"messages"`
 			Tools    []map[string]any `json:"tools"`
@@ -244,7 +268,7 @@ func TestPluginHandlesToolCalls(t *testing.T) {
 			t.Fatalf("decode request: %v", err)
 		}
 
-		if requests == 1 {
+		if reqNum == 1 {
 			if len(body.Tools) != 1 {
 				t.Fatalf("tools = %#v, want one tool", body.Tools)
 			}
@@ -294,7 +318,7 @@ func TestPluginHandlesToolCalls(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	plugin := &dashscope.DashScope{APIKey: "test-key", BaseURL: server.URL + "/compatible-mode/v1"}
+	plugin := &dashscope.DashScope{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/compatible-mode/v1")}}
 	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("dashscope/qwen-plus"))
 
 	lookup := genkit.DefineTool(g, "lookup", "Looks up a value.",
@@ -312,6 +336,8 @@ func TestPluginHandlesToolCalls(t *testing.T) {
 	if got := resp.Text(); got != "Tool loop complete" {
 		t.Errorf("Text() = %q, want %q", got, "Tool loop complete")
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if requests != 2 {
 		t.Errorf("requests = %d, want 2", requests)
 	}
@@ -384,13 +410,40 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 			},
 			response: "A test image.",
 		},
+		{
+			name:  "extra passthrough",
+			model: "qwen-plus",
+			options: []ai.GenerateOption{
+				ai.WithPrompt("hi"),
+				ai.WithConfig(map[string]any{
+					"enableSearch": false,
+					"extra": map[string]any{
+						"enable_search":  true,
+						"search_options": map[string]any{"forced_search": true},
+					},
+				}),
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				if got := body["enable_search"]; got != true {
+					t.Errorf("enable_search = %v, want the extra winning over the extra the config wrote", got)
+				}
+				searchOptions, _ := body["search_options"].(map[string]any)
+				if got := searchOptions["forced_search"]; got != true {
+					t.Errorf("search_options = %#v, want the undeclared field on the wire", body["search_options"])
+				}
+			},
+			response: "Extra fields ride.",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			var mu sync.Mutex
 			var requests int
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
 				requests++
+				mu.Unlock()
 				var body map[string]any
 				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 					t.Fatalf("decode request: %v", err)
@@ -413,7 +466,7 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 			defer server.Close()
 
 			ctx := context.Background()
-			plugin := &dashscope.DashScope{APIKey: "test-key", BaseURL: server.URL + "/compatible-mode/v1"}
+			plugin := &dashscope.DashScope{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/compatible-mode/v1")}}
 			g := genkit.Init(ctx, genkit.WithPlugins(plugin))
 			options := append([]ai.GenerateOption{ai.WithModelName("dashscope/" + test.model)}, test.options...)
 
@@ -424,6 +477,8 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 			if got := resp.Text(); got != test.response {
 				t.Errorf("Text() = %q, want %q", got, test.response)
 			}
+			mu.Lock()
+			defer mu.Unlock()
 			if requests != 1 {
 				t.Errorf("requests = %d, want 1", requests)
 			}
@@ -439,7 +494,7 @@ func TestPluginRejectsUnsupportedToolChoice(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	plugin := &dashscope.DashScope{APIKey: "test-key", BaseURL: server.URL + "/compatible-mode/v1"}
+	plugin := &dashscope.DashScope{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/compatible-mode/v1")}}
 	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("dashscope/qwen-plus"))
 
 	_, err := genkit.Generate(ctx, g, ai.WithPrompt("Use a tool."), ai.WithToolChoice(ai.ToolChoiceRequired))
@@ -459,9 +514,12 @@ func TestPluginRejectsUnsupportedToolChoice(t *testing.T) {
 // dashscope), so pinning that behavior here would be asserting a bug rather
 // than a contract.
 func TestPluginValidatesModelVersions(t *testing.T) {
+	var mu sync.Mutex
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requests++
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"id":"c-version","object":"chat.completion","created":1,"model":"qwen-plus",
@@ -471,10 +529,10 @@ func TestPluginValidatesModelVersions(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	plugin := &dashscope.DashScope{APIKey: "test-key", BaseURL: server.URL + "/compatible-mode/v1"}
+	plugin := &dashscope.DashScope{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/compatible-mode/v1")}}
 	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("dashscope/qwen-plus"))
 
-	model := plugin.Model(g, "qwen-plus")
+	model := genkit.LookupModel(g, "dashscope/qwen-plus")
 	desc := model.(api.Action).Desc()
 	modelMetadata := desc.Metadata["model"].(map[string]any)
 	versions, _ := modelMetadata["versions"].([]string)
@@ -494,7 +552,9 @@ func TestPluginValidatesModelVersions(t *testing.T) {
 	})
 
 	t.Run("unsupported version is rejected", func(t *testing.T) {
+		mu.Lock()
 		before := requests
+		mu.Unlock()
 		_, err := genkit.Generate(ctx, g,
 			ai.WithPrompt("hi"),
 			ai.WithConfig(map[string]any{"version": "qwen-plus-9999-01-01"}),
@@ -502,8 +562,120 @@ func TestPluginValidatesModelVersions(t *testing.T) {
 		if err == nil {
 			t.Fatal("Generate() error = nil, want unsupported version error")
 		}
+		mu.Lock()
+		defer mu.Unlock()
 		if requests != before {
 			t.Errorf("requests = %d, want no additional request for rejected version", requests)
 		}
 	})
+}
+
+// TestModelRefAndConfigSchema pins the call-site surface: the ref carries the
+// prefixed name and the typed config, and the registered models advertise the
+// camelCase config contract including the DashScope-specific fields.
+func TestModelRefAndConfigSchema(t *testing.T) {
+	cfg := &dashscope.ChatConfig{EnableThinking: openai.Ptr(true)}
+	for _, name := range []string{"qwen-plus", "dashscope/qwen-plus"} {
+		ref := dashscope.ModelRef(name, cfg)
+		if want := "dashscope/qwen-plus"; ref.Name() != want {
+			t.Errorf("ModelRef(%q).Name() = %q, want %q", name, ref.Name(), want)
+		}
+		if ref.Config() != cfg {
+			t.Errorf("ModelRef(%q).Config() = %v, want the config it was built with", name, ref.Config())
+		}
+	}
+
+	plugin := &dashscope.DashScope{APIKey: "test-key"}
+	g := genkit.Init(context.Background(), genkit.WithPlugins(plugin))
+
+	m := genkit.LookupModel(g, "dashscope/qwen-plus")
+	if m == nil {
+		t.Fatal("qwen-plus not registered by Init")
+	}
+	model := m.(api.Action).Desc().Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions missing, got %v", model["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions has no properties: %v", schema)
+	}
+	for _, key := range []string{"temperature", "maxOutputTokens", "stopSequences", "seed", "enableThinking", "thinkingBudget", "enableSearch", "version", "extra"} {
+		if props[key] == nil {
+			t.Errorf("config schema is missing the %q property", key)
+		}
+	}
+
+	// The constraints DashScope documents ride on the schema, where the
+	// framework enforces them, exclusive ends included: temperature is [0, 2)
+	// and topP is (0, 1].
+	for field, want := range map[string]map[string]any{
+		"temperature":     {"minimum": 0.0, "exclusiveMaximum": 2.0},
+		"topP":            {"exclusiveMinimum": 0.0, "maximum": 1.0},
+		"presencePenalty": {"minimum": -2.0, "maximum": 2.0},
+		"seed":            {"minimum": 0.0, "maximum": 2147483647.0},
+		"maxOutputTokens": {"minimum": 1.0},
+	} {
+		prop, _ := props[field].(map[string]any)
+		for key, value := range want {
+			if got := prop[key]; !reflect.DeepEqual(got, value) {
+				t.Errorf("%s %s = %#v, want %#v", field, key, got, value)
+			}
+		}
+	}
+}
+
+// TestDynamicListingAndResolution pins the on-demand surface: models the
+// endpoint reports are listed with the plugin's config schema, and generating
+// with an uncurated name resolves it instead of failing with model-not-found.
+func TestDynamicListingAndResolution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/compatible-mode/v1/models" {
+			_, _ = io.WriteString(w, `{"object":"list","data":[{"id":"qwen-brand-new","object":"model"}]}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"qwen-brand-new",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"resolved"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &dashscope.DashScope{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/compatible-mode/v1")}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	var listed *api.ActionDesc
+	for _, desc := range plugin.ListActions(ctx) {
+		if desc.Name == "dashscope/qwen-brand-new" {
+			listed = &desc
+			break
+		}
+	}
+	if listed == nil {
+		t.Fatal("ListActions() does not include the endpoint's model")
+	}
+	model := listed.Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("listed model has no customOptions: %v", model)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if props["enableThinking"] == nil {
+		t.Error("listed model schema is missing the plugin's enableThinking property")
+	}
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("dashscope/qwen-brand-new"),
+		ai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() with an uncurated model error = %v", err)
+	}
+	if got := resp.Text(); got != "resolved" {
+		t.Fatalf("Text() = %q, want %q", got, "resolved")
+	}
 }

--- a/go/plugins/compat_oai/dashscope/dashscope_test.go
+++ b/go/plugins/compat_oai/dashscope/dashscope_test.go
@@ -163,15 +163,24 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 		t.Fatalf("Name() = %q, want %q", plugin.Name(), "dashscope")
 	}
 
-	// Mirrors the Media flags set in supportedModels.
-	textModels := []string{"qwen-flash", "qwen-plus", "qwen3.7-max", "qwen3-max", "qwen3-coder-plus"}
-	mediaModels := []string{"qwen3.5-flash", "qwen3.5-plus", "qwen3.6-flash", "qwen3.6-plus", "qwen3.7-plus", "qwen3-vl-plus"}
+	// Mirrors the Media and Output claims in supportedModels: qwen3.7-max and
+	// qwen3-coder-plus document structured output as unsupported so they
+	// advertise text only, and the 2026-06-08 max snapshot alone adds media.
+	textAndJSON := []string{"text", "json"}
+	textOutputOnly := []string{"text"}
 	for _, group := range []struct {
-		models    []string
-		wantMedia bool
+		models     []string
+		wantMedia  bool
+		wantOutput []string
 	}{
-		{models: textModels, wantMedia: false},
-		{models: mediaModels, wantMedia: true},
+		{models: []string{"qwen-flash", "qwen-plus", "qwen3-max"},
+			wantMedia: false, wantOutput: textAndJSON},
+		{models: []string{"qwen3.5-flash", "qwen3.5-plus", "qwen3.6-flash", "qwen3.6-plus", "qwen3.7-plus", "qwen3-vl-plus"},
+			wantMedia: true, wantOutput: textAndJSON},
+		{models: []string{"qwen3.7-max", "qwen3-coder-plus"},
+			wantMedia: false, wantOutput: textOutputOnly},
+		{models: []string{"qwen3.7-max-2026-06-08"},
+			wantMedia: true, wantOutput: textOutputOnly},
 	} {
 		for _, modelID := range group.models {
 			model := genkit.LookupModel(g, "dashscope/"+modelID)
@@ -195,8 +204,8 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 				t.Errorf("%s toolChoice support = %v, want false", modelID, got)
 			}
 			output, _ := supports["output"].([]string)
-			if !slices.Equal(output, []string{"text", "json"}) {
-				t.Errorf("%s output = %v, want [text json]", modelID, output)
+			if !slices.Equal(output, group.wantOutput) {
+				t.Errorf("%s output = %v, want %v", modelID, output, group.wantOutput)
 			}
 		}
 	}
@@ -346,6 +355,35 @@ func TestPluginHandlesToolCalls(t *testing.T) {
 func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 	const imageDataURI = "data:image/png;base64,iVBORw0KGgo="
 
+	checkImageBody := func(t *testing.T, body map[string]any) {
+		messages, ok := body["messages"].([]any)
+		if !ok || len(messages) != 1 {
+			t.Fatalf("messages = %#v, want one message", body["messages"])
+		}
+		message, ok := messages[0].(map[string]any)
+		if !ok {
+			t.Fatalf("message = %#v, want object", messages[0])
+		}
+		content, ok := message["content"].([]any)
+		if !ok || len(content) != 2 {
+			t.Fatalf("content = %#v, want image and text parts", message["content"])
+		}
+		imagePart, ok := content[0].(map[string]any)
+		if !ok {
+			t.Fatalf("image part = %#v, want object", content[0])
+		}
+		if got := imagePart["type"]; got != "image_url" {
+			t.Errorf("image part type = %v, want %q", got, "image_url")
+		}
+		imageURL, ok := imagePart["image_url"].(map[string]any)
+		if !ok {
+			t.Fatalf("image_url = %#v, want object", imagePart["image_url"])
+		}
+		if got := imageURL["url"]; got != imageDataURI {
+			t.Errorf("image_url.url = %v, want %q", got, imageDataURI)
+		}
+	}
+
 	tests := []struct {
 		name      string
 		model     string
@@ -372,6 +410,23 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 			response: `{"answer":"ok"}`,
 		},
 		{
+			// qwen3.7-max documents structured output as unsupported, so a
+			// JSON request must reach it without the response_format DashScope
+			// would fail on, carried by the framework's format instructions.
+			name:  "json output without structured output support",
+			model: "qwen3.7-max",
+			options: []ai.GenerateOption{
+				ai.WithPrompt("Return a JSON object."),
+				ai.WithOutputFormat(ai.OutputFormatJSON),
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				if got, ok := body["response_format"]; ok {
+					t.Errorf("response_format = %#v, want none for a model without structured output", got)
+				}
+			},
+			response: `{"answer":"ok"}`,
+		},
+		{
 			name:  "vision input",
 			model: "qwen3-vl-plus",
 			options: []ai.GenerateOption{
@@ -380,35 +435,23 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 					ai.NewTextPart("Describe this image."),
 				)),
 			},
-			checkBody: func(t *testing.T, body map[string]any) {
-				messages, ok := body["messages"].([]any)
-				if !ok || len(messages) != 1 {
-					t.Fatalf("messages = %#v, want one message", body["messages"])
-				}
-				message, ok := messages[0].(map[string]any)
-				if !ok {
-					t.Fatalf("message = %#v, want object", messages[0])
-				}
-				content, ok := message["content"].([]any)
-				if !ok || len(content) != 2 {
-					t.Fatalf("content = %#v, want image and text parts", message["content"])
-				}
-				imagePart, ok := content[0].(map[string]any)
-				if !ok {
-					t.Fatalf("image part = %#v, want object", content[0])
-				}
-				if got := imagePart["type"]; got != "image_url" {
-					t.Errorf("image part type = %v, want %q", got, "image_url")
-				}
-				imageURL, ok := imagePart["image_url"].(map[string]any)
-				if !ok {
-					t.Fatalf("image_url = %#v, want object", imagePart["image_url"])
-				}
-				if got := imageURL["url"]; got != imageDataURI {
-					t.Errorf("image_url.url = %v, want %q", got, imageDataURI)
-				}
+			checkBody: checkImageBody,
+			response:  "A test image.",
+		},
+		{
+			// The dated snapshot is the one qwen3.7-max entry that takes
+			// media, so an image request through it must pass validation and
+			// reach the wire.
+			name:  "vision input on the multimodal max snapshot",
+			model: "qwen3.7-max-2026-06-08",
+			options: []ai.GenerateOption{
+				ai.WithMessages(ai.NewUserMessage(
+					ai.NewMediaPart("image/png", imageDataURI),
+					ai.NewTextPart("Describe this image."),
+				)),
 			},
-			response: "A test image.",
+			checkBody: checkImageBody,
+			response:  "A test image.",
 		},
 		{
 			name:  "extra passthrough",

--- a/go/samples/compat_oai/dashscope/main.go
+++ b/go/samples/compat_oai/dashscope/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
 	"github.com/firebase/genkit/go/plugins/server"
+	"github.com/openai/openai-go"
 )
 
 func main() {
@@ -27,7 +28,10 @@ func main() {
 	g := genkit.Init(ctx, genkit.WithPlugins(ds))
 
 	genkit.DefineFlow(g, "dashscope", func(ctx context.Context, subject string) (string, error) {
-		model := ds.Model(g, "qwen-plus")
+		model := dashscope.ModelRef("qwen-plus", &dashscope.ChatConfig{
+			Temperature:    openai.Ptr(0.7),
+			EnableThinking: openai.Ptr(false),
+		})
 
 		prompt := fmt.Sprintf("tell me a joke about %s", subject)
 		foo, err := genkit.Generate(ctx, g, ai.WithModel(model), ai.WithPrompt(prompt))
@@ -65,7 +69,7 @@ func main() {
 		if modelID == "" {
 			modelID = "qwen-plus"
 		}
-		model := ds.Model(g, modelID)
+		model := dashscope.ModelRef(modelID, nil)
 
 		prompt := fmt.Sprintf("What's the current temperature in %s? Use the tool to check, don't guess.", input.City)
 		resp, err := genkit.Generate(ctx, g,
@@ -92,7 +96,7 @@ func main() {
 		if modelID == "" {
 			modelID = "qwen3-vl-plus"
 		}
-		model := ds.Model(g, modelID)
+		model := dashscope.ModelRef(modelID, nil)
 
 		resp, err := genkit.Generate(ctx, g,
 			ai.WithModel(model),

--- a/go/samples/compat_oai/dashscope/main.go
+++ b/go/samples/compat_oai/dashscope/main.go
@@ -1,16 +1,35 @@
-// Copyright 2024 Google LLC
-// SPDX-License-Identifier: Apache-2.0
-
-// This program can be manually tested like so:
-// Start the server listening on port 3100:
+// Copyright 2026 Google LLC
 //
-//	genkit start -o -- go run .
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+// This sample demonstrates the DashScope plugin for Alibaba Cloud's Qwen
+// models: a flow that generates a joke with a model pinned through
+// dashscope.ModelRef and its typed config.
+//
+// To run:
+//
+//	export DASHSCOPE_API_KEY=...
+//	go run .
+//
+// In another terminal:
+//
+//	curl -X POST http://localhost:8080/jokesFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": "bananas"}'
 package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 
@@ -24,95 +43,26 @@ import (
 func main() {
 	ctx := context.Background()
 
-	ds := &dashscope.DashScope{}
-	g := genkit.Init(ctx, genkit.WithPlugins(ds))
+	// The plugin reads the API key from the DASHSCOPE_API_KEY environment variable.
+	g := genkit.Init(ctx, genkit.WithPlugins(&dashscope.DashScope{}))
 
-	genkit.DefineFlow(g, "dashscope", func(ctx context.Context, subject string) (string, error) {
-		model := dashscope.ModelRef("qwen-plus", &dashscope.ChatConfig{
-			Temperature:    openai.Ptr(0.7),
-			EnableThinking: openai.Ptr(false),
-		})
-
-		prompt := fmt.Sprintf("tell me a joke about %s", subject)
-		foo, err := genkit.Generate(ctx, g, ai.WithModel(model), ai.WithPrompt(prompt))
-		if err != nil {
-			return "", err
+	// Define a flow that generates a joke about a given topic. The config
+	// turns on DashScope's thinking mode with a budget on its length.
+	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		if topic == "" {
+			topic = "airplane food"
 		}
-		return fmt.Sprintf("foo: %s", foo.Text()), nil
-	})
 
-	// getWeather returns a deliberately made-up temperature. If the model's
-	// final answer mentions it, that proves the model actually called the
-	// tool rather than answering from its own knowledge - confirming that
-	// Tools: true is correct for this model.
-	getWeather := genkit.DefineTool(g, "getWeather", "Get the current temperature for a city",
-		func(ctx *ai.ToolContext, input struct {
-			City string `json:"city"`
-		}) (struct {
-			TempC int `json:"tempC"`
-		}, error) {
-			return struct {
-				TempC int `json:"tempC"`
-			}{TempC: 22}, nil
-		},
-	)
-
-	type ToolTestInput struct {
-		City string `json:"city"`
-		// Model is a dashscope model id, e.g. "qwen-plus" or "qwen3-coder-plus".
-		// Defaults to "qwen-plus" if left blank.
-		Model string `json:"model,omitempty"`
-	}
-
-	genkit.DefineFlow(g, "dashscope-tool-test", func(ctx context.Context, input ToolTestInput) (string, error) {
-		modelID := input.Model
-		if modelID == "" {
-			modelID = "qwen-plus"
-		}
-		model := dashscope.ModelRef(modelID, nil)
-
-		prompt := fmt.Sprintf("What's the current temperature in %s? Use the tool to check, don't guess.", input.City)
-		resp, err := genkit.Generate(ctx, g,
-			ai.WithModel(model),
-			ai.WithPrompt(prompt),
-			ai.WithTools(getWeather),
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(dashscope.ModelRef("qwen-plus", &dashscope.ChatConfig{
+				EnableThinking: openai.Ptr(true),
+				ThinkingBudget: openai.Ptr(2048),
+			})),
+			ai.WithPrompt("Share a joke about %s.", topic),
 		)
-		if err != nil {
-			return "", err
-		}
-		return resp.Text(), nil
 	})
 
-	type VisionTestInput struct {
-		// ImageURL is a publicly reachable image URL to describe.
-		ImageURL string `json:"imageUrl"`
-		// Model is a dashscope model id, e.g. "qwen3-vl-plus".
-		// Defaults to "qwen3-vl-plus" if left blank.
-		Model string `json:"model,omitempty"`
-	}
-
-	genkit.DefineFlow(g, "dashscope-vision-test", func(ctx context.Context, input VisionTestInput) (string, error) {
-		modelID := input.Model
-		if modelID == "" {
-			modelID = "qwen3-vl-plus"
-		}
-		model := dashscope.ModelRef(modelID, nil)
-
-		resp, err := genkit.Generate(ctx, g,
-			ai.WithModel(model),
-			ai.WithMessages(
-				ai.NewUserMessage(
-					ai.NewTextPart("Describe exactly what is in this image, in one sentence."),
-					ai.NewMediaPart("", input.ImageURL),
-				),
-			),
-		)
-		if err != nil {
-			return "", err
-		}
-		return resp.Text(), nil
-	})
-
+	// Optionally, start a web server to make the flow callable via HTTP.
 	mux := http.NewServeMux()
 	for _, a := range genkit.ListFlows(g) {
 		mux.HandleFunc("POST /"+a.Name(), genkit.Handler(a))


### PR DESCRIPTION
Migrates the DashScope plugin onto the typed-config base (#5976); stacked on #6031.

## The plugin and its config, at a glance

```go
type DashScope struct {
	APIKey string
	Opts   []option.RequestOption
	Models map[string]ai.ModelOptions
}

type ChatConfig struct {
	compat_oai.RequestConfig
	Temperature     *float64 `json:"temperature,omitempty"`
	TopP            *float64 `json:"topP,omitempty"`
	MaxOutputTokens int      `json:"maxOutputTokens,omitempty"`
	StopSequences   []string `json:"stopSequences,omitempty"`
	PresencePenalty *float64 `json:"presencePenalty,omitempty"`
	Seed            *int     `json:"seed,omitempty"`
	EnableThinking  *bool    `json:"enableThinking,omitempty"`
	ThinkingBudget  *int     `json:"thinkingBudget,omitempty"`
	EnableSearch    *bool    `json:"enableSearch,omitempty"`
}
```

`BaseURL` leaves the plugin struct (merged but never released): the endpoint override rides `Opts` (`option.WithBaseURL`) or `DASHSCOPE_BASE_URL`, applied after the plugin defaults so it wins.

Every constraint is verified against Alibaba's published reference, which corrected the ranges the old comments carried: the docs give `temperature` as `[0, 2)` and `top_p` as `(0, 1.0]`, where the comments had both ends exclusive on each. Also enforced: `seed` 0 to 2147483647, `presencePenalty` within plus or minus 2, positive token counts. Thinking moves from a loose `enable_thinking` extra key to the declared fields.

The catalog moves to the shared `ModelOptionsFor` overlay with a `Models` field; constrained generation stays unclaimed (DashScope documents `json_object` only, so prompt instructions keep doing the enforcement); the plugin joins the conformance sweep, and the sample pins its config through `dashscope.ModelRef`.

Two capability corrections against the model pages: `qwen3.7-max` and `qwen3-coder-plus` document structured output as unsupported, so they advertise text output only and a JSON request rides the framework's format instructions instead of a `response_format` DashScope would fail on. And `qwen3.7-max-2026-06-08` documents image and video input the floating model does not take, so that snapshot gets a standalone multimodal entry, staying in the base entry's `Versions` so pinning it there keeps working.

`dashscope` has never been in a release, so deleting `DefineModel` and the deprecated `Model` cannot break a caller, and this train is the last point they can go without a deprecation cycle.

```go
// Added
type ChatConfig struct { compat_oai.RequestConfig; Temperature *float64; TopP *float64; MaxOutputTokens int; StopSequences []string; PresencePenalty *float64; Seed *int; EnableThinking *bool; ThinkingBudget *int; EnableSearch *bool }
DashScope.Models map[string]ai.ModelOptions
func ModelRef(id string, config *ChatConfig) ai.ModelRef

// Deleted (never released)
dashscope.DefineModel, dashscope.Model
```

## Testing

Go 1.26.3: `go build ./...` and `go test ./plugins/compat_oai/...` pass at this level of the stack; the package is 19 cases counting subtests, the live one skipping without `DASHSCOPE_API_KEY`. The schema test pins the corrected exclusive bounds, the reasoning tests exercise the declared thinking fields instead of extra keys, and the shaping suite proves a JSON request against `qwen3.7-max` carries no `response_format` and an image request through the snapshot entry reaches the wire. The live test runs the shared checklist from the base PR's `internal/livetest` harness: `qwen-plus` carries the cheap checks, reasoning is stream-only (DashScope serves thinking only on streaming calls), and `qwen3-vl-plus` takes the vision check.

