### PR TITLE
feat(go/plugins/compat_oai/kimi): migrate to a typed config and the shared catalog

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1128,7 +1128,7 @@ Genkit provides a unified interface across all major AI providers. Use whichever
 | **Vertex AI** | `vertexai.VertexAI` | Gemini 3.5 Flash, Gemini 3.1 Pro via Google Cloud |
 | **Anthropic** | `anthropic.Anthropic` | Claude Opus 4.8, Claude Sonnet 4.6, Claude Haiku 4.5 |
 | **Ollama** | `ollama.Ollama` | Llama 4, Qwen 3, DeepSeek, and other local models |
-| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Qwen, and any OpenAI-compatible API |
+| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Qwen, Kimi, and any OpenAI-compatible API |
 
 ```go
 // Google AI

--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -189,8 +189,8 @@ providers and `max_completion_tokens` on others. Use the same camelCase name
 other plugins use for the same setting; `conformance_test.go` enforces that
 across the package.
 
-See the `openai`, `anthropic`, and `dashscope` directories for complete
-implementations.
+See the `openai`, `anthropic`, `dashscope`, and `kimi` directories for
+complete implementations.
 
 ## Running Tests
 

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -16,6 +16,7 @@ package compat_oai_test
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -185,5 +186,49 @@ func TestModelsOverrideConformance(t *testing.T) {
 				t.Error("label is empty, want the curated one kept by the overlay")
 			}
 		})
+	}
+}
+
+// TestClosedEnumsUseNamedTypes pins the family rule for closed sets: a config
+// field whose schema declares an enum is typed as a named string type of its
+// package, so the allowed values are discoverable as constants in code rather
+// than only in the schema. Open sets carry no enum and stay bare strings,
+// since constants would imply a closure the provider's docs refuse to give.
+// Each new plugin adds its config here.
+func TestClosedEnumsUseNamedTypes(t *testing.T) {
+	configs := map[string]any{
+		"anthropic": anthropic.ChatConfig{},
+		"dashscope": dashscope.ChatConfig{},
+		"kimi":      kimi.ChatConfig{},
+	}
+	for name, config := range configs {
+		t.Run(name, func(t *testing.T) {
+			checkClosedEnums(t, "", reflect.TypeOf(config))
+		})
+	}
+}
+
+// checkClosedEnums walks a config struct's fields, recursing through structs
+// and pointers to structs, and fails for any enum-tagged field typed as a
+// bare string.
+func checkClosedEnums(t *testing.T, path string, typ reflect.Type) {
+	t.Helper()
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		name := path + field.Name
+		ft := field.Type
+		for ft.Kind() == reflect.Pointer {
+			ft = ft.Elem()
+		}
+		if ft.Kind() == reflect.Struct {
+			checkClosedEnums(t, name+".", ft)
+			continue
+		}
+		if !strings.Contains(field.Tag.Get("jsonschema"), "enum=") {
+			continue
+		}
+		if ft.Kind() == reflect.String && ft.PkgPath() == "" {
+			t.Errorf("%s declares a schema enum on a bare string, want a named string type with exported constants", name)
+		}
 	}
 }

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
 	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
+	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
 )
 
 // canonicalTypes is the JSON type each shared config field must have wherever
@@ -52,15 +53,18 @@ var canonicalTypes = map[string]string{
 func TestConfigSchemaConformance(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
+	t.Setenv("KIMI_API_KEY", "test-key")
 
 	g := genkit.Init(context.Background(), genkit.WithPlugins(
 		&anthropic.Anthropic{},
 		&dashscope.DashScope{},
+		&kimi.Kimi{},
 	))
 
 	models := []string{
 		"anthropic/claude-sonnet-4-5-20250929",
 		"dashscope/qwen-plus",
+		"kimi/kimi-k3",
 	}
 
 	for _, name := range models {
@@ -141,6 +145,7 @@ func requireDescriptions(t *testing.T, path string, props map[string]any) {
 func TestModelsOverrideConformance(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
+	t.Setenv("KIMI_API_KEY", "test-key")
 
 	// Keyed provider-prefixed on half of them, bare on the rest: both forms
 	// name the same model.
@@ -150,11 +155,13 @@ func TestModelsOverrideConformance(t *testing.T) {
 		&anthropic.Anthropic{Models: map[string]ai.ModelOptions{
 			"anthropic/claude-sonnet-4-5-20250929": pinned}},
 		&dashscope.DashScope{Models: map[string]ai.ModelOptions{"qwen-plus": pinned}},
+		&kimi.Kimi{Models: map[string]ai.ModelOptions{"kimi-k3": pinned}},
 	))
 
 	for _, name := range []string{
 		"anthropic/claude-sonnet-4-5-20250929",
 		"dashscope/qwen-plus",
+		"kimi/kimi-k3",
 	} {
 		t.Run(name, func(t *testing.T) {
 			m := genkit.LookupModel(g, name)

--- a/go/plugins/compat_oai/kimi/README.md
+++ b/go/plugins/compat_oai/kimi/README.md
@@ -1,10 +1,9 @@
 # Kimi Plugin
 
 This plugin provides Genkit support for Moonshot AI's OpenAI-compatible Kimi
-models, including Kimi K3, Kimi K2.6, and Kimi K2.7 Code. Kimi K2.5 remains
-registered as deprecated for existing users during its platform sunset period.
+models.
 
-## Usage
+## Setup
 
 Set a Moonshot API key:
 
@@ -14,7 +13,8 @@ export KIMI_API_KEY=<your-api-key>
 
 `MOONSHOT_API_KEY` is also accepted. The plugin uses
 `https://api.moonshot.ai/v1` by default; set `KIMI_BASE_URL` or
-`MOONSHOT_BASE_URL` to use another Moonshot-compatible endpoint.
+`MOONSHOT_BASE_URL`, or pass `option.WithBaseURL` through the plugin's
+`Opts`, to use another Moonshot-compatible endpoint.
 
 ```go
 import (
@@ -30,31 +30,60 @@ plugin := &kimi.Kimi{}
 g := genkit.Init(
     ctx,
     genkit.WithPlugins(plugin),
-    genkit.WithDefaultModel("kimi/"+kimi.ModelKimiK3),
+    genkit.WithDefaultModel("kimi/kimi-k3"),
 )
 
 response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain mixture-of-experts models."))
 ```
 
 Kimi's `reasoning_content` output is returned as Genkit reasoning parts and is
-available through `response.Reasoning()`. Reasoning parts are also preserved as
-`reasoning_content` during multi-turn and tool-call requests.
+available through `response.Reasoning()`. Reasoning parts are also preserved
+as `reasoning_content` during multi-turn and tool-call requests.
 
-Kimi-specific request fields are passed through when configuration is supplied
-as a map. For example, Kimi K2.6 thinking can be disabled per request:
+## Models
+
+`kimi-k3`, `kimi-k2.6`, `kimi-k2.7-code`, and `kimi-k2.7-code-highspeed` are
+registered, with `kimi-k2.5` kept as deprecated for existing users during its
+platform sunset period. The catalog is not a ceiling: any model ID Moonshot
+serves resolves on demand, and the `Models` field describes or corrects any
+model, curated or not:
 
 ```go
-response, err := genkit.Generate(
-    ctx,
-    g,
+plugin := &kimi.Kimi{Models: map[string]ai.ModelOptions{
+    "kimi-k4": {Label: "Kimi K4", Supports: &compat_oai.Multimodal},
+}}
+```
+
+Moonshot's API documentation, including the current model list, is at
+https://platform.kimi.ai/docs.
+
+## Config
+
+Models take a typed `kimi.ChatConfig`: the generation fields the K-series
+accepts plus the Kimi-specific controls (`thinking`, `reasoningEffort`).
+`kimi.ModelRef` carries the config with the model ID. For example, Kimi K2.6
+thinking can be disabled per request:
+
+```go
+response, err := genkit.Generate(ctx, g,
+    ai.WithModel(kimi.ModelRef("kimi-k2.6", &kimi.ChatConfig{
+        Thinking: &kimi.ThinkingConfig{Type: "disabled"},
+    })),
     ai.WithPrompt("Answer concisely."),
-    ai.WithConfig(map[string]any{
-        "thinking": map[string]any{
-            "type": "disabled",
-        },
-    }),
 )
 ```
+
+`reasoningEffort` controls how hard a Kimi K3 generation thinks (`low`,
+`high`, or `max`, the default), and `thinking.keep` controls how much
+reasoning is preserved across turns. Moonshot documents `temperature`,
+`topP`, and the frequency and presence penalties for the legacy `moonshot-v1`
+family only, so the config does not offer them, and `maxOutputTokens` reaches
+Moonshot as `max_completion_tokens`.
+
+Every config also carries the settings Genkit owns: `version` pins the exact
+model version a request is served by, `apiKey` (settable only from Go code)
+serves one request with a different credential, and `extra` forwards request
+body fields the config does not declare, keyed by Moonshot's wire names.
 
 ## Live tests
 

--- a/go/plugins/compat_oai/kimi/README.md
+++ b/go/plugins/compat_oai/kimi/README.md
@@ -43,9 +43,11 @@ as `reasoning_content` during multi-turn and tool-call requests.
 
 `kimi-k3`, `kimi-k2.6`, `kimi-k2.7-code`, and `kimi-k2.7-code-highspeed` are
 registered, with `kimi-k2.5` kept as deprecated for existing users during its
-platform sunset period. The catalog is not a ceiling: any model ID Moonshot
-serves resolves on demand, and the `Models` field describes or corrects any
-model, curated or not:
+platform sunset period. Tool-choice steering (`ai.WithToolChoice`) is
+advertised for `kimi-k3` only: the K2 generation rejects a forced tool call
+as incompatible with thinking, which is on by default. The catalog is not a
+ceiling: any model ID Moonshot serves resolves on demand, and the `Models`
+field describes or corrects any model, curated or not:
 
 ```go
 plugin := &kimi.Kimi{Models: map[string]ai.ModelOptions{

--- a/go/plugins/compat_oai/kimi/README.md
+++ b/go/plugins/compat_oai/kimi/README.md
@@ -27,8 +27,7 @@ import (
 
 ctx := context.Background()
 plugin := &kimi.Kimi{}
-g := genkit.Init(
-    ctx,
+g := genkit.Init(ctx,
     genkit.WithPlugins(plugin),
     genkit.WithDefaultModel("kimi/kimi-k3"),
 )
@@ -67,7 +66,7 @@ thinking can be disabled per request:
 ```go
 response, err := genkit.Generate(ctx, g,
     ai.WithModel(kimi.ModelRef("kimi-k2.6", &kimi.ChatConfig{
-        Thinking: &kimi.ThinkingConfig{Type: "disabled"},
+        Thinking: &kimi.ThinkingConfig{Type: kimi.ThinkingTypeDisabled},
     })),
     ai.WithPrompt("Answer concisely."),
 )

--- a/go/plugins/compat_oai/kimi/kimi.go
+++ b/go/plugins/compat_oai/kimi/kimi.go
@@ -32,6 +32,30 @@ const (
 	defaultBaseURL = "https://api.moonshot.ai/v1"
 )
 
+// ReasoningEffort is how hard the Kimi K3 generation thinks before it
+// answers. Moonshot documents three levels, with [ReasoningEffortMax] the
+// default.
+type ReasoningEffort string
+
+const (
+	// ReasoningEffortLow is the fastest, shallowest reasoning.
+	ReasoningEffortLow ReasoningEffort = "low"
+	// ReasoningEffortHigh is deeper reasoning, below the default.
+	ReasoningEffortHigh ReasoningEffort = "high"
+	// ReasoningEffortMax is the deepest reasoning, and the default.
+	ReasoningEffortMax ReasoningEffort = "max"
+)
+
+// ThinkingType turns the reasoning of thinking-capable Kimi models on or off.
+type ThinkingType string
+
+const (
+	// ThinkingTypeEnabled turns thinking on.
+	ThinkingTypeEnabled ThinkingType = "enabled"
+	// ThinkingTypeDisabled turns thinking off.
+	ThinkingTypeDisabled ThinkingType = "disabled"
+)
+
 // ChatConfig is the per-request config for Kimi models: the generation fields
 // the K-series accepts plus the Moonshot-specific controls. See
 // https://platform.kimi.ai/docs/api/chat.
@@ -57,15 +81,15 @@ type ChatConfig struct {
 	// Thinking controls the reasoning mode of thinking-capable Kimi models,
 	// sent as the API's thinking field.
 	Thinking *ThinkingConfig `json:"thinking,omitempty" jsonschema_description:"Reasoning mode controls for thinking-capable Kimi models, sent as the API's thinking field."`
-	// ReasoningEffort adjusts how hard the Kimi K3 generation thinks: "low",
-	// "high", or "max", the default.
-	ReasoningEffort string `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=high,enum=max" jsonschema_description:"How hard the Kimi K3 generation thinks: low, high, or max (the default)."`
+	// ReasoningEffort adjusts how hard the Kimi K3 generation thinks, from
+	// [ReasoningEffortLow] to [ReasoningEffortMax], the default.
+	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=high,enum=max" jsonschema_description:"How hard the Kimi K3 generation thinks: low, high, or max (the default)."`
 }
 
 // ThinkingConfig configures the reasoning of thinking-capable Kimi models.
 type ThinkingConfig struct {
-	// Type turns thinking "enabled" or "disabled".
-	Type string `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled or disabled."`
+	// Type turns thinking [ThinkingTypeEnabled] or [ThinkingTypeDisabled].
+	Type ThinkingType `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled or disabled."`
 	// Keep controls how much reasoning is preserved across turns, "all" or
 	// unset. It is not an enum in the schema: Moonshot documents one value
 	// today, and a list of one would reject whatever it adds next.
@@ -97,7 +121,7 @@ func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams
 	if c.Thinking != nil {
 		thinking := map[string]any{}
 		if c.Thinking.Type != "" {
-			thinking["type"] = c.Thinking.Type
+			thinking["type"] = string(c.Thinking.Type)
 		}
 		if c.Thinking.Keep != "" {
 			thinking["keep"] = c.Thinking.Keep

--- a/go/plugins/compat_oai/kimi/kimi.go
+++ b/go/plugins/compat_oai/kimi/kimi.go
@@ -71,8 +71,9 @@ type ChatConfig struct {
 	// and the ceiling vary by model.
 	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_completion_tokens. The default and the ceiling vary by model."`
 	// StopSequences stop generation when produced by the model, up to five of
-	// at most 32 bytes each.
-	StopSequences []string `json:"stopSequences,omitempty" jsonschema:"maxItems=5" jsonschema_description:"Stop generation when produced by the model, up to five sequences of at most 32 bytes each."`
+	// at most 32 bytes each. The schema enforces the per-entry limit in
+	// characters; Moonshot counts bytes.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema:"maxItems=5,maxLength=32" jsonschema_description:"Stop generation when produced by the model, up to five sequences of at most 32 bytes each."`
 	// LogProbs requests log probabilities for the output tokens.
 	LogProbs *bool `json:"logProbs,omitempty" jsonschema_description:"Requests log probabilities for the output tokens."`
 	// TopLogProbs is how many of the most likely tokens to return log
@@ -134,20 +135,37 @@ func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams
 	}
 }
 
-// multimodal is the capability set every K-series Kimi model shares: text and
-// images in, text or JSON out, and tools. Moonshot's chat API takes
-// response_format json_schema, so structured output is generated natively
-// rather than coaxed through prompt instructions. See
-// https://platform.kimi.ai/docs/api/chat.
-var multimodal = ai.ModelSupports{
-	Multiturn:   true,
-	Tools:       true,
-	SystemRole:  true,
-	Media:       true,
-	ToolChoice:  true,
-	Output:      []string{"text", "json"},
-	Constrained: ai.ConstrainedSupportAll,
-}
+// Capability sets shared by the entries below: text and images in, text or
+// JSON out, and tools. Moonshot's chat API takes response_format json_schema,
+// so structured output is generated natively rather than coaxed through
+// prompt instructions. See https://platform.kimi.ai/docs/api/chat.
+var (
+	// multimodal is the Kimi K3 set, with free tool choice.
+	multimodal = ai.ModelSupports{
+		Multiturn:   true,
+		Tools:       true,
+		SystemRole:  true,
+		Media:       true,
+		ToolChoice:  true,
+		Output:      []string{"text", "json"},
+		Constrained: ai.ConstrainedSupportAll,
+	}
+	// multimodalNoToolChoice is multimodal minus tool-choice steering: the K2
+	// generation rejects tool_choice required as incompatible with thinking,
+	// which is on by default (K2.7 Code cannot even turn it off), so only the
+	// auto default is dependable and the framework waves auto through while
+	// rejecting the rest. A caller who always disables thinking can restore
+	// the claim through [Kimi.Models].
+	multimodalNoToolChoice = ai.ModelSupports{
+		Multiturn:   true,
+		Tools:       true,
+		SystemRole:  true,
+		Media:       true,
+		ToolChoice:  false,
+		Output:      []string{"text", "json"},
+		Constrained: ai.ConstrainedSupportAll,
+	}
+)
 
 // supportedModels curates capabilities for well-known Kimi models. It is not
 // the set of usable models: any Kimi model resolves on demand and takes
@@ -159,14 +177,15 @@ var multimodal = ai.ModelSupports{
 // Catalog: https://platform.kimi.ai/docs/api/chat
 var supportedModels = map[string]ai.ModelOptions{
 	"kimi-k3":                  {Label: "Kimi K3", Supports: &multimodal},
-	"kimi-k2.5":                {Label: "Kimi K2.5 (Deprecated)", Supports: &multimodal, Stage: ai.ModelStageDeprecated},
-	"kimi-k2.6":                {Label: "Kimi K2.6", Supports: &multimodal},
-	"kimi-k2.7-code":           {Label: "Kimi K2.7 Code", Supports: &multimodal},
-	"kimi-k2.7-code-highspeed": {Label: "Kimi K2.7 Code Highspeed", Supports: &multimodal},
+	"kimi-k2.5":                {Label: "Kimi K2.5 (Deprecated)", Supports: &multimodalNoToolChoice, Stage: ai.ModelStageDeprecated},
+	"kimi-k2.6":                {Label: "Kimi K2.6", Supports: &multimodalNoToolChoice},
+	"kimi-k2.7-code":           {Label: "Kimi K2.7 Code", Supports: &multimodalNoToolChoice},
+	"kimi-k2.7-code-highspeed": {Label: "Kimi K2.7 Code Highspeed", Supports: &multimodalNoToolChoice},
 }
 
 // dynamicModelOptions is advertised for Kimi models that resolve dynamically
-// rather than appearing in supportedModels.
+// rather than appearing in supportedModels. A model Moonshot adds later is
+// assumed K3-shaped, with free tool choice.
 var dynamicModelOptions = ai.ModelOptions{
 	Supports: &multimodal,
 	Versions: []string{},

--- a/go/plugins/compat_oai/kimi/kimi.go
+++ b/go/plugins/compat_oai/kimi/kimi.go
@@ -21,89 +21,132 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
-	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/shared"
 )
 
 const (
 	provider       = "kimi"
 	defaultBaseURL = "https://api.moonshot.ai/v1"
-
-	// ModelKimiK3 is the latest Kimi flagship multimodal model.
-	ModelKimiK3 = "kimi-k3"
-	// ModelKimiK25 is the Kimi K2.5 multimodal model.
-	ModelKimiK25 = "kimi-k2.5"
-	// ModelKimiK26 is the Kimi K2.6 multimodal model.
-	ModelKimiK26 = "kimi-k2.6"
-	// ModelKimiK27Code is the Kimi K2.7 coding model.
-	ModelKimiK27Code = "kimi-k2.7-code"
-	// ModelKimiK27CodeHighspeed is the high-speed Kimi K2.7 coding model.
-	ModelKimiK27CodeHighspeed = "kimi-k2.7-code-highspeed"
 )
 
+// ChatConfig is the per-request config for Kimi models: the generation fields
+// the K-series accepts plus the Moonshot-specific controls. See
+// https://platform.kimi.ai/docs/api/chat.
+//
+// Moonshot documents temperature, topP, and the frequency and presence
+// penalties for the legacy moonshot-v1 family only, so the K-series models
+// this plugin serves do not take them and they are deliberately absent.
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as the
+	// API's max_completion_tokens; Moonshot deprecated max_tokens. The default
+	// and the ceiling vary by model.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_completion_tokens. The default and the ceiling vary by model."`
+	// StopSequences stop generation when produced by the model, up to five of
+	// at most 32 bytes each.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema:"maxItems=5" jsonschema_description:"Stop generation when produced by the model, up to five sequences of at most 32 bytes each."`
+	// LogProbs requests log probabilities for the output tokens.
+	LogProbs *bool `json:"logProbs,omitempty" jsonschema_description:"Requests log probabilities for the output tokens."`
+	// TopLogProbs is how many of the most likely tokens to return log
+	// probabilities for at each position, from 0 to 20; it requires LogProbs.
+	TopLogProbs *int `json:"topLogProbs,omitempty" jsonschema:"minimum=0,maximum=20" jsonschema_description:"How many of the most likely tokens to return log probabilities for at each position, from 0 to 20; requires logProbs."`
+	// Thinking controls the reasoning mode of thinking-capable Kimi models,
+	// sent as the API's thinking field.
+	Thinking *ThinkingConfig `json:"thinking,omitempty" jsonschema_description:"Reasoning mode controls for thinking-capable Kimi models, sent as the API's thinking field."`
+	// ReasoningEffort adjusts how hard the Kimi K3 generation thinks: "low",
+	// "high", or "max", the default.
+	ReasoningEffort string `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=high,enum=max" jsonschema_description:"How hard the Kimi K3 generation thinks: low, high, or max (the default)."`
+}
+
+// ThinkingConfig configures the reasoning of thinking-capable Kimi models.
+type ThinkingConfig struct {
+	// Type turns thinking "enabled" or "disabled".
+	Type string `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled or disabled."`
+	// Keep controls how much reasoning is preserved across turns, "all" or
+	// unset. It is not an enum in the schema: Moonshot documents one value
+	// today, and a list of one would reject whatever it adds next.
+	Keep string `json:"keep,omitempty" jsonschema_description:"How much reasoning is preserved across turns: all, or unset for the default."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the generation
+// fields land on their chat completion counterparts, reasoning effort on the
+// SDK's reasoning_effort, and thinking rides as Moonshot's extra request
+// field.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.MaxOutputTokens > 0 {
+		params.MaxCompletionTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+	if c.LogProbs != nil {
+		params.Logprobs = openai.Bool(*c.LogProbs)
+	}
+	if c.TopLogProbs != nil {
+		params.TopLogprobs = openai.Int(int64(*c.TopLogProbs))
+	}
+	if c.ReasoningEffort != "" {
+		params.ReasoningEffort = shared.ReasoningEffort(c.ReasoningEffort)
+	}
+	if c.Thinking != nil {
+		thinking := map[string]any{}
+		if c.Thinking.Type != "" {
+			thinking["type"] = c.Thinking.Type
+		}
+		if c.Thinking.Keep != "" {
+			thinking["keep"] = c.Thinking.Keep
+		}
+		// An all-zero ThinkingConfig adds nothing rather than sending an
+		// empty thinking object the API could reject.
+		if len(thinking) > 0 {
+			compat_oai.AddExtraFields(params, map[string]any{"thinking": thinking})
+		}
+	}
+}
+
+// multimodal is the capability set every K-series Kimi model shares: text and
+// images in, text or JSON out, and tools. Moonshot's chat API takes
+// response_format json_schema, so structured output is generated natively
+// rather than coaxed through prompt instructions. See
+// https://platform.kimi.ai/docs/api/chat.
+var multimodal = ai.ModelSupports{
+	Multiturn:   true,
+	Tools:       true,
+	SystemRole:  true,
+	Media:       true,
+	ToolChoice:  true,
+	Output:      []string{"text", "json"},
+	Constrained: ai.ConstrainedSupportAll,
+}
+
+// supportedModels curates capabilities for well-known Kimi models. It is not
+// the set of usable models: any Kimi model resolves on demand and takes
+// [dynamicModelOptions], so an ID absent here still works. No versions are
+// declared, since Moonshot serves each model under one ID whose snapshot moves
+// underneath it, and an undeclared list leaves config version pinning
+// unconstrained.
+//
+// Catalog: https://platform.kimi.ai/docs/api/chat
 var supportedModels = map[string]ai.ModelOptions{
-	ModelKimiK3: {
-		Label: "Kimi K3",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			ToolChoice: true,
-			Output:     []string{"text", "json"},
-		},
-		Versions: []string{ModelKimiK3},
-	},
-	ModelKimiK25: {
-		Label: "Kimi K2.5 (Deprecated)",
-		Stage: ai.ModelStageDeprecated,
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			ToolChoice: true,
-			Output:     []string{"text", "json"},
-		},
-		Versions: []string{ModelKimiK25},
-	},
-	ModelKimiK26: {
-		Label: "Kimi K2.6",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			ToolChoice: true,
-			Output:     []string{"text", "json"},
-		},
-		Versions: []string{ModelKimiK26},
-	},
-	ModelKimiK27Code: {
-		Label: "Kimi K2.7 Code",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			ToolChoice: true,
-			Output:     []string{"text", "json"},
-		},
-		Versions: []string{ModelKimiK27Code},
-	},
-	ModelKimiK27CodeHighspeed: {
-		Label: "Kimi K2.7 Code Highspeed",
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      true,
-			ToolChoice: true,
-			Output:     []string{"text", "json"},
-		},
-		Versions: []string{ModelKimiK27CodeHighspeed},
-	},
+	"kimi-k3":                  {Label: "Kimi K3", Supports: &multimodal},
+	"kimi-k2.5":                {Label: "Kimi K2.5 (Deprecated)", Supports: &multimodal, Stage: ai.ModelStageDeprecated},
+	"kimi-k2.6":                {Label: "Kimi K2.6", Supports: &multimodal},
+	"kimi-k2.7-code":           {Label: "Kimi K2.7 Code", Supports: &multimodal},
+	"kimi-k2.7-code-highspeed": {Label: "Kimi K2.7 Code Highspeed", Supports: &multimodal},
+}
+
+// dynamicModelOptions is advertised for Kimi models that resolve dynamically
+// rather than appearing in supportedModels.
+var dynamicModelOptions = ai.ModelOptions{
+	Supports: &multimodal,
+	Versions: []string{},
+	Stage:    ai.ModelStageStable,
 }
 
 // Kimi configures the Moonshot AI Kimi plugin.
@@ -111,12 +154,30 @@ type Kimi struct {
 	// APIKey is the Moonshot API key. If empty, KIMI_API_KEY and then
 	// MOONSHOT_API_KEY are consulted.
 	APIKey string
-	// BaseURL overrides the Moonshot API endpoint. If empty, KIMI_BASE_URL,
-	// MOONSHOT_BASE_URL, and then the default international endpoint are used.
-	BaseURL string
-	// Opts contains additional OpenAI client request options. Options supplied
-	// here are applied after the plugin defaults.
+	// Opts contains additional OpenAI client request options, such as
+	// [option.WithBaseURL] for a different endpoint (KIMI_BASE_URL and
+	// MOONSHOT_BASE_URL work too). Options supplied here are applied after
+	// the plugin defaults, so they win on overlap.
 	Opts []option.RequestOption
+
+	// Models overrides what the plugin knows about a Kimi model, keyed by
+	// model ID, bare or provider-prefixed. Every Kimi model already works
+	// without an entry: known IDs carry curated capabilities and the rest take
+	// the Kimi defaults. Supply an entry only to correct or extend what the
+	// plugin resolves, most often for a model released after this version of
+	// the plugin.
+	//
+	//	&kimi.Kimi{Models: map[string]ai.ModelOptions{
+	//		"kimi-k3": {Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+	//	}}
+	//
+	// Fields left at their zero value keep what the plugin resolves, so an
+	// entry can pin one capability without restating the label or the
+	// versions. Entries apply to the models Init registers as well as the
+	// ones [Kimi.ListActions] advertises and [Kimi.ResolveAction] builds,
+	// which is the way to describe a curated model differently: Init has
+	// already registered those and nothing can re-register them.
+	Models map[string]ai.ModelOptions
 
 	openAICompatible compat_oai.OpenAICompatible
 }
@@ -128,10 +189,7 @@ func (k *Kimi) Name() string {
 
 // Init implements genkit.Plugin.
 func (k *Kimi) Init(ctx context.Context) []api.Action {
-	baseURL := k.BaseURL
-	if baseURL == "" {
-		baseURL = os.Getenv("KIMI_BASE_URL")
-	}
+	baseURL := os.Getenv("KIMI_BASE_URL")
 	if baseURL == "" {
 		baseURL = os.Getenv("MOONSHOT_BASE_URL")
 	}
@@ -160,28 +218,49 @@ func (k *Kimi) Init(ctx context.Context) []api.Action {
 	k.openAICompatible.Opts = opts
 	actions := k.openAICompatible.Init(ctx)
 
-	for model, modelOpts := range supportedModels {
-		actions = append(actions, k.DefineModel(model, modelOpts).(api.Action))
+	for model := range supportedModels {
+		actions = append(actions, k.newModel(model, k.modelOptions(model)))
 	}
 	return actions
 }
 
-// Model returns a registered Kimi model.
-func (k *Kimi) Model(g *genkit.Genkit, id string) ai.Model {
-	return k.openAICompatible.Model(g, api.NewName(provider, id))
+// newModel creates a Kimi model without registering it.
+func (k *Kimi) newModel(id string, opts ai.ModelOptions) *ai.ModelAction {
+	return compat_oai.NewChatModel[ChatConfig](&k.openAICompatible, id, opts)
 }
 
-// DefineModel registers a Kimi model, including models not in the built-in list.
-func (k *Kimi) DefineModel(id string, opts ai.ModelOptions) ai.Model {
-	return k.openAICompatible.DefineModel(provider, id, opts)
+// modelOptions returns the ModelOptions for a Kimi model ID: curated
+// capabilities for a known model and the Kimi defaults for the rest, with
+// an entry from [Kimi.Models] overlaid on whichever applies.
+//
+// Every path that describes a model goes through this one, which is what
+// makes a caller's entry authoritative whether Init, ListActions or
+// ResolveAction gets there first.
+func (k *Kimi) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, supportedModels, dynamicModelOptions, k.Models)
 }
 
-// ListActions lists models exposed by the configured Kimi endpoint.
+// ModelRef names a Kimi model and carries the config to generate with, so the
+// config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(kimi.ModelRef("kimi-k3", &kimi.ChatConfig{
+//		ReasoningEffort: "high",
+//	}))
+//
+// id is the model ID, with or without the provider prefix.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// ListActions lists the models the configured Kimi endpoint exposes,
+// described by the plugin's config schema and capabilities.
 func (k *Kimi) ListActions(ctx context.Context) []api.ActionDesc {
-	return k.openAICompatible.ListActions(ctx)
+	return compat_oai.ListChatActions[ChatConfig](ctx, &k.openAICompatible, k.modelOptions)
 }
 
-// ResolveAction dynamically registers a model exposed by the Kimi endpoint.
-func (k *Kimi) ResolveAction(atype api.ActionType, name string) api.Action {
-	return k.openAICompatible.ResolveAction(atype, name)
+// ResolveAction dynamically builds a model exposed by the Kimi endpoint,
+// described by the plugin's config schema and capabilities.
+func (k *Kimi) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&k.openAICompatible, atype, id, k.modelOptions)
 }

--- a/go/plugins/compat_oai/kimi/kimi_live_test.go
+++ b/go/plugins/compat_oai/kimi/kimi_live_test.go
@@ -17,72 +17,32 @@ package kimi_test
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
 	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
 )
 
 func TestPluginLive(t *testing.T) {
-	apiKey := os.Getenv("KIMI_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("MOONSHOT_API_KEY")
-	}
-	if apiKey == "" {
+	if os.Getenv("KIMI_API_KEY") == "" && os.Getenv("MOONSHOT_API_KEY") == "" {
 		t.Skip("KIMI_API_KEY and MOONSHOT_API_KEY are not set")
 	}
 
 	ctx := context.Background()
-	plugin := &kimi.Kimi{}
-	g := genkit.Init(
-		ctx,
-		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("kimi/"+kimi.ModelKimiK3),
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&kimi.Kimi{}),
+		genkit.WithDefaultModel("kimi/kimi-k3"),
 	)
 
-	t.Run("kimi k3 complete", func(t *testing.T) {
-		resp, err := genkit.Generate(
-			ctx,
-			g,
-			ai.WithPrompt("What is the capital of France? Answer with the city only."),
-		)
-		if err != nil {
-			t.Fatalf("Generate() error = %v", err)
-		}
-		if !strings.Contains(strings.ToLower(resp.Text()), "paris") {
-			t.Fatalf("Text() = %q, want Paris", resp.Text())
-		}
-	})
-
-	t.Run("kimi k2.6 streaming reasoning", func(t *testing.T) {
-		var streamedReasoning, streamedText strings.Builder
-		resp, err := genkit.Generate(
-			ctx,
-			g,
-			ai.WithModel(plugin.Model(g, kimi.ModelKimiK26)),
-			ai.WithPrompt("Explain briefly why the sky appears blue."),
-			ai.WithStreaming(func(_ context.Context, chunk *ai.ModelResponseChunk) error {
-				streamedReasoning.WriteString(chunk.Reasoning())
-				streamedText.WriteString(chunk.Text())
-				return nil
-			}),
-		)
-		if err != nil {
-			t.Fatalf("Generate() error = %v", err)
-		}
-		if streamedReasoning.String() == "" {
-			t.Fatal("streamed reasoning is empty")
-		}
-		if streamedText.String() == "" {
-			t.Fatal("streamed text is empty")
-		}
-		if resp.Reasoning() != streamedReasoning.String() {
-			t.Fatalf("final reasoning = %q, want streamed %q", resp.Reasoning(), streamedReasoning.String())
-		}
-		if resp.Text() != streamedText.String() {
-			t.Fatalf("final text = %q, want streamed %q", resp.Text(), streamedText.String())
-		}
+	livetest.Run(t, g, livetest.Suite{
+		Model:            kimi.ModelRef("kimi-k3", nil),
+		ReasoningModel:   kimi.ModelRef("kimi-k2.6", nil),
+		ReasoningContent: true,
+		VisionModel:      kimi.ModelRef("kimi-k3", nil),
+		ToolChoice:       true,
+		ExtraConfig: map[string]any{
+			"extra": map[string]any{"thinking": map[string]any{"type": "disabled"}},
+		},
 	})
 }

--- a/go/plugins/compat_oai/kimi/kimi_test.go
+++ b/go/plugins/compat_oai/kimi/kimi_test.go
@@ -54,17 +54,17 @@ func TestPluginRegistersKimiModelsAndHandlesReasoning(t *testing.T) {
 			t.Errorf("decode request: %v", err)
 			return
 		}
-		if body.Model != "kimi-k2.6" {
-			t.Errorf("model = %q, want %q", body.Model, "kimi-k2.6")
+		if body.Model != "kimi-k3" {
+			t.Errorf("model = %q, want %q", body.Model, "kimi-k3")
 		}
 
 		if body.Stream {
 			w.Header().Set("Content-Type", "text/event-stream")
 			for _, event := range []string{
-				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"kimi-k2.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Think "},"finish_reason":null}]}`,
-				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"kimi-k2.6","choices":[{"index":0,"delta":{"reasoning_content":"carefully."},"finish_reason":null}]}`,
-				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"kimi-k2.6","choices":[{"index":0,"delta":{"content":"Final answer"},"finish_reason":null}]}`,
-				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"kimi-k2.6","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Think "},"finish_reason":null}]}`,
+				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{"reasoning_content":"carefully."},"finish_reason":null}]}`,
+				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{"content":"Final answer"},"finish_reason":null}]}`,
+				`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
 			} {
 				_, _ = io.WriteString(w, "data: "+event+"\n\n")
 			}
@@ -77,7 +77,7 @@ func TestPluginRegistersKimiModelsAndHandlesReasoning(t *testing.T) {
 			"id":"chatcmpl-1",
 			"object":"chat.completion",
 			"created":1,
-			"model":"kimi-k2.6",
+			"model":"kimi-k3",
 			"choices":[{
 				"index":0,
 				"message":{
@@ -100,21 +100,30 @@ func TestPluginRegistersKimiModelsAndHandlesReasoning(t *testing.T) {
 	g := genkit.Init(
 		ctx,
 		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("kimi/kimi-k2.6"),
+		genkit.WithDefaultModel("kimi/kimi-k3"),
 	)
 
 	if plugin.Name() != "kimi" {
 		t.Fatalf("Name() = %q, want %q", plugin.Name(), "kimi")
 	}
-	for _, model := range []string{
-		"kimi-k3",
-		"kimi-k2.5",
-		"kimi-k2.6",
-		"kimi-k2.7-code",
-		"kimi-k2.7-code-highspeed",
+	// Tool-choice steering is K3's alone: the K2 generation rejects
+	// tool_choice required as incompatible with thinking, which is on by
+	// default.
+	for model, wantToolChoice := range map[string]bool{
+		"kimi-k3":                  true,
+		"kimi-k2.5":                false,
+		"kimi-k2.6":                false,
+		"kimi-k2.7-code":           false,
+		"kimi-k2.7-code-highspeed": false,
 	} {
-		if genkit.LookupModel(g, "kimi/"+model) == nil {
+		m := genkit.LookupModel(g, "kimi/"+model)
+		if m == nil {
 			t.Errorf("LookupModel(%q) = nil", model)
+			continue
+		}
+		supports := m.(api.Action).Desc().Metadata["model"].(map[string]any)["supports"].(map[string]any)
+		if got := supports["toolChoice"]; got != wantToolChoice {
+			t.Errorf("%s toolChoice support = %v, want %v", model, got, wantToolChoice)
 		}
 	}
 	for _, model := range []string{
@@ -215,8 +224,8 @@ func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
 			t.Errorf("decode request: %v", err)
 			return
 		}
-		if body.Model != "kimi-k2.6" {
-			t.Errorf("model = %q, want %q", body.Model, "kimi-k2.6")
+		if body.Model != "kimi-k3" {
+			t.Errorf("model = %q, want %q", body.Model, "kimi-k3")
 		}
 		if got := body.Thinking["type"]; got != "enabled" {
 			t.Errorf("thinking.type = %v, want %q", got, "enabled")
@@ -234,7 +243,7 @@ func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
 				"id":"chatcmpl-tool-1",
 				"object":"chat.completion",
 				"created":1,
-				"model":"kimi-k2.6",
+				"model":"kimi-k3",
 				"choices":[{
 					"index":0,
 					"message":{
@@ -275,7 +284,7 @@ func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
 			"id":"chatcmpl-tool-2",
 			"object":"chat.completion",
 			"created":1,
-			"model":"kimi-k2.6",
+			"model":"kimi-k3",
 			"choices":[{
 				"index":0,
 				"message":{
@@ -294,7 +303,7 @@ func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
 	g := genkit.Init(
 		ctx,
 		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("kimi/kimi-k2.6"),
+		genkit.WithDefaultModel("kimi/kimi-k3"),
 	)
 	lookup := genkit.DefineTool(
 		g,
@@ -463,6 +472,13 @@ func TestModelRefAndConfigSchema(t *testing.T) {
 			}
 		}
 	}
+	// The per-entry limit lands on the items schema, where each sequence is
+	// checked against Moonshot's 32 maximum.
+	stop, _ := props["stopSequences"].(map[string]any)
+	stopItems, _ := stop["items"].(map[string]any)
+	if got := stopItems["maxLength"]; got != 32.0 {
+		t.Errorf("stopSequences items maxLength = %v, want 32 to match Moonshot's per-entry limit", got)
+	}
 	thinking, _ := props["thinking"].(map[string]any)
 	thinkingProps, _ := thinking["properties"].(map[string]any)
 	thinkingType, _ := thinkingProps["type"].(map[string]any)
@@ -475,5 +491,63 @@ func TestModelRefAndConfigSchema(t *testing.T) {
 	keep, _ := thinkingProps["keep"].(map[string]any)
 	if got, has := keep["enum"]; has {
 		t.Errorf("thinking.keep enum = %v, want none since the set is Moonshot's to grow", got)
+	}
+}
+
+// TestToolChoiceRejectedOnK2Generation pins the capability split: Moonshot
+// rejects tool_choice required on the K2 generation as "incompatible with
+// thinking enabled", and thinking is on by default, so those models advertise
+// no tool-choice steering and Genkit fails the request before the wire.
+func TestToolChoiceRejectedOnK2Generation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("request reached the server, want local rejection")
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &kimi.Kimi{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/v1")}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+	lookup := genkit.DefineTool(g, "lookup", "Looks up a value.",
+		func(_ *ai.ToolContext, input struct {
+			Value string `json:"value"`
+		}) (string, error) {
+			return "result for " + input.Value, nil
+		})
+
+	for _, model := range []string{"kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "kimi-k2.7-code-highspeed"} {
+		if _, err := genkit.Generate(ctx, g,
+			ai.WithModelName("kimi/"+model),
+			ai.WithPrompt("Use the lookup tool."),
+			ai.WithTools(lookup),
+			ai.WithToolChoice(ai.ToolChoiceRequired),
+		); err == nil {
+			t.Errorf("%s Generate() error = nil, want the tool choice rejected", model)
+		}
+	}
+}
+
+// TestStopSequenceLengthRejected pins the per-entry limit end to end:
+// Moonshot rejects a stop sequence over 32 ("stop sequence must not be longer
+// than 32"), so the schema catches one before the wire.
+func TestStopSequenceLengthRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("request reached the server, want boundary validation to reject the config")
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &kimi.Kimi{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/v1")}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	_, err := genkit.Generate(ctx, g,
+		ai.WithModelName("kimi/kimi-k3"),
+		ai.WithPrompt("Say OK."),
+		ai.WithConfig(map[string]any{"stopSequences": []string{strings.Repeat("x", 33)}}),
+	)
+	if err == nil {
+		t.Fatal("Generate() error = nil, want the 33-character stop sequence rejected")
+	}
+	if !strings.Contains(err.Error(), "stopSequences") {
+		t.Errorf("error = %v, want it to name stopSequences", err)
 	}
 }

--- a/go/plugins/compat_oai/kimi/kimi_test.go
+++ b/go/plugins/compat_oai/kimi/kimi_test.go
@@ -20,19 +20,25 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
+	"github.com/openai/openai-go/option"
 )
 
 func TestPluginRegistersKimiModelsAndHandlesReasoning(t *testing.T) {
+	var mu sync.Mutex
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requests++
+		mu.Unlock()
 		if r.URL.Path != "/v1/chat/completions" {
 			t.Errorf("path = %q, want %q", r.URL.Path, "/v1/chat/completions")
 		}
@@ -48,8 +54,8 @@ func TestPluginRegistersKimiModelsAndHandlesReasoning(t *testing.T) {
 			t.Errorf("decode request: %v", err)
 			return
 		}
-		if body.Model != kimi.ModelKimiK26 {
-			t.Errorf("model = %q, want %q", body.Model, kimi.ModelKimiK26)
+		if body.Model != "kimi-k2.6" {
+			t.Errorf("model = %q, want %q", body.Model, "kimi-k2.6")
 		}
 
 		if body.Stream {
@@ -88,47 +94,47 @@ func TestPluginRegistersKimiModelsAndHandlesReasoning(t *testing.T) {
 
 	ctx := context.Background()
 	plugin := &kimi.Kimi{
-		APIKey:  "test-key",
-		BaseURL: server.URL + "/v1",
+		APIKey: "test-key",
+		Opts:   []option.RequestOption{option.WithBaseURL(server.URL + "/v1")},
 	}
 	g := genkit.Init(
 		ctx,
 		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("kimi/"+kimi.ModelKimiK26),
+		genkit.WithDefaultModel("kimi/kimi-k2.6"),
 	)
 
 	if plugin.Name() != "kimi" {
 		t.Fatalf("Name() = %q, want %q", plugin.Name(), "kimi")
 	}
 	for _, model := range []string{
-		kimi.ModelKimiK3,
-		kimi.ModelKimiK25,
-		kimi.ModelKimiK26,
-		kimi.ModelKimiK27Code,
-		kimi.ModelKimiK27CodeHighspeed,
+		"kimi-k3",
+		"kimi-k2.5",
+		"kimi-k2.6",
+		"kimi-k2.7-code",
+		"kimi-k2.7-code-highspeed",
 	} {
-		if plugin.Model(g, model) == nil {
-			t.Errorf("Model(%q) = nil", model)
+		if genkit.LookupModel(g, "kimi/"+model) == nil {
+			t.Errorf("LookupModel(%q) = nil", model)
 		}
 	}
 	for _, model := range []string{
-		kimi.ModelKimiK3,
-		kimi.ModelKimiK25,
-		kimi.ModelKimiK26,
-		kimi.ModelKimiK27Code,
-		kimi.ModelKimiK27CodeHighspeed,
+		"kimi-k3",
+		"kimi-k2.5",
+		"kimi-k2.6",
+		"kimi-k2.7-code",
+		"kimi-k2.7-code-highspeed",
 	} {
-		action := plugin.Model(g, model).(api.Action)
+		action := genkit.LookupModel(g, "kimi/"+model).(api.Action)
 		modelMetadata := action.Desc().Metadata["model"].(map[string]any)
 		supports := modelMetadata["supports"].(map[string]any)
 		if got := supports["media"]; got != true {
 			t.Errorf("%s media support = %v, want true", model, got)
 		}
 	}
-	k25Metadata := plugin.Model(g, kimi.ModelKimiK25).(api.Action).
+	k25Metadata := genkit.LookupModel(g, "kimi/kimi-k2.5").(api.Action).
 		Desc().Metadata["model"].(map[string]any)
 	if got := k25Metadata["stage"]; got != ai.ModelStageDeprecated {
-		t.Errorf("%s stage = %v, want %q", kimi.ModelKimiK25, got, ai.ModelStageDeprecated)
+		t.Errorf("%s stage = %v, want %q", "kimi-k2.5", got, ai.ModelStageDeprecated)
 	}
 
 	t.Run("complete", func(t *testing.T) {
@@ -184,15 +190,21 @@ func TestPluginRegistersKimiModelsAndHandlesReasoning(t *testing.T) {
 		}
 	})
 
+	mu.Lock()
+	defer mu.Unlock()
 	if requests != 2 {
 		t.Fatalf("requests = %d, want 2", requests)
 	}
 }
 
 func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
+	var mu sync.Mutex
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requests++
+		reqNum := requests
+		mu.Unlock()
 		var body struct {
 			Messages   []map[string]any `json:"messages"`
 			Model      string           `json:"model"`
@@ -203,8 +215,8 @@ func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
 			t.Errorf("decode request: %v", err)
 			return
 		}
-		if body.Model != kimi.ModelKimiK26 {
-			t.Errorf("model = %q, want %q", body.Model, kimi.ModelKimiK26)
+		if body.Model != "kimi-k2.6" {
+			t.Errorf("model = %q, want %q", body.Model, "kimi-k2.6")
 		}
 		if got := body.Thinking["type"]; got != "enabled" {
 			t.Errorf("thinking.type = %v, want %q", got, "enabled")
@@ -217,7 +229,7 @@ func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		if requests == 1 {
+		if reqNum == 1 {
 			_, _ = io.WriteString(w, `{
 				"id":"chatcmpl-tool-1",
 				"object":"chat.completion",
@@ -278,11 +290,11 @@ func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	plugin := &kimi.Kimi{APIKey: "test-key", BaseURL: server.URL + "/v1"}
+	plugin := &kimi.Kimi{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/v1")}}
 	g := genkit.Init(
 		ctx,
 		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("kimi/"+kimi.ModelKimiK26),
+		genkit.WithDefaultModel("kimi/kimi-k2.6"),
 	)
 	lookup := genkit.DefineTool(
 		g,
@@ -317,8 +329,62 @@ func TestPluginPreservesReasoningAndConfigAcrossToolCalls(t *testing.T) {
 	if got := resp.Reasoning(); got != "The tool returned the result." {
 		t.Errorf("Reasoning() = %q, want final-turn reasoning", got)
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if requests != 2 {
 		t.Errorf("requests = %d, want 2", requests)
+	}
+}
+
+// TestExtraPassthroughRidesTheWire pins the inherited passthrough on this
+// plugin's own config: an undeclared field lands at the top level of the
+// request, and a collision with the extra the plugin itself writes (thinking)
+// resolves toward the caller's.
+func TestExtraPassthroughRidesTheWire(t *testing.T) {
+	var mu sync.Mutex
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"kimi-k3",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &kimi.Kimi{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/v1")}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	_, err := genkit.Generate(ctx, g,
+		ai.WithModelName("kimi/kimi-k3"),
+		ai.WithPrompt("hi"),
+		ai.WithConfig(map[string]any{
+			"thinking": map[string]any{"type": "disabled"},
+			"extra": map[string]any{
+				"thinking":  map[string]any{"type": "enabled"},
+				"kimi_beta": "on",
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := body["kimi_beta"]; got != "on" {
+		t.Errorf("kimi_beta = %v, want the undeclared field on the wire", got)
+	}
+	thinking, _ := body["thinking"].(map[string]any)
+	if got := thinking["type"]; got != "enabled" {
+		t.Errorf("thinking.type = %v, want the caller's extra winning over the config's own thinking", got)
 	}
 }
 
@@ -334,4 +400,77 @@ func TestPluginRequiresAPIKey(t *testing.T) {
 	}()
 
 	(&kimi.Kimi{}).Init(context.Background())
+}
+
+// TestModelRefAndConfigSchema pins the call-site surface: the ref carries the
+// prefixed name and the typed config, and the registered models advertise the
+// camelCase config contract including the Kimi-specific fields.
+func TestModelRefAndConfigSchema(t *testing.T) {
+	cfg := &kimi.ChatConfig{ReasoningEffort: "high"}
+	for _, name := range []string{"kimi-k3", "kimi/kimi-k3"} {
+		ref := kimi.ModelRef(name, cfg)
+		if want := "kimi/kimi-k3"; ref.Name() != want {
+			t.Errorf("ModelRef(%q).Name() = %q, want %q", name, ref.Name(), want)
+		}
+		if ref.Config() != cfg {
+			t.Errorf("ModelRef(%q).Config() = %v, want the config it was built with", name, ref.Config())
+		}
+	}
+
+	plugin := &kimi.Kimi{APIKey: "test-key"}
+	g := genkit.Init(context.Background(), genkit.WithPlugins(plugin))
+
+	m := genkit.LookupModel(g, "kimi/kimi-k3")
+	if m == nil {
+		t.Fatal("kimi-k3 not registered by Init")
+	}
+	model := m.(api.Action).Desc().Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions missing, got %v", model["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions has no properties: %v", schema)
+	}
+	for _, key := range []string{"maxOutputTokens", "stopSequences", "logProbs", "topLogProbs", "thinking", "reasoningEffort", "version", "extra"} {
+		if props[key] == nil {
+			t.Errorf("config schema is missing the %q property", key)
+		}
+	}
+	// Moonshot documents these for the legacy moonshot-v1 family only, so the
+	// K-series models this plugin serves must not advertise them.
+	for _, key := range []string{"temperature", "topP", "frequencyPenalty", "presencePenalty"} {
+		if props[key] != nil {
+			t.Errorf("config schema advertises %q, which the Kimi K-series does not take", key)
+		}
+	}
+
+	// The constraints Moonshot documents ride on the schema, where the
+	// framework enforces them.
+	for field, want := range map[string]map[string]any{
+		"maxOutputTokens": {"minimum": 1.0},
+		"stopSequences":   {"maxItems": 5.0},
+		"topLogProbs":     {"minimum": 0.0, "maximum": 20.0},
+		"reasoningEffort": {"enum": []any{"low", "high", "max"}},
+	} {
+		prop, _ := props[field].(map[string]any)
+		for key, value := range want {
+			if got := prop[key]; !reflect.DeepEqual(got, value) {
+				t.Errorf("%s %s = %#v, want %#v", field, key, got, value)
+			}
+		}
+	}
+	thinking, _ := props["thinking"].(map[string]any)
+	thinkingProps, _ := thinking["properties"].(map[string]any)
+	thinkingType, _ := thinkingProps["type"].(map[string]any)
+	if got, want := thinkingType["enum"], []any{"enabled", "disabled"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("thinking.type enum = %#v, want %#v", got, want)
+	}
+	// keep carries no enum: Moonshot documents a single value today, and a
+	// list of one would reject whatever it adds next.
+	keep, _ := thinkingProps["keep"].(map[string]any)
+	if got, has := keep["enum"]; has {
+		t.Errorf("thinking.keep enum = %v, want none since the set is Moonshot's to grow", got)
+	}
 }

--- a/go/plugins/compat_oai/kimi/kimi_test.go
+++ b/go/plugins/compat_oai/kimi/kimi_test.go
@@ -452,7 +452,9 @@ func TestModelRefAndConfigSchema(t *testing.T) {
 		"maxOutputTokens": {"minimum": 1.0},
 		"stopSequences":   {"maxItems": 5.0},
 		"topLogProbs":     {"minimum": 0.0, "maximum": 20.0},
-		"reasoningEffort": {"enum": []any{"low", "high", "max"}},
+		"reasoningEffort": {"enum": []any{
+			string(kimi.ReasoningEffortLow), string(kimi.ReasoningEffortHigh),
+			string(kimi.ReasoningEffortMax)}},
 	} {
 		prop, _ := props[field].(map[string]any)
 		for key, value := range want {
@@ -464,7 +466,8 @@ func TestModelRefAndConfigSchema(t *testing.T) {
 	thinking, _ := props["thinking"].(map[string]any)
 	thinkingProps, _ := thinking["properties"].(map[string]any)
 	thinkingType, _ := thinkingProps["type"].(map[string]any)
-	if got, want := thinkingType["enum"], []any{"enabled", "disabled"}; !reflect.DeepEqual(got, want) {
+	if got, want := thinkingType["enum"], []any{
+		string(kimi.ThinkingTypeEnabled), string(kimi.ThinkingTypeDisabled)}; !reflect.DeepEqual(got, want) {
 		t.Errorf("thinking.type enum = %#v, want %#v", got, want)
 	}
 	// keep carries no enum: Moonshot documents a single value today, and a

--- a/go/samples/compat_oai/kimi/main.go
+++ b/go/samples/compat_oai/kimi/main.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This sample demonstrates the Kimi plugin for Moonshot AI's models: a flow
+// that generates a joke with a model pinned through kimi.ModelRef and its
+// typed config.
+//
+// To run:
+//
+//	export KIMI_API_KEY=...
+//	go run .
+//
+// In another terminal:
+//
+//	curl -X POST http://localhost:8080/jokesFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": "bananas"}'
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
+	"github.com/firebase/genkit/go/plugins/server"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// The plugin reads the API key from the KIMI_API_KEY (or MOONSHOT_API_KEY)
+	// environment variable.
+	g := genkit.Init(ctx, genkit.WithPlugins(&kimi.Kimi{}))
+
+	// Define a flow that generates a joke about a given topic. Thinking is on
+	// by default for the K2 generation, so the config turns it off for a
+	// quick conversational answer.
+	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		if topic == "" {
+			topic = "airplane food"
+		}
+
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(kimi.ModelRef("kimi-k2.6", &kimi.ChatConfig{
+				Thinking: &kimi.ThinkingConfig{Type: kimi.ThinkingTypeDisabled},
+			})),
+			ai.WithPrompt("Share a joke about %s.", topic),
+		)
+	})
+
+	// Optionally, start a web server to make the flow callable via HTTP.
+	mux := http.NewServeMux()
+	for _, a := range genkit.ListFlows(g) {
+		mux.HandleFunc("POST /"+a.Name(), genkit.Handler(a))
+	}
+	log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+}


### PR DESCRIPTION
Migrates the Kimi plugin onto the typed-config base (#5976); stacked on #6032.

## The plugin and its config, at a glance

```go
type Kimi struct {
	APIKey string
	Opts   []option.RequestOption
	Models map[string]ai.ModelOptions
}

type ChatConfig struct {
	compat_oai.RequestConfig
	MaxOutputTokens int             `json:"maxOutputTokens,omitempty"`
	StopSequences   []string        `json:"stopSequences,omitempty"`
	LogProbs        *bool           `json:"logProbs,omitempty"`
	TopLogProbs     *int            `json:"topLogProbs,omitempty"`
	Thinking        *ThinkingConfig `json:"thinking,omitempty"`
	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty"`
}

type ThinkingConfig struct {
	Type ThinkingType `json:"type,omitempty"`
	Keep string       `json:"keep,omitempty"`
}

type ReasoningEffort string // "low", "high", "max"

type ThinkingType string // "enabled", "disabled"
```

`BaseURL` leaves the plugin struct (merged but never released): the endpoint override rides `Opts` (`option.WithBaseURL`) or `KIMI_BASE_URL`/`MOONSHOT_BASE_URL`, applied after the plugin defaults so it wins.

Every constraint is verified against Moonshot's published reference, which turned up limits the old code did not state: up to five stop sequences of at most 32 bytes each (the per-entry limit enforced as `maxLength` on the items schema; Moonshot rejects longer ones with "stop sequence must not be longer than 32", verified live), `top_logprobs` 0 to 20, and `reasoning_effort` of `low`, `high`, or `max` (`max` the default). No `temperature` or penalty fields: the K-series accepts none. `thinking.type` enumerates the documented `enabled`/`disabled` set, while `keep` deliberately stays open: Moonshot documents one value today, and a list of one would reject whatever it adds next. The closed sets are named types with exported constants (`ReasoningEffortMax`, `ThinkingTypeEnabled`), the pattern the xai plugin set; a new conformance rule pins it family-wide: an enum-tagged field uses a named type, while open sets stay bare strings.

The catalog moves to the shared `ModelOptionsFor` overlay with a `Models` field; constrained generation stays claimed, matching Moonshot's documented `json_schema` support; the plugin joins the conformance sweep. A runnable sample lives at `go/samples/compat_oai/kimi`, verified against the live API.

Tool choice is claimed for `kimi-k3` alone. Moonshot rejects a forced call on the K2 generation as "incompatible with thinking enabled" (verified live), and thinking is on by default with K2.7 Code unable to turn it off, so those models advertise no tool-choice steering: the framework waves `auto` through and fails `required` before the wire. A `Models` entry restores the claim for a caller who always disables thinking, and K3, which documents `tool_choice: "required"`, keeps it.

`kimi` has never been in a release, so deleting `DefineModel`, the deprecated `Model`, and the five exported model-ID constants cannot break a caller. The map key is already the single source of truth the catalog looks up, and a model on its way out is data (`Stage: ModelStageDeprecated`) rather than API surface.

```go
// Added
type ChatConfig struct { compat_oai.RequestConfig; MaxOutputTokens int; StopSequences []string; LogProbs *bool; TopLogProbs *int; Thinking *ThinkingConfig; ReasoningEffort ReasoningEffort }
type ThinkingConfig struct { Type ThinkingType; Keep string }
type ReasoningEffort string   // Low, High, Max
type ThinkingType string      // Enabled, Disabled
Kimi.Models map[string]ai.ModelOptions
func ModelRef(id string, config *ChatConfig) ai.ModelRef

// Deleted (never released)
kimi.DefineModel, kimi.Model
kimi.ModelKimiK3 and 4 other model-ID constants
```

## Testing

Go 1.26.3: `go build ./...` and `go test ./plugins/compat_oai/...` pass at this level of the stack; the package is 10 cases counting subtests. The schema test pins the constraint values including the per-entry stop limit, the enums (written through the exported constants, tying them to the tags), and the deliberate absence of a `keep` enum; new tests pin that a forced tool call on every K2 model and a 33-character stop entry both fail before the wire. The live test runs the shared checklist from the base PR's `internal/livetest` harness: `kimi-k3` carries the cheap checks, vision, and the tool-choice cases, `kimi-k2.6` the reasoning ones, and a `thinking` key rides the `extra` passthrough. Against the real API: 16/16 pass.


