### PR TITLE
feat(py/plugins/amazon-bedrock): add rerank helper (Cohere, Amazon)

### DIFF
--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -3,10 +3,11 @@
 Amazon Bedrock plugin for Genkit Python. Provides text generation with
 Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama, Mistral,
 Cohere, and others) through the Bedrock Converse and ConverseStream APIs, and
-embeddings and image generation through InvokeModel.
+embeddings, image generation, and reranking through InvokeModel.
 
-> Status: in progress. Text generation (streaming and non-streaming),
-> embedders, and image generation are available. Reranking is still to come.
+> Status: text generation (streaming and non-streaming), embedders, image
+> generation, and reranking are available. The work left is sample app and
+> docsite coverage, not plugin surfaces.
 
 ## Installation
 
@@ -239,6 +240,79 @@ Notes:
 - Nova Canvas may return fewer images than `numberOfImages` asked for.
   Individually content-filtered images are dropped silently, and the plugin
   returns whatever arrived.
+
+## Reranking
+
+Reranking scores documents against a query, so a retrieval step can return its
+hits in relevance order. It is a method on the plugin instance rather than a
+Genkit action, so keep a reference to the `Bedrock` you pass to `Genkit`:
+
+```python
+from genkit import Document, Genkit
+from genkit_amazon_bedrock import Bedrock, BedrockRerankOptions
+
+bedrock = Bedrock(region='us-east-1')
+ai = Genkit(plugins=[bedrock])
+
+response = await bedrock.rerank(
+    'cohere.rerank-v3-5:0',
+    query='How do I configure authentication for Bedrock?',
+    documents=[
+        Document.from_text('Configure AWS credentials with environment variables or AWS SSO.'),
+        Document.from_text('Nova Canvas returns generated images as base64-encoded PNG data.'),
+        Document.from_text('Model access is granted per account and region in the Bedrock console.'),
+    ],
+    options=BedrockRerankOptions(top_n=2),
+)
+
+for document in response.documents:
+    print(document.metadata.score, document.content[0].root.text)
+```
+
+Genkit Python has no reranker primitive: `ActionKind.RERANKER` exists as a bare
+enum member, and the request and response types are not generated, so there is
+nothing to register an action against. The Go plugin's `Rerank` is a standalone
+function for the same reason. The types this plugin exports
+(`BedrockRerankOptions`, `RankedDocumentData`, `RankedDocumentMetadata`,
+`RerankerRequest`, `RerankerResponse`) mirror the schema types by the same
+names.
+
+Notes:
+
+- `top_n` (`topN` when the options are passed as a dict) is clamped down to the
+  number of documents sent, and `<= 0` or unset means all of them.
+- Results arrive in the service's descending-relevance order and are neither
+  re-sorted nor truncated client-side.
+- A ranked document carries the input document's content verbatim and fresh
+  `{score}` metadata. The input document's own metadata is not carried through.
+- Rerank models have no Converse path, so they never resolve as chat models.
+  Listing one in `models=` is ignored; pass the ID to `rerank()` instead.
+- Only `bedrock:InvokeModel` is required. `bedrock:Rerank` is not: that
+  permission belongs to the separate Bedrock Agent Runtime `Rerank` API, which
+  this plugin does not call.
+
+### Model support
+
+Verified against `aws bedrock get-foundation-model` on 2026-08-11, and matching
+AWS's [supported regions and models for reranking](https://docs.aws.amazon.com/bedrock/latest/userguide/rerank-supported.html):
+
+| Model                  | Status | Regions                                                                    |
+| ---------------------- | ------ | -------------------------------------------------------------------------- |
+| `cohere.rerank-v3-5:0` | Active | `us-east-1`, `us-west-2`, `eu-central-1`, `ap-northeast-1`, `ca-central-1` |
+| `amazon.rerank-v1:0`   | Active | `us-west-2`, `eu-central-1`, `ap-northeast-1`, `ca-central-1`              |
+
+**`amazon.rerank-v1:0` is not offered in `us-east-1`.** Only
+`cohere.rerank-v3-5:0` covers every region on the list, so a setup that defaults
+to `us-east-1` has one rerank model available, not two.
+
+The two families take different bodies, so the request is built from the model
+ID. Both send `query`, `documents` and `top_n`; only Cohere takes
+`api_version`, whose schema requires the key, while the Amazon schema rejects
+any body carrying it. An ID matching neither family gets the Cohere body, that
+being the only shape AWS documents for InvokeModel reranking.
+
+Any model ID is passed to InvokeModel verbatim, so inference profiles and ARNs
+work too.
 
 ## License
 

--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -271,8 +271,7 @@ for document in response.documents:
 
 Genkit Python has no reranker primitive: `ActionKind.RERANKER` exists as a bare
 enum member, and the request and response types are not generated, so there is
-nothing to register an action against. The Go plugin's `Rerank` is a standalone
-function for the same reason. The types this plugin exports
+nothing to register an action against. The types this plugin exports
 (`BedrockRerankOptions`, `RankedDocumentData`, `RankedDocumentMetadata`,
 `RerankerRequest`, `RerankerResponse`) mirror the schema types by the same
 names.

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/__init__.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/__init__.py
@@ -19,12 +19,24 @@
 from genkit_amazon_bedrock.config import BedrockConfig, BedrockImageConfig, ModelDefinition
 from genkit_amazon_bedrock.converters import cache_point_part
 from genkit_amazon_bedrock.plugin import Bedrock, bedrock_name
+from genkit_amazon_bedrock.rerank import (
+    BedrockRerankOptions,
+    RankedDocumentData,
+    RankedDocumentMetadata,
+    RerankerRequest,
+    RerankerResponse,
+)
 
 __all__ = [
     'Bedrock',
     'BedrockConfig',
     'BedrockImageConfig',
+    'BedrockRerankOptions',
     'ModelDefinition',
+    'RankedDocumentData',
+    'RankedDocumentMetadata',
+    'RerankerRequest',
+    'RerankerResponse',
     'bedrock_name',
     'cache_point_part',
 ]

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
@@ -21,12 +21,10 @@ families nest their options under ``imageGenerationConfig`` while the modern
 Stability models take flat top-level fields, so routing by model ID is
 unavoidable.
 
-Ported from the Go plugin's ``image.go``, with three deviations. Go's legacy
-SDXL builder (``stable-diffusion``, ``text_prompts``/``artifacts``) is dropped
-because every model of that shape is end-of-life on Bedrock. The Stability
-family patterns are narrower than Go's bare ``stable-image``. And the response
-MIME type follows the requested ``output_format`` instead of Go's hardcoded
-``image/png``, which mislabels a jpeg or webp response.
+The legacy SDXL shape (``stable-diffusion``, ``text_prompts``/``artifacts``) is
+not supported, because every model of that shape is end-of-life on Bedrock. The
+response MIME type follows the requested ``output_format`` rather than a
+hardcoded ``image/png``, which would mislabel a jpeg or webp response.
 """
 
 import json
@@ -101,9 +99,9 @@ def is_image_model(model_id: str) -> bool:
 def image_prompt(request: ModelRequest[Any]) -> str:
     """Extracts the image prompt from the most recent user message.
 
-    Ported from the Go plugin's ``imagePrompt``: messages are scanned newest
-    first, only user messages count, and their text parts are concatenated
-    without a separator. A user message with no text is skipped rather than
+    Messages are scanned newest first, only user messages count, and their text
+    parts are concatenated without a separator. A user message with no text is
+    skipped rather than
     ending the scan. Non-text parts are ignored; these models are text-to-image
     only.
 
@@ -126,7 +124,7 @@ def build_amazon_image_body(prompt: str, config: dict[str, Any], *, include_qual
     """Builds the InvokeModel body for Titan Image and Nova Canvas.
 
     Only ``imageGenerationConfig`` is honoured, and only when it is a mapping;
-    every other config key is dropped, matching the Go plugin. Its entries are
+    every other config key is dropped. Its entries are
     merged key-by-key over the defaults. ``image_generation_config`` is accepted
     as an alternative spelling, as BedrockConfig accepts both casings, and the
     camelCase key wins when a caller passes both.
@@ -167,8 +165,8 @@ def build_stability_image_body(prompt: str, config: dict[str, Any]) -> dict[str,
 
     The whole config is merged over the defaults at the top level, so a caller
     can override ``prompt`` and ``output_format`` as well as add flat fields
-    like ``aspect_ratio`` or ``seed``. Matches the Go plugin. Genkit's generic
-    generation knobs are already gone by here; see ``_normalize_image_config``.
+    like ``aspect_ratio`` or ``seed``. Genkit's generic generation knobs are
+    already gone by here; see ``_normalize_image_config``.
 
     Args:
         prompt: The text prompt.
@@ -329,8 +327,8 @@ class BedrockImageModel:
         """Reads the images off a modern Stability response.
 
         ``seeds`` is ignored. ``finish_reasons`` is checked before the images,
-        as in the Go plugin, so a refusal is reported by its reason rather than
-        as a missing image. JSON ``null`` is the success value on that field.
+        so a refusal is reported by its reason rather than as a missing image.
+        JSON ``null`` is the success value on that field.
 
         Raises:
             GenkitError: INTERNAL for a non-success finish reason, or when no

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -287,8 +287,7 @@ class Bedrock(Plugin):
 
         A helper rather than a registered action: Genkit Python has no
         first-class reranker primitive, so there is nothing to register
-        against. The Go plugin's ``Rerank`` is a standalone function for the
-        same reason. Both the Cohere and Amazon rerank families are supported,
+        against. Both the Cohere and Amazon rerank families are supported,
         and the request body is built from the model ID because they disagree
         over ``api_version``. The ID itself is sent to the service verbatim.
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -19,12 +19,16 @@
 Registers Bedrock-hosted models (Anthropic Claude, Amazon Nova, Meta Llama,
 Mistral, Cohere, and others) as Genkit model actions. Text generation uses the
 Bedrock Converse and ConverseStream APIs; embedders and image generation use
-InvokeModel. Reranking is not supported yet.
+InvokeModel. Reranking also uses InvokeModel but ships as the ``Bedrock.rerank``
+helper: Genkit Python has no reranker primitive to register an action against.
 """
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-from genkit import ModelRequest, ModelResponse
+from genkit import Document, ModelRequest, ModelResponse
+
+# DocumentData has no public re-export yet; the rerank helper is built on it.
+from genkit._core._typing import DocumentData
 from genkit.embedder import EmbedRequest, EmbedResponse, embedder_action_metadata
 from genkit.model import model_action_metadata
 from genkit.plugin_api import (
@@ -32,6 +36,7 @@ from genkit.plugin_api import (
     ActionKind,
     ActionMetadata,
     ActionRunContext,
+    GenkitError,
     Plugin,
     to_json_schema,
 )
@@ -50,6 +55,13 @@ from genkit_amazon_bedrock.embedders import (
 from genkit_amazon_bedrock.image import BedrockImageModel, is_image_model
 from genkit_amazon_bedrock.model_info import get_model_info
 from genkit_amazon_bedrock.models import BedrockModel
+from genkit_amazon_bedrock.rerank import (
+    BedrockReranker,
+    BedrockRerankOptions,
+    RerankerRequest,
+    RerankerResponse,
+    is_rerank_model,
+)
 from genkit_amazon_bedrock.transport import BedrockTransport
 
 if TYPE_CHECKING:
@@ -174,6 +186,9 @@ class Bedrock(Plugin):
             # Embedding models speak InvokeModel, not Converse; resolving one
             # as a chat model only defers the failure to call time.
             return None
+        if is_rerank_model(model_id):
+            # Same story for rerank models; reranking is the Bedrock.rerank helper.
+            return None
         declared = self._declared_model_type(model_id)
         # Classifying undeclared IDs diverges from Go, which routes on the
         # declared type alone: this plugin resolves lazily, so without it
@@ -250,6 +265,7 @@ class Bedrock(Plugin):
             )
             for definition in self.models
             if not looks_like_embedding_model(definition.name)
+            and not is_rerank_model(definition.name)
             and (definition.type != 'image' or is_image_model(definition.name))
         ]
         actions.extend(
@@ -258,3 +274,47 @@ class Bedrock(Plugin):
             if is_embedding_model(model_id)
         )
         return actions
+
+    async def rerank(
+        self,
+        model_id: str,
+        *,
+        query: str | DocumentData,
+        documents: list[DocumentData],
+        options: BedrockRerankOptions | dict[str, Any] | None = None,
+    ) -> RerankerResponse:
+        """Rerank documents by relevance to a query.
+
+        A helper rather than a registered action: Genkit Python has no
+        first-class reranker primitive, so there is nothing to register
+        against. The Go plugin's ``Rerank`` is a standalone function for the
+        same reason. Both the Cohere and Amazon rerank families are supported,
+        and the request body is built from the model ID because they disagree
+        over ``api_version``. The ID itself is sent to the service verbatim.
+
+        Args:
+            model_id: Bedrock rerank model ID, e.g. ``cohere.rerank-v3-5:0``
+                or ``amazon.rerank-v1:0``.
+            query: The query to rank against, as text or as a document.
+            documents: The documents to rank.
+            options: Per-call options, as ``BedrockRerankOptions`` or a mapping.
+
+        Returns:
+            The ranked documents in the order the service returned them, each
+            carrying its relevance score.
+
+        Raises:
+            GenkitError: INVALID_ARGUMENT for a missing model ID or a query or
+                document with no text, INTERNAL for a malformed response, and
+                the mapped AWS status for a failed call.
+        """
+        if not model_id:
+            raise GenkitError(message='bedrock rerank: model ID required', status='INVALID_ARGUMENT')
+        reranker = BedrockReranker(model_id=model_id, transport=self._transport)
+        return await reranker.rerank(
+            RerankerRequest(
+                query=Document.from_text(query) if isinstance(query, str) else query,
+                documents=documents,
+                options=options,
+            )
+        )

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/rerank.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/rerank.py
@@ -1,0 +1,370 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bedrock reranking implementation (InvokeModel API).
+
+Reranking is a helper, ``Bedrock.rerank()``, not a registered action: Genkit
+Python carries only the bare ``ActionKind.RERANKER`` enum member, and the
+reranker schema types sit on the codegen denylist (``py/scripts/schema_to_typing.py``),
+so there is no primitive to register against. The Go plugin's ``rerank.go``
+reaches the same conclusion about Go for the same reason. The four types below
+mirror ``genkit-tools/genkit-schema.json`` field for field, so call sites
+survive if core ever re-adds the primitive.
+
+Ported from the Go plugin's ``rerank.go``, with two deviations. A malformed
+result entry is an error, where Go's ``json.Unmarshal`` zero-fills it and a
+result with no ``index`` silently scores the first document. And the
+``amazon.rerank-*`` family is supported by omitting ``api_version``: the Amazon
+schema rejects the key (``extraneous key [api_version] is not permitted``) as
+firmly as the Cohere schema requires it, and Go's request struct carries the
+field with no ``omitempty``, so Go cannot call the Amazon model at all.
+
+Two parity notes worth stating, because both are visible to callers: results
+come back in the service's order, never re-sorted and never truncated
+client-side (``top_n`` only caps what the service returns), and a ranked
+document carries its score alone, dropping the original document's metadata.
+"""
+
+import json
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from botocore.exceptions import BotoCoreError, ClientError
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+from pydantic.alias_generators import to_camel
+
+from genkit import DocumentPart
+
+# DocumentData has no public re-export yet; the reranker types are built on it.
+from genkit._core._typing import DocumentData
+from genkit.plugin_api import GenkitError
+from genkit_amazon_bedrock.embedders import InvokeModelTransport, document_text
+from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
+from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
+
+# The current Bedrock contract for the Cohere Rerank InvokeModel body.
+COHERE_RERANK_API_VERSION = 2
+
+RerankFamily = Literal['cohere', 'amazon']
+
+# Substring matches over the base model ID.
+_RERANK_PATTERNS: tuple[tuple[str, RerankFamily], ...] = (
+    ('cohere.rerank', 'cohere'),
+    ('amazon.rerank', 'amazon'),
+)
+
+
+class RankedDocumentMetadata(BaseModel):
+    """Metadata carried by a reranked document.
+
+    Mirrors the genkit-schema type of the same name.
+    """
+
+    # The only reranker type the schema opens up; the other three forbid extras.
+    model_config = ConfigDict(alias_generator=to_camel, extra='allow', populate_by_name=True)
+
+    score: float
+    """The model's relevance score for this document against the query."""
+
+
+class RankedDocumentData(BaseModel):
+    """A document with its relevance score attached.
+
+    Mirrors the genkit-schema type of the same name.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+
+    content: list[DocumentPart]
+    """The ranked document's parts, taken verbatim from the input document."""
+
+    metadata: RankedDocumentMetadata
+    """The score. The input document's own metadata is deliberately not carried."""
+
+
+class RerankerRequest(BaseModel):
+    """A rerank call: a query, the documents to rank, and driver options.
+
+    Mirrors the genkit-schema type of the same name.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+
+    query: DocumentData
+    """The query to rank the documents against."""
+
+    documents: list[DocumentData]
+    """The documents to rank."""
+
+    options: Any | None = None
+    """Driver-specific options; this plugin reads ``BedrockRerankOptions``."""
+
+
+class RerankerResponse(BaseModel):
+    """The ranked documents returned by a rerank call.
+
+    Mirrors the genkit-schema type of the same name.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+
+    documents: list[RankedDocumentData]
+    """The ranked documents, in the order the service returned them."""
+
+
+class BedrockRerankOptions(BaseModel):
+    """Per-call options for a Bedrock rerank call."""
+
+    # Unknown keys are ignored rather than forbidden: Go's json.Unmarshal drops them.
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    top_n: int | None = None
+    """Caps how many ranked documents the service returns. Unset, ``<= 0``, or
+    a value above the document count all mean every input document."""
+
+    @field_validator('top_n', mode='before')
+    @classmethod
+    def _reject_bool_top_n(cls, value: Any) -> Any:  # noqa: ANN401
+        # bool is an int subclass, and True would silently rank down to one document.
+        if isinstance(value, bool):
+            raise ValueError('top_n must be an integer, not a bool')
+        return value
+
+
+def _rerank_family(model_id: str) -> RerankFamily | None:
+    """Routes a model ID to its rerank family, or None if it is not one."""
+    base_id = strip_inference_profile_prefix(model_id)
+    for pattern, family in _RERANK_PATTERNS:
+        if pattern in base_id:
+            return family
+    return None
+
+
+def is_rerank_model(model_id: str) -> bool:
+    """Reports whether a Bedrock model ID names a reranking model.
+
+    True for both the Cohere and Amazon families: neither has a Converse path,
+    so neither may be resolved as a chat model.
+
+    Args:
+        model_id: Bedrock model ID, inference-profile ID, or ARN.
+
+    Returns:
+        True when the ID routes to a known rerank family.
+    """
+    return _rerank_family(model_id) is not None
+
+
+def coerce_rerank_options(options: Any) -> BedrockRerankOptions | None:  # noqa: ANN401
+    """Coerces a request's raw options into ``BedrockRerankOptions``.
+
+    Accepts the typed value or a mapping, keyed by either ``topN`` or
+    ``top_n``. Unknown keys are ignored, matching the Go plugin's
+    ``json.Unmarshal``.
+
+    Args:
+        options: The raw ``RerankerRequest.options`` value.
+
+    Returns:
+        The coerced options, or None when none were given.
+
+    Raises:
+        GenkitError: INVALID_ARGUMENT for an unsupported type or an
+            unparseable mapping.
+    """
+    if options is None:
+        return None
+    if isinstance(options, BedrockRerankOptions):
+        return options
+    if isinstance(options, Mapping):
+        try:
+            return BedrockRerankOptions.model_validate(dict(options))
+        except ValidationError as error:
+            raise GenkitError(
+                message=f'bedrock rerank: invalid rerank options: {error}',
+                status='INVALID_ARGUMENT',
+            ) from error
+    raise GenkitError(
+        message=f'bedrock rerank: unsupported rerank options type {type(options).__name__}',
+        status='INVALID_ARGUMENT',
+    )
+
+
+def build_rerank_body(query: str, documents: list[str], top_n: int, *, include_api_version: bool) -> dict[str, Any]:
+    """Builds the InvokeModel body for a Bedrock reranking model.
+
+    ``query``, ``documents`` and ``top_n`` are always present and identical for
+    both families. ``api_version`` is the only difference, and it is added
+    rather than set to None: the Cohere schema rejects a body without the key,
+    and the Amazon schema rejects any body carrying it.
+
+    Args:
+        query: The query text.
+        documents: The document texts, in input order.
+        top_n: How many ranked documents to ask for.
+        include_api_version: Whether to send ``api_version``; the Cohere family
+            requires it, the Amazon family refuses it.
+
+    Returns:
+        The request body to marshal.
+    """
+    body: dict[str, Any] = {
+        'query': query,
+        'documents': documents,
+        'top_n': top_n,
+    }
+    if include_api_version:
+        body['api_version'] = COHERE_RERANK_API_VERSION
+    return body
+
+
+def _result_fields(result: Any, position: int) -> tuple[int, float]:  # noqa: ANN401
+    """Reads the index and score off one rerank result."""
+    if not isinstance(result, dict):
+        raise GenkitError(message=f'bedrock rerank: result {position} is not an object', status='INTERNAL')
+    index = result.get('index')
+    # bool is an int subclass, and True would silently rank document 1.
+    if isinstance(index, bool) or not isinstance(index, int):
+        raise GenkitError(message=f'bedrock rerank: result {position} has no integer index', status='INTERNAL')
+    score = result.get('relevance_score')
+    if isinstance(score, bool) or not isinstance(score, int | float):
+        raise GenkitError(
+            message=f'bedrock rerank: result {position} has no numeric relevance_score',
+            status='INTERNAL',
+        )
+    return index, float(score)
+
+
+def build_rerank_response(payload: dict[str, Any], documents: list[DocumentData]) -> RerankerResponse:
+    """Maps the scored results back onto the original documents.
+
+    Both families answer with the same ``results`` shape, so one mapping serves
+    them. The service's order is preserved verbatim: results are never
+    re-sorted and never truncated, so a caller that asked for a smaller
+    ``top_n`` than the service honoured still sees everything it sent back.
+
+    Args:
+        payload: The parsed InvokeModel response body.
+        documents: The documents the request was built from, in input order.
+
+    Returns:
+        One ranked document per result, each carrying its relevance score.
+
+    Raises:
+        GenkitError: INTERNAL when the results are malformed or reference a
+            document that was never sent.
+    """
+    results = payload.get('results')
+    # An absent results field is a valid empty ranking, not a protocol error.
+    if results is None:
+        return RerankerResponse(documents=[])
+    if not isinstance(results, list):
+        raise GenkitError(message='bedrock rerank: response results is not a list', status='INTERNAL')
+
+    ranked: list[RankedDocumentData] = []
+    for position, result in enumerate(results):
+        index, score = _result_fields(result, position)
+        if not 0 <= index < len(documents):
+            raise GenkitError(
+                message=f'bedrock rerank: result index {index} out of range for {len(documents)} documents',
+                status='INTERNAL',
+            )
+        ranked.append(
+            RankedDocumentData(
+                content=documents[index].content,
+                metadata=RankedDocumentMetadata(score=score),
+            )
+        )
+    return RerankerResponse(documents=ranked)
+
+
+class BedrockReranker:
+    """Handles a rerank call for one Bedrock reranking model."""
+
+    def __init__(self, model_id: str, transport: InvokeModelTransport) -> None:
+        """Initializes the reranker.
+
+        Args:
+            model_id: Bedrock model ID, inference-profile ID, or ARN, sent to
+                the InvokeModel API verbatim.
+            transport: The shared transport seam owning the boto3 client.
+        """
+        self._model_id = model_id
+        self._transport = transport
+
+    async def rerank(self, request: RerankerRequest) -> RerankerResponse:
+        """Ranks the request's documents by relevance to its query.
+
+        The body is built from the model ID, since the two families disagree
+        over ``api_version``: Cohere requires it and Amazon rejects it. An ID
+        matching neither family is not blocked and gets the Cohere body, that
+        being the only shape AWS documents for InvokeModel reranking.
+
+        The model ID itself is sent to InvokeModel verbatim, so inference
+        profiles and ARNs work too.
+
+        Args:
+            request: The query, documents, and options to rank with.
+
+        Returns:
+            The ranked documents, each carrying its relevance score.
+
+        Raises:
+            GenkitError: INVALID_ARGUMENT for a query or document with no text
+                or for unusable options, INTERNAL for a malformed response, and
+                the mapped AWS status for a failed call.
+        """
+        query = document_text(request.query)
+        if not query:
+            raise GenkitError(message='bedrock rerank: query has no text content', status='INVALID_ARGUMENT')
+
+        texts: list[str] = []
+        for index, document in enumerate(request.documents):
+            text = document_text(document)
+            # Failing beats skipping: a skipped document desyncs the index mapping.
+            if not text:
+                raise GenkitError(
+                    message=f'bedrock rerank: document {index} has no text content',
+                    status='INVALID_ARGUMENT',
+                )
+            texts.append(text)
+        # Before options are coerced, as in Go: nothing to rank outranks bad options.
+        if not texts:
+            return RerankerResponse(documents=[])
+
+        top_n = len(texts)
+        options = coerce_rerank_options(request.options)
+        # Clamped down only; asking for more than was sent is not a request the API takes.
+        if options is not None and options.top_n is not None and 0 < options.top_n < top_n:
+            top_n = options.top_n
+
+        # Only the Amazon family drops api_version; an unknown ID takes Cohere's body.
+        include_api_version = _rerank_family(self._model_id) != 'amazon'
+        payload = await self._invoke(build_rerank_body(query, texts, top_n, include_api_version=include_api_version))
+        return build_rerank_response(payload, request.documents)
+
+    async def _invoke(self, body: dict[str, Any]) -> dict[str, Any]:
+        try:
+            return await self._transport.invoke_model(
+                modelId=self._model_id,
+                body=json.dumps(body),
+                contentType='application/json',
+                accept='application/json',
+            )
+        except ClientError as error:
+            raise _from_client_error(error, 'invoke model') from error
+        except BotoCoreError as error:
+            raise _from_botocore_error(error, 'invoke model') from error

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/rerank.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/rerank.py
@@ -19,20 +19,17 @@
 Reranking is a helper, ``Bedrock.rerank()``, not a registered action: Genkit
 Python carries only the bare ``ActionKind.RERANKER`` enum member, and the
 reranker schema types sit on the codegen denylist (``py/scripts/schema_to_typing.py``),
-so there is no primitive to register against. The Go plugin's ``rerank.go``
-reaches the same conclusion about Go for the same reason. The four types below
-mirror ``genkit-tools/genkit-schema.json`` field for field, so call sites
-survive if core ever re-adds the primitive.
+so there is no primitive to register against. The four types below mirror
+``genkit-tools/genkit-schema.json`` field for field, so call sites survive if
+core ever re-adds the primitive.
 
-Ported from the Go plugin's ``rerank.go``, with two deviations. A malformed
-result entry is an error, where Go's ``json.Unmarshal`` zero-fills it and a
-result with no ``index`` silently scores the first document. And the
+A malformed result entry is an error rather than a zero-filled document, so a
+result with no ``index`` never silently scores the first document. The
 ``amazon.rerank-*`` family is supported by omitting ``api_version``: the Amazon
 schema rejects the key (``extraneous key [api_version] is not permitted``) as
-firmly as the Cohere schema requires it, and Go's request struct carries the
-field with no ``omitempty``, so Go cannot call the Amazon model at all.
+firmly as the Cohere schema requires it.
 
-Two parity notes worth stating, because both are visible to callers: results
+Two behaviours worth stating, because both are visible to callers: results
 come back in the service's order, never re-sorted and never truncated
 client-side (``top_n`` only caps what the service returns), and a ranked
 document carries its score alone, dropping the original document's metadata.
@@ -128,7 +125,7 @@ class RerankerResponse(BaseModel):
 class BedrockRerankOptions(BaseModel):
     """Per-call options for a Bedrock rerank call."""
 
-    # Unknown keys are ignored rather than forbidden: Go's json.Unmarshal drops them.
+    # Unknown keys are ignored rather than forbidden.
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     top_n: int | None = None
@@ -172,8 +169,7 @@ def coerce_rerank_options(options: Any) -> BedrockRerankOptions | None:  # noqa:
     """Coerces a request's raw options into ``BedrockRerankOptions``.
 
     Accepts the typed value or a mapping, keyed by either ``topN`` or
-    ``top_n``. Unknown keys are ignored, matching the Go plugin's
-    ``json.Unmarshal``.
+    ``top_n``. Unknown keys are ignored.
 
     Args:
         options: The raw ``RerankerRequest.options`` value.
@@ -341,7 +337,7 @@ class BedrockReranker:
                     status='INVALID_ARGUMENT',
                 )
             texts.append(text)
-        # Before options are coerced, as in Go: nothing to rank outranks bad options.
+        # Before options are coerced: nothing to rank outranks bad options.
         if not texts:
             return RerankerResponse(documents=[])
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
@@ -16,7 +16,7 @@
 
 """ConverseStream event reassembly.
 
-Ported from the Go plugin's ``stream.go``. Bedrock streams a message as
+Bedrock streams a message as
 deltas tagged with a ``contentBlockIndex``; this module accumulates them per
 block, emits Genkit chunks as they arrive, and assembles the final message in
 block order. Request conversion is shared with the non-streaming path.
@@ -165,7 +165,7 @@ def _append_delta(block: _StreamBlock, delta: dict[str, Any]) -> Part | None:
     if (reasoning := delta.get('reasoningContent')) is not None:
         return _append_reasoning_delta(block, reasoning)
     # Unhandled variants (citation today) are dropped rather than raised on:
-    # Bedrock adds delta variants without notice, and Go's fail-loud default
+    # Bedrock adds delta variants without notice, and failing loud here
     # would kill any stream that used one. The sync path fails loud instead,
     # because dropping a whole content block would lose model output.
     return None

--- a/py/packages/genkit-amazon-bedrock/tests/image_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/image_test.py
@@ -217,7 +217,7 @@ async def test_the_last_user_message_wins_and_its_text_parts_concatenate() -> No
     )
     await generate(TITAN_IMAGE, transport, request)
 
-    # Concatenated with no separator, as in the Go plugin.
+    # Concatenated with no separator.
     assert transport.bodies()[0]['textToImageParams'] == {'text': 'new prompt detail'}
 
 

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -82,7 +82,7 @@ COHERE_RERANK = 'cohere.rerank-v3-5:0'
 AMAZON_RERANK = 'amazon.rerank-v1:0'
 AMAZON_RERANK_REGIONS = ('us-west-2', 'eu-central-1', 'ap-northeast-1', 'ca-central-1')
 
-# Smallest PNG Titan accepts, ported from the Go plugin's live tests.
+# Smallest PNG Titan accepts.
 PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
 PNG_1X1_DATA_URL = f'data:image/png;base64,{PNG_1X1}'
 
@@ -105,9 +105,9 @@ def make_image_model(model_id: str) -> BedrockImageModel:
     return BedrockImageModel(model_id=model_id, transport=make_transport())
 
 
-# Bedrock refusing the model itself, rather than the request, ported from the Go
-# plugin's skipIfModelUnavailable. Model access is per account: a Legacy model
-# also drops out after 30 days of disuse, which no test can control.
+# Bedrock refusing the model itself, rather than the request. Model access is
+# per account: a Legacy model also drops out after 30 days of disuse, which no
+# test can control.
 _UNAVAILABLE_MARKERS = (
     'AccessDeniedException',
     'ResourceNotFoundException',

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -36,6 +36,7 @@ from genkit_amazon_bedrock.converters import (
 from genkit_amazon_bedrock.embedders import BedrockEmbedder
 from genkit_amazon_bedrock.image import BedrockImageModel
 from genkit_amazon_bedrock.models import BedrockModel
+from genkit_amazon_bedrock.rerank import BedrockReranker, BedrockRerankOptions, RerankerRequest
 from genkit_amazon_bedrock.transport import BedrockTransport
 
 from genkit import (
@@ -76,6 +77,10 @@ NOVA_EMBED = 'amazon.nova-2-multimodal-embeddings-v1:0'
 
 NOVA_CANVAS = 'amazon.nova-canvas-v1:0'
 SD3 = 'stability.sd3-5-large-v1:0'
+
+COHERE_RERANK = 'cohere.rerank-v3-5:0'
+AMAZON_RERANK = 'amazon.rerank-v1:0'
+AMAZON_RERANK_REGIONS = ('us-west-2', 'eu-central-1', 'ap-northeast-1', 'ca-central-1')
 
 # Smallest PNG Titan accepts, ported from the Go plugin's live tests.
 PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
@@ -419,6 +424,52 @@ async def test_embed_cohere_rejects_an_image() -> None:
     # is refused locally rather than sent and rejected as a bad request.
     with pytest.raises(GenkitError, match='text-only'):
         await embed(COHERE_EMBED, [image_doc()])
+
+
+async def test_rerank_cohere() -> None:
+    reranker = BedrockReranker(model_id=COHERE_RERANK, transport=make_transport())
+    response = await reranker.rerank(
+        RerankerRequest(
+            query=text_doc('What is the capital of France?'),
+            documents=[
+                text_doc('The capital of France is Paris.'),
+                text_doc('The tallest mountain is Everest.'),
+                text_doc('Bananas are yellow.'),
+            ],
+            options=BedrockRerankOptions(top_n=2),
+        )
+    )
+
+    assert len(response.documents) == 2
+    top = [part.root for part in response.documents[0].content if isinstance(part.root, TextPart)]
+    assert top and 'Paris' in (top[0].text or '')
+    assert response.documents[0].metadata.score >= response.documents[1].metadata.score
+
+
+@pytest.mark.skipif(
+    os.environ.get('AWS_REGION') not in AMAZON_RERANK_REGIONS,
+    reason='amazon.rerank-v1:0 is offered in us-west-2, eu-central-1, ap-northeast-1 and ca-central-1 only',
+)
+async def test_rerank_amazon() -> None:
+    # The Amazon family takes the same body minus api_version, which its schema
+    # rejects outright, so this is the only wire check of that difference.
+    reranker = BedrockReranker(model_id=AMAZON_RERANK, transport=make_transport())
+    response = await reranker.rerank(
+        RerankerRequest(
+            query=text_doc('What is the capital of France?'),
+            documents=[
+                text_doc('The capital of France is Paris.'),
+                text_doc('The tallest mountain is Everest.'),
+                text_doc('Bananas are yellow.'),
+            ],
+            options=BedrockRerankOptions(top_n=2),
+        )
+    )
+
+    assert len(response.documents) == 2
+    top = [part.root for part in response.documents[0].content if isinstance(part.root, TextPart)]
+    assert top and 'Paris' in (top[0].text or '')
+    assert response.documents[0].metadata.score >= response.documents[1].metadata.score
 
 
 @pytest.mark.skipif(

--- a/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/plugin_test.py
@@ -261,7 +261,17 @@ async def test_embedding_models_do_not_resolve_as_chat_models() -> None:
 async def test_the_cross_guard_leaves_cohere_chat_models_alone() -> None:
     plugin = Bedrock(region='us-east-1')
     assert await plugin.resolve(ActionKind.MODEL, bedrock_name('cohere.command-r-v1:0')) is not None
-    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('cohere.rerank-v3-5:0')) is not None
+
+
+@pytest.mark.asyncio
+async def test_rerank_models_do_not_resolve_as_chat_models() -> None:
+    # Neither rerank family has a Converse path, so resolving one as a chat
+    # model would only defer the failure to call time.
+    plugin = Bedrock(region='us-east-1')
+    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('cohere.rerank-v3-5:0')) is None
+    assert await plugin.resolve(ActionKind.MODEL, bedrock_name('amazon.rerank-v1:0')) is None
+    assert await plugin.resolve(ActionKind.EMBEDDER, bedrock_name('cohere.rerank-v3-5:0')) is None
+    assert await plugin.resolve(ActionKind.EMBEDDER, bedrock_name('amazon.rerank-v1:0')) is None
 
 
 @pytest.mark.asyncio
@@ -330,6 +340,22 @@ async def test_everything_listed_can_actually_resolve() -> None:
     for metadata in listed:
         assert metadata.action_type is not None
         assert await plugin.resolve(ActionKind(metadata.action_type), metadata.name) is not None
+
+
+@pytest.mark.asyncio
+async def test_a_declared_rerank_model_is_not_listed() -> None:
+    # The other side of the listed-can-resolve invariant: reranking is the
+    # Bedrock.rerank helper, so a rerank ID has no action to advertise.
+    plugin = Bedrock(
+        region='us-east-1',
+        models=[
+            ModelDefinition(name='amazon.nova-lite-v1:0'),
+            ModelDefinition(name='cohere.rerank-v3-5:0'),
+            ModelDefinition(name='amazon.rerank-v1:0'),
+        ],
+    )
+    listed = await plugin.list_actions()
+    assert [a.name for a in listed] == ['bedrock/amazon.nova-lite-v1:0']
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-amazon-bedrock/tests/rerank_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/rerank_test.py
@@ -1,0 +1,470 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Bedrock rerank helper (no AWS involved)."""
+
+import json
+from typing import Any, cast
+
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
+from genkit_amazon_bedrock import Bedrock
+from genkit_amazon_bedrock.rerank import (
+    BedrockReranker,
+    BedrockRerankOptions,
+    RerankerRequest,
+    RerankerResponse,
+    build_rerank_body,
+    build_rerank_response,
+    coerce_rerank_options,
+    is_rerank_model,
+)
+from genkit_amazon_bedrock.transport import BedrockTransport
+
+from genkit import Document, DocumentPart, TextPart
+from genkit._core._typing import DocumentData
+from genkit.plugin_api import GenkitError
+
+COHERE_RERANK = 'cohere.rerank-v3-5:0'
+AMAZON_RERANK = 'amazon.rerank-v1:0'
+
+
+class FakeInvokeTransport:
+    """Stands in for BedrockTransport; records the InvokeModel kwargs."""
+
+    def __init__(self, response: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+        self.response = response if response is not None else {}
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    def bodies(self) -> list[dict[str, Any]]:
+        """The parsed request bodies, in call order."""
+        return [json.loads(call['body']) for call in self.calls]
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+class ForbiddenTransport:
+    """Fails the test if the reranker reaches the wire at all."""
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError(f'no InvokeModel call expected, got {kwargs}')
+
+
+def text_doc(*texts: str, metadata: dict[str, Any] | None = None) -> DocumentData:
+    return DocumentData(
+        content=[DocumentPart(root=TextPart(text=text)) for text in texts],
+        metadata=metadata,
+    )
+
+
+def scored(*results: tuple[int, float]) -> dict[str, Any]:
+    """A rerank response body, in the order the service returned it."""
+    return {'results': [{'index': index, 'relevance_score': score} for index, score in results]}
+
+
+def ranked_texts(response: RerankerResponse) -> list[str]:
+    """The text of each ranked document, in ranked order."""
+    return [
+        '\n'.join(part.root.text for part in document.content if isinstance(part.root, TextPart))
+        for document in response.documents
+    ]
+
+
+def scores(response: RerankerResponse) -> list[float]:
+    return [document.metadata.score for document in response.documents]
+
+
+async def rerank(
+    model_id: str,
+    transport: Any,  # noqa: ANN401
+    query: DocumentData,
+    documents: list[DocumentData],
+    options: Any = None,  # noqa: ANN401
+) -> RerankerResponse:
+    reranker = BedrockReranker(model_id=model_id, transport=transport)
+    return await reranker.rerank(RerankerRequest(query=query, documents=documents, options=options))
+
+
+# ---- Routing ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('model_id', 'routable'),
+    [
+        (COHERE_RERANK, True),
+        (AMAZON_RERANK, True),
+        # Inference-profile prefixes and full foundation-model ARNs still route
+        # as rerank models.
+        ('us.amazon.rerank-v1:0', True),
+        ('eu.cohere.rerank-v3-5:0', True),
+        ('arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0', True),
+        ('arn:aws:bedrock:us-east-1::foundation-model/amazon.rerank-v1:0', True),
+        # Bare 'cohere' routing would swallow these two.
+        ('cohere.embed-english-v3', False),
+        ('cohere.command-r-v1:0', False),
+        ('anthropic.claude-sonnet-4-5-20250929-v1:0', False),
+    ],
+)
+def test_rerank_model_routing(model_id: str, routable: bool) -> None:
+    assert is_rerank_model(model_id) is routable
+
+
+# ---- Request body -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohere_rerank_sends_the_documented_body_and_maps_scores() -> None:
+    transport = FakeInvokeTransport(scored((1, 0.94), (0, 0.42)))
+    response = await rerank(
+        COHERE_RERANK,
+        transport,
+        text_doc('query text'),
+        [
+            text_doc('first document', metadata={'id': 'first'}),
+            text_doc('second document', metadata={'id': 'second'}),
+        ],
+        options=BedrockRerankOptions(top_n=1),
+    )
+
+    call = transport.calls[0]
+    assert call['modelId'] == COHERE_RERANK
+    assert call['contentType'] == 'application/json'
+    assert call['accept'] == 'application/json'
+    body = json.loads(call['body'])
+    assert body == {
+        'query': 'query text',
+        'documents': ['first document', 'second document'],
+        'top_n': 1,
+        'api_version': 2,
+    }
+
+    # top_n only caps what the service returns; nothing is truncated here.
+    assert len(response.documents) == 2
+    assert ranked_texts(response) == ['second document', 'first document']
+    assert scores(response) == [0.94, 0.42]
+    # The input document's own metadata is deliberately dropped for the score.
+    assert response.documents[0].metadata.model_dump() == {'score': 0.94}
+
+
+@pytest.mark.asyncio
+async def test_a_multi_part_query_is_joined_before_it_reaches_the_wire() -> None:
+    # document_text itself is covered by embedders_test; this pins the reuse.
+    transport = FakeInvokeTransport(scored())
+    await rerank(COHERE_RERANK, transport, text_doc('a', 'b'), [text_doc('document')])
+    assert transport.bodies()[0]['query'] == 'a\nb'
+
+
+@pytest.mark.parametrize('model_id', [AMAZON_RERANK, 'us.amazon.rerank-v1:0'])
+@pytest.mark.asyncio
+async def test_amazon_rerank_sends_a_body_with_no_api_version(model_id: str) -> None:
+    transport = FakeInvokeTransport(scored((0, 0.87)))
+    response = await rerank(model_id, transport, text_doc('query text'), [text_doc('first document')])
+
+    body = transport.bodies()[0]
+    assert body == {'query': 'query text', 'documents': ['first document'], 'top_n': 1}
+    # The Amazon schema rejects the key outright, so a null value would fail too.
+    assert 'api_version' not in body
+    assert scores(response) == [0.87]
+
+
+@pytest.mark.asyncio
+async def test_an_unrecognized_model_id_gets_the_cohere_body() -> None:
+    # Not blocked, and Cohere's is the only documented InvokeModel rerank body.
+    transport = FakeInvokeTransport(scored())
+    await rerank('some.rerankifier-v9:0', transport, text_doc('query'), [text_doc('a')])
+    assert transport.bodies()[0] == {
+        'query': 'query',
+        'documents': ['a'],
+        'top_n': 1,
+        'api_version': 2,
+    }
+
+
+def test_the_cohere_body_carries_api_version() -> None:
+    assert build_rerank_body('q', ['a'], 1, include_api_version=True) == {
+        'query': 'q',
+        'documents': ['a'],
+        'top_n': 1,
+        'api_version': 2,
+    }
+
+
+def test_the_amazon_body_omits_api_version_entirely() -> None:
+    body = build_rerank_body('q', ['a'], 1, include_api_version=False)
+    assert body == {'query': 'q', 'documents': ['a'], 'top_n': 1}
+    assert 'api_version' not in body
+
+
+# ---- top_n ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_top_n_defaults_to_the_document_count() -> None:
+    transport = FakeInvokeTransport(scored())
+    await rerank(COHERE_RERANK, transport, text_doc('query'), [text_doc('a'), text_doc('b')])
+    assert transport.bodies()[0]['top_n'] == 2
+
+
+@pytest.mark.asyncio
+async def test_top_n_above_the_document_count_is_clamped_down() -> None:
+    # A float, not an int: that is what survives a JSON round-trip from a flow.
+    transport = FakeInvokeTransport(scored())
+    await rerank(
+        COHERE_RERANK,
+        transport,
+        text_doc('query'),
+        [text_doc('a'), text_doc('b')],
+        options={'topN': 99.0},
+    )
+    assert transport.bodies()[0]['top_n'] == 2
+
+
+@pytest.mark.parametrize('top_n', [0, -1])
+@pytest.mark.asyncio
+async def test_a_non_positive_top_n_asks_for_every_document(top_n: int) -> None:
+    transport = FakeInvokeTransport(scored())
+    await rerank(
+        COHERE_RERANK,
+        transport,
+        text_doc('query'),
+        [text_doc('a'), text_doc('b')],
+        options={'topN': top_n},
+    )
+    assert transport.bodies()[0]['top_n'] == 2
+
+
+# ---- Validation -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_whitespace_only_query_is_rejected() -> None:
+    with pytest.raises(GenkitError, match='query has no text content') as excinfo:
+        await rerank(COHERE_RERANK, ForbiddenTransport(), text_doc(' '), [text_doc('document')])
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.parametrize(
+    ('texts', 'position'),
+    [
+        (('',), 0),
+        # The index names the original position, not the count of good documents.
+        (('good', ''), 1),
+    ],
+)
+@pytest.mark.asyncio
+async def test_an_empty_document_names_its_original_position(texts: tuple[str, ...], position: int) -> None:
+    documents = [text_doc(text) for text in texts]
+    with pytest.raises(GenkitError, match=f'document {position} has no text content') as excinfo:
+        await rerank(COHERE_RERANK, ForbiddenTransport(), text_doc('query'), documents)
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_an_unsupported_options_type_is_rejected() -> None:
+    with pytest.raises(GenkitError, match='unsupported rerank options type str') as excinfo:
+        await rerank(
+            COHERE_RERANK,
+            ForbiddenTransport(),
+            text_doc('query'),
+            [text_doc('document')],
+            options='bad options',
+        )
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_no_documents_returns_early_without_calling() -> None:
+    response = await rerank(COHERE_RERANK, ForbiddenTransport(), text_doc('query text'), [])
+    assert response.documents == []
+
+
+@pytest.mark.asyncio
+async def test_no_documents_returns_before_the_options_are_coerced() -> None:
+    # Nothing to rank outranks bad options; coercing first would raise here.
+    response = await rerank(COHERE_RERANK, ForbiddenTransport(), text_doc('query text'), [], options='garbage')
+    assert response.documents == []
+
+
+# ---- Options coercion -------------------------------------------------------
+
+
+def test_absent_options_coerce_to_nothing() -> None:
+    assert coerce_rerank_options(None) is None
+
+
+def test_typed_options_are_passed_through_unchanged() -> None:
+    options = BedrockRerankOptions(top_n=3)
+    assert coerce_rerank_options(options) is options
+
+
+@pytest.mark.parametrize(
+    ('options', 'top_n'),
+    [
+        ({'topN': 7.0}, 7),
+        ({'top_n': 7}, 7),
+        # Unknown keys are ignored, matching Go's json.Unmarshal.
+        ({'somethingElse': 1}, None),
+    ],
+)
+def test_mapping_options_are_coerced(options: dict[str, Any], top_n: int | None) -> None:
+    coerced = coerce_rerank_options(options)
+    assert coerced is not None
+    assert coerced.top_n == top_n
+
+
+@pytest.mark.parametrize(
+    ('options', 'message'),
+    [
+        ('nonsense', 'unsupported rerank options type str'),
+        ({'topN': 'many'}, 'invalid rerank options'),
+        # bool subclasses int, so True would otherwise rank down to one document.
+        ({'topN': True}, 'invalid rerank options'),
+    ],
+)
+def test_unusable_options_are_invalid_argument(
+    options: Any,  # noqa: ANN401
+    message: str,
+) -> None:
+    with pytest.raises(GenkitError, match=message) as excinfo:
+        coerce_rerank_options(options)
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+# ---- Response mapping -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_services_order_is_preserved_verbatim() -> None:
+    # Ascending scores: the API's order is trusted, never re-sorted.
+    transport = FakeInvokeTransport(scored((0, 0.1), (1, 0.9)))
+    response = await rerank(COHERE_RERANK, transport, text_doc('query'), [text_doc('a'), text_doc('b')])
+
+    assert ranked_texts(response) == ['a', 'b']
+    assert scores(response) == [0.1, 0.9]
+
+
+@pytest.mark.parametrize('payload', [{'results': []}, {}, {'results': None}])
+def test_an_empty_ranking_is_not_an_error(payload: dict[str, Any]) -> None:
+    assert build_rerank_response(payload, [text_doc('a')]).documents == []
+
+
+@pytest.mark.parametrize('index', [1, -1])
+def test_an_out_of_range_index_is_internal(index: int) -> None:
+    with pytest.raises(GenkitError, match=f'result index {index} out of range') as excinfo:
+        build_rerank_response(scored((index, 0.9)), [text_doc('only document')])
+    assert excinfo.value.status == 'INTERNAL'
+
+
+# Go's nil-document leg is dropped: a typed list[DocumentData] plus the
+# pre-call text validation make a nil document unreachable in Python.
+
+
+@pytest.mark.parametrize(
+    ('payload', 'message'),
+    [
+        ({'results': 'nope'}, 'response results is not a list'),
+        ({'results': ['nope']}, 'result 0 is not an object'),
+        ({'results': [{'relevance_score': 0.9}]}, 'result 0 has no integer index'),
+        ({'results': [{'index': '0', 'relevance_score': 0.9}]}, 'result 0 has no integer index'),
+        # bool subclasses int, so True would otherwise silently rank document 1.
+        ({'results': [{'index': True, 'relevance_score': 0.9}]}, 'result 0 has no integer index'),
+        ({'results': [{'index': 0}]}, 'result 0 has no numeric relevance_score'),
+        ({'results': [{'index': 0, 'relevance_score': 'high'}]}, 'result 0 has no numeric relevance_score'),
+        ({'results': [{'index': 0, 'relevance_score': True}]}, 'result 0 has no numeric relevance_score'),
+        # The position names the result, not the document it points at.
+        ({'results': [{'index': 0, 'relevance_score': 0.9}, 'nope']}, 'result 1 is not an object'),
+    ],
+)
+def test_a_malformed_result_is_internal(payload: dict[str, Any], message: str) -> None:
+    with pytest.raises(GenkitError, match=message) as excinfo:
+        build_rerank_response(payload, [text_doc('a'), text_doc('b')])
+    assert excinfo.value.status == 'INTERNAL'
+
+
+# ---- AWS failures -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_errors_map_to_genkit_statuses() -> None:
+    error = ClientError({'Error': {'Code': 'ThrottlingException', 'Message': 'boom'}}, 'InvokeModel')
+    transport = FakeInvokeTransport(error=error)
+    with pytest.raises(GenkitError, match='invoke model failed') as excinfo:
+        await rerank(COHERE_RERANK, transport, text_doc('query'), [text_doc('document')])
+    assert excinfo.value.status == 'RESOURCE_EXHAUSTED'
+
+
+@pytest.mark.asyncio
+async def test_botocore_errors_map_to_genkit_statuses() -> None:
+    transport = FakeInvokeTransport(error=NoCredentialsError())
+    with pytest.raises(GenkitError, match='invoke model failed') as excinfo:
+        await rerank(COHERE_RERANK, transport, text_doc('query'), [text_doc('document')])
+    assert excinfo.value.status == 'UNAUTHENTICATED'
+
+
+# ---- Plugin helper ----------------------------------------------------------
+
+# Go's nil-genkit, unregistered-plugin and uninitialized-plugin legs have no
+# Python analogue: rerank() is a method on the plugin instance itself.
+
+
+@pytest.mark.asyncio
+async def test_the_plugin_helper_requires_a_model_id() -> None:
+    plugin = Bedrock(region='us-east-1')
+    plugin._transport = cast(BedrockTransport, ForbiddenTransport())  # noqa: SLF001
+    with pytest.raises(GenkitError, match='bedrock rerank: model ID required') as excinfo:
+        await plugin.rerank('', query='query', documents=[text_doc('document')])
+    assert excinfo.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_the_plugin_helper_delegates_to_the_shared_transport() -> None:
+    plugin = Bedrock(region='us-east-1')
+    transport = FakeInvokeTransport(scored((0, 0.77)))
+    plugin._transport = cast(BedrockTransport, transport)  # noqa: SLF001
+
+    # A plain str query pins the Document.from_text coercion, and a plain dict
+    # of options pins the JSON path a flow or the Dev UI would take.
+    response = await plugin.rerank(
+        COHERE_RERANK,
+        query='query text',
+        documents=[text_doc('document text')],
+        options={'topN': 1},
+    )
+
+    assert transport.bodies()[0] == {
+        'query': 'query text',
+        'documents': ['document text'],
+        'top_n': 1,
+        'api_version': 2,
+    }
+    assert ranked_texts(response) == ['document text']
+    assert scores(response) == [0.77]
+
+
+@pytest.mark.asyncio
+async def test_the_plugin_helper_accepts_a_document_built_by_the_veneer() -> None:
+    plugin = Bedrock(region='us-east-1')
+    transport = FakeInvokeTransport(scored((0, 0.77)))
+    plugin._transport = cast(BedrockTransport, transport)  # noqa: SLF001
+
+    await plugin.rerank(COHERE_RERANK, query='query text', documents=[Document.from_text('document text')])
+
+    assert transport.bodies()[0]['documents'] == ['document text']

--- a/py/packages/genkit-amazon-bedrock/tests/rerank_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/rerank_test.py
@@ -320,7 +320,7 @@ def test_typed_options_are_passed_through_unchanged() -> None:
     [
         ({'topN': 7.0}, 7),
         ({'top_n': 7}, 7),
-        # Unknown keys are ignored, matching Go's json.Unmarshal.
+        # Unknown keys are ignored.
         ({'somethingElse': 1}, None),
     ],
 )
@@ -373,10 +373,6 @@ def test_an_out_of_range_index_is_internal(index: int) -> None:
     assert excinfo.value.status == 'INTERNAL'
 
 
-# Go's nil-document leg is dropped: a typed list[DocumentData] plus the
-# pre-call text validation make a nil document unreachable in Python.
-
-
 @pytest.mark.parametrize(
     ('payload', 'message'),
     [
@@ -420,9 +416,6 @@ async def test_botocore_errors_map_to_genkit_statuses() -> None:
 
 
 # ---- Plugin helper ----------------------------------------------------------
-
-# Go's nil-genkit, unregistered-plugin and uninitialized-plugin legs have no
-# Python analogue: rerank() is a method on the plugin instance itself.
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Slice 7 of the Bedrock Python port (#5820) adds reranking. Stacked on #6011. Reranking ships the same way Go ships it, as a plugin helper and not as a first-class ActionKind.RERANKER action as suggested by the issue.

## Changes

`Bedrock.rerank(model_id, query=..., documents=..., options=...)` calls Cohere Rerank over the existing InvokeModel transport. No new boto3 client, and no IAM beyond `bedrock:InvokeModel`.

Both rerank families are supported, and the body is built from the model ID because they are mutually incompatible: `cohere.rerank-*` requires `api_version` and rejects a body without it, `amazon.rerank-*` rejects the key outright as extraneous. Everything else about the two is identical, including the response shape. Go always sends `api_version`, so it cannot call `amazon.rerank-v1:0` at all (filed upstream as genkit-ai/aws-bedrock-go-plugin#190). That is the second divergence from `rerank.go`. The first: a malformed result entry is an error, where Go's `json.Unmarshal` zero-fills it, so a result missing `index` silently scores the first document. 

`resolve()` now returns None for rerank IDs under `ActionKind.MODEL`. They previously resolved as Converse chat models, which Cohere's model card marks unsupported, so the action could only fail when called. This flips an assertion added in slice 3.

