### PR TITLE
feat(go/plugins/compat_oai/zai): migrate to a typed config and retire the untyped model path

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1128,7 +1128,7 @@ Genkit provides a unified interface across all major AI providers. Use whichever
 | **Vertex AI** | `vertexai.VertexAI` | Gemini 3.5 Flash, Gemini 3.1 Pro via Google Cloud |
 | **Anthropic** | `anthropic.Anthropic` | Claude Opus 4.8, Claude Sonnet 4.6, Claude Haiku 4.5 |
 | **Ollama** | `ollama.Ollama` | Llama 4, Qwen 3, DeepSeek, and other local models |
-| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Qwen, Kimi, and any OpenAI-compatible API |
+| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Qwen, Kimi, GLM, and any OpenAI-compatible API |
 
 ```go
 // Google AI

--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -189,8 +189,8 @@ providers and `max_completion_tokens` on others. Use the same camelCase name
 other plugins use for the same setting; `conformance_test.go` enforces that
 across the package.
 
-See the `openai`, `anthropic`, `dashscope`, and `kimi` directories for
-complete implementations.
+See the `openai`, `anthropic`, `dashscope`, `kimi`, and `zai` directories
+for complete implementations.
 
 ## Running Tests
 

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
 	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
 	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
+	"github.com/firebase/genkit/go/plugins/compat_oai/zai"
 )
 
 // canonicalTypes is the JSON type each shared config field must have wherever
@@ -55,17 +56,20 @@ func TestConfigSchemaConformance(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
 	t.Setenv("KIMI_API_KEY", "test-key")
+	t.Setenv("ZAI_API_KEY", "test-key")
 
 	g := genkit.Init(context.Background(), genkit.WithPlugins(
 		&anthropic.Anthropic{},
 		&dashscope.DashScope{},
 		&kimi.Kimi{},
+		&zai.ZAI{},
 	))
 
 	models := []string{
 		"anthropic/claude-sonnet-4-5-20250929",
 		"dashscope/qwen-plus",
 		"kimi/kimi-k3",
+		"zai/glm-5.1",
 	}
 
 	for _, name := range models {
@@ -147,6 +151,7 @@ func TestModelsOverrideConformance(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
 	t.Setenv("KIMI_API_KEY", "test-key")
+	t.Setenv("ZAI_API_KEY", "test-key")
 
 	// Keyed provider-prefixed on half of them, bare on the rest: both forms
 	// name the same model.
@@ -157,12 +162,14 @@ func TestModelsOverrideConformance(t *testing.T) {
 			"anthropic/claude-sonnet-4-5-20250929": pinned}},
 		&dashscope.DashScope{Models: map[string]ai.ModelOptions{"qwen-plus": pinned}},
 		&kimi.Kimi{Models: map[string]ai.ModelOptions{"kimi-k3": pinned}},
+		&zai.ZAI{Models: map[string]ai.ModelOptions{"glm-5.1": pinned}},
 	))
 
 	for _, name := range []string{
 		"anthropic/claude-sonnet-4-5-20250929",
 		"dashscope/qwen-plus",
 		"kimi/kimi-k3",
+		"zai/glm-5.1",
 	} {
 		t.Run(name, func(t *testing.T) {
 			m := genkit.LookupModel(g, name)

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -207,6 +207,7 @@ func TestClosedEnumsUseNamedTypes(t *testing.T) {
 		"anthropic": anthropic.ChatConfig{},
 		"dashscope": dashscope.ChatConfig{},
 		"kimi":      kimi.ChatConfig{},
+		"zai":       zai.ChatConfig{},
 	}
 	for name, config := range configs {
 		t.Run(name, func(t *testing.T) {

--- a/go/plugins/compat_oai/zai/README.md
+++ b/go/plugins/compat_oai/zai/README.md
@@ -26,8 +26,7 @@ import (
 
 ctx := context.Background()
 plugin := &zai.ZAI{}
-g := genkit.Init(
-    ctx,
+g := genkit.Init(ctx,
     genkit.WithPlugins(plugin),
     genkit.WithDefaultModel("zai/glm-5.1"),
 )
@@ -64,7 +63,7 @@ with the model ID:
 ```go
 response, err := genkit.Generate(ctx, g,
     ai.WithModel(zai.ModelRef("glm-5.1", &zai.ChatConfig{
-        Thinking: &zai.ThinkingConfig{Type: "disabled"},
+        Thinking: &zai.ThinkingConfig{Type: zai.ThinkingTypeDisabled},
     })),
     ai.WithPrompt("Answer concisely."),
 )

--- a/go/plugins/compat_oai/zai/README.md
+++ b/go/plugins/compat_oai/zai/README.md
@@ -3,7 +3,7 @@
 This plugin provides Genkit support for Z.ai's OpenAI-compatible GLM text and
 vision models.
 
-## Usage
+## Setup
 
 Set a Z.ai API key:
 
@@ -12,7 +12,8 @@ export ZAI_API_KEY=<your-api-key>
 ```
 
 The plugin uses `https://api.z.ai/api/paas/v4` by default. Set
-`ZAI_BASE_URL` to use another compatible endpoint.
+`ZAI_BASE_URL`, or pass `option.WithBaseURL` through the plugin's `Opts`,
+to use another compatible endpoint.
 
 ```go
 import (
@@ -28,35 +29,58 @@ plugin := &zai.ZAI{}
 g := genkit.Init(
     ctx,
     genkit.WithPlugins(plugin),
-    genkit.WithDefaultModel("zai/"+zai.ModelGLM51),
+    genkit.WithDefaultModel("zai/glm-5.1"),
 )
 
-response, err := genkit.Generate(
-    ctx,
-    g,
-    ai.WithPrompt("Explain mixture-of-experts models."),
-)
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain mixture-of-experts models."))
 ```
 
 GLM's `reasoning_content` output is returned as Genkit reasoning parts and is
-available through `response.Reasoning()`. Provider-specific fields such as
-`thinking` are passed through when configuration is supplied as a map:
+available through `response.Reasoning()`.
+
+## Models
+
+The registered catalog spans the GLM text line (`glm-5.1`, `glm-5-turbo`,
+`glm-5`, the `glm-4.7` and `glm-4.5` families) and the GLM vision line
+(`glm-5v-turbo`, `glm-4.6v`, `glm-4.5v` and variants). The catalog is not a
+ceiling: any model ID Z.ai serves resolves on demand, and the `Models` field
+describes or corrects any model, curated or not:
 
 ```go
-response, err := genkit.Generate(
-    ctx,
-    g,
+plugin := &zai.ZAI{Models: map[string]ai.ModelOptions{
+    "glm-6": {Label: "GLM 6", Supports: &compat_oai.Multimodal},
+}}
+```
+
+Z.ai's API documentation is at https://docs.z.ai, and the current model list
+is at https://docs.z.ai/guides/overview/pricing.
+
+## Config
+
+Models take a typed `zai.ChatConfig`: the generation fields Z.ai accepts plus
+its own controls (`thinking`, `doSample`). `zai.ModelRef` carries the config
+with the model ID:
+
+```go
+response, err := genkit.Generate(ctx, g,
+    ai.WithModel(zai.ModelRef("glm-5.1", &zai.ChatConfig{
+        Thinking: &zai.ThinkingConfig{Type: "disabled"},
+    })),
     ai.WithPrompt("Answer concisely."),
-    ai.WithConfig(map[string]any{
-        "thinking": map[string]any{
-            "type": "disabled",
-        },
-    }),
 )
 ```
 
-Z.ai currently documents only automatic tool choice. Tool calling is supported,
-but forced `required` and `none` modes are not advertised by this plugin.
+Every config also carries the settings Genkit owns: `version` pins the exact
+model version a request is served by, `apiKey` (settable only from Go code)
+serves one request with a different credential, and `extra` forwards request
+body fields the config does not declare, keyed by Z.ai's wire names (for
+example `user_id`).
+
+## Tool choice
+
+Z.ai currently documents only automatic tool choice. Tool calling is
+supported, but forced `required` and `none` modes are not advertised by this
+plugin.
 
 ## Live tests
 

--- a/go/plugins/compat_oai/zai/zai.go
+++ b/go/plugins/compat_oai/zai/zai.go
@@ -31,6 +31,16 @@ const (
 	defaultBaseURL = "https://api.z.ai/api/paas/v4"
 )
 
+// ThinkingType turns the chain-of-thought of GLM models on or off.
+type ThinkingType string
+
+const (
+	// ThinkingTypeEnabled turns thinking on, which is Z.ai's default.
+	ThinkingTypeEnabled ThinkingType = "enabled"
+	// ThinkingTypeDisabled turns thinking off.
+	ThinkingTypeDisabled ThinkingType = "disabled"
+)
+
 // ChatConfig is the per-request config for GLM models: the generation fields
 // Z.ai accepts plus the Z.ai-specific controls. See
 // https://docs.z.ai/api-reference/llm/chat-completion.
@@ -61,8 +71,9 @@ type ChatConfig struct {
 
 // ThinkingConfig configures the chain-of-thought mode of GLM models.
 type ThinkingConfig struct {
-	// Type turns thinking "enabled" (the default) or "disabled".
-	Type string `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled (the default) or disabled."`
+	// Type turns thinking [ThinkingTypeEnabled] (the default) or
+	// [ThinkingTypeDisabled].
+	Type ThinkingType `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled (the default) or disabled."`
 	// ClearThinking controls whether the reasoning content is cleared from
 	// the response, sent as the API's clear_thinking; Z.ai defaults it to
 	// true.
@@ -91,7 +102,7 @@ func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams
 	if c.Thinking != nil {
 		thinking := map[string]any{}
 		if c.Thinking.Type != "" {
-			thinking["type"] = c.Thinking.Type
+			thinking["type"] = string(c.Thinking.Type)
 		}
 		if c.Thinking.ClearThinking != nil {
 			thinking["clear_thinking"] = *c.Thinking.ClearThinking

--- a/go/plugins/compat_oai/zai/zai.go
+++ b/go/plugins/compat_oai/zai/zai.go
@@ -21,81 +21,183 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
-	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 )
 
 const (
 	provider       = "zai"
 	defaultBaseURL = "https://api.z.ai/api/paas/v4"
-
-	ModelGLM51           = "glm-5.1"
-	ModelGLM5Turbo       = "glm-5-turbo"
-	ModelGLM5            = "glm-5"
-	ModelGLM47           = "glm-4.7"
-	ModelGLM47Flash      = "glm-4.7-flash"
-	ModelGLM47FlashX     = "glm-4.7-flashx"
-	ModelGLM46           = "glm-4.6"
-	ModelGLM45           = "glm-4.5"
-	ModelGLM45Air        = "glm-4.5-air"
-	ModelGLM45X          = "glm-4.5-x"
-	ModelGLM45AirX       = "glm-4.5-airx"
-	ModelGLM45Flash      = "glm-4.5-flash"
-	ModelGLM432B0414128K = "glm-4-32b-0414-128k"
-	ModelGLM5VTurbo      = "glm-5v-turbo"
-	ModelGLM46V          = "glm-4.6v"
-	ModelGLM46VFlash     = "glm-4.6v-flash"
-	ModelGLM46VFlashX    = "glm-4.6v-flashx"
-	ModelGLM45V          = "glm-4.5v"
 )
 
-var supportedModels = map[string]ai.ModelOptions{
-	ModelGLM51:           modelOptions(ModelGLM51, "Z.ai GLM 5.1", false),
-	ModelGLM5Turbo:       modelOptions(ModelGLM5Turbo, "Z.ai GLM 5 Turbo", false),
-	ModelGLM5:            modelOptions(ModelGLM5, "Z.ai GLM 5", false),
-	ModelGLM47:           modelOptions(ModelGLM47, "Z.ai GLM 4.7", false),
-	ModelGLM47Flash:      modelOptions(ModelGLM47Flash, "Z.ai GLM 4.7 Flash", false),
-	ModelGLM47FlashX:     modelOptions(ModelGLM47FlashX, "Z.ai GLM 4.7 FlashX", false),
-	ModelGLM46:           modelOptions(ModelGLM46, "Z.ai GLM 4.6", false),
-	ModelGLM45:           modelOptions(ModelGLM45, "Z.ai GLM 4.5", false),
-	ModelGLM45Air:        modelOptions(ModelGLM45Air, "Z.ai GLM 4.5 Air", false),
-	ModelGLM45X:          modelOptions(ModelGLM45X, "Z.ai GLM 4.5 X", false),
-	ModelGLM45AirX:       modelOptions(ModelGLM45AirX, "Z.ai GLM 4.5 AirX", false),
-	ModelGLM45Flash:      modelOptions(ModelGLM45Flash, "Z.ai GLM 4.5 Flash", false),
-	ModelGLM432B0414128K: modelOptions(ModelGLM432B0414128K, "Z.ai GLM 4 32B 128K", false),
-	ModelGLM5VTurbo:      modelOptions(ModelGLM5VTurbo, "Z.ai GLM 5V Turbo", true),
-	ModelGLM46V:          modelOptions(ModelGLM46V, "Z.ai GLM 4.6V", true),
-	ModelGLM46VFlash:     modelOptions(ModelGLM46VFlash, "Z.ai GLM 4.6V Flash", true),
-	ModelGLM46VFlashX:    modelOptions(ModelGLM46VFlashX, "Z.ai GLM 4.6V FlashX", true),
-	ModelGLM45V:          modelOptions(ModelGLM45V, "Z.ai GLM 4.5V", true),
+// ChatConfig is the per-request config for GLM models: the generation fields
+// Z.ai accepts plus the Z.ai-specific controls. See
+// https://docs.z.ai/api-reference/llm/chat-completion.
+//
+// Z.ai documents no penalties, log probabilities, or seed, so those are
+// deliberately absent, and its temperature range stops at 1 rather than the 2
+// OpenAI allows.
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// Temperature controls the degree of randomness in token selection, from
+	// 0 to 1; the default varies by model.
+	Temperature *float64 `json:"temperature,omitempty" jsonschema:"minimum=0,maximum=1" jsonschema_description:"Controls the degree of randomness in token selection, from 0 to 1. The default varies by model."`
+	// TopP is the nucleus sampling threshold, from 0.01 to 1.
+	TopP *float64 `json:"topP,omitempty" jsonschema:"minimum=0.01,maximum=1" jsonschema_description:"Nucleus sampling threshold, from 0.01 to 1."`
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as the
+	// API's max_tokens; Z.ai documents up to 131072.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1,maximum=131072" jsonschema_description:"Maximum number of tokens to generate, from 1 to 131072; sent as the API's max_tokens."`
+	// StopSequences stop generation when produced by the model, up to four.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema:"maxItems=4" jsonschema_description:"Stop generation when produced by the model, up to four sequences."`
+	// Thinking controls the chain-of-thought mode of GLM 4.5 and later
+	// models, sent as the API's thinking field.
+	Thinking *ThinkingConfig `json:"thinking,omitempty" jsonschema_description:"Chain-of-thought controls for GLM 4.5 and later models, sent as the API's thinking field."`
+	// DoSample turns sampling off when set to false, making temperature and
+	// TopP inert; sent as the API's do_sample.
+	DoSample *bool `json:"doSample,omitempty" jsonschema_description:"Turns sampling off when false, making temperature and topP inert; sent as the API's do_sample."`
 }
 
-func modelOptions(id, label string, media bool) ai.ModelOptions {
-	return ai.ModelOptions{
-		Label: label,
-		Supports: &ai.ModelSupports{
-			Multiturn:  true,
-			Tools:      true,
-			SystemRole: true,
-			Media:      media,
-			ToolChoice: false,
-			Output:     []string{"text", "json"},
-		},
-		Versions: []string{id},
+// ThinkingConfig configures the chain-of-thought mode of GLM models.
+type ThinkingConfig struct {
+	// Type turns thinking "enabled" (the default) or "disabled".
+	Type string `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled (the default) or disabled."`
+	// ClearThinking controls whether the reasoning content is cleared from
+	// the response, sent as the API's clear_thinking; Z.ai defaults it to
+	// true.
+	ClearThinking *bool `json:"clearThinking,omitempty" jsonschema_description:"Whether the reasoning content is cleared from the response, sent as the API's clear_thinking; defaults to true."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the generation
+// fields land on their chat completion counterparts and the Z.ai controls ride
+// as extra request fields.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.Temperature != nil {
+		params.Temperature = openai.Float(*c.Temperature)
 	}
+	if c.TopP != nil {
+		params.TopP = openai.Float(*c.TopP)
+	}
+	if c.MaxOutputTokens > 0 {
+		params.MaxTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+
+	if c.Thinking != nil {
+		thinking := map[string]any{}
+		if c.Thinking.Type != "" {
+			thinking["type"] = c.Thinking.Type
+		}
+		if c.Thinking.ClearThinking != nil {
+			thinking["clear_thinking"] = *c.Thinking.ClearThinking
+		}
+		// An all-zero ThinkingConfig adds nothing rather than sending an
+		// empty thinking object the API could reject.
+		if len(thinking) > 0 {
+			compat_oai.AddExtraFields(params, map[string]any{"thinking": thinking})
+		}
+	}
+	if c.DoSample != nil {
+		compat_oai.AddExtraFields(params, map[string]any{"do_sample": *c.DoSample})
+	}
+}
+
+// Capability sets shared by the entries below. No GLM model advertises
+// ToolChoice, so the plugin always uses automatic tool selection and rejects a
+// forced tool choice before the request goes out. Nor is constrained
+// generation advertised: Z.ai's response_format takes text or json_object
+// only, not json_schema, so a schema reaches the model as prompt
+// instructions. See https://docs.z.ai/api-reference/llm/chat-completion.
+var (
+	textOnly = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		SystemRole: true,
+		Media:      false,
+		ToolChoice: false,
+		Output:     []string{"text", "json"},
+	}
+	multimodal = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      true,
+		SystemRole: true,
+		Media:      true,
+		ToolChoice: false,
+		Output:     []string{"text", "json"},
+	}
+)
+
+// supportedModels curates capabilities for well-known GLM models. It is not
+// the set of usable models: any GLM model resolves on demand and takes
+// [dynamicModelOptions], so an ID absent here still works. No versions are
+// declared, since Z.ai serves dated snapshots the plugin cannot enumerate,
+// and an undeclared list leaves config version pinning unconstrained.
+//
+// Catalog: https://docs.z.ai/guides/llm/overview
+var supportedModels = map[string]ai.ModelOptions{
+	"glm-5.1":             {Label: "Z.ai GLM 5.1", Supports: &textOnly},
+	"glm-5-turbo":         {Label: "Z.ai GLM 5 Turbo", Supports: &textOnly},
+	"glm-5":               {Label: "Z.ai GLM 5", Supports: &textOnly},
+	"glm-4.7":             {Label: "Z.ai GLM 4.7", Supports: &textOnly},
+	"glm-4.7-flash":       {Label: "Z.ai GLM 4.7 Flash", Supports: &textOnly},
+	"glm-4.7-flashx":      {Label: "Z.ai GLM 4.7 FlashX", Supports: &textOnly},
+	"glm-4.6":             {Label: "Z.ai GLM 4.6", Supports: &textOnly},
+	"glm-4.5":             {Label: "Z.ai GLM 4.5", Supports: &textOnly},
+	"glm-4.5-air":         {Label: "Z.ai GLM 4.5 Air", Supports: &textOnly},
+	"glm-4.5-x":           {Label: "Z.ai GLM 4.5 X", Supports: &textOnly},
+	"glm-4.5-airx":        {Label: "Z.ai GLM 4.5 AirX", Supports: &textOnly},
+	"glm-4.5-flash":       {Label: "Z.ai GLM 4.5 Flash", Supports: &textOnly},
+	"glm-4-32b-0414-128k": {Label: "Z.ai GLM 4 32B 128K", Supports: &textOnly},
+
+	// Vision models.
+	"glm-5v-turbo":    {Label: "Z.ai GLM 5V Turbo", Supports: &multimodal},
+	"glm-4.6v":        {Label: "Z.ai GLM 4.6V", Supports: &multimodal},
+	"glm-4.6v-flash":  {Label: "Z.ai GLM 4.6V Flash", Supports: &multimodal},
+	"glm-4.6v-flashx": {Label: "Z.ai GLM 4.6V FlashX", Supports: &multimodal},
+	"glm-4.5v":        {Label: "Z.ai GLM 4.5V", Supports: &multimodal},
+}
+
+// dynamicModelOptions is advertised for GLM models that resolve dynamically
+// rather than appearing in supportedModels.
+var dynamicModelOptions = ai.ModelOptions{
+	Supports: &textOnly,
+	Versions: []string{},
+	Stage:    ai.ModelStageStable,
 }
 
 // ZAI configures the Z.ai GLM plugin.
 type ZAI struct {
 	// APIKey is the Z.ai API key. If empty, ZAI_API_KEY is consulted.
 	APIKey string
-	// BaseURL overrides the Z.ai API endpoint. If empty, ZAI_BASE_URL and then
-	// the default international endpoint are used.
-	BaseURL string
-	// Opts contains additional OpenAI client request options. Options supplied
-	// here are applied after the plugin defaults.
+	// Opts contains additional OpenAI client request options, such as
+	// [option.WithBaseURL] for a different endpoint (ZAI_BASE_URL works too).
+	// Options supplied here are applied after the plugin defaults, so they
+	// win on overlap.
 	Opts []option.RequestOption
+
+	// Models overrides what the plugin knows about a GLM model, keyed by
+	// model ID, bare or provider-prefixed. Every GLM model already works
+	// without an entry: known IDs carry curated capabilities and the rest take
+	// the GLM defaults. Supply an entry only to correct or extend what the
+	// plugin resolves, most often for a model released after this version of
+	// the plugin.
+	//
+	//	&zai.ZAI{Models: map[string]ai.ModelOptions{
+	//		"glm-5.1": {Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+	//	}}
+	//
+	// Fields left at their zero value keep what the plugin resolves, so an
+	// entry can pin one capability without restating the label or the
+	// versions. Entries apply to the models Init registers as well as the
+	// ones [ZAI.ListActions] advertises and [ZAI.ResolveAction] builds,
+	// which is the way to describe a curated model differently: Init has
+	// already registered those and nothing can re-register them.
+	Models map[string]ai.ModelOptions
 
 	openAICompatible compat_oai.OpenAICompatible
 }
@@ -107,10 +209,7 @@ func (z *ZAI) Name() string {
 
 // Init implements genkit.Plugin.
 func (z *ZAI) Init(ctx context.Context) []api.Action {
-	baseURL := z.BaseURL
-	if baseURL == "" {
-		baseURL = os.Getenv("ZAI_BASE_URL")
-	}
+	baseURL := os.Getenv("ZAI_BASE_URL")
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
@@ -133,28 +232,49 @@ func (z *ZAI) Init(ctx context.Context) []api.Action {
 	z.openAICompatible.Opts = opts
 	actions := z.openAICompatible.Init(ctx)
 
-	for model, modelOpts := range supportedModels {
-		actions = append(actions, z.DefineModel(model, modelOpts).(api.Action))
+	for model := range supportedModels {
+		actions = append(actions, z.newModel(model, z.modelOptions(model)))
 	}
 	return actions
 }
 
-// Model returns a registered Z.ai model.
-func (z *ZAI) Model(g *genkit.Genkit, id string) ai.Model {
-	return z.openAICompatible.Model(g, api.NewName(provider, id))
+// newModel creates a GLM model without registering it.
+func (z *ZAI) newModel(id string, opts ai.ModelOptions) *ai.ModelAction {
+	return compat_oai.NewChatModel[ChatConfig](&z.openAICompatible, id, opts)
 }
 
-// DefineModel registers a Z.ai model, including models not in the built-in list.
-func (z *ZAI) DefineModel(id string, opts ai.ModelOptions) ai.Model {
-	return z.openAICompatible.DefineModel(provider, id, opts)
+// modelOptions returns the ModelOptions for a GLM model ID: curated
+// capabilities for a known model and the GLM defaults for the rest, with
+// an entry from [ZAI.Models] overlaid on whichever applies.
+//
+// Every path that describes a model goes through this one, which is what
+// makes a caller's entry authoritative whether Init, ListActions or
+// ResolveAction gets there first.
+func (z *ZAI) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, supportedModels, dynamicModelOptions, z.Models)
 }
 
-// ListActions lists models exposed by the configured Z.ai endpoint.
+// ModelRef names a GLM model and carries the config to generate with, so the
+// config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(zai.ModelRef("glm-5", &zai.ChatConfig{
+//		Thinking: &zai.ThinkingConfig{Type: "enabled"},
+//	}))
+//
+// id is the model ID, with or without the provider prefix.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// ListActions lists the models the configured Z.ai endpoint exposes,
+// described by the plugin's config schema and capabilities.
 func (z *ZAI) ListActions(ctx context.Context) []api.ActionDesc {
-	return z.openAICompatible.ListActions(ctx)
+	return compat_oai.ListChatActions[ChatConfig](ctx, &z.openAICompatible, z.modelOptions)
 }
 
-// ResolveAction dynamically registers a model exposed by the Z.ai endpoint.
-func (z *ZAI) ResolveAction(atype api.ActionType, name string) api.Action {
-	return z.openAICompatible.ResolveAction(atype, name)
+// ResolveAction dynamically builds a model exposed by the Z.ai endpoint,
+// described by the plugin's config schema and capabilities.
+func (z *ZAI) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&z.openAICompatible, atype, id, z.modelOptions)
 }

--- a/go/plugins/compat_oai/zai/zai_live_test.go
+++ b/go/plugins/compat_oai/zai/zai_live_test.go
@@ -17,11 +17,10 @@ package zai_test
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
 	"github.com/firebase/genkit/go/plugins/compat_oai/zai"
 )
 
@@ -31,63 +30,25 @@ func TestPluginLive(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	plugin := &zai.ZAI{}
-	g := genkit.Init(
-		ctx,
-		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("zai/"+zai.ModelGLM51),
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&zai.ZAI{}),
+		genkit.WithDefaultModel("zai/glm-5.1"),
 	)
-	config := map[string]any{
-		"thinking": map[string]any{
-			"type": "enabled",
+
+	// Thinking is on by default, so the cheap checks turn it off and the
+	// reasoning checks turn it back on.
+	livetest.Run(t, g, livetest.Suite{
+		Model: zai.ModelRef("glm-5.1", &zai.ChatConfig{
+			Thinking: &zai.ThinkingConfig{Type: "disabled"},
+		}),
+		ReasoningModel: zai.ModelRef("glm-5.1", &zai.ChatConfig{
+			Thinking: &zai.ThinkingConfig{Type: "enabled"},
+		}),
+		ReasoningContent: true,
+		VisionModel:      zai.ModelRef("glm-4.6v-flash", nil),
+		ExtraConfig: map[string]any{
+			"thinking": map[string]any{"type": "disabled"},
+			"extra":    map[string]any{"user_id": "genkit-livetest"},
 		},
-	}
-
-	t.Run("complete", func(t *testing.T) {
-		resp, err := genkit.Generate(
-			ctx,
-			g,
-			ai.WithPrompt("What is the capital of France? Answer with the city only."),
-			ai.WithConfig(config),
-		)
-		if err != nil {
-			t.Fatalf("Generate() error = %v", err)
-		}
-		if !strings.Contains(strings.ToLower(resp.Text()), "paris") {
-			t.Fatalf("Text() = %q, want Paris", resp.Text())
-		}
-		if resp.Reasoning() == "" {
-			t.Fatal("Reasoning() is empty")
-		}
-	})
-
-	t.Run("streaming reasoning", func(t *testing.T) {
-		var reasoning, text strings.Builder
-		resp, err := genkit.Generate(
-			ctx,
-			g,
-			ai.WithPrompt("Explain briefly why the sky appears blue."),
-			ai.WithConfig(config),
-			ai.WithStreaming(func(_ context.Context, chunk *ai.ModelResponseChunk) error {
-				reasoning.WriteString(chunk.Reasoning())
-				text.WriteString(chunk.Text())
-				return nil
-			}),
-		)
-		if err != nil {
-			t.Fatalf("Generate() error = %v", err)
-		}
-		if reasoning.String() == "" {
-			t.Fatal("streamed reasoning is empty")
-		}
-		if text.String() == "" {
-			t.Fatal("streamed text is empty")
-		}
-		if resp.Reasoning() != reasoning.String() {
-			t.Fatalf("final reasoning = %q, want streamed %q", resp.Reasoning(), reasoning.String())
-		}
-		if resp.Text() != text.String() {
-			t.Fatalf("final text = %q, want streamed %q", resp.Text(), text.String())
-		}
 	})
 }

--- a/go/plugins/compat_oai/zai/zai_test.go
+++ b/go/plugins/compat_oai/zai/zai_test.go
@@ -613,7 +613,8 @@ func TestModelRefAndConfigSchema(t *testing.T) {
 	thinking, _ := props["thinking"].(map[string]any)
 	thinkingProps, _ := thinking["properties"].(map[string]any)
 	thinkingType, _ := thinkingProps["type"].(map[string]any)
-	if got, want := thinkingType["enum"], []any{"enabled", "disabled"}; !reflect.DeepEqual(got, want) {
+	if got, want := thinkingType["enum"], []any{
+		string(zai.ThinkingTypeEnabled), string(zai.ThinkingTypeDisabled)}; !reflect.DeepEqual(got, want) {
 		t.Errorf("thinking.type enum = %#v, want %#v", got, want)
 	}
 }

--- a/go/plugins/compat_oai/zai/zai_test.go
+++ b/go/plugins/compat_oai/zai/zai_test.go
@@ -20,19 +20,27 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
 	"github.com/firebase/genkit/go/plugins/compat_oai/zai"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
 )
 
 func TestPluginRegistersGLMModelsAndHandlesReasoning(t *testing.T) {
+	var mu sync.Mutex
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requests++
+		mu.Unlock()
 		if r.URL.Path != "/api/paas/v4/chat/completions" {
 			t.Errorf("path = %q, want %q", r.URL.Path, "/api/paas/v4/chat/completions")
 		}
@@ -49,8 +57,8 @@ func TestPluginRegistersGLMModelsAndHandlesReasoning(t *testing.T) {
 			t.Errorf("decode request: %v", err)
 			return
 		}
-		if body.Model != zai.ModelGLM51 {
-			t.Errorf("model = %q, want %q", body.Model, zai.ModelGLM51)
+		if body.Model != "glm-5.1" {
+			t.Errorf("model = %q, want %q", body.Model, "glm-5.1")
 		}
 		if got := body.Thinking["type"]; got != "enabled" {
 			t.Errorf("thinking.type = %v, want %q", got, "enabled")
@@ -101,7 +109,7 @@ func TestPluginRegistersGLMModelsAndHandlesReasoning(t *testing.T) {
 	g := genkit.Init(
 		ctx,
 		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("zai/"+zai.ModelGLM51),
+		genkit.WithDefaultModel("zai/glm-5.1"),
 	)
 
 	if plugin.Name() != "zai" {
@@ -109,26 +117,26 @@ func TestPluginRegistersGLMModelsAndHandlesReasoning(t *testing.T) {
 	}
 
 	textModels := []string{
-		zai.ModelGLM51,
-		zai.ModelGLM5Turbo,
-		zai.ModelGLM5,
-		zai.ModelGLM47,
-		zai.ModelGLM47Flash,
-		zai.ModelGLM47FlashX,
-		zai.ModelGLM46,
-		zai.ModelGLM45,
-		zai.ModelGLM45Air,
-		zai.ModelGLM45X,
-		zai.ModelGLM45AirX,
-		zai.ModelGLM45Flash,
-		zai.ModelGLM432B0414128K,
+		"glm-5.1",
+		"glm-5-turbo",
+		"glm-5",
+		"glm-4.7",
+		"glm-4.7-flash",
+		"glm-4.7-flashx",
+		"glm-4.6",
+		"glm-4.5",
+		"glm-4.5-air",
+		"glm-4.5-x",
+		"glm-4.5-airx",
+		"glm-4.5-flash",
+		"glm-4-32b-0414-128k",
 	}
 	visionModels := []string{
-		zai.ModelGLM5VTurbo,
-		zai.ModelGLM46V,
-		zai.ModelGLM46VFlash,
-		zai.ModelGLM46VFlashX,
-		zai.ModelGLM45V,
+		"glm-5v-turbo",
+		"glm-4.6v",
+		"glm-4.6v-flash",
+		"glm-4.6v-flashx",
+		"glm-4.5v",
 	}
 	for _, group := range []struct {
 		models    []string
@@ -138,9 +146,9 @@ func TestPluginRegistersGLMModelsAndHandlesReasoning(t *testing.T) {
 		{models: visionModels, wantMedia: true},
 	} {
 		for _, modelName := range group.models {
-			model := plugin.Model(g, modelName)
+			model := genkit.LookupModel(g, "zai/"+modelName)
 			if model == nil {
-				t.Errorf("Model(%q) = nil", modelName)
+				t.Errorf("LookupModel(%q) = nil", modelName)
 				continue
 			}
 			modelMetadata := model.(api.Action).Desc().Metadata["model"].(map[string]any)
@@ -157,10 +165,12 @@ func TestPluginRegistersGLMModelsAndHandlesReasoning(t *testing.T) {
 		}
 	}
 
+	// The Genkit config speaks the plugin's camelCase contract; the handler
+	// above asserts it reaches the wire as clear_thinking.
 	config := map[string]any{
 		"thinking": map[string]any{
-			"type":           "enabled",
-			"clear_thinking": false,
+			"type":          "enabled",
+			"clearThinking": false,
 		},
 	}
 	t.Run("complete", func(t *testing.T) {
@@ -211,15 +221,21 @@ func TestPluginRegistersGLMModelsAndHandlesReasoning(t *testing.T) {
 		}
 	})
 
+	mu.Lock()
+	defer mu.Unlock()
 	if requests != 2 {
 		t.Fatalf("requests = %d, want 2", requests)
 	}
 }
 
 func TestPluginPreservesReasoningAcrossToolCalls(t *testing.T) {
+	var mu sync.Mutex
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requests++
+		reqNum := requests
+		mu.Unlock()
 		var body struct {
 			Messages []map[string]any `json:"messages"`
 			Thinking map[string]any   `json:"thinking"`
@@ -233,7 +249,7 @@ func TestPluginPreservesReasoningAcrossToolCalls(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		if requests == 1 {
+		if reqNum == 1 {
 			_, _ = io.WriteString(w, `{
 				"id":"chatcmpl-tool-1",
 				"object":"chat.completion",
@@ -289,11 +305,11 @@ func TestPluginPreservesReasoningAcrossToolCalls(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	plugin := &zai.ZAI{APIKey: "test-key", BaseURL: server.URL + "/api/paas/v4"}
+	plugin := &zai.ZAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/api/paas/v4")}}
 	g := genkit.Init(
 		ctx,
 		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("zai/"+zai.ModelGLM51),
+		genkit.WithDefaultModel("zai/glm-5.1"),
 	)
 	lookup := genkit.DefineTool(
 		g,
@@ -313,8 +329,8 @@ func TestPluginPreservesReasoningAcrossToolCalls(t *testing.T) {
 		ai.WithTools(lookup),
 		ai.WithConfig(map[string]any{
 			"thinking": map[string]any{
-				"type":           "enabled",
-				"clear_thinking": false,
+				"type":          "enabled",
+				"clearThinking": false,
 			},
 		}),
 	)
@@ -327,6 +343,8 @@ func TestPluginPreservesReasoningAcrossToolCalls(t *testing.T) {
 	if got := resp.Reasoning(); got != "The tool returned the result." {
 		t.Errorf("Reasoning() = %q, want final-turn reasoning", got)
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if requests != 2 {
 		t.Errorf("requests = %d, want 2", requests)
 	}
@@ -344,7 +362,7 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 	}{
 		{
 			name:  "json output",
-			model: zai.ModelGLM51,
+			model: "glm-5.1",
 			options: []ai.GenerateOption{
 				ai.WithPrompt("Return a JSON object."),
 				ai.WithOutputFormat(ai.OutputFormatJSON),
@@ -362,7 +380,7 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 		},
 		{
 			name:  "vision input",
-			model: zai.ModelGLM5VTurbo,
+			model: "glm-5v-turbo",
 			options: []ai.GenerateOption{
 				ai.WithMessages(ai.NewUserMessage(
 					ai.NewMediaPart("image/png", imageDataURI),
@@ -399,13 +417,40 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 			},
 			response: "A test image.",
 		},
+		{
+			name:  "extra passthrough",
+			model: "glm-5.1",
+			options: []ai.GenerateOption{
+				ai.WithPrompt("hi"),
+				ai.WithConfig(map[string]any{
+					"thinking": map[string]any{"type": "disabled"},
+					"extra": map[string]any{
+						"thinking": map[string]any{"type": "enabled"},
+						"user_id":  "app-user-1",
+					},
+				}),
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				if got := body["user_id"]; got != "app-user-1" {
+					t.Errorf("user_id = %v, want the undeclared field on the wire", got)
+				}
+				thinking, _ := body["thinking"].(map[string]any)
+				if got := thinking["type"]; got != "enabled" {
+					t.Errorf("thinking.type = %v, want the caller's extra winning over the config's own thinking", got)
+				}
+			},
+			response: "Extra fields ride.",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			var mu sync.Mutex
 			var requests int
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
 				requests++
+				mu.Unlock()
 				var body map[string]any
 				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 					t.Errorf("decode request: %v", err)
@@ -437,7 +482,7 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 			defer server.Close()
 
 			ctx := context.Background()
-			plugin := &zai.ZAI{APIKey: "test-key", BaseURL: server.URL + "/api/paas/v4"}
+			plugin := &zai.ZAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/api/paas/v4")}}
 			g := genkit.Init(ctx, genkit.WithPlugins(plugin))
 			options := append([]ai.GenerateOption{
 				ai.WithModelName("zai/" + test.model),
@@ -450,6 +495,8 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 			if got := resp.Text(); got != test.response {
 				t.Errorf("Text() = %q, want %q", got, test.response)
 			}
+			mu.Lock()
+			defer mu.Unlock()
 			if requests != 1 {
 				t.Errorf("requests = %d, want 1", requests)
 			}
@@ -458,20 +505,23 @@ func TestPluginShapesJSONAndVisionRequests(t *testing.T) {
 }
 
 func TestPluginRejectsUnsupportedToolChoice(t *testing.T) {
+	var mu sync.Mutex
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requests++
+		mu.Unlock()
 		t.Error("unexpected HTTP request")
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
 	ctx := context.Background()
-	plugin := &zai.ZAI{APIKey: "test-key", BaseURL: server.URL + "/api/paas/v4"}
+	plugin := &zai.ZAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/api/paas/v4")}}
 	g := genkit.Init(
 		ctx,
 		genkit.WithPlugins(plugin),
-		genkit.WithDefaultModel("zai/"+zai.ModelGLM51),
+		genkit.WithDefaultModel("zai/glm-5.1"),
 	)
 
 	_, err := genkit.Generate(
@@ -486,6 +536,8 @@ func TestPluginRejectsUnsupportedToolChoice(t *testing.T) {
 	if !strings.Contains(err.Error(), "does not support tool choice") {
 		t.Fatalf("Generate() error = %q, want unsupported tool choice error", err)
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if requests != 0 {
 		t.Errorf("requests = %d, want 0", requests)
 	}
@@ -502,4 +554,187 @@ func TestPluginRequiresAPIKey(t *testing.T) {
 	}()
 
 	(&zai.ZAI{}).Init(context.Background())
+}
+
+// TestModelRefAndConfigSchema pins the call-site surface: the ref carries the
+// prefixed name and the typed config, and the registered models advertise the
+// camelCase config contract including the Z.ai-specific fields.
+func TestModelRefAndConfigSchema(t *testing.T) {
+	cfg := &zai.ChatConfig{Thinking: &zai.ThinkingConfig{Type: "enabled"}}
+	for _, name := range []string{"glm-5", "zai/glm-5"} {
+		ref := zai.ModelRef(name, cfg)
+		if want := "zai/glm-5"; ref.Name() != want {
+			t.Errorf("ModelRef(%q).Name() = %q, want %q", name, ref.Name(), want)
+		}
+		if ref.Config() != cfg {
+			t.Errorf("ModelRef(%q).Config() = %v, want the config it was built with", name, ref.Config())
+		}
+	}
+
+	t.Setenv("ZAI_API_KEY", "test-key")
+	plugin := &zai.ZAI{}
+	g := genkit.Init(context.Background(), genkit.WithPlugins(plugin))
+
+	m := genkit.LookupModel(g, "zai/glm-5")
+	if m == nil {
+		t.Fatal("glm-5 not registered by Init")
+	}
+	model := m.(api.Action).Desc().Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions missing, got %v", model["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions has no properties: %v", schema)
+	}
+	for _, key := range []string{"temperature", "maxOutputTokens", "stopSequences", "thinking", "doSample", "version", "extra"} {
+		if props[key] == nil {
+			t.Errorf("config schema is missing the %q property", key)
+		}
+	}
+
+	// The constraints Z.ai documents ride on the schema, where the framework
+	// enforces them: temperature stops at 1 rather than OpenAI's 2, and topP
+	// starts at 0.01.
+	for field, want := range map[string]map[string]any{
+		"temperature":     {"minimum": 0.0, "maximum": 1.0},
+		"topP":            {"minimum": 0.01, "maximum": 1.0},
+		"maxOutputTokens": {"minimum": 1.0, "maximum": 131072.0},
+		"stopSequences":   {"maxItems": 4.0},
+	} {
+		prop, _ := props[field].(map[string]any)
+		for key, value := range want {
+			if got := prop[key]; !reflect.DeepEqual(got, value) {
+				t.Errorf("%s %s = %#v, want %#v", field, key, got, value)
+			}
+		}
+	}
+	thinking, _ := props["thinking"].(map[string]any)
+	thinkingProps, _ := thinking["properties"].(map[string]any)
+	thinkingType, _ := thinkingProps["type"].(map[string]any)
+	if got, want := thinkingType["enum"], []any{"enabled", "disabled"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("thinking.type enum = %#v, want %#v", got, want)
+	}
+}
+
+// TestModelRefConfigReachesTheWire pins the whole typed path: a ModelRef
+// carrying a typed ChatConfig passes the framework's schema validation, the
+// common fields land on their snake_case wire names, and the Z.ai extras ride
+// along, all in one Generate call.
+func TestModelRefConfigReachesTheWire(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model       string         `json:"model"`
+			Temperature float64        `json:"temperature"`
+			MaxTokens   int            `json:"max_tokens"`
+			Thinking    map[string]any `json:"thinking"`
+			DoSample    *bool          `json:"do_sample"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if body.Model != "glm-5-20260101" {
+			t.Errorf("model = %q, want the pinned version %q", body.Model, "glm-5-20260101")
+		}
+		if body.Temperature != 0.3 {
+			t.Errorf("temperature = %v, want 0.3", body.Temperature)
+		}
+		if body.MaxTokens != 512 {
+			t.Errorf("max_tokens = %v, want 512", body.MaxTokens)
+		}
+		if got := body.Thinking["type"]; got != "enabled" {
+			t.Errorf("thinking.type = %v, want enabled", got)
+		}
+		if body.DoSample == nil || *body.DoSample != true {
+			t.Errorf("do_sample = %v, want true", body.DoSample)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"glm-5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"typed config works"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &zai.ZAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModel(zai.ModelRef("glm-5", &zai.ChatConfig{
+			RequestConfig:   compat_oai.RequestConfig{Version: "glm-5-20260101"},
+			Temperature:     openai.Ptr(0.3),
+			MaxOutputTokens: 512,
+			Thinking:        &zai.ThinkingConfig{Type: "enabled"},
+			DoSample:        openai.Ptr(true),
+		})),
+		ai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Text(); got != "typed config works" {
+		t.Fatalf("Text() = %q, want %q", got, "typed config works")
+	}
+}
+
+// TestPerRequestAPIKey pins the credential override path: a typed config
+// carrying an APIKey authenticates that request alone with the override, the
+// plugin's key serves requests without one, and the key never appears in the
+// request body.
+func TestPerRequestAPIKey(t *testing.T) {
+	var mu sync.Mutex
+	var auths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		auths = append(auths, r.Header.Get("Authorization"))
+		mu.Unlock()
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request: %v", err)
+		}
+		if strings.Contains(string(body), "override-key") || strings.Contains(string(body), "apiKey") {
+			t.Errorf("request body leaks the API key: %s", body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"glm-5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &zai.ZAI{APIKey: "plugin-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	if _, err := genkit.Generate(ctx, g,
+		ai.WithModel(zai.ModelRef("glm-5", &zai.ChatConfig{
+			RequestConfig: compat_oai.RequestConfig{APIKey: "override-key"},
+		})),
+		ai.WithPrompt("hi"),
+	); err != nil {
+		t.Fatalf("Generate() with override error = %v", err)
+	}
+
+	if _, err := genkit.Generate(ctx, g,
+		ai.WithModel(zai.ModelRef("glm-5", nil)),
+		ai.WithPrompt("hi"),
+	); err != nil {
+		t.Fatalf("Generate() without override error = %v", err)
+	}
+
+	want := []string{"Bearer override-key", "Bearer plugin-key"}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(auths) != 2 || auths[0] != want[0] || auths[1] != want[1] {
+		t.Fatalf("Authorization headers = %v, want %v", auths, want)
+	}
 }

--- a/go/samples/compat_oai/zai/main.go
+++ b/go/samples/compat_oai/zai/main.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This sample demonstrates the Z.ai plugin for the GLM models: a flow that
+// generates a joke with a model pinned through zai.ModelRef and its typed
+// config.
+//
+// To run:
+//
+//	export ZAI_API_KEY=...
+//	go run .
+//
+// In another terminal:
+//
+//	curl -X POST http://localhost:8080/jokesFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": "bananas"}'
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/zai"
+	"github.com/firebase/genkit/go/plugins/server"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// The plugin reads the API key from the ZAI_API_KEY environment variable.
+	g := genkit.Init(ctx, genkit.WithPlugins(&zai.ZAI{}))
+
+	// Define a flow that generates a joke about a given topic. Thinking is on
+	// by default for the GLM models, so the config turns it off for a quick
+	// conversational answer.
+	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		if topic == "" {
+			topic = "airplane food"
+		}
+
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(zai.ModelRef("glm-5.1", &zai.ChatConfig{
+				Thinking: &zai.ThinkingConfig{Type: zai.ThinkingTypeDisabled},
+			})),
+			ai.WithPrompt("Share a joke about %s.", topic),
+		)
+	})
+
+	// Optionally, start a web server to make the flow callable via HTTP.
+	mux := http.NewServeMux()
+	for _, a := range genkit.ListFlows(g) {
+		mux.HandleFunc("POST /"+a.Name(), genkit.Handler(a))
+	}
+	log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+}


### PR DESCRIPTION
Migrates the Z.ai plugin onto the typed-config base (#5976) and, as the last plugin off the pre-typed path, retires it; stacked on #6033.

## The plugin and its config, at a glance

```go
type ZAI struct {
	APIKey string
	Opts   []option.RequestOption
	Models map[string]ai.ModelOptions
}

type ChatConfig struct {
	compat_oai.RequestConfig
	Temperature     *float64        `json:"temperature,omitempty"`
	TopP            *float64        `json:"topP,omitempty"`
	MaxOutputTokens int             `json:"maxOutputTokens,omitempty"`
	StopSequences   []string        `json:"stopSequences,omitempty"`
	Thinking        *ThinkingConfig `json:"thinking,omitempty"`
	DoSample        *bool           `json:"doSample,omitempty"`
}

type ThinkingConfig struct {
	Type          ThinkingType `json:"type,omitempty"`
	ClearThinking *bool        `json:"clearThinking,omitempty"`
}

type ThinkingType string // "enabled", "disabled"
```

`BaseURL` leaves the plugin struct (merged but never released): the endpoint override rides `Opts` (`option.WithBaseURL`) or `ZAI_BASE_URL`, applied after the plugin defaults so it wins.

Every constraint is verified against the GLM reference, which turned up limits the old code did not state: `temperature` and `top_p` capped at 1 (`top_p` from 0.01), `max_tokens` up to 131072, up to four stop sequences. Thinking moves from a loose extra key to `ThinkingConfig`, its `type` the named `ThinkingType` with exported constants (`enabled` the default), per the family's named-enum rule, alongside `clearThinking` and `doSample`. Constrained generation stays unclaimed (Z.ai documents `json_object` only); the catalog moves to the shared `ModelOptionsFor` overlay with a `Models` field; the plugin joins the conformance sweep. A runnable sample lives at `go/samples/compat_oai/zai`, verified against the live API.

`zai` has never been in a release, so deleting `DefineModel`, the deprecated `Model`, and the eighteen exported model-ID constants cannot break a caller, and this train is the last point they can go without a deprecation cycle.

## The pre-typed model path retires

`zai` was the last sub-plugin routing provider extensions through loose config keys, so the transitional behavior the base PR kept on `OpenAICompatible.DefineModel` has no remaining user. It becomes a deprecated alias of `NewModel`: the SDK request schema is advertised and enforced on that path too, and a config key the SDK does not model is rejected instead of forwarded verbatim. `ModelGenerator.WithConfig` stays as a deprecated shim for callers driving the generator directly, its map normalization and extra-field passthrough intact.

`compat_oai` shipped in `go/v1.11.0`, so an external caller on `DefineModel` keeps compiling with its signature intact; what changes is that an undeclared config key now fails the request loudly instead of riding to the provider silently, the same trade the rest of the train makes.

```go
// Added
type ChatConfig struct { compat_oai.RequestConfig; Temperature *float64; TopP *float64; MaxOutputTokens int; StopSequences []string; Thinking *ThinkingConfig; DoSample *bool }
type ThinkingConfig struct { Type ThinkingType; ClearThinking *bool }
type ThinkingType string      // Enabled, Disabled
ZAI.Models map[string]ai.ModelOptions
func ModelRef(id string, config *ChatConfig) ai.ModelRef

// Deprecated (was transitional, now an alias of NewModel)
compat_oai.OpenAICompatible.DefineModel

// Deleted (never released)
zai.DefineModel, zai.Model
zai.ModelGLM51 and 17 other model-ID constants
```

## Testing

Go 1.26.3: `go build ./...` and full `go test ./...` in `go/` pass at this level of the stack, the full suite because this PR changes the shared core; the package is 14 cases counting subtests, the live one skipping without `ZAI_API_KEY`. The schema test pins the documented caps and the thinking enum through its constants, and the reasoning tests exercise the declared fields through the now-enforcing path. The live test runs the shared checklist from the base PR's `internal/livetest` harness: thinking disabled for the cheap checks, re-enabled for the reasoning ones, and `glm-4.6v-flash` takes the vision check.

