### PR TITLE
fix(py): enforce strict ID validation and error handling in get_snapshot

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
@@ -73,17 +73,33 @@ def parse_snapshot_lookup_kw(
     snapshot_id: str | None = None,
     session_id: str | None = None,
 ) -> tuple[str | None, str | None]:
-    """Require exactly one of ``snapshot_id`` or ``session_id``.
+    """Require exactly one non-blank ``snapshot_id`` or ``session_id``.
 
-    A bad selector is a caller mistake, so it raises ``INVALID_ARGUMENT`` — over a
-    transport that surfaces as a 400, not a 500 the way a bare ``ValueError`` would.
+    Whitespace-only ids are rejected so they can't become unusable document keys.
+    A bad selector raises ``INVALID_ARGUMENT`` (400 over HTTP), not a bare
+    ``ValueError``.
     """
-    if bool(snapshot_id) == bool(session_id):
+    if snapshot_id and not snapshot_id.strip():
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=f'get_snapshot rejected whitespace-only snapshot_id={snapshot_id!r}.',
+        )
+    if session_id and not session_id.strip():
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=f'get_snapshot rejected whitespace-only session_id={session_id!r}.',
+        )
+    if not snapshot_id and not session_id:
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=("get_snapshot requires exactly one of 'snapshot_id' or 'session_id' (got neither)."),
+        )
+    if snapshot_id and session_id:
         raise GenkitError(
             status='INVALID_ARGUMENT',
             message=(
                 "get_snapshot requires exactly one of 'snapshot_id' or 'session_id' "
-                f'(got snapshot_id={snapshot_id!r}, session_id={session_id!r}).'
+                f'(got both snapshot_id={snapshot_id!r} and session_id={session_id!r}).'
             ),
         )
     return snapshot_id, session_id
@@ -137,6 +153,12 @@ async def resolve_snapshot(
     state_transform: StateTransform | None = None,
     context: dict[str, Any] | None = None,
 ) -> SessionSnapshot | None:
+    """Load a snapshot for clients, applying read-time liveness overlays.
+
+    A pending snapshot whose heartbeat has gone stale is returned as
+    ``expired`` here. That overlay is not persisted and does not appear on
+    ``on_snapshot_status_change`` streams.
+    """
     snapshot_id, session_id = parse_snapshot_lookup_kw(snapshot_id=snapshot_id, session_id=session_id)
     if snapshot_id is not None:
         snapshot = await store.get_snapshot(snapshot_id=snapshot_id, context=context)
@@ -172,10 +194,10 @@ async def abort_snapshot_in_store(
     There's no dedicated store abort call: aborting is an ordinary atomic
     snapshot write whose mutator flips a still-pending turn to aborted and leaves
     an already-finished one untouched, so a late abort never rewrites a
-    completed/failed result. The write also notifies any status subscribers,
-    which is how a detached turn learns it was aborted. Returns the snapshot's
-    resulting status (aborted when this call did the flip), or None if it doesn't
-    exist.
+    completed/failed result. Detached workers notice the flip through their
+    store's status subscription (in-memory notify, or a durable watch after
+    commit). Returns the snapshot's resulting status (aborted when this call did
+    the flip), or None if it doesn't exist.
     """
     saved = await store.save_snapshot(snapshot_id, abort_if_pending, context=context)
     if saved is not None:

--- a/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
@@ -123,6 +123,19 @@ async def test_get_snapshot_requires_exactly_one_selector() -> None:
         await store.get_snapshot(snapshot_id='a', session_id='b')
 
 
+@pytest.mark.asyncio
+async def test_get_snapshot_rejects_whitespace_only_selector() -> None:
+    """Whitespace-only ids are rejected (unusable as document keys)."""
+    store = InMemorySessionStore()
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='   ')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(session_id='\t')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
 # --- Abort lifecycle ---
 
 


### PR DESCRIPTION
## Summary

Strictens selector parsing in `parse_snapshot_lookup_kw` for `get_snapshot`:

- **Whitespace Validation**: Rejects whitespace-only `snapshot_id` or `session_id` with an `INVALID_ARGUMENT` error so invalid strings cannot become corrupt document keys.
- **Clearer Error Messages**: Explicitly differentiates between callers providing neither selector vs both selectors.