### PR TITLE
feat(go/plugins/compat_oai/deepseek): add a DeepSeek plugin

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1128,7 +1128,7 @@ Genkit provides a unified interface across all major AI providers. Use whichever
 | **Vertex AI** | `vertexai.VertexAI` | Gemini 3.5 Flash, Gemini 3.1 Pro via Google Cloud |
 | **Anthropic** | `anthropic.Anthropic` | Claude Opus 4.8, Claude Sonnet 4.6, Claude Haiku 4.5 |
 | **Ollama** | `ollama.Ollama` | Llama 4, Qwen 3, DeepSeek, and other local models |
-| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Qwen, Kimi, GLM, and any OpenAI-compatible API |
+| **OpenAI Compatible** | `compat_oai` | GPT-5.6, DeepSeek, Qwen, Kimi, GLM, and any OpenAI-compatible API |
 
 ```go
 // Google AI

--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -189,8 +189,8 @@ providers and `max_completion_tokens` on others. Use the same camelCase name
 other plugins use for the same setting; `conformance_test.go` enforces that
 across the package.
 
-See the `openai`, `anthropic`, `dashscope`, `kimi`, and `zai` directories
-for complete implementations.
+See the `openai`, `anthropic`, `dashscope`, `deepseek`, `kimi`, and `zai`
+directories for complete implementations.
 
 ## Running Tests
 
@@ -201,6 +201,7 @@ export ANTHROPIC_API_KEY=<your-anthropic-key>
 export DASHSCOPE_API_KEY=<your-dashscope-key>
 export ZAI_API_KEY=<your-zai-key>
 export KIMI_API_KEY=<your-kimi-key>
+export DEEPSEEK_API_KEY=<your-deepseek-key>
 ```
 
 Run all tests:
@@ -224,6 +225,9 @@ go test -v ./zai
 
 # Kimi tests
 go test -v ./kimi
+
+# DeepSeek tests
+go test -v ./deepseek
 ```
 
 Note: Tests will be skipped if the required API keys are not set.

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -214,6 +214,7 @@ func TestClosedEnumsUseNamedTypes(t *testing.T) {
 	configs := map[string]any{
 		"anthropic": anthropic.ChatConfig{},
 		"dashscope": dashscope.ChatConfig{},
+		"deepseek":  deepseek.ChatConfig{},
 		"kimi":      kimi.ChatConfig{},
 		"zai":       zai.ChatConfig{},
 	}

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/anthropic"
 	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
+	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
 	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
 	"github.com/firebase/genkit/go/plugins/compat_oai/zai"
 )
@@ -55,12 +56,14 @@ var canonicalTypes = map[string]string{
 func TestConfigSchemaConformance(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("KIMI_API_KEY", "test-key")
 	t.Setenv("ZAI_API_KEY", "test-key")
 
 	g := genkit.Init(context.Background(), genkit.WithPlugins(
 		&anthropic.Anthropic{},
 		&dashscope.DashScope{},
+		&deepseek.DeepSeek{},
 		&kimi.Kimi{},
 		&zai.ZAI{},
 	))
@@ -68,6 +71,7 @@ func TestConfigSchemaConformance(t *testing.T) {
 	models := []string{
 		"anthropic/claude-sonnet-4-5-20250929",
 		"dashscope/qwen-plus",
+		"deepseek/deepseek-v4-pro",
 		"kimi/kimi-k3",
 		"zai/glm-5.1",
 	}
@@ -150,6 +154,7 @@ func requireDescriptions(t *testing.T, path string, props map[string]any) {
 func TestModelsOverrideConformance(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("KIMI_API_KEY", "test-key")
 	t.Setenv("ZAI_API_KEY", "test-key")
 
@@ -161,6 +166,8 @@ func TestModelsOverrideConformance(t *testing.T) {
 		&anthropic.Anthropic{Models: map[string]ai.ModelOptions{
 			"anthropic/claude-sonnet-4-5-20250929": pinned}},
 		&dashscope.DashScope{Models: map[string]ai.ModelOptions{"qwen-plus": pinned}},
+		&deepseek.DeepSeek{Models: map[string]ai.ModelOptions{
+			"deepseek/deepseek-v4-pro": pinned}},
 		&kimi.Kimi{Models: map[string]ai.ModelOptions{"kimi-k3": pinned}},
 		&zai.ZAI{Models: map[string]ai.ModelOptions{"glm-5.1": pinned}},
 	))
@@ -168,6 +175,7 @@ func TestModelsOverrideConformance(t *testing.T) {
 	for _, name := range []string{
 		"anthropic/claude-sonnet-4-5-20250929",
 		"dashscope/qwen-plus",
+		"deepseek/deepseek-v4-pro",
 		"kimi/kimi-k3",
 		"zai/glm-5.1",
 	} {

--- a/go/plugins/compat_oai/deepseek/README.md
+++ b/go/plugins/compat_oai/deepseek/README.md
@@ -49,8 +49,8 @@ at https://api-docs.deepseek.com.
 ## Config
 
 Models take a typed `deepseek.ChatConfig`: the generation fields DeepSeek
-accepts plus `thinking`, which carries both the mode and the effort DeepSeek
-nests inside it (`reasoningEffort`: `low`, `high`, or `max`).
+accepts plus its thinking controls, `thinking` for the mode and
+`reasoningEffort` (`low`, `high`, or `max`) for the depth.
 `deepseek.ModelRef` carries the config with the model ID. Thinking is on by
 default, so turning it off is the common case:
 

--- a/go/plugins/compat_oai/deepseek/README.md
+++ b/go/plugins/compat_oai/deepseek/README.md
@@ -26,8 +26,7 @@ import (
 
 ctx := context.Background()
 plugin := &deepseek.DeepSeek{}
-g := genkit.Init(
-    ctx,
+g := genkit.Init(ctx,
     genkit.WithPlugins(plugin),
     genkit.WithDefaultModel("deepseek/deepseek-v4-flash"),
 )
@@ -56,11 +55,9 @@ nests inside it (`reasoningEffort`: `low`, `high`, or `max`).
 default, so turning it off is the common case:
 
 ```go
-response, err := genkit.Generate(
-    ctx,
-    g,
+response, err := genkit.Generate(ctx, g,
     ai.WithModel(deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
-        Thinking: &deepseek.ThinkingConfig{Type: "disabled"},
+        Thinking: &deepseek.ThinkingConfig{Type: deepseek.ThinkingTypeDisabled},
     })),
     ai.WithPrompt("Answer concisely."),
 )
@@ -84,9 +81,7 @@ to partition that cache per end user, so users neither read nor evict each
 other's cached prefixes:
 
 ```go
-response, err := genkit.Generate(
-    ctx,
-    g,
+response, err := genkit.Generate(ctx, g,
     ai.WithModel(deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
         UserID: "tenant-42",
     })),

--- a/go/plugins/compat_oai/deepseek/README.md
+++ b/go/plugins/compat_oai/deepseek/README.md
@@ -1,0 +1,108 @@
+# DeepSeek Plugin
+
+This plugin provides Genkit support for DeepSeek's OpenAI-compatible models,
+DeepSeek V4 Flash and DeepSeek V4 Pro.
+
+## Setup
+
+Set a DeepSeek API key:
+
+```bash
+export DEEPSEEK_API_KEY=<your-api-key>
+```
+
+The plugin uses `https://api.deepseek.com` by default. Set `DEEPSEEK_BASE_URL`,
+or pass `option.WithBaseURL` through the plugin's `Opts`, to use another
+compatible endpoint, such as DeepSeek's beta endpoint.
+
+```go
+import (
+    "context"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
+)
+
+ctx := context.Background()
+plugin := &deepseek.DeepSeek{}
+g := genkit.Init(
+    ctx,
+    genkit.WithPlugins(plugin),
+    genkit.WithDefaultModel("deepseek/deepseek-v4-flash"),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain mixture-of-experts models."))
+```
+
+DeepSeek's `reasoning_content` output is returned as Genkit reasoning parts and
+is available through `response.Reasoning()`.
+
+## Models
+
+`deepseek-v4-flash` and `deepseek-v4-pro` are registered. The catalog is not
+a ceiling: any model ID DeepSeek serves resolves on demand, and the `Models`
+field describes or corrects any model, curated or not. The current model list
+and pricing, including the dated snapshots a config `version` can pin, are at
+https://api-docs.deepseek.com/quick_start/pricing, and the API reference is
+at https://api-docs.deepseek.com.
+
+## Config
+
+Models take a typed `deepseek.ChatConfig`: the generation fields DeepSeek
+accepts plus `thinking`, which carries both the mode and the effort DeepSeek
+nests inside it (`reasoningEffort`: `low`, `high`, or `max`).
+`deepseek.ModelRef` carries the config with the model ID. Thinking is on by
+default, so turning it off is the common case:
+
+```go
+response, err := genkit.Generate(
+    ctx,
+    g,
+    ai.WithModel(deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
+        Thinking: &deepseek.ThinkingConfig{Type: "disabled"},
+    })),
+    ai.WithPrompt("Answer concisely."),
+)
+```
+
+`maxOutputTokens` reaches DeepSeek as the `max_tokens` it reads. DeepSeek no
+longer supports the frequency and presence penalties, so the config does not
+offer them.
+
+Every config also carries the settings Genkit owns: `version` pins the exact
+model version a request is served by, `apiKey` (settable only from Go code)
+serves one request with a different credential, and `extra` forwards request
+body fields the config does not declare, keyed by DeepSeek's wire names (for
+example `logprobs`).
+
+## Prompt caching
+
+DeepSeek caches prompt prefixes automatically and bills a cache hit at a lower
+rate; the hits come back as `response.Usage.CachedContentTokens`. Set `userId`
+to partition that cache per end user, so users neither read nor evict each
+other's cached prefixes:
+
+```go
+response, err := genkit.Generate(
+    ctx,
+    g,
+    ai.WithModel(deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
+        UserID: "tenant-42",
+    })),
+    ai.WithPrompt("Answer concisely."),
+)
+```
+
+## Not supported
+
+The V4 models are text-only, so image inputs are not advertised. DeepSeek's
+beta features (chat prefix completion and FIM) are not exposed by this plugin.
+
+## Live tests
+
+Live tests are skipped unless `DEEPSEEK_API_KEY` is set:
+
+```bash
+go test -race ./plugins/compat_oai/deepseek -run '^TestPluginLive$' -v -count=1
+```

--- a/go/plugins/compat_oai/deepseek/deepseek.go
+++ b/go/plugins/compat_oai/deepseek/deepseek.go
@@ -31,6 +31,28 @@ const (
 	defaultBaseURL = "https://api.deepseek.com"
 )
 
+// ThinkingType turns the thinking mode of DeepSeek models on or off.
+type ThinkingType string
+
+const (
+	// ThinkingTypeEnabled turns thinking on, which is DeepSeek's default.
+	ThinkingTypeEnabled ThinkingType = "enabled"
+	// ThinkingTypeDisabled turns thinking off.
+	ThinkingTypeDisabled ThinkingType = "disabled"
+)
+
+// ReasoningEffort is how hard a DeepSeek model thinks before it answers.
+type ReasoningEffort string
+
+const (
+	// ReasoningEffortLow is the fastest, shallowest reasoning.
+	ReasoningEffortLow ReasoningEffort = "low"
+	// ReasoningEffortHigh is deeper reasoning.
+	ReasoningEffortHigh ReasoningEffort = "high"
+	// ReasoningEffortMax is the deepest reasoning.
+	ReasoningEffortMax ReasoningEffort = "max"
+)
+
 // ChatConfig is the per-request config for DeepSeek models: the generation
 // fields DeepSeek accepts plus its thinking controls. See
 // https://api-docs.deepseek.com/api/create-chat-completion.
@@ -67,12 +89,12 @@ type ChatConfig struct {
 
 // ThinkingConfig configures the thinking mode of DeepSeek models.
 type ThinkingConfig struct {
-	// Type turns thinking "enabled" or "disabled".
-	Type string `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled or disabled."`
-	// ReasoningEffort adjusts how hard the model thinks: "low", "high", or
-	// "max"; sent as the API's reasoning_effort inside the thinking object,
-	// not as a top-level field.
-	ReasoningEffort string `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=high,enum=max" jsonschema_description:"How hard the model thinks: low, high, or max. Sent as the API's reasoning_effort inside the thinking object."`
+	// Type turns thinking [ThinkingTypeEnabled] or [ThinkingTypeDisabled].
+	Type ThinkingType `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled or disabled."`
+	// ReasoningEffort adjusts how hard the model thinks, [ReasoningEffortLow]
+	// to [ReasoningEffortMax]; sent as the API's reasoning_effort inside the
+	// thinking object, not as a top-level field.
+	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=high,enum=max" jsonschema_description:"How hard the model thinks: low, high, or max. Sent as the API's reasoning_effort inside the thinking object."`
 }
 
 // ApplyToChatCompletion implements [compat_oai.ChatConfig]: the generation
@@ -107,10 +129,10 @@ func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams
 	if c.Thinking != nil {
 		thinking := map[string]any{}
 		if c.Thinking.Type != "" {
-			thinking["type"] = c.Thinking.Type
+			thinking["type"] = string(c.Thinking.Type)
 		}
 		if c.Thinking.ReasoningEffort != "" {
-			thinking["reasoning_effort"] = c.Thinking.ReasoningEffort
+			thinking["reasoning_effort"] = string(c.Thinking.ReasoningEffort)
 		}
 		// An all-zero ThinkingConfig adds nothing rather than sending an
 		// empty thinking object the API could reject.

--- a/go/plugins/compat_oai/deepseek/deepseek.go
+++ b/go/plugins/compat_oai/deepseek/deepseek.go
@@ -24,6 +24,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/compat_oai"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/shared"
 )
 
 const (
@@ -82,6 +83,13 @@ type ChatConfig struct {
 	// this ID, so end users neither read nor evict each other's cached
 	// prefixes; sent as the API's user_id, not OpenAI's user.
 	UserID string `json:"userId,omitempty" jsonschema:"maxLength=512,pattern=^[a-zA-Z0-9_-]*$" jsonschema_description:"Identifies the end user a request is made on behalf of, up to 512 characters of letters, digits, hyphen and underscore. DeepSeek partitions its context cache by this ID; sent as the API's user_id."`
+	// ReasoningEffort adjusts how hard the model thinks, [ReasoningEffortLow]
+	// to [ReasoningEffortMax]; DeepSeek's default is high. Sent as the API's
+	// top-level reasoning_effort: the create-chat-completion reference also
+	// documents it nested inside thinking, but the service silently ignores it
+	// there and reads only the top-level field the thinking-mode guide's
+	// examples use.
+	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=high,enum=max" jsonschema_description:"How hard the model thinks: low, high, or max. DeepSeek's default is high."`
 	// Thinking controls the thinking mode of DeepSeek models, which is on by
 	// default; sent as the API's thinking field.
 	Thinking *ThinkingConfig `json:"thinking,omitempty" jsonschema_description:"Thinking mode controls, on by default; sent as the API's thinking field."`
@@ -91,16 +99,13 @@ type ChatConfig struct {
 type ThinkingConfig struct {
 	// Type turns thinking [ThinkingTypeEnabled] or [ThinkingTypeDisabled].
 	Type ThinkingType `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled or disabled."`
-	// ReasoningEffort adjusts how hard the model thinks, [ReasoningEffortLow]
-	// to [ReasoningEffortMax]; sent as the API's reasoning_effort inside the
-	// thinking object, not as a top-level field.
-	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=high,enum=max" jsonschema_description:"How hard the model thinks: low, high, or max. Sent as the API's reasoning_effort inside the thinking object."`
 }
 
 // ApplyToChatCompletion implements [compat_oai.ChatConfig]: the generation
 // fields land on their chat completion counterparts, MaxOutputTokens on the
-// max_tokens DeepSeek reads, and the fields DeepSeek names differently than
-// OpenAI, thinking and user_id, ride as extra request fields.
+// max_tokens DeepSeek reads, ReasoningEffort on the SDK's reasoning_effort,
+// and the fields DeepSeek names differently than OpenAI, thinking and
+// user_id, ride as extra request fields.
 func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
 	c.ApplyVersion(params)
 
@@ -122,23 +127,16 @@ func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams
 	if c.TopLogProbs != nil {
 		params.TopLogprobs = openai.Int(int64(*c.TopLogProbs))
 	}
+	if c.ReasoningEffort != "" {
+		params.ReasoningEffort = shared.ReasoningEffort(c.ReasoningEffort)
+	}
 	if c.UserID != "" {
 		compat_oai.AddExtraFields(params, map[string]any{"user_id": c.UserID})
 	}
-
-	if c.Thinking != nil {
-		thinking := map[string]any{}
-		if c.Thinking.Type != "" {
-			thinking["type"] = string(c.Thinking.Type)
-		}
-		if c.Thinking.ReasoningEffort != "" {
-			thinking["reasoning_effort"] = string(c.Thinking.ReasoningEffort)
-		}
-		// An all-zero ThinkingConfig adds nothing rather than sending an
-		// empty thinking object the API could reject.
-		if len(thinking) > 0 {
-			compat_oai.AddExtraFields(params, map[string]any{"thinking": thinking})
-		}
+	if c.Thinking != nil && c.Thinking.Type != "" {
+		compat_oai.AddExtraFields(params, map[string]any{
+			"thinking": map[string]any{"type": string(c.Thinking.Type)},
+		})
 	}
 }
 

--- a/go/plugins/compat_oai/deepseek/deepseek.go
+++ b/go/plugins/compat_oai/deepseek/deepseek.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deepseek provides a Genkit plugin for DeepSeek's models.
+package deepseek
+
+import (
+	"context"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+const (
+	provider       = "deepseek"
+	defaultBaseURL = "https://api.deepseek.com"
+)
+
+// ChatConfig is the per-request config for DeepSeek models: the generation
+// fields DeepSeek accepts plus its thinking controls. See
+// https://api-docs.deepseek.com/api/create-chat-completion.
+//
+// DeepSeek no longer supports the frequency and presence penalties, so those
+// are deliberately absent.
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// Temperature controls the degree of randomness in token selection, from
+	// 0 to 2; DeepSeek's default is 1.
+	Temperature *float64 `json:"temperature,omitempty" jsonschema:"minimum=0,maximum=2" jsonschema_description:"Controls the degree of randomness in token selection, from 0 to 2. DeepSeek's default is 1."`
+	// TopP is the nucleus sampling threshold, up to 1.
+	TopP *float64 `json:"topP,omitempty" jsonschema:"maximum=1" jsonschema_description:"Nucleus sampling threshold, up to 1."`
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as the
+	// API's max_tokens.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_tokens."`
+	// StopSequences stop generation when produced by the model, up to sixteen.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema:"maxItems=16" jsonschema_description:"Stop generation when produced by the model, up to sixteen sequences."`
+	// LogProbs requests log probabilities for the output tokens.
+	LogProbs *bool `json:"logProbs,omitempty" jsonschema_description:"Requests log probabilities for the output tokens."`
+	// TopLogProbs is how many of the most likely tokens to return log
+	// probabilities for at each position, from 0 to 20; it requires LogProbs.
+	TopLogProbs *int `json:"topLogProbs,omitempty" jsonschema:"minimum=0,maximum=20" jsonschema_description:"How many of the most likely tokens to return log probabilities for at each position, from 0 to 20; requires logProbs."`
+	// UserID identifies the end user a request is made on behalf of, up to 512
+	// characters of [a-zA-Z0-9_-]. DeepSeek partitions its context cache by
+	// this ID, so end users neither read nor evict each other's cached
+	// prefixes; sent as the API's user_id, not OpenAI's user.
+	UserID string `json:"userId,omitempty" jsonschema:"maxLength=512,pattern=^[a-zA-Z0-9_-]*$" jsonschema_description:"Identifies the end user a request is made on behalf of, up to 512 characters of letters, digits, hyphen and underscore. DeepSeek partitions its context cache by this ID; sent as the API's user_id."`
+	// Thinking controls the thinking mode of DeepSeek models, which is on by
+	// default; sent as the API's thinking field.
+	Thinking *ThinkingConfig `json:"thinking,omitempty" jsonschema_description:"Thinking mode controls, on by default; sent as the API's thinking field."`
+}
+
+// ThinkingConfig configures the thinking mode of DeepSeek models.
+type ThinkingConfig struct {
+	// Type turns thinking "enabled" or "disabled".
+	Type string `json:"type,omitempty" jsonschema:"enum=enabled,enum=disabled" jsonschema_description:"Turns thinking enabled or disabled."`
+	// ReasoningEffort adjusts how hard the model thinks: "low", "high", or
+	// "max"; sent as the API's reasoning_effort inside the thinking object,
+	// not as a top-level field.
+	ReasoningEffort string `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=high,enum=max" jsonschema_description:"How hard the model thinks: low, high, or max. Sent as the API's reasoning_effort inside the thinking object."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the generation
+// fields land on their chat completion counterparts, MaxOutputTokens on the
+// max_tokens DeepSeek reads, and the fields DeepSeek names differently than
+// OpenAI, thinking and user_id, ride as extra request fields.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.Temperature != nil {
+		params.Temperature = openai.Float(*c.Temperature)
+	}
+	if c.TopP != nil {
+		params.TopP = openai.Float(*c.TopP)
+	}
+	if c.MaxOutputTokens > 0 {
+		params.MaxTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+	if c.LogProbs != nil {
+		params.Logprobs = openai.Bool(*c.LogProbs)
+	}
+	if c.TopLogProbs != nil {
+		params.TopLogprobs = openai.Int(int64(*c.TopLogProbs))
+	}
+	if c.UserID != "" {
+		compat_oai.AddExtraFields(params, map[string]any{"user_id": c.UserID})
+	}
+
+	if c.Thinking != nil {
+		thinking := map[string]any{}
+		if c.Thinking.Type != "" {
+			thinking["type"] = c.Thinking.Type
+		}
+		if c.Thinking.ReasoningEffort != "" {
+			thinking["reasoning_effort"] = c.Thinking.ReasoningEffort
+		}
+		// An all-zero ThinkingConfig adds nothing rather than sending an
+		// empty thinking object the API could reject.
+		if len(thinking) > 0 {
+			compat_oai.AddExtraFields(params, map[string]any{"thinking": thinking})
+		}
+	}
+}
+
+// textOnly is the capability set every DeepSeek model shares: text in, text
+// or JSON out, tools, and thinking. No constrained generation is advertised:
+// DeepSeek's response_format takes json_object only, not json_schema, so a
+// schema reaches the model as prompt instructions. See
+// https://api-docs.deepseek.com/guides/json_mode.
+var textOnly = ai.ModelSupports{
+	Multiturn:  true,
+	Tools:      true,
+	SystemRole: true,
+	Media:      false,
+	ToolChoice: true,
+	Output:     []string{"text", "json"},
+}
+
+// supportedModels curates capabilities for well-known DeepSeek models. It is
+// not the set of usable models: any DeepSeek model resolves on demand and
+// takes [dynamicModelOptions], so an ID absent here still works. No versions
+// are declared, since DeepSeek serves each model under one ID whose snapshot
+// moves underneath it, and an undeclared list leaves config version pinning
+// unconstrained.
+//
+// Catalog: https://api-docs.deepseek.com/quick_start/pricing
+var supportedModels = map[string]ai.ModelOptions{
+	"deepseek-v4-flash": {Label: "DeepSeek V4 Flash", Supports: &textOnly},
+	"deepseek-v4-pro":   {Label: "DeepSeek V4 Pro", Supports: &textOnly},
+}
+
+// dynamicModelOptions is advertised for DeepSeek models that resolve
+// dynamically rather than appearing in supportedModels.
+var dynamicModelOptions = ai.ModelOptions{
+	Supports: &textOnly,
+	Versions: []string{},
+	Stage:    ai.ModelStageStable,
+}
+
+// DeepSeek configures the DeepSeek plugin.
+type DeepSeek struct {
+	// APIKey is the DeepSeek API key. If empty, DEEPSEEK_API_KEY is consulted.
+	APIKey string
+	// Opts contains additional OpenAI client request options, such as
+	// [option.WithBaseURL] for a different endpoint, e.g. DeepSeek's beta one
+	// (DEEPSEEK_BASE_URL works too). Options supplied here are applied after
+	// the plugin defaults, so they win on overlap.
+	Opts []option.RequestOption
+
+	// Models overrides what the plugin knows about a DeepSeek model, keyed by
+	// model ID, bare or provider-prefixed. Every DeepSeek model already works
+	// without an entry: known IDs carry curated capabilities and the rest take
+	// the DeepSeek defaults. Supply an entry only to correct or extend what the
+	// plugin resolves, most often for a model released after this version of
+	// the plugin.
+	//
+	//	&deepseek.DeepSeek{Models: map[string]ai.ModelOptions{
+	//		"deepseek-v4-pro": {Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+	//	}}
+	//
+	// Fields left at their zero value keep what the plugin resolves, so an
+	// entry can pin one capability without restating the label or the
+	// versions. Entries apply to the models Init registers as well as the
+	// ones [DeepSeek.ListActions] advertises and [DeepSeek.ResolveAction] builds,
+	// which is the way to describe a curated model differently: Init has
+	// already registered those and nothing can re-register them.
+	Models map[string]ai.ModelOptions
+
+	openAICompatible compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (d *DeepSeek) Name() string {
+	return provider
+}
+
+// Init implements genkit.Plugin.
+func (d *DeepSeek) Init(ctx context.Context) []api.Action {
+	baseURL := os.Getenv("DEEPSEEK_BASE_URL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiKey := d.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("DEEPSEEK_API_KEY")
+	}
+	if apiKey == "" {
+		panic("deepseek plugin initialization failed: apiKey is required")
+	}
+
+	opts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL),
+	}
+	opts = append(opts, d.Opts...)
+
+	d.openAICompatible.Provider = provider
+	d.openAICompatible.Opts = opts
+	actions := d.openAICompatible.Init(ctx)
+
+	for model := range supportedModels {
+		actions = append(actions, d.newModel(model, d.modelOptions(model)))
+	}
+	return actions
+}
+
+// newModel creates a DeepSeek model without registering it.
+func (d *DeepSeek) newModel(id string, opts ai.ModelOptions) *ai.ModelAction {
+	return compat_oai.NewChatModel[ChatConfig](&d.openAICompatible, id, opts)
+}
+
+// modelOptions returns the ModelOptions for a DeepSeek model ID: curated
+// capabilities for a known model and the DeepSeek defaults for the rest, with
+// an entry from [DeepSeek.Models] overlaid on whichever applies.
+//
+// Every path that describes a model goes through this one, which is what
+// makes a caller's entry authoritative whether Init, ListActions or
+// ResolveAction gets there first.
+func (d *DeepSeek) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, supportedModels, dynamicModelOptions, d.Models)
+}
+
+// ModelRef names a DeepSeek model and carries the config to generate with, so
+// the config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(deepseek.ModelRef("deepseek-v4-pro", &deepseek.ChatConfig{
+//		Thinking: &deepseek.ThinkingConfig{Type: "disabled"},
+//	}))
+//
+// id is the model ID, with or without the provider prefix.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// ListActions lists the models the configured DeepSeek endpoint exposes,
+// described by the plugin's config schema and capabilities.
+func (d *DeepSeek) ListActions(ctx context.Context) []api.ActionDesc {
+	return compat_oai.ListChatActions[ChatConfig](ctx, &d.openAICompatible, d.modelOptions)
+}
+
+// ResolveAction dynamically builds a model exposed by the DeepSeek endpoint,
+// described by the plugin's config schema and capabilities.
+func (d *DeepSeek) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&d.openAICompatible, atype, id, d.modelOptions)
+}

--- a/go/plugins/compat_oai/deepseek/deepseek_live_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_live_test.go
@@ -39,10 +39,11 @@ func TestPluginLive(t *testing.T) {
 	// reasoning checks turn it back on.
 	livetest.Run(t, g, livetest.Suite{
 		Model: deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
-			Thinking: &deepseek.ThinkingConfig{Type: "disabled"},
+			Thinking: &deepseek.ThinkingConfig{Type: deepseek.ThinkingTypeDisabled},
 		}),
 		ReasoningModel: deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
-			Thinking: &deepseek.ThinkingConfig{Type: "enabled", ReasoningEffort: "low"},
+			ReasoningEffort: deepseek.ReasoningEffortLow,
+			Thinking:        &deepseek.ThinkingConfig{Type: deepseek.ThinkingTypeEnabled},
 		}),
 		ReasoningContent: true,
 		ToolChoice:       true,

--- a/go/plugins/compat_oai/deepseek/deepseek_live_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_live_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deepseek_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
+	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
+)
+
+func TestPluginLive(t *testing.T) {
+	if os.Getenv("DEEPSEEK_API_KEY") == "" {
+		t.Skip("DEEPSEEK_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&deepseek.DeepSeek{}),
+		genkit.WithDefaultModel("deepseek/deepseek-v4-flash"),
+	)
+
+	// Thinking is on by default, so the cheap checks turn it off and the
+	// reasoning checks turn it back on.
+	livetest.Run(t, g, livetest.Suite{
+		Model: deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
+			Thinking: &deepseek.ThinkingConfig{Type: "disabled"},
+		}),
+		ReasoningModel: deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
+			Thinking: &deepseek.ThinkingConfig{Type: "enabled", ReasoningEffort: "low"},
+		}),
+		ReasoningContent: true,
+		ToolChoice:       true,
+		ExtraConfig: map[string]any{
+			"thinking": map[string]any{"type": "disabled"},
+			"extra":    map[string]any{"logprobs": true},
+		},
+	})
+}

--- a/go/plugins/compat_oai/deepseek/deepseek_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_test.go
@@ -131,13 +131,13 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 		if got := body.Thinking["type"]; got != "enabled" {
 			t.Errorf("thinking.type = %v, want %q", got, "enabled")
 		}
-		// DeepSeek nests the effort inside thinking rather than taking the
-		// OpenAI top-level field.
-		if got := body.Thinking["reasoning_effort"]; got != "max" {
-			t.Errorf("thinking.reasoning_effort = %v, want %q", got, "max")
+		// DeepSeek reads the effort only as the top-level OpenAI field;
+		// nested inside thinking the service silently ignores it.
+		if body.ReasoningEffort != "max" {
+			t.Errorf("reasoning_effort = %q, want %q", body.ReasoningEffort, "max")
 		}
-		if body.ReasoningEffort != "" {
-			t.Errorf("reasoning_effort = %q, want it nested inside thinking", body.ReasoningEffort)
+		if got, ok := body.Thinking["reasoning_effort"]; ok {
+			t.Errorf("thinking.reasoning_effort = %v, want the top-level field only", got)
 		}
 
 		if body.Stream {
@@ -198,8 +198,9 @@ func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
 	}
 
 	// The Genkit config speaks the plugin's camelCase contract; the handler
-	// above asserts it reaches the wire as thinking.reasoning_effort.
-	config := map[string]any{"thinking": map[string]any{"type": "enabled", "reasoningEffort": "max"}}
+	// above asserts the effort reaches the wire as the top-level
+	// reasoning_effort DeepSeek reads.
+	config := map[string]any{"reasoningEffort": "max", "thinking": map[string]any{"type": "enabled"}}
 	t.Run("complete", func(t *testing.T) {
 		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Say hi."), ai.WithConfig(config))
 		if err != nil {
@@ -368,7 +369,7 @@ func TestModelRefAndConfigSchema(t *testing.T) {
 	if !ok {
 		t.Fatalf("customOptions has no properties: %v", schema)
 	}
-	for _, key := range []string{"temperature", "maxOutputTokens", "stopSequences", "thinking", "userId", "version", "extra"} {
+	for _, key := range []string{"temperature", "maxOutputTokens", "stopSequences", "reasoningEffort", "thinking", "userId", "version", "extra"} {
 		if props[key] == nil {
 			t.Errorf("config schema is missing the %q property", key)
 		}
@@ -396,17 +397,17 @@ func TestModelRefAndConfigSchema(t *testing.T) {
 	if got, has := topP["minimum"]; has {
 		t.Errorf("topP minimum = %v, want none since DeepSeek documents only the upper bound", got)
 	}
+	effort, _ := props["reasoningEffort"].(map[string]any)
+	if got, want := effort["enum"], []any{string(deepseek.ReasoningEffortLow),
+		string(deepseek.ReasoningEffortHigh), string(deepseek.ReasoningEffortMax)}; !reflect.DeepEqual(got, want) {
+		t.Errorf("reasoningEffort enum = %#v, want %#v", got, want)
+	}
 	thinking, _ := props["thinking"].(map[string]any)
 	thinkingProps, _ := thinking["properties"].(map[string]any)
-	for field, want := range map[string][]any{
-		"type": {string(deepseek.ThinkingTypeEnabled), string(deepseek.ThinkingTypeDisabled)},
-		"reasoningEffort": {string(deepseek.ReasoningEffortLow),
-			string(deepseek.ReasoningEffortHigh), string(deepseek.ReasoningEffortMax)},
-	} {
-		prop, _ := thinkingProps[field].(map[string]any)
-		if got := prop["enum"]; !reflect.DeepEqual(got, want) {
-			t.Errorf("thinking.%s enum = %#v, want %#v", field, got, want)
-		}
+	thinkingType, _ := thinkingProps["type"].(map[string]any)
+	if got, want := thinkingType["enum"], []any{string(deepseek.ThinkingTypeEnabled),
+		string(deepseek.ThinkingTypeDisabled)}; !reflect.DeepEqual(got, want) {
+		t.Errorf("thinking.type enum = %#v, want %#v", got, want)
 	}
 }
 

--- a/go/plugins/compat_oai/deepseek/deepseek_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_test.go
@@ -1,0 +1,548 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deepseek_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+func TestPluginRequiresAPIKey(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	// An OPENAI_API_KEY must never be picked up as a fallback: sending it to
+	// DeepSeek would silently authenticate with the wrong provider's key.
+	t.Setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+
+	defer func() {
+		got := recover()
+		if got != "deepseek plugin initialization failed: apiKey is required" {
+			t.Fatalf("panic = %v, want missing API key error", got)
+		}
+	}()
+
+	(&deepseek.DeepSeek{}).Init(context.Background())
+}
+
+func TestPluginConfigPrecedence(t *testing.T) {
+	var mu sync.Mutex
+	var rightHit, wrongHit bool
+	var gotAuth string
+
+	right := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		rightHit = true
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"deepseek-v4-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer right.Close()
+
+	wrong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		wrongHit = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer wrong.Close()
+
+	// Explicit configuration must win over env vars: the struct field for the
+	// key, and an Opts [option.WithBaseURL] for the endpoint, which the
+	// plugin applies after its own defaults.
+	t.Setenv("DEEPSEEK_API_KEY", "env-key")
+	t.Setenv("DEEPSEEK_BASE_URL", wrong.URL)
+
+	ctx := context.Background()
+	plugin := &deepseek.DeepSeek{APIKey: "struct-key", Opts: []option.RequestOption{option.WithBaseURL(right.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("deepseek/deepseek-v4-pro"))
+
+	if _, err := genkit.Generate(ctx, g, ai.WithPrompt("hi")); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !rightHit || wrongHit {
+		t.Fatalf("rightHit = %v, wrongHit = %v, want struct fields to take precedence over env vars", rightHit, wrongHit)
+	}
+	if gotAuth != "Bearer struct-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer struct-key")
+	}
+}
+
+func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
+	var mu sync.Mutex
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %q, want %q", r.URL.Path, "/chat/completions")
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+
+		var body struct {
+			Model           string         `json:"model"`
+			Stream          bool           `json:"stream"`
+			Thinking        map[string]any `json:"thinking"`
+			ReasoningEffort string         `json:"reasoning_effort"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if body.Model != "deepseek-v4-pro" {
+			t.Errorf("model = %q, want %q", body.Model, "deepseek-v4-pro")
+		}
+		if got := body.Thinking["type"]; got != "enabled" {
+			t.Errorf("thinking.type = %v, want %q", got, "enabled")
+		}
+		// DeepSeek nests the effort inside thinking rather than taking the
+		// OpenAI top-level field.
+		if got := body.Thinking["reasoning_effort"]; got != "max" {
+			t.Errorf("thinking.reasoning_effort = %v, want %q", got, "max")
+		}
+		if body.ReasoningEffort != "" {
+			t.Errorf("reasoning_effort = %q, want it nested inside thinking", body.ReasoningEffort)
+		}
+
+		if body.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			for _, event := range []string{
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Think "},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"reasoning_content":"carefully."},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"content":"DeepSeek streaming works"},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			} {
+				_, _ = io.WriteString(w, "data: "+event+"\n\n")
+			}
+			_, _ = io.WriteString(w, "data: [DONE]\n\n")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"deepseek-v4-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","reasoning_content":"Think carefully.","content":"DeepSeek completion works"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}
+		}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("DEEPSEEK_BASE_URL", server.URL)
+
+	ctx := context.Background()
+	plugin := &deepseek.DeepSeek{}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("deepseek/deepseek-v4-pro"))
+
+	if plugin.Name() != "deepseek" {
+		t.Fatalf("Name() = %q, want %q", plugin.Name(), "deepseek")
+	}
+
+	for _, modelID := range []string{"deepseek-v4-flash", "deepseek-v4-pro"} {
+		model := genkit.LookupModel(g, "deepseek/"+modelID)
+		if model == nil {
+			t.Errorf("LookupModel(%q) = nil", modelID)
+			continue
+		}
+		desc := model.(api.Action).Desc()
+		if got, want := desc.Name, "deepseek/"+modelID; got != want {
+			t.Errorf("%s Desc().Name = %q, want %q", modelID, got, want)
+		}
+		supports := desc.Metadata["model"].(map[string]any)["supports"].(map[string]any)
+		// The V4 models are text-only, so media support must stay off.
+		for field, want := range map[string]bool{"media": false, "tools": true, "toolChoice": true, "multiturn": true} {
+			if got := supports[field]; got != want {
+				t.Errorf("%s %s support = %v, want %v", modelID, field, got, want)
+			}
+		}
+		output, _ := supports["output"].([]string)
+		if !slices.Equal(output, []string{"text", "json"}) {
+			t.Errorf("%s output = %v, want [text json]", modelID, output)
+		}
+	}
+
+	// The Genkit config speaks the plugin's camelCase contract; the handler
+	// above asserts it reaches the wire as thinking.reasoning_effort.
+	config := map[string]any{"thinking": map[string]any{"type": "enabled", "reasoningEffort": "max"}}
+	t.Run("complete", func(t *testing.T) {
+		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Say hi."), ai.WithConfig(config))
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if got := resp.Reasoning(); got != "Think carefully." {
+			t.Fatalf("Reasoning() = %q, want %q", got, "Think carefully.")
+		}
+		if got := resp.Text(); got != "DeepSeek completion works" {
+			t.Fatalf("Text() = %q, want %q", got, "DeepSeek completion works")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		var reasoning, text strings.Builder
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithPrompt("Say hi, streamed."),
+			ai.WithConfig(config),
+			ai.WithStreaming(func(_ context.Context, chunk *ai.ModelResponseChunk) error {
+				reasoning.WriteString(chunk.Reasoning())
+				text.WriteString(chunk.Text())
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if got := reasoning.String(); got != "Think carefully." {
+			t.Fatalf("streamed reasoning = %q, want %q", got, "Think carefully.")
+		}
+		if got := text.String(); got != "DeepSeek streaming works" {
+			t.Fatalf("streamed text = %q, want %q", got, "DeepSeek streaming works")
+		}
+		if resp.Reasoning() != reasoning.String() {
+			t.Fatalf("final reasoning = %q, want streamed %q", resp.Reasoning(), reasoning.String())
+		}
+		if resp.Text() != text.String() {
+			t.Fatalf("final text = %q, want streamed %q", resp.Text(), text.String())
+		}
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestPluginPreservesReasoningAcrossToolCalls(t *testing.T) {
+	var mu sync.Mutex
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		reqNum := requests
+		mu.Unlock()
+		var body struct {
+			Messages []map[string]any `json:"messages"`
+			Tools    []map[string]any `json:"tools"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if reqNum == 1 {
+			if len(body.Tools) != 1 {
+				t.Fatalf("tools = %#v, want one tool", body.Tools)
+			}
+			_, _ = io.WriteString(w, `{
+				"id":"c-tool-1","object":"chat.completion","created":1,"model":"deepseek-v4-pro",
+				"choices":[{
+					"index":0,
+					"message":{
+						"role":"assistant",
+						"reasoning_content":"I should call the lookup tool.",
+						"content":null,
+						"tool_calls":[{"id":"call-1","type":"function","function":{"name":"lookup","arguments":"{\"value\":\"question\"}"}}]
+					},
+					"finish_reason":"tool_calls"
+				}]
+			}`)
+			return
+		}
+
+		var assistant, toolResult map[string]any
+		for _, m := range body.Messages {
+			switch m["role"] {
+			case "assistant":
+				assistant = m
+			case "tool":
+				toolResult = m
+			}
+		}
+		if assistant == nil {
+			t.Error("second request has no assistant message")
+		} else if got := assistant["reasoning_content"]; got != "I should call the lookup tool." {
+			t.Errorf("assistant reasoning_content = %v, want preserved reasoning", got)
+		}
+		if toolResult == nil || toolResult["tool_call_id"] != "call-1" {
+			t.Errorf("tool result = %#v, want tool_call_id %q", toolResult, "call-1")
+		}
+
+		_, _ = io.WriteString(w, `{
+			"id":"c-tool-2","object":"chat.completion","created":1,"model":"deepseek-v4-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"Tool loop complete"},"finish_reason":"stop"}]
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &deepseek.DeepSeek{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("deepseek/deepseek-v4-pro"))
+
+	lookup := genkit.DefineTool(g, "lookup", "Looks up a value.",
+		func(_ *ai.ToolContext, input struct {
+			Value string `json:"value"`
+		}) (string, error) {
+			return "result for " + input.Value, nil
+		},
+	)
+
+	resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Use the lookup tool."), ai.WithTools(lookup))
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Text(); got != "Tool loop complete" {
+		t.Errorf("Text() = %q, want %q", got, "Tool loop complete")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 2 {
+		t.Errorf("requests = %d, want 2", requests)
+	}
+}
+
+// TestModelRefAndConfigSchema pins the call-site surface: the ref carries the
+// prefixed name and the typed config, and the registered models advertise the
+// camelCase config contract including the DeepSeek-specific fields.
+func TestModelRefAndConfigSchema(t *testing.T) {
+	cfg := &deepseek.ChatConfig{Thinking: &deepseek.ThinkingConfig{Type: "disabled"}}
+	for _, name := range []string{"deepseek-v4-pro", "deepseek/deepseek-v4-pro"} {
+		ref := deepseek.ModelRef(name, cfg)
+		if want := "deepseek/deepseek-v4-pro"; ref.Name() != want {
+			t.Errorf("ModelRef(%q).Name() = %q, want %q", name, ref.Name(), want)
+		}
+		if ref.Config() != cfg {
+			t.Errorf("ModelRef(%q).Config() = %v, want the config it was built with", name, ref.Config())
+		}
+	}
+
+	plugin := &deepseek.DeepSeek{APIKey: "test-key"}
+	g := genkit.Init(context.Background(), genkit.WithPlugins(plugin))
+
+	m := genkit.LookupModel(g, "deepseek/deepseek-v4-pro")
+	if m == nil {
+		t.Fatalf("%s not registered by Init", "deepseek-v4-pro")
+	}
+	model := m.(api.Action).Desc().Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions missing, got %v", model["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions has no properties: %v", schema)
+	}
+	for _, key := range []string{"temperature", "maxOutputTokens", "stopSequences", "thinking", "userId", "version", "extra"} {
+		if props[key] == nil {
+			t.Errorf("config schema is missing the %q property", key)
+		}
+	}
+
+	// The constraints DeepSeek documents ride on the schema, where the
+	// framework enforces them.
+	for field, want := range map[string]map[string]any{
+		"temperature":     {"minimum": 0.0, "maximum": 2.0},
+		"topP":            {"maximum": 1.0},
+		"maxOutputTokens": {"minimum": 1.0},
+		"stopSequences":   {"maxItems": 16.0},
+		"topLogProbs":     {"minimum": 0.0, "maximum": 20.0},
+		"userId":          {"maxLength": 512.0, "pattern": "^[a-zA-Z0-9_-]*$"},
+	} {
+		prop, _ := props[field].(map[string]any)
+		for key, value := range want {
+			if got := prop[key]; !reflect.DeepEqual(got, value) {
+				t.Errorf("%s %s = %#v, want %#v", field, key, got, value)
+			}
+		}
+	}
+	// topP has no documented lower bound, so the schema declares none.
+	topP, _ := props["topP"].(map[string]any)
+	if got, has := topP["minimum"]; has {
+		t.Errorf("topP minimum = %v, want none since DeepSeek documents only the upper bound", got)
+	}
+	thinking, _ := props["thinking"].(map[string]any)
+	thinkingProps, _ := thinking["properties"].(map[string]any)
+	for field, want := range map[string][]any{
+		"type":            {"enabled", "disabled"},
+		"reasoningEffort": {"low", "high", "max"},
+	} {
+		prop, _ := thinkingProps[field].(map[string]any)
+		if got := prop["enum"]; !reflect.DeepEqual(got, want) {
+			t.Errorf("thinking.%s enum = %#v, want %#v", field, got, want)
+		}
+	}
+}
+
+// TestModelRefConfigReachesTheWire pins the whole typed path: a ModelRef
+// carrying a typed ChatConfig passes the framework's schema validation, the
+// common fields land on their wire names (maxOutputTokens on the max_tokens
+// DeepSeek reads, not max_completion_tokens), and the thinking controls ride
+// along, all in one Generate call.
+func TestModelRefConfigReachesTheWire(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model               string         `json:"model"`
+			Temperature         float64        `json:"temperature"`
+			MaxTokens           int            `json:"max_tokens"`
+			MaxCompletionTokens *int           `json:"max_completion_tokens"`
+			Thinking            map[string]any `json:"thinking"`
+			UserID              string         `json:"user_id"`
+			User                string         `json:"user"`
+			Logprobs            *bool          `json:"logprobs"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if body.Model != "deepseek-v4-pro-0731" {
+			t.Errorf("model = %q, want the pinned version %q", body.Model, "deepseek-v4-pro-0731")
+		}
+		if body.Temperature != 0.3 {
+			t.Errorf("temperature = %v, want 0.3", body.Temperature)
+		}
+		if body.MaxTokens != 512 {
+			t.Errorf("max_tokens = %v, want 512", body.MaxTokens)
+		}
+		if body.MaxCompletionTokens != nil {
+			t.Errorf("max_completion_tokens = %v, want DeepSeek's max_tokens instead", *body.MaxCompletionTokens)
+		}
+		if got := body.Thinking["type"]; got != "disabled" {
+			t.Errorf("thinking.type = %v, want %q", got, "disabled")
+		}
+		// DeepSeek partitions its cache by user_id; OpenAI's user is a
+		// different field it does not read.
+		if body.UserID != "tenant-42" {
+			t.Errorf("user_id = %q, want %q", body.UserID, "tenant-42")
+		}
+		if body.User != "" {
+			t.Errorf("user = %q, want it sent as user_id instead", body.User)
+		}
+		if body.Logprobs == nil || !*body.Logprobs {
+			t.Errorf("logprobs = %v, want the config's extra field on the wire", body.Logprobs)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"deepseek-v4-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"typed config works"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &deepseek.DeepSeek{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModel(deepseek.ModelRef("deepseek-v4-pro", &deepseek.ChatConfig{
+			RequestConfig: compat_oai.RequestConfig{
+				Version: "deepseek-v4-pro-0731",
+				// logprobs is a field the config does not declare, riding
+				// the inherited passthrough.
+				Extra: map[string]any{"logprobs": true},
+			},
+			Temperature:     openai.Ptr(0.3),
+			MaxOutputTokens: 512,
+			UserID:          "tenant-42",
+			Thinking:        &deepseek.ThinkingConfig{Type: "disabled"},
+		})),
+		ai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Text(); got != "typed config works" {
+		t.Fatalf("Text() = %q, want %q", got, "typed config works")
+	}
+}
+
+// TestDynamicListingAndResolution pins the on-demand surface: models the
+// endpoint reports are listed with the plugin's config schema, and generating
+// with an uncurated name resolves it instead of failing with model-not-found.
+func TestDynamicListingAndResolution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/models" {
+			_, _ = io.WriteString(w, `{"object":"list","data":[{"id":"deepseek-brand-new","object":"model","owned_by":"deepseek"}]}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"deepseek-brand-new",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"resolved"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &deepseek.DeepSeek{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	var listed *api.ActionDesc
+	for _, desc := range plugin.ListActions(ctx) {
+		if desc.Name == "deepseek/deepseek-brand-new" {
+			listed = &desc
+			break
+		}
+	}
+	if listed == nil {
+		t.Fatal("ListActions() does not include the endpoint's model")
+	}
+	model := listed.Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("listed model has no customOptions: %v", model)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if props["thinking"] == nil {
+		t.Error("listed model schema is missing the plugin's thinking property")
+	}
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("deepseek/deepseek-brand-new"),
+		ai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() with an uncurated model error = %v", err)
+	}
+	if got := resp.Text(); got != "resolved" {
+		t.Fatalf("Text() = %q, want %q", got, "resolved")
+	}
+}

--- a/go/plugins/compat_oai/deepseek/deepseek_test.go
+++ b/go/plugins/compat_oai/deepseek/deepseek_test.go
@@ -399,8 +399,9 @@ func TestModelRefAndConfigSchema(t *testing.T) {
 	thinking, _ := props["thinking"].(map[string]any)
 	thinkingProps, _ := thinking["properties"].(map[string]any)
 	for field, want := range map[string][]any{
-		"type":            {"enabled", "disabled"},
-		"reasoningEffort": {"low", "high", "max"},
+		"type": {string(deepseek.ThinkingTypeEnabled), string(deepseek.ThinkingTypeDisabled)},
+		"reasoningEffort": {string(deepseek.ReasoningEffortLow),
+			string(deepseek.ReasoningEffortHigh), string(deepseek.ReasoningEffortMax)},
 	} {
 		prop, _ := thinkingProps[field].(map[string]any)
 		if got := prop["enum"]; !reflect.DeepEqual(got, want) {

--- a/go/samples/compat_oai/deepseek/main.go
+++ b/go/samples/compat_oai/deepseek/main.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This sample demonstrates the DeepSeek plugin: a flow that generates a joke
+// with a model pinned through deepseek.ModelRef and its typed config.
+//
+// To run:
+//
+//	export DEEPSEEK_API_KEY=...
+//	go run .
+//
+// In another terminal:
+//
+//	curl -X POST http://localhost:8080/jokesFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": "bananas"}'
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
+	"github.com/firebase/genkit/go/plugins/server"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// The plugin reads the API key from the DEEPSEEK_API_KEY environment variable.
+	g := genkit.Init(ctx, genkit.WithPlugins(&deepseek.DeepSeek{}))
+
+	// Define a flow that generates a joke about a given topic. Thinking is on
+	// by default for DeepSeek's V4 models, so the config turns it off for a
+	// quick conversational answer.
+	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		if topic == "" {
+			topic = "airplane food"
+		}
+
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(deepseek.ModelRef("deepseek-v4-flash", &deepseek.ChatConfig{
+				Thinking: &deepseek.ThinkingConfig{Type: deepseek.ThinkingTypeDisabled},
+			})),
+			ai.WithPrompt("Share a joke about %s.", topic),
+		)
+	})
+
+	// Optionally, start a web server to make the flow callable via HTTP.
+	mux := http.NewServeMux()
+	for _, a := range genkit.ListFlows(g) {
+		mux.HandleFunc("POST /"+a.Name(), genkit.Handler(a))
+	}
+	log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+}


### PR DESCRIPTION
Adds a DeepSeek plugin on the typed-config base (#5976); stacked on #6034.

## The plugin and its config, at a glance

```go
type DeepSeek struct {
	APIKey string
	Opts   []option.RequestOption
	Models map[string]ai.ModelOptions
}

type ChatConfig struct {
	compat_oai.RequestConfig
	Temperature     *float64        `json:"temperature,omitempty"`
	TopP            *float64        `json:"topP,omitempty"`
	MaxOutputTokens int             `json:"maxOutputTokens,omitempty"`
	StopSequences   []string        `json:"stopSequences,omitempty"`
	LogProbs        *bool           `json:"logProbs,omitempty"`
	TopLogProbs     *int            `json:"topLogProbs,omitempty"`
	UserID          string          `json:"userId,omitempty"`
	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty"`
	Thinking        *ThinkingConfig `json:"thinking,omitempty"`
}

type ThinkingConfig struct {
	Type ThinkingType `json:"type,omitempty"`
}

type ThinkingType string // "enabled", "disabled"

type ReasoningEffort string // "low", "high", "max"
```

DeepSeek's config is shaped unlike its siblings: it accepts neither penalty. `reasoningEffort` is sent as the top-level `reasoning_effort`, and `thinking` carries only the on/off mode: DeepSeek's create-chat-completion reference also documents the effort nested inside `thinking`, but the service silently ignores it there, verified live (bogus values pass unvalidated nested while the top-level field is strictly validated, and only the top-level placement moves reasoning token counts, 396 to 2004 for low to max versus noise nested). Documented limits ride the schema: `temperature` 0 to 2 (default 1), up to 16 stop sequences, `top_logprobs` 0 to 20, `topP` upper-bounded only (DeepSeek documents no lower bound, pinned by a test), `thinking.type` `enabled`/`disabled` and `reasoningEffort` `low`/`high`/`max`, both named types with exported constants per the family's named-enum rule. `userId` (512 characters of the documented alphabet) is sent as DeepSeek's `user_id` rather than OpenAI's `user`, which DeepSeek does not read; it partitions the prompt cache that is on by default.

The response side pins the base PR's shared mappings against DeepSeek's shapes: `prompt_cache_hit_tokens` stands in for the `prompt_tokens_details` breakdown DeepSeek never sends, so cache hits (billed at a lower rate) stop reading as zero, and `insufficient_system_resource` maps under `FinishReasonOther` instead of falling through to unknown.

The catalog curates the V4 family on the shared `ModelOptionsFor` overlay with a `Models` field; constrained generation stays unclaimed (DeepSeek documents `json_object` only); the plugin joins the conformance sweep. A runnable sample lives at `go/samples/compat_oai/deepseek`, verified against the live API.

```go
// Added (new package)
type DeepSeek struct { APIKey string; Opts []option.RequestOption; Models map[string]ai.ModelOptions; ... }
type ChatConfig struct { compat_oai.RequestConfig; Temperature *float64; TopP *float64; MaxOutputTokens int; StopSequences []string; LogProbs *bool; TopLogProbs *int; UserID string; ReasoningEffort ReasoningEffort; Thinking *ThinkingConfig }
type ThinkingConfig struct { Type ThinkingType }
type ThinkingType string      // Enabled, Disabled
type ReasoningEffort string   // Low, High, Max
func ModelRef(id string, config *ChatConfig) ai.ModelRef
```

## Testing

Go 1.26.3: `go build ./...` and `go test ./plugins/compat_oai/...` pass at this level of the stack; the package is 10 cases counting subtests. The schema test pins every documented constraint (enums through their constants) and the deliberate absence of a `topP` lower bound; the request tests cover the top-level effort placement with the thinking object, `user_id`, and the cache-hit and finish-reason mappings. The live test runs the shared checklist from the base PR's `internal/livetest` harness (thinking disabled for the cheap checks, low effort for the reasoning ones, `logprobs` riding the `extra` passthrough); against the real API, 14/14 pass on `deepseek-v4-flash`.


