### PR TITLE
feat(go/plugins/compat_oai/xai): add an xAI plugin

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1128,7 +1128,7 @@ Genkit provides a unified interface across all major AI providers. Use whichever
 | **Vertex AI** | `vertexai.VertexAI` | Gemini 3.5 Flash, Gemini 3.1 Pro via Google Cloud |
 | **Anthropic** | `anthropic.Anthropic` | Claude Opus 4.8, Claude Sonnet 4.6, Claude Haiku 4.5 |
 | **Ollama** | `ollama.Ollama` | Llama 4, Qwen 3, DeepSeek, and other local models |
-| **OpenAI Compatible** | `compat_oai` | GPT-5.6, DeepSeek, Qwen, Kimi, GLM, and any OpenAI-compatible API |
+| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Grok, DeepSeek, Qwen, Kimi, GLM, and any OpenAI-compatible API |
 
 ```go
 // Google AI

--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -189,8 +189,8 @@ providers and `max_completion_tokens` on others. Use the same camelCase name
 other plugins use for the same setting; `conformance_test.go` enforces that
 across the package.
 
-See the `openai`, `anthropic`, `dashscope`, `deepseek`, `kimi`, and `zai`
-directories for complete implementations.
+See the `openai`, `anthropic`, `dashscope`, `deepseek`, `kimi`, `xai`, and
+`zai` directories for complete implementations.
 
 ## Running Tests
 
@@ -201,6 +201,7 @@ export ANTHROPIC_API_KEY=<your-anthropic-key>
 export DASHSCOPE_API_KEY=<your-dashscope-key>
 export ZAI_API_KEY=<your-zai-key>
 export KIMI_API_KEY=<your-kimi-key>
+export XAI_API_KEY=<your-xai-key>
 export DEEPSEEK_API_KEY=<your-deepseek-key>
 ```
 
@@ -225,6 +226,9 @@ go test -v ./zai
 
 # Kimi tests
 go test -v ./kimi
+
+# xAI tests
+go test -v ./xai
 
 # DeepSeek tests
 go test -v ./deepseek

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
 	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
 	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
+	"github.com/firebase/genkit/go/plugins/compat_oai/xai"
 	"github.com/firebase/genkit/go/plugins/compat_oai/zai"
 )
 
@@ -58,6 +59,7 @@ func TestConfigSchemaConformance(t *testing.T) {
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("KIMI_API_KEY", "test-key")
+	t.Setenv("XAI_API_KEY", "test-key")
 	t.Setenv("ZAI_API_KEY", "test-key")
 
 	g := genkit.Init(context.Background(), genkit.WithPlugins(
@@ -65,6 +67,7 @@ func TestConfigSchemaConformance(t *testing.T) {
 		&dashscope.DashScope{},
 		&deepseek.DeepSeek{},
 		&kimi.Kimi{},
+		&xai.XAI{},
 		&zai.ZAI{},
 	))
 
@@ -73,6 +76,7 @@ func TestConfigSchemaConformance(t *testing.T) {
 		"dashscope/qwen-plus",
 		"deepseek/deepseek-v4-pro",
 		"kimi/kimi-k3",
+		"xai/grok-4.5",
 		"zai/glm-5.1",
 	}
 
@@ -156,6 +160,7 @@ func TestModelsOverrideConformance(t *testing.T) {
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("KIMI_API_KEY", "test-key")
+	t.Setenv("XAI_API_KEY", "test-key")
 	t.Setenv("ZAI_API_KEY", "test-key")
 
 	// Keyed provider-prefixed on half of them, bare on the rest: both forms
@@ -169,6 +174,7 @@ func TestModelsOverrideConformance(t *testing.T) {
 		&deepseek.DeepSeek{Models: map[string]ai.ModelOptions{
 			"deepseek/deepseek-v4-pro": pinned}},
 		&kimi.Kimi{Models: map[string]ai.ModelOptions{"kimi-k3": pinned}},
+		&xai.XAI{Models: map[string]ai.ModelOptions{"xai/grok-4.5": pinned}},
 		&zai.ZAI{Models: map[string]ai.ModelOptions{"glm-5.1": pinned}},
 	))
 
@@ -177,6 +183,7 @@ func TestModelsOverrideConformance(t *testing.T) {
 		"dashscope/qwen-plus",
 		"deepseek/deepseek-v4-pro",
 		"kimi/kimi-k3",
+		"xai/grok-4.5",
 		"zai/glm-5.1",
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -223,6 +223,7 @@ func TestClosedEnumsUseNamedTypes(t *testing.T) {
 		"dashscope": dashscope.ChatConfig{},
 		"deepseek":  deepseek.ChatConfig{},
 		"kimi":      kimi.ChatConfig{},
+		"xai":       xai.ChatConfig{},
 		"zai":       zai.ChatConfig{},
 	}
 	for name, config := range configs {

--- a/go/plugins/compat_oai/xai/README.md
+++ b/go/plugins/compat_oai/xai/README.md
@@ -25,8 +25,7 @@ import (
 
 ctx := context.Background()
 plugin := &xai.XAI{}
-g := genkit.Init(
-    ctx,
+g := genkit.Init(ctx,
     genkit.WithPlugins(plugin),
     genkit.WithDefaultModel("xai/grok-4.5"),
 )
@@ -60,9 +59,7 @@ its own controls (`reasoningEffort`, `searchParameters`). `xai.ModelRef`
 carries the config with the model ID:
 
 ```go
-response, err := genkit.Generate(
-    ctx,
-    g,
+response, err := genkit.Generate(ctx, g,
     ai.WithModel(xai.ModelRef("grok-4.6", &xai.ChatConfig{
         ReasoningEffort: xai.ReasoningEffortHigh,
     })),

--- a/go/plugins/compat_oai/xai/README.md
+++ b/go/plugins/compat_oai/xai/README.md
@@ -55,8 +55,8 @@ reference is at https://docs.x.ai.
 ## Config
 
 Models take a typed `xai.ChatConfig`: the generation fields xAI accepts plus
-its own controls (`reasoningEffort`, `searchParameters`). `xai.ModelRef`
-carries the config with the model ID:
+its own controls (`reasoningEffort`, `serviceTier`, `promptCacheKey`).
+`xai.ModelRef` carries the config with the model ID:
 
 ```go
 response, err := genkit.Generate(ctx, g,

--- a/go/plugins/compat_oai/xai/README.md
+++ b/go/plugins/compat_oai/xai/README.md
@@ -1,0 +1,109 @@
+# xAI Plugin
+
+This plugin provides Genkit support for xAI's OpenAI-compatible Grok models.
+
+## Setup
+
+Set an xAI API key:
+
+```bash
+export XAI_API_KEY=<your-api-key>
+```
+
+The plugin uses `https://api.x.ai/v1` by default. Set `XAI_BASE_URL`, or pass
+`option.WithBaseURL` through the plugin's `Opts`, to use another compatible
+endpoint.
+
+```go
+import (
+    "context"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/xai"
+)
+
+ctx := context.Background()
+plugin := &xai.XAI{}
+g := genkit.Init(
+    ctx,
+    genkit.WithPlugins(plugin),
+    genkit.WithDefaultModel("xai/grok-4.5"),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain reinforcement learning."))
+```
+
+Grok's `reasoning_content` output is returned as Genkit reasoning parts and is
+available through `response.Reasoning()`.
+
+## Models
+
+Grok 4.6, Grok 4.5, Grok 4.3, the Grok 4.20 line, and the Grok Build coding
+model are registered. The catalog is not a ceiling: any model ID xAI serves
+resolves on demand, and the `Models` field describes or corrects any model,
+curated or not:
+
+```go
+plugin := &xai.XAI{Models: map[string]ai.ModelOptions{
+    "grok-5": {Label: "Grok 5", Supports: &compat_oai.Multimodal},
+}}
+```
+
+The current model list is at https://docs.x.ai/docs/models, and the API
+reference is at https://docs.x.ai.
+
+## Config
+
+Models take a typed `xai.ChatConfig`: the generation fields xAI accepts plus
+its own controls (`reasoningEffort`, `searchParameters`). `xai.ModelRef`
+carries the config with the model ID:
+
+```go
+response, err := genkit.Generate(
+    ctx,
+    g,
+    ai.WithModel(xai.ModelRef("grok-4.6", &xai.ChatConfig{
+        ReasoningEffort: xai.ReasoningEffortHigh,
+    })),
+    ai.WithPrompt("Work through this step by step."),
+)
+```
+
+`reasoningEffort` runs from `none` through `xhigh`. Which levels a model takes
+is xAI's to decide: `none` is documented for the chat completions endpoint and
+`xhigh` for Grok 4.6, so a level a model does not accept comes back as an error
+from xAI.
+
+`maxOutputTokens` reaches xAI as `max_completion_tokens`, since xAI deprecated
+`max_tokens`, and `topLogProbs` accepts 0 through 8 rather than OpenAI's 20.
+Streamed generations report token usage, including reasoning tokens, the same
+way non-streamed ones do.
+
+Every config also carries the settings Genkit owns: `version` pins the exact
+model version a request is served by, `apiKey` (settable only from Go code)
+serves one request with a different credential, and `extra` forwards request
+body fields the config does not declare, keyed by xAI's wire names.
+
+## Not supported
+
+xAI's image, video, and voice models are not part of this plugin: it serves the
+chat completions endpoint only.
+
+Search is not reachable through this plugin. xAI retired the chat completion
+endpoint's `search_parameters` (the API answers any request carrying it with
+410 Gone), and its successors, the `web_search` and `x_search` server-side
+tools, are Responses API features, while chat completions accepts only
+function tools.
+
+Two request fields are left out on purpose. `n` asks for several completion
+choices and bills for all of them while Genkit reads only the first, and
+`deferred` answers with a request ID to poll rather than a completion.
+
+## Live tests
+
+Live tests are skipped unless `XAI_API_KEY` is set:
+
+```bash
+go test -race ./plugins/compat_oai/xai -run '^TestPluginLive$' -v -count=1
+```

--- a/go/plugins/compat_oai/xai/xai.go
+++ b/go/plugins/compat_oai/xai/xai.go
@@ -116,8 +116,7 @@ type ChatConfig struct {
 	// Seed makes generation reproducible across calls when set.
 	Seed *int `json:"seed,omitempty" jsonschema_description:"Makes generation reproducible across calls when set, on a best-effort basis."`
 	// ReasoningEffort adjusts how hard a reasoning-capable Grok model thinks.
-	// On grok-4.20-multi-agent it sets how many agents collaborate instead.
-	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty" jsonschema:"enum=none,enum=low,enum=medium,enum=high,enum=xhigh" jsonschema_description:"How hard a reasoning-capable Grok model thinks, from none to xhigh. Which levels a model takes is the model's to decide; on grok-4.20-multi-agent it sets how many agents collaborate instead."`
+	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty" jsonschema:"enum=none,enum=low,enum=medium,enum=high,enum=xhigh" jsonschema_description:"How hard a reasoning-capable Grok model thinks, from none to xhigh. Which levels a model takes is the model's to decide."`
 	// ParallelToolCalls lets the model request several tool calls in one
 	// response, which it may do by default. Setting it false caps the model at
 	// one call per response. It applies to a request that carries tools.
@@ -228,12 +227,14 @@ var supportedModels = map[string]ai.ModelOptions{
 	"grok-4.3":                     {Label: "Grok 4.3", Supports: &multimodal},
 	"grok-4.20-0309-reasoning":     {Label: "Grok 4.20 Reasoning", Supports: &multimodal},
 	"grok-4.20-0309-non-reasoning": {Label: "Grok 4.20 Non-Reasoning", Supports: &multimodal},
-	// Takes ChatConfig.ReasoningEffort as a count of collaborating agents
-	// rather than a depth of thought.
-	"grok-4.20-multi-agent-0309": {Label: "Grok 4.20 Multi-Agent", Supports: &multimodal},
 	// The agentic coding model, also served as "grok-code-fast-1". Outside the
 	// Grok 4 family, so structured output and tools cannot be combined.
 	"grok-build-0.1": {Label: "Grok Build 0.1", Supports: &multimodalNoToolConstraint},
+
+	// grok-4.20-multi-agent-0309 is deliberately absent: xAI serves the
+	// multi-agent model only through the Responses API and its own SDK, and
+	// chat completions rejects it ("Multi Agent requests are not allowed on
+	// chat completions").
 }
 
 // dynamicModelOptions is advertised for Grok models that resolve dynamically

--- a/go/plugins/compat_oai/xai/xai.go
+++ b/go/plugins/compat_oai/xai/xai.go
@@ -1,0 +1,355 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xai provides a Genkit plugin for xAI's Grok models.
+package xai
+
+import (
+	"context"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/shared"
+)
+
+const (
+	provider       = "xai"
+	defaultBaseURL = "https://api.x.ai/v1"
+)
+
+// ReasoningEffort is how hard a reasoning-capable Grok model thinks before it
+// answers.
+//
+// xAI documents two sets of levels, because it documents two APIs. The chat
+// completions reference this plugin serves lists [ReasoningEffortNone] through
+// [ReasoningEffortHigh] with low the default; the model capability guide, which
+// covers the Responses API, lists low through [ReasoningEffortXHigh] with high
+// the default and no way to turn reasoning off. The schema enumerates the
+// union of both sets; which subset a model takes is the model's to decide, so
+// a declared level a model does not take is an error from xAI rather than one
+// from here.
+type ReasoningEffort string
+
+const (
+	// ReasoningEffortNone disables reasoning. Models documented only by the
+	// capability guide cannot turn it off and reject this.
+	ReasoningEffortNone ReasoningEffort = "none"
+	// ReasoningEffortLow is fast reasoning, for latency-sensitive work and
+	// simple tool calling.
+	ReasoningEffortLow ReasoningEffort = "low"
+	// ReasoningEffortMedium adds thinking for complex analysis and
+	// long-context tasks.
+	ReasoningEffortMedium ReasoningEffort = "medium"
+	// ReasoningEffortHigh is deeper thinking, for hard problems and multi-step
+	// logic.
+	ReasoningEffortHigh ReasoningEffort = "high"
+	// ReasoningEffortXHigh is the maximum depth, which xAI documents for
+	// grok-4.6 alone.
+	ReasoningEffortXHigh ReasoningEffort = "xhigh"
+)
+
+// ServiceTier selects how a request is scheduled and billed.
+//
+// xAI takes two of the tiers the OpenAI SDK models, so it is declared here
+// rather than reused from [openai.ChatCompletionNewParamsServiceTier]: a
+// config advertising that type would offer "auto", "flex", and "scale", which
+// xAI rejects.
+type ServiceTier string
+
+const (
+	// ServiceTierDefault is standard scheduling and billing.
+	ServiceTierDefault ServiceTier = "default"
+	// ServiceTierPriority buys faster scheduling at a higher rate.
+	ServiceTierPriority ServiceTier = "priority"
+)
+
+// ChatConfig is the per-request config for Grok models: the common generation
+// fields plus the xAI-specific controls. See
+// https://docs.x.ai/docs/api-reference.
+//
+// Two documented request fields are deliberately absent. n asks for several
+// completion choices and bills for all of them, while Genkit reads only the
+// first, so declaring it would only sell tokens that are then thrown away.
+// deferred answers with a request ID to poll rather than a completion, which
+// is not a shape this model action can return.
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// Temperature controls the degree of randomness in token selection, from
+	// 0 to 2.
+	Temperature *float64 `json:"temperature,omitempty" jsonschema:"minimum=0,maximum=2" jsonschema_description:"Controls the degree of randomness in token selection, from 0 to 2."`
+	// TopP is the nucleus sampling threshold. xAI documents no range for it,
+	// so the schema declares none.
+	TopP *float64 `json:"topP,omitempty" jsonschema_description:"Nucleus sampling threshold: only the tokens comprising the top P probability mass are considered."`
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as the
+	// API's max_completion_tokens; xAI deprecated max_tokens.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_completion_tokens."`
+	// StopSequences stop generation when produced by the model, up to four.
+	// Reasoning models do not support them.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema:"maxItems=4" jsonschema_description:"Stop generation when produced by the model, up to four sequences. Reasoning models do not support them."`
+	// FrequencyPenalty penalizes tokens by their frequency so far, from -2.0
+	// to 2.0. Reasoning models do not support it.
+	FrequencyPenalty *float64 `json:"frequencyPenalty,omitempty" jsonschema:"minimum=-2,maximum=2" jsonschema_description:"Penalizes tokens by their frequency so far, from -2.0 to 2.0. Reasoning models do not support it."`
+	// PresencePenalty penalizes tokens that have appeared at all, from -2.0 to
+	// 2.0. Reasoning models do not support it.
+	PresencePenalty *float64 `json:"presencePenalty,omitempty" jsonschema:"minimum=-2,maximum=2" jsonschema_description:"Penalizes tokens that have appeared at all, from -2.0 to 2.0. Reasoning models do not support it."`
+	// LogProbs requests log probabilities for the output tokens.
+	LogProbs *bool `json:"logProbs,omitempty" jsonschema_description:"Requests log probabilities for the output tokens."`
+	// TopLogProbs is how many of the most likely tokens to return log
+	// probabilities for at each position, from 0 to 8; it requires LogProbs.
+	TopLogProbs *int `json:"topLogProbs,omitempty" jsonschema:"minimum=0,maximum=8" jsonschema_description:"How many of the most likely tokens to return log probabilities for at each position, from 0 to 8; requires logProbs."`
+	// Seed makes generation reproducible across calls when set.
+	Seed *int `json:"seed,omitempty" jsonschema_description:"Makes generation reproducible across calls when set, on a best-effort basis."`
+	// ReasoningEffort adjusts how hard a reasoning-capable Grok model thinks.
+	// On grok-4.20-multi-agent it sets how many agents collaborate instead.
+	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty" jsonschema:"enum=none,enum=low,enum=medium,enum=high,enum=xhigh" jsonschema_description:"How hard a reasoning-capable Grok model thinks, from none to xhigh. Which levels a model takes is the model's to decide; on grok-4.20-multi-agent it sets how many agents collaborate instead."`
+	// ParallelToolCalls lets the model request several tool calls in one
+	// response, which it may do by default. Setting it false caps the model at
+	// one call per response. It applies to a request that carries tools.
+	ParallelToolCalls *bool `json:"parallelToolCalls,omitempty" jsonschema_description:"Lets the model request several tool calls in one response, which it may do by default; false caps it at one call per response."`
+	// User identifies the end user a request is made for, which xAI uses to
+	// monitor and detect abuse.
+	User string `json:"user,omitempty" jsonschema_description:"Identifies the end user a request is made for, which xAI uses to monitor and detect abuse."`
+	// PromptCacheKey routes requests sharing a prompt prefix to the same
+	// backend, for best-effort prompt cache hits, and is sent as the API's
+	// prompt_cache_key. Hits come back as the response usage's
+	// CachedContentTokens.
+	PromptCacheKey string `json:"promptCacheKey,omitempty" jsonschema_description:"Routes requests sharing a prompt prefix to the same backend for best-effort prompt cache hits, sent as the API's prompt_cache_key."`
+	// ServiceTier selects how the request is scheduled and billed.
+	ServiceTier ServiceTier `json:"serviceTier,omitempty" jsonschema:"enum=default,enum=priority" jsonschema_description:"How the request is scheduled and billed: default, or priority for faster scheduling at a higher rate."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the generation
+// fields land on their chat completion counterparts, reasoning effort on the
+// SDK's reasoning_effort, and the xAI controls ride as extra request fields.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.Temperature != nil {
+		params.Temperature = openai.Float(*c.Temperature)
+	}
+	if c.TopP != nil {
+		params.TopP = openai.Float(*c.TopP)
+	}
+	if c.MaxOutputTokens > 0 {
+		params.MaxCompletionTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+	if c.FrequencyPenalty != nil {
+		params.FrequencyPenalty = openai.Float(*c.FrequencyPenalty)
+	}
+	if c.PresencePenalty != nil {
+		params.PresencePenalty = openai.Float(*c.PresencePenalty)
+	}
+	if c.LogProbs != nil {
+		params.Logprobs = openai.Bool(*c.LogProbs)
+	}
+	if c.TopLogProbs != nil {
+		params.TopLogprobs = openai.Int(int64(*c.TopLogProbs))
+	}
+	if c.Seed != nil {
+		params.Seed = openai.Int(int64(*c.Seed))
+	}
+	if c.ReasoningEffort != "" {
+		params.ReasoningEffort = shared.ReasoningEffort(c.ReasoningEffort)
+	}
+	if c.ParallelToolCalls != nil {
+		params.ParallelToolCalls = openai.Bool(*c.ParallelToolCalls)
+	}
+	if c.User != "" {
+		params.User = openai.String(c.User)
+	}
+	if c.ServiceTier != "" {
+		params.ServiceTier = openai.ChatCompletionNewParamsServiceTier(c.ServiceTier)
+	}
+	if c.PromptCacheKey != "" {
+		compat_oai.AddExtraFields(params, map[string]any{"prompt_cache_key": c.PromptCacheKey})
+	}
+}
+
+// Capability sets shared by the entries below. Every Grok model xAI serves
+// through chat completions takes text and images and answers with text or
+// JSON, and calls tools. They differ on constrained generation: xAI documents
+// that "structured outputs with tools is only available for supported Grok 4
+// family models", so anything outside that family advertises no-tools and
+// falls back to schema instructions in the prompt once a request carries
+// tools. See https://docs.x.ai/developers/model-capabilities/text/structured-outputs.
+var (
+	multimodal = ai.ModelSupports{
+		Multiturn:   true,
+		Tools:       true,
+		SystemRole:  true,
+		Media:       true,
+		ToolChoice:  true,
+		Output:      []string{"text", "json"},
+		Constrained: ai.ConstrainedSupportAll,
+	}
+	multimodalNoToolConstraint = ai.ModelSupports{
+		Multiturn:   true,
+		Tools:       true,
+		SystemRole:  true,
+		Media:       true,
+		ToolChoice:  true,
+		Output:      []string{"text", "json"},
+		Constrained: ai.ConstrainedSupportNoTools,
+	}
+)
+
+// supportedModels curates capabilities for well-known Grok models. It is not
+// the set of usable models: any Grok model resolves on demand and takes
+// [dynamicModelOptions], so an ID absent here still works. No versions are
+// declared, since xAI serves each model under floating aliases and dated
+// snapshots the plugin cannot enumerate, and an undeclared list leaves config
+// version pinning unconstrained.
+//
+// Catalog: https://docs.x.ai/docs/models
+var supportedModels = map[string]ai.ModelOptions{
+	// The flagship, and the one model xAI documents ReasoningEffortXHigh for.
+	"grok-4.6": {Label: "Grok 4.6", Supports: &multimodal},
+	"grok-4.5": {Label: "Grok 4.5", Supports: &multimodal},
+	// The long-context model.
+	"grok-4.3":                     {Label: "Grok 4.3", Supports: &multimodal},
+	"grok-4.20-0309-reasoning":     {Label: "Grok 4.20 Reasoning", Supports: &multimodal},
+	"grok-4.20-0309-non-reasoning": {Label: "Grok 4.20 Non-Reasoning", Supports: &multimodal},
+	// Takes ChatConfig.ReasoningEffort as a count of collaborating agents
+	// rather than a depth of thought.
+	"grok-4.20-multi-agent-0309": {Label: "Grok 4.20 Multi-Agent", Supports: &multimodal},
+	// The agentic coding model, also served as "grok-code-fast-1". Outside the
+	// Grok 4 family, so structured output and tools cannot be combined.
+	"grok-build-0.1": {Label: "Grok Build 0.1", Supports: &multimodalNoToolConstraint},
+}
+
+// dynamicModelOptions is advertised for Grok models that resolve dynamically
+// rather than appearing in supportedModels. A model xAI adds later may sit
+// outside the Grok 4 family, so it takes the narrower constrained support.
+var dynamicModelOptions = ai.ModelOptions{
+	Supports: &multimodalNoToolConstraint,
+	Versions: []string{},
+	Stage:    ai.ModelStageStable,
+}
+
+// XAI configures the xAI Grok plugin.
+type XAI struct {
+	// APIKey is the xAI API key. If empty, XAI_API_KEY is consulted.
+	APIKey string
+	// Opts contains additional OpenAI client request options, such as
+	// [option.WithBaseURL] for a different endpoint (XAI_BASE_URL works too).
+	// Options supplied here are applied after the plugin defaults, so they
+	// win on overlap.
+	Opts []option.RequestOption
+
+	// Models overrides what the plugin knows about a Grok model, keyed by
+	// model ID, bare or provider-prefixed. Every Grok model already works
+	// without an entry: known IDs carry curated capabilities and the rest take
+	// the Grok defaults. Supply an entry only to correct or extend what the
+	// plugin resolves, most often for a model released after this version of
+	// the plugin.
+	//
+	//	&xai.XAI{Models: map[string]ai.ModelOptions{
+	//		"grok-4.5": {Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+	//	}}
+	//
+	// Fields left at their zero value keep what the plugin resolves, so an
+	// entry can pin one capability without restating the label or the
+	// versions. Entries apply to the models Init registers as well as the
+	// ones [XAI.ListActions] advertises and [XAI.ResolveAction] builds,
+	// which is the way to describe a curated model differently: Init has
+	// already registered those and nothing can re-register them.
+	Models map[string]ai.ModelOptions
+
+	openAICompatible compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (x *XAI) Name() string {
+	return provider
+}
+
+// Init implements genkit.Plugin.
+func (x *XAI) Init(ctx context.Context) []api.Action {
+	baseURL := os.Getenv("XAI_BASE_URL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiKey := x.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("XAI_API_KEY")
+	}
+	if apiKey == "" {
+		panic("xai plugin initialization failed: apiKey is required")
+	}
+
+	opts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL),
+	}
+	opts = append(opts, x.Opts...)
+
+	x.openAICompatible.Provider = provider
+	x.openAICompatible.Opts = opts
+	actions := x.openAICompatible.Init(ctx)
+
+	for model := range supportedModels {
+		actions = append(actions, x.newModel(model, x.modelOptions(model)))
+	}
+	return actions
+}
+
+// newModel creates a Grok model without registering it.
+func (x *XAI) newModel(id string, opts ai.ModelOptions) *ai.ModelAction {
+	return compat_oai.NewChatModel[ChatConfig](&x.openAICompatible, id, opts)
+}
+
+// modelOptions returns the ModelOptions for a Grok model ID: curated
+// capabilities for a known model and the Grok defaults for the rest, with
+// an entry from [XAI.Models] overlaid on whichever applies.
+//
+// Every path that describes a model goes through this one, which is what
+// makes a caller's entry authoritative whether Init, ListActions or
+// ResolveAction gets there first.
+func (x *XAI) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, supportedModels, dynamicModelOptions, x.Models)
+}
+
+// ModelRef names a Grok model and carries the config to generate with, so the
+// config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(xai.ModelRef("grok-4.3", &xai.ChatConfig{
+//		ReasoningEffort: "high",
+//	}))
+//
+// id is the model ID, with or without the provider prefix.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// ListActions lists the models the configured xAI endpoint exposes, described
+// by the plugin's config schema and capabilities.
+func (x *XAI) ListActions(ctx context.Context) []api.ActionDesc {
+	return compat_oai.ListChatActions[ChatConfig](ctx, &x.openAICompatible, x.modelOptions)
+}
+
+// ResolveAction dynamically builds a model exposed by the xAI endpoint,
+// described by the plugin's config schema and capabilities.
+func (x *XAI) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&x.openAICompatible, atype, id, x.modelOptions)
+}

--- a/go/plugins/compat_oai/xai/xai_live_test.go
+++ b/go/plugins/compat_oai/xai/xai_live_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xai_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
+	"github.com/firebase/genkit/go/plugins/compat_oai/xai"
+)
+
+func TestPluginLive(t *testing.T) {
+	if os.Getenv("XAI_API_KEY") == "" {
+		t.Skip("XAI_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&xai.XAI{}),
+		genkit.WithDefaultModel("xai/grok-4.5"),
+	)
+
+	livetest.Run(t, g, livetest.Suite{
+		Model: xai.ModelRef("grok-4.5", nil),
+		// Grok takes the effort knob but keeps the reasoning content
+		// server-side.
+		ReasoningModel: xai.ModelRef("grok-4.3", &xai.ChatConfig{
+			MaxOutputTokens: 512,
+			ReasoningEffort: xai.ReasoningEffortLow,
+		}),
+		VisionModel: xai.ModelRef("grok-4.5", nil),
+		ToolChoice:  true,
+		ExtraConfig: map[string]any{
+			"extra": map[string]any{"user": "genkit-livetest"},
+		},
+	})
+}

--- a/go/plugins/compat_oai/xai/xai_live_test.go
+++ b/go/plugins/compat_oai/xai/xai_live_test.go
@@ -17,8 +17,10 @@ package xai_test
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
 	"github.com/firebase/genkit/go/plugins/compat_oai/xai"
@@ -49,4 +51,29 @@ func TestPluginLive(t *testing.T) {
 			"extra": map[string]any{"user": "genkit-livetest"},
 		},
 	})
+}
+
+// TestReasoningEffortXHighLive pins [xai.ReasoningEffortXHigh] end to end on
+// grok-4.6, the one model xAI documents the level for.
+func TestReasoningEffortXHighLive(t *testing.T) {
+	if os.Getenv("XAI_API_KEY") == "" {
+		t.Skip("XAI_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&xai.XAI{}))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModel(xai.ModelRef("grok-4.6", &xai.ChatConfig{
+			MaxOutputTokens: 2048,
+			ReasoningEffort: xai.ReasoningEffortXHigh,
+		})),
+		ai.WithPrompt("What is 27 * 43? Answer with just the number."),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if !strings.Contains(resp.Text(), "1161") {
+		t.Errorf("Text() = %q, want it to contain 1161", resp.Text())
+	}
 }

--- a/go/plugins/compat_oai/xai/xai_test.go
+++ b/go/plugins/compat_oai/xai/xai_test.go
@@ -753,7 +753,6 @@ func TestConstrainedSupport(t *testing.T) {
 		"grok-4.3":                     ai.ConstrainedSupportAll,
 		"grok-4.20-0309-reasoning":     ai.ConstrainedSupportAll,
 		"grok-4.20-0309-non-reasoning": ai.ConstrainedSupportAll,
-		"grok-4.20-multi-agent-0309":   ai.ConstrainedSupportAll,
 		"grok-build-0.1":               ai.ConstrainedSupportNoTools,
 	} {
 		m := genkit.LookupModel(g, "xai/"+id)

--- a/go/plugins/compat_oai/xai/xai_test.go
+++ b/go/plugins/compat_oai/xai/xai_test.go
@@ -1,0 +1,777 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xai_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/firebase/genkit/go/plugins/compat_oai/xai"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+func TestPluginRequiresAPIKey(t *testing.T) {
+	t.Setenv("XAI_API_KEY", "")
+	// An OPENAI_API_KEY must never be picked up as a fallback: sending it to
+	// xAI would silently authenticate with the wrong provider's key.
+	t.Setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+
+	defer func() {
+		got := recover()
+		if got != "xai plugin initialization failed: apiKey is required" {
+			t.Fatalf("panic = %v, want missing API key error", got)
+		}
+	}()
+
+	(&xai.XAI{}).Init(context.Background())
+}
+
+func TestPluginConfigPrecedence(t *testing.T) {
+	var mu sync.Mutex
+	var rightHit, wrongHit bool
+	var gotAuth string
+
+	right := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		rightHit = true
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"grok-4.5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer right.Close()
+
+	wrong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		wrongHit = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer wrong.Close()
+
+	// Explicit configuration must win over env vars: the struct field for the
+	// key, and an Opts [option.WithBaseURL] for the endpoint, which the
+	// plugin applies after its own defaults.
+	t.Setenv("XAI_API_KEY", "env-key")
+	t.Setenv("XAI_BASE_URL", wrong.URL+"/v1")
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "struct-key", Opts: []option.RequestOption{option.WithBaseURL(right.URL + "/v1")}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("xai/grok-4.5"))
+
+	if _, err := genkit.Generate(ctx, g, ai.WithPrompt("hi")); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !rightHit || wrongHit {
+		t.Fatalf("rightHit = %v, wrongHit = %v, want struct fields to take precedence over env vars", rightHit, wrongHit)
+	}
+	if gotAuth != "Bearer struct-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer struct-key")
+	}
+}
+
+func TestPluginRegistersModelsAndHandlesReasoning(t *testing.T) {
+	var mu sync.Mutex
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q, want %q", r.URL.Path, "/v1/chat/completions")
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+
+		var body struct {
+			Model           string `json:"model"`
+			Stream          bool   `json:"stream"`
+			ReasoningEffort string `json:"reasoning_effort"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if body.Model != "grok-4.3" {
+			t.Errorf("model = %q, want %q", body.Model, "grok-4.3")
+		}
+		if body.ReasoningEffort != "high" {
+			t.Errorf("reasoning_effort = %q, want %q", body.ReasoningEffort, "high")
+		}
+
+		if body.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			for _, event := range []string{
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"grok-4.3","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Think "},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"grok-4.3","choices":[{"index":0,"delta":{"reasoning_content":"carefully."},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"grok-4.3","choices":[{"index":0,"delta":{"content":"Grok streaming works"},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"grok-4.3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			} {
+				_, _ = io.WriteString(w, "data: "+event+"\n\n")
+			}
+			_, _ = io.WriteString(w, "data: [DONE]\n\n")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"grok-4.3",
+			"choices":[{"index":0,"message":{"role":"assistant","reasoning_content":"Think carefully.","content":"Grok completion works"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}
+		}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("XAI_API_KEY", "test-key")
+	t.Setenv("XAI_BASE_URL", server.URL+"/v1")
+
+	ctx := context.Background()
+	plugin := &xai.XAI{}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("xai/grok-4.3"))
+
+	if plugin.Name() != "xai" {
+		t.Fatalf("Name() = %q, want %q", plugin.Name(), "xai")
+	}
+
+	for _, modelID := range []string{
+		"grok-4.5",
+		"grok-4.3",
+		"grok-4.20-0309-reasoning",
+		"grok-4.20-0309-non-reasoning",
+		"grok-build-0.1",
+	} {
+		model := genkit.LookupModel(g, "xai/"+modelID)
+		if model == nil {
+			t.Errorf("LookupModel(%q) = nil", modelID)
+			continue
+		}
+		desc := model.(api.Action).Desc()
+		if got, want := desc.Name, "xai/"+modelID; got != want {
+			t.Errorf("%s Desc().Name = %q, want %q", modelID, got, want)
+		}
+		supports := desc.Metadata["model"].(map[string]any)["supports"].(map[string]any)
+		for field, want := range map[string]bool{"media": true, "tools": true, "toolChoice": true, "multiturn": true} {
+			if got := supports[field]; got != want {
+				t.Errorf("%s %s support = %v, want %v", modelID, field, got, want)
+			}
+		}
+		output, _ := supports["output"].([]string)
+		if !slices.Equal(output, []string{"text", "json"}) {
+			t.Errorf("%s output = %v, want [text json]", modelID, output)
+		}
+	}
+
+	// The Genkit config speaks the plugin's camelCase contract; the handler
+	// above asserts it reaches the wire as reasoning_effort.
+	config := map[string]any{"reasoningEffort": "high"}
+	t.Run("complete", func(t *testing.T) {
+		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Say hi."), ai.WithConfig(config))
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if got := resp.Reasoning(); got != "Think carefully." {
+			t.Fatalf("Reasoning() = %q, want %q", got, "Think carefully.")
+		}
+		if got := resp.Text(); got != "Grok completion works" {
+			t.Fatalf("Text() = %q, want %q", got, "Grok completion works")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		var reasoning, text strings.Builder
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithPrompt("Say hi, streamed."),
+			ai.WithConfig(config),
+			ai.WithStreaming(func(_ context.Context, chunk *ai.ModelResponseChunk) error {
+				reasoning.WriteString(chunk.Reasoning())
+				text.WriteString(chunk.Text())
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+		if got := reasoning.String(); got != "Think carefully." {
+			t.Fatalf("streamed reasoning = %q, want %q", got, "Think carefully.")
+		}
+		if got := text.String(); got != "Grok streaming works" {
+			t.Fatalf("streamed text = %q, want %q", got, "Grok streaming works")
+		}
+		if resp.Reasoning() != reasoning.String() {
+			t.Fatalf("final reasoning = %q, want streamed %q", resp.Reasoning(), reasoning.String())
+		}
+		if resp.Text() != text.String() {
+			t.Fatalf("final text = %q, want streamed %q", resp.Text(), text.String())
+		}
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestPluginHandlesToolCalls(t *testing.T) {
+	var mu sync.Mutex
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		reqNum := requests
+		mu.Unlock()
+		var body struct {
+			Messages   []map[string]any `json:"messages"`
+			Tools      []map[string]any `json:"tools"`
+			ToolChoice string           `json:"tool_choice"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if reqNum == 1 {
+			if len(body.Tools) != 1 {
+				t.Fatalf("tools = %#v, want one tool", body.Tools)
+			}
+			fn, ok := body.Tools[0]["function"].(map[string]any)
+			if !ok || fn["name"] != "lookup" {
+				t.Errorf("tool function = %#v, want name %q", body.Tools[0], "lookup")
+			}
+			// Grok models advertise tool choice, so the request carries it.
+			if body.ToolChoice != "required" {
+				t.Errorf("tool_choice = %q, want %q", body.ToolChoice, "required")
+			}
+
+			_, _ = io.WriteString(w, `{
+				"id":"c-tool-1","object":"chat.completion","created":1,"model":"grok-4.5",
+				"choices":[{
+					"index":0,
+					"message":{
+						"role":"assistant",
+						"content":null,
+						"tool_calls":[{"id":"call-1","type":"function","function":{"name":"lookup","arguments":"{\"value\":\"question\"}"}}]
+					},
+					"finish_reason":"tool_calls"
+				}]
+			}`)
+			return
+		}
+
+		var toolResult map[string]any
+		for _, m := range body.Messages {
+			if m["role"] == "tool" {
+				toolResult = m
+			}
+		}
+		if toolResult == nil || toolResult["tool_call_id"] != "call-1" {
+			t.Errorf("tool result = %#v, want tool_call_id %q", toolResult, "call-1")
+		}
+
+		_, _ = io.WriteString(w, `{
+			"id":"c-tool-2","object":"chat.completion","created":1,"model":"grok-4.5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"Tool loop complete"},"finish_reason":"stop"}]
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/v1")}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("xai/grok-4.5"))
+
+	lookup := genkit.DefineTool(g, "lookup", "Looks up a value.",
+		func(_ *ai.ToolContext, input struct {
+			Value string `json:"value"`
+		}) (string, error) {
+			return "result for " + input.Value, nil
+		},
+	)
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithPrompt("Use the lookup tool."),
+		ai.WithTools(lookup),
+		ai.WithToolChoice(ai.ToolChoiceRequired),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Text(); got != "Tool loop complete" {
+		t.Errorf("Text() = %q, want %q", got, "Tool loop complete")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 2 {
+		t.Errorf("requests = %d, want 2", requests)
+	}
+}
+
+// TestModelRefAndConfigSchema pins the call-site surface: the ref carries the
+// prefixed name and the typed config, and the registered models advertise the
+// camelCase config contract including the xAI-specific fields.
+func TestModelRefAndConfigSchema(t *testing.T) {
+	cfg := &xai.ChatConfig{ReasoningEffort: "low"}
+	for _, name := range []string{"grok-4.5", "xai/grok-4.5"} {
+		ref := xai.ModelRef(name, cfg)
+		if want := "xai/grok-4.5"; ref.Name() != want {
+			t.Errorf("ModelRef(%q).Name() = %q, want %q", name, ref.Name(), want)
+		}
+		if ref.Config() != cfg {
+			t.Errorf("ModelRef(%q).Config() = %v, want the config it was built with", name, ref.Config())
+		}
+	}
+
+	plugin := &xai.XAI{APIKey: "test-key"}
+	g := genkit.Init(context.Background(), genkit.WithPlugins(plugin))
+
+	m := genkit.LookupModel(g, "xai/grok-4.5")
+	if m == nil {
+		t.Fatalf("%s not registered by Init", "grok-4.5")
+	}
+	model := m.(api.Action).Desc().Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions missing, got %v", model["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions has no properties: %v", schema)
+	}
+	for _, key := range []string{"temperature", "maxOutputTokens", "stopSequences", "reasoningEffort", "version", "extra"} {
+		if props[key] == nil {
+			t.Errorf("config schema is missing the %q property", key)
+		}
+	}
+
+	// The constraints xAI documents ride on the schema, where the framework
+	// enforces them; the values are the ones docs.x.ai gives.
+	for field, want := range map[string]map[string]any{
+		"temperature":      {"minimum": 0.0, "maximum": 2.0},
+		"frequencyPenalty": {"minimum": -2.0, "maximum": 2.0},
+		"presencePenalty":  {"minimum": -2.0, "maximum": 2.0},
+		"topLogProbs":      {"minimum": 0.0, "maximum": 8.0},
+		"maxOutputTokens":  {"minimum": 1.0},
+		"stopSequences":    {"maxItems": 4.0},
+		"reasoningEffort":  {"enum": []any{"none", "low", "medium", "high", "xhigh"}},
+		"serviceTier":      {"enum": []any{"default", "priority"}},
+	} {
+		prop, _ := props[field].(map[string]any)
+		for key, value := range want {
+			if got := prop[key]; !reflect.DeepEqual(got, value) {
+				t.Errorf("%s %s = %#v, want %#v", field, key, got, value)
+			}
+		}
+	}
+	// topP deliberately carries no range: xAI documents none for it.
+	topP, _ := props["topP"].(map[string]any)
+	for _, key := range []string{"minimum", "maximum"} {
+		if got, has := topP[key]; has {
+			t.Errorf("topP %s = %v, want none since xAI documents no range", key, got)
+		}
+	}
+	// searchParameters is deliberately absent: xAI retired live search, and
+	// the API answers any request carrying it with 410 Gone.
+	if props["searchParameters"] != nil {
+		t.Error("config schema still declares searchParameters, which the API rejects with 410 Gone")
+	}
+}
+
+// TestConfigConstraintsRejected pins that a documented constraint is enforced,
+// not just advertised: validation runs against the schema the model declares,
+// so an out-of-range value or an unknown level fails the request before it is
+// sent and billed. The server answers success so that, were validation to let
+// one through, the test fails on the nil error rather than on a network call.
+func TestConfigConstraintsRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"grok-4.5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"should not be reached"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	for name, tc := range map[string]struct {
+		config map[string]any
+		field  string
+	}{
+		"temperature above 2":     {map[string]any{"temperature": 3}, "temperature"},
+		"unknown reasoning level": {map[string]any{"reasoningEffort": "ultra"}, "reasoningEffort"},
+		"fifth stop sequence":     {map[string]any{"stopSequences": []any{"a", "b", "c", "d", "e"}}, "stopSequences"},
+		"retired search field":    {map[string]any{"searchParameters": map[string]any{"mode": "on"}}, "searchParameters"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := genkit.Generate(ctx, g,
+				ai.WithModelName("xai/grok-4.5"),
+				ai.WithConfig(tc.config),
+				ai.WithPrompt("hi"),
+			)
+			if err == nil {
+				t.Fatal("Generate() error = nil, want the config rejected by schema validation")
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("error = %v, want it to name %q", err, tc.field)
+			}
+		})
+	}
+}
+
+// TestModelRefConfigReachesTheWire pins the whole typed path: a ModelRef
+// carrying a typed ChatConfig passes the framework's schema validation, the
+// common fields land on their wire names (with maxOutputTokens moved to the
+// max_completion_tokens xAI wants instead of the deprecated max_tokens), all
+// in one Generate call.
+func TestModelRefConfigReachesTheWire(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model               string  `json:"model"`
+			Temperature         float64 `json:"temperature"`
+			MaxTokens           *int    `json:"max_tokens"`
+			MaxCompletionTokens int     `json:"max_completion_tokens"`
+			ReasoningEffort     string  `json:"reasoning_effort"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if body.Model != "grok-4.5-latest" {
+			t.Errorf("model = %q, want the pinned version %q", body.Model, "grok-4.5-latest")
+		}
+		if body.Temperature != 0.3 {
+			t.Errorf("temperature = %v, want 0.3", body.Temperature)
+		}
+		if body.MaxTokens != nil {
+			t.Errorf("max_tokens = %v, want it moved to max_completion_tokens", *body.MaxTokens)
+		}
+		if body.MaxCompletionTokens != 512 {
+			t.Errorf("max_completion_tokens = %v, want 512", body.MaxCompletionTokens)
+		}
+		if body.ReasoningEffort != "high" {
+			t.Errorf("reasoning_effort = %q, want %q", body.ReasoningEffort, "high")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"grok-4.5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"typed config works"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModel(xai.ModelRef("grok-4.5", &xai.ChatConfig{
+			RequestConfig:   compat_oai.RequestConfig{Version: "grok-4.5-latest"},
+			Temperature:     openai.Ptr(0.3),
+			MaxOutputTokens: 512,
+			ReasoningEffort: "high",
+		})),
+		ai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Text(); got != "typed config works" {
+		t.Fatalf("Text() = %q, want %q", got, "typed config works")
+	}
+}
+
+// TestRequestControlsReachTheWire pins the xAI request controls that are not
+// generation settings. The config type is the only way to set them, since the
+// schema it advertises admits no properties of its own, so a field missing
+// here is a field no caller can reach.
+func TestRequestControlsReachTheWire(t *testing.T) {
+	var mu sync.Mutex
+	var body struct {
+		ParallelToolCalls *bool  `json:"parallel_tool_calls"`
+		User              string `json:"user"`
+		ServiceTier       string `json:"service_tier"`
+		PromptCacheKey    string `json:"prompt_cache_key"`
+		ReasoningEffort   string `json:"reasoning_effort"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		err := json.NewDecoder(r.Body).Decode(&body)
+		mu.Unlock()
+		if err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"grok-4.6",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"end_turn"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModel(xai.ModelRef("grok-4.6", &xai.ChatConfig{
+			ReasoningEffort:   xai.ReasoningEffortXHigh,
+			ParallelToolCalls: openai.Ptr(false),
+			User:              "user-7",
+			ServiceTier:       xai.ServiceTierPriority,
+			PromptCacheKey:    "prefix-a",
+		})),
+		ai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	// end_turn is xAI's own finish reason for an answer the model chose to end.
+	if resp.FinishReason != ai.FinishReasonStop {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, ai.FinishReasonStop)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if body.ParallelToolCalls == nil || *body.ParallelToolCalls {
+		t.Errorf("parallel_tool_calls = %v, want false", body.ParallelToolCalls)
+	}
+	for _, tc := range []struct{ field, got, want string }{
+		{"user", body.User, "user-7"},
+		{"service_tier", body.ServiceTier, "priority"},
+		{"prompt_cache_key", body.PromptCacheKey, "prefix-a"},
+		{"reasoning_effort", body.ReasoningEffort, "xhigh"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.field, tc.got, tc.want)
+		}
+	}
+}
+
+// TestCitationsReachTheCaller pins the response-metadata mapping: a
+// completion carrying a citations array and a num_sources_used usage field
+// hands both to the caller, the sources on the response metadata and the
+// count on the usage's custom counters.
+func TestCitationsReachTheCaller(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"grok-4.6",
+			"citations":["https://x.ai/news","https://x.com/xai"],
+			"choices":[{"index":0,"message":{"role":"assistant","content":"searched"},"finish_reason":"end_turn"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2,"num_sources_used":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("xai/grok-4.6"),
+		ai.WithPrompt("What did xAI announce?"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	custom, _ := resp.Custom.(map[string]any)
+	got, _ := custom["citations"].([]any)
+	want := []any{"https://x.ai/news", "https://x.com/xai"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("custom[citations] = %#v, want %#v", got, want)
+	}
+	if n := resp.Usage.Custom["numSourcesUsed"]; n != 2 {
+		t.Errorf("Usage.Custom[numSourcesUsed] = %v, want 2", n)
+	}
+}
+
+// TestJSONConfigExtraRidesTheWire pins the JSON contract of the inherited
+// passthrough: a map config (what the Dev UI and cross-runtime callers send)
+// passes this plugin's schema validation and its extra fields reach the wire
+// under xAI's own names.
+func TestJSONConfigExtraRidesTheWire(t *testing.T) {
+	var mu sync.Mutex
+	var deferred *bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Deferred *bool `json:"deferred"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		mu.Lock()
+		deferred = body.Deferred
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"grok-4.5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"searched"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin), genkit.WithDefaultModel("xai/grok-4.5"))
+
+	if _, err := genkit.Generate(ctx, g,
+		ai.WithPrompt("What is new?"),
+		ai.WithConfig(map[string]any{
+			// deferred is a field the config does not declare, riding the
+			// inherited passthrough.
+			"extra": map[string]any{"deferred": true},
+		}),
+	); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if deferred == nil || !*deferred {
+		t.Errorf("deferred = %v, want the config's extra field on the wire", deferred)
+	}
+}
+
+// TestDynamicListingAndResolution pins the on-demand surface: models the
+// endpoint reports are listed with the plugin's config schema, and generating
+// with an uncurated name resolves it instead of failing with model-not-found.
+func TestDynamicListingAndResolution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/models" {
+			_, _ = io.WriteString(w, `{"object":"list","data":[{"id":"grok-brand-new","object":"model"}]}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"grok-brand-new",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"resolved"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &xai.XAI{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL + "/v1")}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	var listed *api.ActionDesc
+	for _, desc := range plugin.ListActions(ctx) {
+		if desc.Name == "xai/grok-brand-new" {
+			listed = &desc
+			break
+		}
+	}
+	if listed == nil {
+		t.Fatal("ListActions() does not include the endpoint's model")
+	}
+	model := listed.Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("listed model has no customOptions: %v", model)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if props["reasoningEffort"] == nil {
+		t.Error("listed model schema is missing the plugin's reasoningEffort property")
+	}
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("xai/grok-brand-new"),
+		ai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("Generate() with an uncurated model error = %v", err)
+	}
+	if got := resp.Text(); got != "resolved" {
+		t.Fatalf("Text() = %q, want %q", got, "resolved")
+	}
+}
+
+// TestConstrainedSupport pins the Grok 4 family carve-out. xAI documents that
+// structured outputs combined with tools is only available on Grok 4 family
+// models, so anything else must advertise no-tools rather than all, and a
+// model resolved dynamically takes the narrower value since it may not be
+// Grok 4. Claiming all where it does not hold would drop the schema
+// instructions Genkit injects into the prompt for a request carrying tools.
+func TestConstrainedSupport(t *testing.T) {
+	t.Setenv("XAI_API_KEY", "test-key")
+
+	ctx := context.Background()
+	plugin := &xai.XAI{}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	constrained := func(a api.Action) ai.ConstrainedSupport {
+		t.Helper()
+		supports := a.Desc().Metadata["model"].(map[string]any)["supports"].(map[string]any)
+		got, _ := supports["constrained"].(ai.ConstrainedSupport)
+		return got
+	}
+
+	for id, want := range map[string]ai.ConstrainedSupport{
+		"grok-4.6":                     ai.ConstrainedSupportAll,
+		"grok-4.5":                     ai.ConstrainedSupportAll,
+		"grok-4.3":                     ai.ConstrainedSupportAll,
+		"grok-4.20-0309-reasoning":     ai.ConstrainedSupportAll,
+		"grok-4.20-0309-non-reasoning": ai.ConstrainedSupportAll,
+		"grok-4.20-multi-agent-0309":   ai.ConstrainedSupportAll,
+		"grok-build-0.1":               ai.ConstrainedSupportNoTools,
+	} {
+		m := genkit.LookupModel(g, "xai/"+id)
+		if m == nil {
+			t.Errorf("LookupModel(%q) = nil", id)
+			continue
+		}
+		if got := constrained(m.(api.Action)); got != want {
+			t.Errorf("%s constrained = %q, want %q", id, got, want)
+		}
+	}
+
+	// A model xAI adds later may sit outside the Grok 4 family.
+	resolved := plugin.ResolveAction(api.ActionTypeModel, "grok-not-yet-released")
+	if resolved == nil {
+		t.Fatal("ResolveAction returned nil for an unknown model")
+	}
+	if got := constrained(resolved); got != ai.ConstrainedSupportNoTools {
+		t.Errorf("dynamic constrained = %q, want %q", got, ai.ConstrainedSupportNoTools)
+	}
+}

--- a/go/samples/compat_oai/xai/main.go
+++ b/go/samples/compat_oai/xai/main.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This sample demonstrates the xAI plugin for the Grok models: a flow that
+// generates a joke with a model pinned through xai.ModelRef and its typed
+// config.
+//
+// To run:
+//
+//	export XAI_API_KEY=...
+//	go run .
+//
+// In another terminal:
+//
+//	curl -X POST http://localhost:8080/jokesFlow \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": "bananas"}'
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/xai"
+	"github.com/firebase/genkit/go/plugins/server"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// The plugin reads the API key from the XAI_API_KEY environment variable.
+	g := genkit.Init(ctx, genkit.WithPlugins(&xai.XAI{}))
+
+	// Define a flow that generates a joke about a given topic. Grok models
+	// reason before answering; low effort keeps a quick joke quick.
+	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		if topic == "" {
+			topic = "airplane food"
+		}
+
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(xai.ModelRef("grok-4.6", &xai.ChatConfig{
+				ReasoningEffort: xai.ReasoningEffortLow,
+			})),
+			ai.WithPrompt("Share a joke about %s.", topic),
+		)
+	})
+
+	// Optionally, start a web server to make the flow callable via HTTP.
+	mux := http.NewServeMux()
+	for _, a := range genkit.ListFlows(g) {
+		mux.HandleFunc("POST /"+a.Name(), genkit.Handler(a))
+	}
+	log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+}


### PR DESCRIPTION
Adds an xAI plugin for Grok on the typed-config base (#5976); stacked on #6035. This is the last PR of the train.

## The plugin and its config, at a glance

```go
type XAI struct {
	APIKey string
	Opts   []option.RequestOption
	Models map[string]ai.ModelOptions
}

type ChatConfig struct {
	compat_oai.RequestConfig
	Temperature       *float64          `json:"temperature,omitempty"`
	TopP              *float64          `json:"topP,omitempty"`
	MaxOutputTokens   int               `json:"maxOutputTokens,omitempty"`
	StopSequences     []string          `json:"stopSequences,omitempty"`
	FrequencyPenalty  *float64          `json:"frequencyPenalty,omitempty"`
	PresencePenalty   *float64          `json:"presencePenalty,omitempty"`
	LogProbs          *bool             `json:"logProbs,omitempty"`
	TopLogProbs       *int              `json:"topLogProbs,omitempty"`
	Seed              *int              `json:"seed,omitempty"`
	ReasoningEffort   ReasoningEffort   `json:"reasoningEffort,omitempty"`
	ParallelToolCalls *bool             `json:"parallelToolCalls,omitempty"`
	User              string            `json:"user,omitempty"`
	PromptCacheKey    string            `json:"promptCacheKey,omitempty"`
	ServiceTier       ServiceTier     `json:"serviceTier,omitempty"`
}

type ReasoningEffort string // "none", "low", "medium", "high", "xhigh"

type ServiceTier string // "default", "priority"
```

The schema enforces xAI's documented limits: `temperature` 0 to 2, both penalties within plus or minus 2, `top_logprobs` 0 to 8, up to four stop sequences; `topP` declares no range because xAI documents none (pinned by a test). Two fields are named types of this package:

- `ReasoningEffort` enumerates the union of the two level sets xAI publishes (`none` through `high` in the chat completions reference, `low` through `xhigh` in the capability guide). Which subset a model takes is xAI's to decide, so a level a model rejects errors from xAI rather than from here.
- `ServiceTier` enumerates `default` and `priority`; the SDK's own type offers `auto`, `flex`, and `scale`, all of which xAI rejects.

Live search is retired on xAI's side: any request carrying `search_parameters` answers `410 Gone` pointing at its Agent Tools successors (Responses API tools, out of this endpoint's reach), so the config does not model search and the schema rejects the key by name. The response side keeps its mapping: `citations`, `num_sources_used`, and the image token breakdown still reach the caller through the response metadata (`Raw`, and the deprecated `Custom`) and the usage counters, read off the chunk directly when streaming since the SDK accumulator rebuilds the completion only from fields it models. `end_turn`, the ordinary completed-answer finish reason, maps under `FinishReasonStop`.

The catalog curates Grok 4 through 4.6 on the shared `ModelOptionsFor` overlay with a `Models` field. Constrained generation is claimed inside the Grok 4 family, where xAI documents `json_schema`; outside it (`grok-build-0.1`, and anything xAI adds later) the plugin claims `no-tools`, since xAI supports schemas there but not alongside tools. The conformance sweep now covers the whole family. A runnable sample lives at `go/samples/compat_oai/xai`, verified against the live API.

**Deliberately absent:** no curated `grok-4.20-multi-agent-0309`, which xAI serves only through the Responses API and its own SDK; chat completions rejects it with "Multi Agent requests are not allowed on chat completions" (verified live), so it rides dynamic listing only, like the imagine models. No `web_search`/`x_search` server-side tools (Responses API tools, while chat completions takes function tools only) and no `search_parameters`, retired above; no `n`, which bills for choices Genkit never reads; no `deferred`, which answers with a request ID to poll rather than a completion (the extra-passthrough test sends it anyway to prove undeclared fields ride).

```go
// Added (new package)
type XAI struct { APIKey string; Opts []option.RequestOption; Models map[string]ai.ModelOptions; ... }
type ChatConfig struct { compat_oai.RequestConfig; Temperature *float64; TopP *float64; MaxOutputTokens int; StopSequences []string; FrequencyPenalty *float64; PresencePenalty *float64; LogProbs *bool; TopLogProbs *int; Seed *int; ReasoningEffort ReasoningEffort; ParallelToolCalls *bool; User string; PromptCacheKey string; ServiceTier ServiceTier }
type ReasoningEffort string   // None, Low, Medium, High, XHigh
type ServiceTier string       // Default, Priority
func ModelRef(id string, config *ChatConfig) ai.ModelRef
```

## Testing

Go 1.26.3: `go build ./...` and full `go test ./...` in `go/` pass at the top of the stack, 44 packages with no failures; the `compat_oai` tree is 9 packages (one the test-only live harness) and 184 cases counting subtests, 20 of them here. The schema test pins every constraint including the enum unions and the deliberate absence of a `topP` range, and an httptest-backed suite drives a violation of each constraint kind through a real request to prove rejection happens before the wire. The live tests run the shared checklist from the base PR's `internal/livetest` harness (Grok takes the effort knob but keeps the reasoning content server-side) plus an `xhigh` case on `grok-4.6`, the one model xAI documents that level for. Against the real API: 17/17 pass, native structured output, vision, and `xhigh` included.


