### PR TITLE
feat(go/plugins/anthropic): add `Opts` to pass SDK request options through

### DIFF
--- a/go/plugins/anthropic/anthropic.go
+++ b/go/plugins/anthropic/anthropic.go
@@ -57,13 +57,27 @@ var dateSuffix = regexp.MustCompile(`-\d{8}$`)
 type Anthropic struct {
 	// APIKey is the key requests are authenticated with. When empty, the
 	// ANTHROPIC_API_KEY environment variable is used, and [Anthropic.Init]
-	// panics if that is empty too.
+	// panics unless authentication arrives another way: an auth token in
+	// ANTHROPIC_AUTH_TOKEN, or a non-empty Opts.
 	APIKey string
 
 	// BaseURL overrides the API endpoint requests are sent to. When empty, the
 	// ANTHROPIC_BASE_URL environment variable is used, and failing that the
 	// SDK's own default.
 	BaseURL string
+
+	// Opts are anthropic-sdk-go request options applied to every request the
+	// client sends. They open the SDK's full client configuration to the
+	// plugin: [option.WithMiddleware], [option.WithMaxRetries],
+	// [option.WithRequestTimeout], extra headers, and the SDK's bedrock and
+	// vertex packages, whose routing helpers are request options too.
+	//
+	// They are applied after the options derived from APIKey and BaseURL, and
+	// the SDK applies options in order, so an option here wins over those
+	// fields on conflict. Options are opaque, so a non-empty Opts is trusted
+	// to carry authentication when no API key is configured; that is what
+	// makes key-less setups such as Bedrock or Vertex routing work.
+	Opts []option.RequestOption
 
 	// Models overrides what the plugin knows about a Claude model, keyed by
 	// model ID, bare or provider-prefixed. Every Claude model already works
@@ -99,7 +113,9 @@ func (a *Anthropic) Name() string {
 // Init prepares the plugin to serve models and registers none: every Claude
 // model arrives through [Anthropic.ResolveAction] on first use.
 //
-// It panics when no API key is configured and when called twice, both being
+// It panics when no authentication is configured (an API key in APIKey or
+// ANTHROPIC_API_KEY, an auth token in ANTHROPIC_AUTH_TOKEN, or a non-empty
+// Opts, which is trusted to carry its own) and when called twice, both being
 // setup mistakes rather than conditions an application can recover from.
 func (a *Anthropic) Init(ctx context.Context) []api.Action {
 	if a == nil {
@@ -116,11 +132,14 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 	if apiKey == "" {
 		apiKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	if apiKey == "" {
-		panic("Anthropic requires setting ANTHROPIC_API_KEY in the environment")
+	if apiKey == "" && os.Getenv("ANTHROPIC_AUTH_TOKEN") == "" && len(a.Opts) == 0 {
+		panic("Anthropic requires authentication: set APIKey, set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN in the environment, or carry it in Opts")
 	}
 
-	opts := []option.RequestOption{option.WithAPIKey(apiKey)}
+	var opts []option.RequestOption
+	if apiKey != "" {
+		opts = append(opts, option.WithAPIKey(apiKey))
+	}
 
 	baseURL := a.BaseURL
 	if baseURL == "" {
@@ -129,6 +148,9 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 	if baseURL != "" {
 		opts = append(opts, option.WithBaseURL(baseURL))
 	}
+
+	// The caller's options come last so they win over the fields above.
+	opts = append(opts, a.Opts...)
 
 	a.client = anthropic.NewClient(opts...)
 	a.initted = true

--- a/go/plugins/anthropic/anthropic.go
+++ b/go/plugins/anthropic/anthropic.go
@@ -74,9 +74,17 @@ type Anthropic struct {
 	//
 	// They are applied after the options derived from APIKey and BaseURL, and
 	// the SDK applies options in order, so an option here wins over those
-	// fields on conflict. Options are opaque, so a non-empty Opts is trusted
-	// to carry authentication when no API key is configured; that is what
-	// makes key-less setups such as Bedrock or Vertex routing work.
+	// fields when it sets the same setting. Distinct settings do not displace
+	// each other: the API key rides an X-Api-Key header and an auth token an
+	// authorization header, so a configured key (here, in APIKey, or in
+	// ANTHROPIC_API_KEY, which the SDK reads on its own) is still sent
+	// alongside whatever Opts configure. A key-less setup such as Bedrock or
+	// Vertex routing therefore needs the key unset everywhere, or an
+	// [option.WithHeaderDel] for X-Api-Key here, which applies after the key
+	// options and so strips the header.
+	//
+	// Options are opaque, so a non-empty Opts is trusted to carry
+	// authentication when no API key is configured.
 	Opts []option.RequestOption
 
 	// Models overrides what the plugin knows about a Claude model, keyed by

--- a/go/plugins/anthropic/anthropic_test.go
+++ b/go/plugins/anthropic/anthropic_test.go
@@ -23,9 +23,11 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
@@ -272,6 +274,112 @@ func modelsListServer(t *testing.T) string {
 	}))
 	t.Cleanup(server.Close)
 	return server.URL
+}
+
+// recordingModelsServer is [modelsListServer] with the headers of the most
+// recent request captured, so a test can observe what the client sent.
+func recordingModelsServer(t *testing.T) (url string, lastHeader func() http.Header) {
+	t.Helper()
+	var mu sync.Mutex
+	var header http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		header = r.Header.Clone()
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"id":"claude-opus-4-5-20251101","type":"model"}],"has_more":false}`)
+	}))
+	t.Cleanup(server.Close)
+	return server.URL, func() http.Header {
+		mu.Lock()
+		defer mu.Unlock()
+		return header
+	}
+}
+
+// TestInitRequiresAuth pins the panic when no authentication is configured
+// anywhere: no APIKey, no key or token in the environment, and no Opts.
+func TestInitRequiresAuth(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Init did not panic with no authentication configured")
+		}
+	}()
+	(&Anthropic{}).Init(context.Background())
+}
+
+// TestInitAuthTokenSuffices covers the bearer-token setups the SDK serves
+// from ANTHROPIC_AUTH_TOKEN on its own: the plugin must not demand an API
+// key on top of one.
+func TestInitAuthTokenSuffices(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "test-token")
+	(&Anthropic{}).Init(context.Background())
+}
+
+// TestInitOptsCarryAuth covers the key-less setups Opts exists for (the SDK's
+// Bedrock and Vertex routing options sign requests themselves): a non-empty
+// Opts waives the API-key requirement, and its options reach every request
+// the client sends.
+func TestInitOptsCarryAuth(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+
+	url, lastHeader := recordingModelsServer(t)
+	a := &Anthropic{Opts: []option.RequestOption{
+		option.WithBaseURL(url),
+		option.WithHeader("X-Test-Opt", "carried"),
+	}}
+	a.Init(context.Background())
+
+	if actions := a.ListActions(context.Background()); len(actions) == 0 {
+		t.Fatal("ListActions() = empty, want the served model list")
+	}
+	header := lastHeader()
+	if header == nil {
+		t.Fatal("the server saw no request")
+	}
+	if got := header.Get("X-Test-Opt"); got != "carried" {
+		t.Errorf("X-Test-Opt = %q, want %q", got, "carried")
+	}
+	if got := header.Get("X-Api-Key"); got != "" {
+		t.Errorf("x-api-key = %q, want none with no key configured", got)
+	}
+}
+
+// TestInitOptsWinOverFields pins the precedence contract: the options derived
+// from APIKey and BaseURL are applied first and the SDK applies options in
+// order, so an explicit option in Opts overrides both fields.
+func TestInitOptsWinOverFields(t *testing.T) {
+	fieldURL, fieldHeader := recordingModelsServer(t)
+	optsURL, optsHeader := recordingModelsServer(t)
+
+	a := &Anthropic{
+		APIKey:  "field-key",
+		BaseURL: fieldURL,
+		Opts: []option.RequestOption{
+			option.WithBaseURL(optsURL),
+			option.WithAPIKey("opts-key"),
+		},
+	}
+	a.Init(context.Background())
+
+	if actions := a.ListActions(context.Background()); len(actions) == 0 {
+		t.Fatal("ListActions() = empty, want the served model list")
+	}
+	if fieldHeader() != nil {
+		t.Error("the BaseURL field's server saw a request, want the Opts base URL to win")
+	}
+	header := optsHeader()
+	if header == nil {
+		t.Fatal("the Opts base URL's server saw no request")
+	}
+	if got := header.Get("X-Api-Key"); got != "opts-key" {
+		t.Errorf("x-api-key = %q, want the Opts key %q", got, "opts-key")
+	}
 }
 
 // TestModelsOverrideReachesResolution is the reason capabilities live in plugin

--- a/go/plugins/anthropic/anthropic_test.go
+++ b/go/plugins/anthropic/anthropic_test.go
@@ -382,6 +382,56 @@ func TestInitOptsWinOverFields(t *testing.T) {
 	}
 }
 
+// TestInitAPIKeyRidesAlongsideOptsAuth pins the limit of "wins over those
+// fields": the API key and an auth token are distinct settings riding
+// distinct headers, so an auth token in Opts displaces nothing and a
+// configured key still goes out beside it.
+func TestInitAPIKeyRidesAlongsideOptsAuth(t *testing.T) {
+	url, lastHeader := recordingModelsServer(t)
+	a := &Anthropic{
+		APIKey: "field-key",
+		Opts: []option.RequestOption{
+			option.WithBaseURL(url),
+			option.WithAuthToken("opts-token"),
+		},
+	}
+	a.Init(context.Background())
+
+	if actions := a.ListActions(context.Background()); len(actions) == 0 {
+		t.Fatal("ListActions() = empty, want the served model list")
+	}
+	header := lastHeader()
+	if got := header.Get("Authorization"); got != "Bearer opts-token" {
+		t.Errorf("authorization = %q, want the Opts token", got)
+	}
+	if got := header.Get("X-Api-Key"); got != "field-key" {
+		t.Errorf("x-api-key = %q, want the configured key still sent beside the token", got)
+	}
+}
+
+// TestInitHeaderDelStripsAPIKey pins the documented escape hatch for setups
+// that cannot keep a key out of the environment: a WithHeaderDel in Opts
+// applies after the options derived from APIKey, so it removes the key
+// header before the request goes out.
+func TestInitHeaderDelStripsAPIKey(t *testing.T) {
+	url, lastHeader := recordingModelsServer(t)
+	a := &Anthropic{
+		APIKey: "field-key",
+		Opts: []option.RequestOption{
+			option.WithBaseURL(url),
+			option.WithHeaderDel("X-Api-Key"),
+		},
+	}
+	a.Init(context.Background())
+
+	if actions := a.ListActions(context.Background()); len(actions) == 0 {
+		t.Fatal("ListActions() = empty, want the served model list")
+	}
+	if got := lastHeader().Get("X-Api-Key"); got != "" {
+		t.Errorf("x-api-key = %q, want it stripped by WithHeaderDel", got)
+	}
+}
+
 // TestModelsOverrideReachesResolution is the reason capabilities live in plugin
 // config. Nothing registers the model up front: the first lookup drives the
 // plugin's ResolveAction, and the caller's entry is what describes what comes


### PR DESCRIPTION
Adds `Opts []option.RequestOption` to the `Anthropic` plugin, opening the anthropic-sdk-go client configuration that had no way in: `option.WithMiddleware`, `option.WithMaxRetries`, `option.WithRequestTimeout`, extra headers, and the SDK's `bedrock` and `vertex` packages, whose routing helpers are request options too. `compat_oai` carries the same field for the same reason: a Stainless SDK's functional options are its entire client-config language, so the plugin passes the language through rather than re-enumerating it as fields.

The options derived from `APIKey` and `BaseURL` are applied first and the SDK applies options in order, so an explicit option in `Opts` wins on conflict, matching `compat_oai`'s precedence.

```go
// Tune the transport.
&anthropic.Anthropic{Opts: []option.RequestOption{
	option.WithMaxRetries(5),
	option.WithRequestTimeout(30 * time.Second),
}}

// Claude on Bedrock: the routing option signs requests, no API key involved.
&anthropic.Anthropic{Opts: []option.RequestOption{bedrock.WithLoadDefaultConfig(ctx)}}
```

## The API-key panic now fires only when nothing authenticates

Init panicked without an API key, which killed exactly the setups `Opts` exists for: the SDK's Bedrock and Vertex options sign requests themselves, and the SDK serves `ANTHROPIC_AUTH_TOKEN` bearer auth from the environment on its own, yet the plugin refused to start before any of that could apply. The panic now fires only when no authentication is configured anywhere: no key in `APIKey` or `ANTHROPIC_API_KEY`, no `ANTHROPIC_AUTH_TOKEN`, and no `Opts`. Options are opaque, so a non-empty `Opts` is trusted to carry authentication. A strict relaxation: every setup that started before starts identically.

## Scope

**No more flat fields.** `Headers`, `HTTPClient`, and the like stay out: `option.WithHeader` and `option.WithHTTPClient` already say it in the SDK's own words. `APIKey` and `BaseURL` stay as the two flat conveniences every plugin names the same way.

**Client-level only.** Nothing threads per-request options; the SDK carries them outside the params type, so that is its own design if ever needed.

## Testing

Go 1.26.3, `go test -race ./plugins/anthropic/`: 22 tests pass, four of them new, covering the auth waiver, `ANTHROPIC_AUTH_TOKEN`-only startup, option application, and field-vs-`Opts` precedence, observed at a recording `httptest` server.
