### PR TITLE
feat(py/plugins/amazon-bedrock): finish the sample app and README

### DIFF
--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -19,10 +19,10 @@ pip install genkit-amazon-bedrock
 
 ### Model access
 
-Nothing on Bedrock is callable by default. Access is granted per AWS account and
-per region, in the Bedrock console under Model access, and it has to be
-requested before any call: a grant in `us-east-1` says nothing about
-`us-west-2`, so a working setup can break purely by changing region.
+Model access is granted per AWS account and per region, in the Bedrock console
+under Model access, and most models cannot be called until it is: a grant in
+`us-east-1` says nothing about `us-west-2`, so a working setup can break purely
+by changing region.
 
 The Anthropic models additionally need the account's one-time use-case
 agreement (Bedrock console, Model access, Anthropic use case details). Until it
@@ -68,7 +68,7 @@ Credentials resolve through the standard AWS SDK chain, so any of these work:
   `AWS_SESSION_TOKEN` for temporary credentials)
 - the shared config and credentials files under `~/.aws`, selected with
   `AWS_PROFILE`
-- IAM roles attached to EC2, ECS, or Lambda, read from instance metadata
+- IAM roles attached to EC2, ECS, or Lambda, supplied by the platform at runtime
 - SSO profiles, after `aws sso login`
 
 Anything the chain does not cover goes through `session=`, which takes a
@@ -220,9 +220,9 @@ Notes:
   not treat a small `input_tokens` as a cache failure, and do not assert on it
   to prove a cache hit.
 - Passing a plain string as `system` sends it through Genkit's dotprompt
-  templating, which rewrites the text and can only produce text parts anyway. A
-  list of parts is what you want here, both to hold the cache point and to keep
-  the cached prefix byte-identical.
+  templating, which rewrites the text and cannot express a cache point. A list
+  of parts is what you want here, both to hold the cache point and to keep the
+  cached prefix byte-identical.
 
 ## Embedders
 

--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -85,10 +85,10 @@ ai = Genkit(
     plugins=[
         Bedrock(
             region='us-east-1',
-            models=[ModelDefinition(name='anthropic.claude-sonnet-4-5-20250929-v1:0')],
+            models=[ModelDefinition(name='us.anthropic.claude-sonnet-4-5-20250929-v1:0')],
         )
     ],
-    model='bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0',
+    model='bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0',
 )
 ```
 

--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -6,14 +6,74 @@ Cohere, and others) through the Bedrock Converse and ConverseStream APIs, and
 embeddings, image generation, and reranking through InvokeModel.
 
 > Status: text generation (streaming and non-streaming), embedders, image
-> generation, and reranking are available. The work left is sample app and
-> docsite coverage, not plugin surfaces.
+> generation, and reranking are available. A runnable sample app covers all of
+> it, so the work left is docsite coverage, not plugin surfaces.
 
 ## Installation
 
 ```bash
 pip install genkit-amazon-bedrock
 ```
+
+## AWS setup
+
+### Model access
+
+Nothing on Bedrock is callable by default. Access is granted per AWS account and
+per region, in the Bedrock console under Model access, and it has to be
+requested before any call: a grant in `us-east-1` says nothing about
+`us-west-2`, so a working setup can break purely by changing region.
+
+The Anthropic models additionally need the account's one-time use-case
+agreement (Bedrock console, Model access, Anthropic use case details). Until it
+is accepted, Claude calls fail with `ResourceNotFoundException`, which reads
+like a mistyped model ID rather than a missing agreement.
+
+### IAM
+
+The minimal policy covering everything this plugin does:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:*:*:inference-profile/*"
+      ]
+    }
+  ]
+}
+```
+
+Converse is authorized by `bedrock:InvokeModel` and ConverseStream by
+`bedrock:InvokeModelWithResponseStream`; there is no separate Converse action to
+grant. Embedding, image generation and reranking all go through InvokeModel, so
+they need only the first.
+
+The inference-profile resource is the part that is easy to leave out.
+Cross-region profile IDs such as `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+are account-scoped inference-profile ARNs rather than foundation-model ARNs, so
+a policy limited to `foundation-model/*` refuses them with
+`AccessDeniedException` even when model access is granted.
+
+### Credentials
+
+Credentials resolve through the standard AWS SDK chain, so any of these work:
+
+- environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+  `AWS_SESSION_TOKEN` for temporary credentials)
+- the shared config and credentials files under `~/.aws`, selected with
+  `AWS_PROFILE`
+- IAM roles attached to EC2, ECS, or Lambda, read from instance metadata
+- SSO profiles, after `aws sso login`
+
+Anything the chain does not cover goes through `session=`, which takes a
+pre-configured `boto3.session.Session`. Region resolution is separate from
+credentials and is described under [Usage](#usage).
 
 ## Usage
 
@@ -38,30 +98,54 @@ Credentials resolve through the standard AWS SDK chain (environment,
 from `region=` or the SDK chain (`AWS_REGION`, `AWS_DEFAULT_REGION`,
 `~/.aws/config`); there is deliberately no default region.
 
-### Client tuning
+### Plugin options
 
-`max_retries`, `read_timeout`, `connect_timeout` and `max_pool_connections`
-are unset by default, so your own AWS configuration wins and the package
-defaults (3 retries in standard mode, a 3600s read timeout, a 60s connect
-timeout and a pool of 50) fill in only where it is silent. Passing an argument
-explicitly overrides both.
+Every `Bedrock()` parameter, with its default:
+
+| Option                 | Default  | Meaning                                                                                                                     |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `region`               | unset    | AWS region. Falls back to the SDK chain; initialization fails when nothing resolves.                                        |
+| `max_retries`          | unset    | Retries after the initial attempt. Falls back to `3`, in botocore's `standard` mode, where your AWS configuration is silent. |
+| `read_timeout`         | unset    | Socket read timeout in seconds. Falls back to `3600.0`.                                                                     |
+| `connect_timeout`      | unset    | Socket connect timeout in seconds, covering the TCP handshake only. Falls back to `60.0`.                                   |
+| `max_pool_connections` | unset    | HTTP connection pool size. Falls back to `50`, raised off botocore's default of 10.                                         |
+| `total_timeout`        | `3600.0` | Whole-call deadline in seconds for a non-streaming generation, retries included. `None` removes it.                         |
+| `session`              | unset    | Pre-configured `boto3.session.Session` for custom credentials or SDK wiring.                                                |
+| `models`               | `[]`     | `ModelDefinition` entries to register. Unlisted IDs still resolve on demand.                                                |
+| `embedders`            | `[]`     | Embedding model IDs to register. Unlisted IDs still resolve on demand.                                                      |
+
+`max_retries`, `read_timeout`, `connect_timeout` and `max_pool_connections` are
+unset by default, so your own AWS configuration wins and the fallbacks above
+fill in only where it is silent. Passing an argument explicitly overrides both.
 
 Which sources apply differs by knob, because botocore only reads some of them:
 
 - Retries come from `AWS_MAX_ATTEMPTS`, `AWS_RETRY_MODE`, the `max_attempts`
   and `retry_mode` keys in `~/.aws/config`, or a session's default client
   config. The attempt count and the mode are resolved separately, so setting
-  just one of them leaves the other at the package default.
+  just one of them leaves the other at the package fallback, and passing
+  `max_retries` tunes the count without dragging you off `adaptive`.
 - The two timeouts and the pool size have no environment or config-file
   equivalent in botocore. Their only external source is a `botocore.config.Config`
   installed on a session you pass via `session=`.
 
-`total_timeout` (3600s, `None` to disable) is separate: it caps the whole
-call, including retries. The read timeout only bounds silence between two
-reads, so a connection that dribbles bytes never trips it. When the deadline
-fires the caller gets a `DEADLINE_EXCEEDED` error, though the boto3 call
-itself cannot be aborted and its worker thread runs until the socket timeouts
-end it.
+**`read_timeout` is a socket read timeout, not a whole-call deadline.** It
+bounds the wait for the next byte off the socket, not the length of the call,
+which is why its fallback is a full hour: a generation can legitimately run for
+many minutes (Nova allows 60-minute inference). Because it resets on every byte
+received, a connection that dribbles bytes never trips it.
+
+`total_timeout` is the wall-clock limit that does. It caps a non-streaming
+generation end to end, retries included, and is on by default at 3600s; pass
+`None` to remove it and leave only the socket timeouts. When the deadline fires
+the caller gets a `DEADLINE_EXCEEDED` error, though the boto3 call itself cannot
+be aborted and its worker thread runs until the socket timeouts end it.
+Streaming generations, embeddings, image generation and reranking are bounded
+by the socket timeouts alone.
+
+`max_pool_connections` falls back to 50 rather than botocore's 10 so the pool is
+never the bottleneck; concurrency is bounded first by the event loop's default
+thread pool, which the boto3 calls are dispatched to.
 
 ### Config fields that are ignored
 
@@ -73,6 +157,72 @@ through `additionalModelRequestFields` instead:
 ```python
 BedrockConfig(additional_model_request_fields={'top_k': 40})
 ```
+
+### Inference profiles
+
+Model IDs carrying one of the prefixes `global.`, `us-gov.`, `us.`, `eu.`,
+`jp.`, `apac.`, or `au.` are cross-region inference profiles, which route a call
+to whichever region in the geography has capacity:
+
+```python
+ModelDefinition(name='us.anthropic.claude-sonnet-4-5-20250929-v1:0')
+```
+
+The full ID is always sent to Bedrock verbatim. The prefix is stripped only for
+the local capability lookup, so a profile inherits its base model's declared
+capabilities instead of falling back to the unknown-model defaults. Several of
+the newer models are only invocable through a profile, never by bare
+foundation-model ID, so this is the normal form rather than an advanced option.
+Any profile ID or full ARN is accepted, across the `arn:aws:`, `arn:aws-us-gov:`
+and `arn:aws-cn:` partitions.
+
+## Prompt caching
+
+Bedrock can cache a prompt prefix and reuse it across calls, which is worth
+doing whenever a large static system prompt is sent repeatedly.
+`cache_point_part()` marks where the cacheable prefix ends:
+
+```python
+from genkit import Part, TextPart
+from genkit_amazon_bedrock import cache_point_part
+
+CLAUDE = 'bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+
+# The cache point goes after the content it should cache.
+system = [Part(root=TextPart(text=LONG_STATIC_PROMPT)), cache_point_part()]
+
+first = await ai.generate(model=CLAUDE, system=system, prompt='What are the delivery tiers?')
+second = await ai.generate(model=CLAUDE, system=system, prompt='Which tier needs a signature?')
+
+print(second.usage.cached_content_tokens)
+```
+
+Notes:
+
+- The cache point goes **after** the content it should cache, never before.
+- Cache points work in the system prompt and in ordinary user and model
+  messages. System messages keep only text and cache points; every other part
+  kind is dropped there.
+- The cached prefix must be byte-identical across calls to hit, so build it from
+  a constant rather than reassembling it per request.
+- A prefix below the model's minimum cacheable size (roughly 1,000 tokens for
+  Claude Sonnet, higher for the smaller models) is silently not cached. There is
+  no error and no warning, so a short prompt just quietly never hits.
+- The cache lives for a few minutes, which also means a re-run inside that
+  window can read a cache the previous run wrote.
+- On usage, `cacheReadInputTokens` surfaces as `usage.cached_content_tokens`.
+  `cacheWriteInputTokens` is deliberately dropped, so a cache write is
+  invisible: the second call reporting cached tokens the first did not is the
+  only evidence you get.
+- Bedrock counts cached tokens **outside** `inputTokens`, not within it, so
+  `usage.input_tokens` is only the uncached remainder and stays small however
+  well the cache works. The cached prefix appears in `usage.total_tokens`. Do
+  not treat a small `input_tokens` as a cache failure, and do not assert on it
+  to prove a cache hit.
+- Passing a plain string as `system` sends it through Genkit's dotprompt
+  templating, which rewrites the text and can only produce text parts anyway. A
+  list of parts is what you want here, both to hold the cache point and to keep
+  the cached prefix byte-identical.
 
 ## Embedders
 
@@ -312,6 +462,56 @@ being the only shape AWS documents for InvokeModel reranking.
 
 Any model ID is passed to InvokeModel verbatim, so inference profiles and ARNs
 work too.
+
+## Troubleshooting
+
+The plugin maps Bedrock error codes onto Genkit error statuses, so these arrive as typed `GenkitError` (`PERMISSION_DENIED`, `NOT_FOUND`, `INVALID_ARGUMENT`, `RESOURCE_EXHAUSTED`, and the rest) with the service's own message preserved. The AWS code is the useful part, and each one means something specific:
+
+**No region resolved.** The plugin fails at initialization rather than on the
+first call, and deliberately does not default to a region: a silent `us-east-1`
+fallback would send traffic and data somewhere you never chose. Set `region=`,
+`AWS_REGION`, `AWS_DEFAULT_REGION`, or a region on the active profile.
+
+**`AccessDeniedException`.** Either model access has not been granted for that
+model in that region, or the IAM policy is missing the inference-profile
+resource. Both are covered under [AWS setup](#aws-setup); check the policy first
+if the model ID carries a cross-region prefix, because that failure looks
+identical to a missing grant.
+
+**`ResourceNotFoundException`.** The model exists but this account cannot use
+it there: an Anthropic model whose use-case agreement has not been accepted, or
+a Legacy model. The Nova Canvas case is its own trap and is described under
+[Availability](#availability). A model that plainly is not offered in the
+region reports as a `ValidationException` instead, below.
+
+**`ValidationException` reading "The provided model identifier is invalid".**
+The ID is mistyped, or the model is not offered in the region the call went to.
+Both Converse and InvokeModel report a missing model this way, verified live,
+so it is what a region mistake actually looks like: calling
+`stability.sd3-5-large-v1:0` (us-west-2 only) from a session whose default
+region is `us-east-1` produces exactly this. Check the region before doubting
+the ID.
+
+**Any other `ValidationException`.** The request or config is malformed for
+that particular model: a thinking budget outside the bounds the model allows,
+or an image config field the family does not accept (the whole config dict
+reaches Stability, and everything inside `imageGenerationConfig` reaches the
+Amazon family). Bedrock validates per model, so a config that works on one
+model can be rejected by the next.
+
+**`ThrottlingException`.** The on-demand capacity limit for that model and
+region. The plugin retries automatically with exponential backoff, up to
+`max_retries` retries after the initial attempt, and surfaces the error once
+those are exhausted. Raise `max_retries`, spread the load, or move to
+provisioned throughput.
+
+## Examples
+
+See [`py/samples/amazon-bedrock-sample`](../../samples/amazon-bedrock-sample)
+for a runnable sample covering every surface here: text generation and
+streaming, structured output, tool calling, reasoning and extended thinking,
+embedders, prompt caching, image and document input, image generation, and
+reranking. Each one is a flow, so they can be run individually in the Dev UI.
 
 ## License
 

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -470,8 +470,7 @@ async def test_nova_image_input() -> None:
     request = media_request(STRIPES_PNG_DATA_URL, 'What colours are the bands in this image?')
     response = await make_model(NOVA).generate(request)
     assert response.finish_reason == FinishReason.STOP
-    assert response.message is not None
-    assert mentions_any(response.message.content[0].root.text, 'red', 'white', 'blue')
+    assert mentions_any(response.text, 'red', 'white', 'blue'), response.text
 
 
 async def test_claude_document_input() -> None:
@@ -479,13 +478,10 @@ async def test_claude_document_input() -> None:
     # double-encoded payload fails the call rather than degrading quietly.
     # Claude, not Nova: document support is per model, and this mirrors the
     # model the Go plugin's document example runs on.
-    request = media_request(
-        MEMO_PDF_DATA_URL, 'What does this document say?', config=BedrockConfig(max_output_tokens=512)
-    )
+    request = media_request(MEMO_PDF_DATA_URL, 'What does this document say?', config=BedrockConfig(max_tokens=512))
     response = await make_model(CLAUDE).generate(request)
     assert response.finish_reason == FinishReason.STOP
-    assert response.message is not None
-    assert mentions_any(response.message.content[0].root.text, 'kettle', 'tea', 'friday')
+    assert mentions_any(response.text, 'kettle', 'tea', 'friday'), response.text
 
 
 async def test_claude_prompt_cache_read() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -26,12 +26,14 @@ the chat models and from each other.
 
 import contextlib
 import os
+import re
 from collections.abc import Iterator
 
 import pytest
 from genkit_amazon_bedrock.config import BedrockConfig
 from genkit_amazon_bedrock.converters import (
     REASONING_SIGNATURE_METADATA_KEY,
+    cache_point_part,
 )
 from genkit_amazon_bedrock.embedders import BedrockEmbedder
 from genkit_amazon_bedrock.image import BedrockImageModel
@@ -85,6 +87,30 @@ AMAZON_RERANK_REGIONS = ('us-west-2', 'eu-central-1', 'ap-northeast-1', 'ca-cent
 # Smallest PNG Titan accepts.
 PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
 PNG_1X1_DATA_URL = f'data:image/png;base64,{PNG_1X1}'
+
+# A 64x48 PNG of three horizontal bands (red, white, blue). The 1x1 pixel above
+# is too small to ask a model about; these bands give a checkable answer.
+STRIPES_PNG_DATA_URL = (
+    'data:image/png;base64,'
+    'iVBORw0KGgoAAAANSUhEUgAAAEAAAAAwCAIAAAAuKetIAAAATklEQVR42u3PMQ0AMAwEsWAKksIOiNLoXg7ZXvLpCLhud/QFAAAAAAAA'
+    'AAAAALAGvPAAAAAAAAAAAAAAAPaAPhM9AAAAAAAAAAAAAMD6DyqspTygWsHeAAAAAElFTkSuQmCC'
+)
+
+# A one-page PDF reading "Genkit Bedrock sample memo / The office kettle is
+# broken. / Tea service resumes on Friday."
+MEMO_PDF_DATA_URL = (
+    'data:application/pdf;base64,'
+    'JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1Bh'
+    'Z2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVk'
+    'aWFCb3ggWzAgMCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA1IDAgUiA+PiA+PiAvQ29udGVudHMgNCAwIFIgPj4K'
+    'ZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCAxNTAgPj4Kc3RyZWFtCkJUCi9GMSAxNCBUZgoxIDAgMCAxIDcyIDcyMCBUbQoxOCBUTAoo'
+    'R2Vua2l0IEJlZHJvY2sgc2FtcGxlIG1lbW8pIFRqClQqCihUaGUgb2ZmaWNlIGtldHRsZSBpcyBicm9rZW4uKSBUagpUKgooVGVhIHNl'
+    'cnZpY2UgcmVzdW1lcyBvbiBGcmlkYXkuKSBUagpUKgpFVAplbmRzdHJlYW0KZW5kb2JqCjUgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1'
+    'YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhIC9FbmNvZGluZyAvV2luQW5zaUVuY29kaW5nID4+CmVuZG9iagp4cmVmCjAg'
+    'NgowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAw'
+    'IG4gCjAwMDAwMDAyNDEgMDAwMDAgbiAKMDAwMDAwMDQ0MiAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDYgL1Jvb3QgMSAwIFIgPj4K'
+    'c3RhcnR4cmVmCjUzOQolJUVPRgo='
+)
 
 
 def make_transport() -> BedrockTransport:
@@ -159,6 +185,69 @@ def text_request(text: str, **kwargs) -> ModelRequest:
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=text))])],
         **kwargs,
     )
+
+
+def media_request(data_url: str, text: str, **kwargs) -> ModelRequest:
+    """A user message carrying media plus the text Converse requires with it."""
+    return ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[Part(root=MediaPart(media=Media(url=data_url))), Part(root=TextPart(text=text))],
+            )
+        ],
+        **kwargs,
+    )
+
+
+_HANDBOOK_TOPICS = [
+    ('Returns', 'fulfilment', 'three business days'),
+    ('Shipping', 'logistics', 'one business day'),
+    ('Warranty', 'aftercare', 'five business days'),
+    ('Billing', 'finance', 'two business days'),
+    ('Accounts', 'identity', 'one business day'),
+    ('Privacy', 'legal', 'ten business days'),
+    ('Accessibility', 'design', 'four business days'),
+    ('Recycling', 'sustainability', 'six business days'),
+]
+
+_HANDBOOK_REGIONS = ['North America', 'Ireland', 'Germany', 'Japan']
+
+
+def mentions_any(text: str | None, *words: str) -> bool:
+    """Whether the text contains any of the words as whole words.
+
+    Substring matching would pass on 'coloured' for 'red' and 'instead' for
+    'tea', which a refusal could satisfy without ever reading the attachment.
+    """
+    haystack = (text or '').lower()
+    return any(re.search(rf'\b{re.escape(word)}\b', haystack) for word in words)
+
+
+def cacheable_prefix() -> str:
+    """A system prompt long enough to be cacheable, at roughly 3,500 tokens.
+
+    Claude will not cache a prefix below about 1,000 tokens, and reports no
+    error when it declines.
+    """
+    articles = []
+    for number, (topic, team, window) in enumerate(_HANDBOOK_TOPICS, start=1):
+        articles.append(
+            f'Article {number}. {topic}\n'
+            f'{topic} requests are handled by the {team} team in {window}. Escalations go to the duty manager, '
+            f'who answers within one business day. Records are retained for seven years and can be exported on '
+            f'request. This article is reviewed every quarter and supersedes any earlier guidance on {topic}.'
+        )
+        for section, region in enumerate(_HANDBOOK_REGIONS, start=1):
+            articles.append(
+                f'Article {number}.{section} {topic} in {region}\n'
+                f'In {region}, {topic.lower()} follows the same {window} target, measured in local business '
+                f'hours and excluding public holidays. The {team} team keeps a regional queue, and a request '
+                f'that misses its target is reported in the weekly service review. Customers are notified by '
+                f'email at intake and again at resolution, and may ask for a written summary of the decision '
+                f'at any point without charge.'
+            )
+    return 'Answer only from this handbook.\n\n' + '\n\n'.join(articles)
 
 
 def streaming_ctx() -> tuple[ActionRunContext, list]:
@@ -372,6 +461,62 @@ async def test_deepseek_reasoning_sync_and_round_trip() -> None:
         config=config,
     )
     assert (await model.generate(follow_up)).finish_reason == FinishReason.STOP
+
+
+async def test_nova_image_input() -> None:
+    # An image block Bedrock cannot parse fails the call outright, so reaching a
+    # normal stop is itself the assertion that the media round-tripped; the
+    # colour check is the evidence the pixels reached the model.
+    request = media_request(STRIPES_PNG_DATA_URL, 'What colours are the bands in this image?')
+    response = await make_model(NOVA).generate(request)
+    assert response.finish_reason == FinishReason.STOP
+    assert response.message is not None
+    assert mentions_any(response.message.content[0].root.text, 'red', 'white', 'blue')
+
+
+async def test_claude_document_input() -> None:
+    # Bedrock parses the PDF server-side, so a malformed document block or a
+    # double-encoded payload fails the call rather than degrading quietly.
+    # Claude, not Nova: document support is per model, and this mirrors the
+    # model the Go plugin's document example runs on.
+    request = media_request(
+        MEMO_PDF_DATA_URL, 'What does this document say?', config=BedrockConfig(max_output_tokens=512)
+    )
+    response = await make_model(CLAUDE).generate(request)
+    assert response.finish_reason == FinishReason.STOP
+    assert response.message is not None
+    assert mentions_any(response.message.content[0].root.text, 'kettle', 'tea', 'friday')
+
+
+async def test_claude_prompt_cache_read() -> None:
+    # Two calls sharing a byte-identical cached prefix: the first writes the
+    # cache, the second reads it. Only reads surface, since the plugin drops
+    # cacheWriteInputTokens, so the second call carries the evidence.
+    model = make_model(CLAUDE)
+    system = Message(
+        role=Role.SYSTEM,
+        content=[Part(root=TextPart(text=cacheable_prefix())), cache_point_part()],
+    )
+    config = BedrockConfig(max_tokens=512)
+
+    def ask(question: str) -> ModelRequest:
+        return ModelRequest(
+            messages=[system, Message(role=Role.USER, content=[Part(root=TextPart(text=question))])],
+            config=config,
+        )
+
+    first = await model.generate(ask('Which article covers returns? Answer with its number.'))
+    assert first.finish_reason == FinishReason.STOP
+
+    second = await model.generate(ask('Which article covers shipping? Answer with its number.'))
+    assert second.finish_reason == FinishReason.STOP
+    assert second.usage is not None
+    cached = second.usage.cached_content_tokens
+    # Above the minimum, not merely above zero: that also catches the prefix
+    # being shrunk under it, which Bedrock answers by quietly not caching.
+    # Do not assert on input_tokens; it excludes cached tokens, so it stays
+    # small on both calls however well the cache works.
+    assert cached is not None and cached > 1024, f'expected a cache read over the minimum, got {cached!r}'
 
 
 async def test_embed_titan_text_v1() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -478,7 +478,9 @@ async def test_claude_document_input() -> None:
     # double-encoded payload fails the call rather than degrading quietly.
     # Claude, not Nova: document support is per model, and this mirrors the
     # model the Go plugin's document example runs on.
-    request = media_request(MEMO_PDF_DATA_URL, 'What does this document say?', config=BedrockConfig(max_tokens=512))
+    request = media_request(
+        MEMO_PDF_DATA_URL, 'What does this document say?', config=BedrockConfig(max_output_tokens=512)
+    )
     response = await make_model(CLAUDE).generate(request)
     assert response.finish_reason == FinishReason.STOP
     assert mentions_any(response.text, 'kettle', 'tea', 'friday'), response.text
@@ -493,7 +495,7 @@ async def test_claude_prompt_cache_read() -> None:
         role=Role.SYSTEM,
         content=[Part(root=TextPart(text=cacheable_prefix())), cache_point_part()],
     )
-    config = BedrockConfig(max_tokens=512)
+    config = BedrockConfig(max_output_tokens=512)
 
     def ask(question: str) -> ModelRequest:
         return ModelRequest(

--- a/py/packages/genkit-amazon-bedrock/tests/live_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/live_test.py
@@ -476,8 +476,7 @@ async def test_nova_image_input() -> None:
 async def test_claude_document_input() -> None:
     # Bedrock parses the PDF server-side, so a malformed document block or a
     # double-encoded payload fails the call rather than degrading quietly.
-    # Claude, not Nova: document support is per model, and this mirrors the
-    # model the Go plugin's document example runs on.
+    # Claude, not Nova: document support is per model.
     request = media_request(
         MEMO_PDF_DATA_URL, 'What does this document say?', config=BedrockConfig(max_output_tokens=512)
     )

--- a/py/samples/README.md
+++ b/py/samples/README.md
@@ -24,6 +24,7 @@ Dev UI: http://localhost:4000. Most samples need `GEMINI_API_KEY`. See [plugins/
 
 | Sample | What it shows |
 |--------|----------------|
+| `amazon-bedrock-sample` | Chat, streaming, tools, reasoning, embeddings, prompt caching, image and PDF input, image generation, and reranking on Amazon Bedrock |
 | `basic-flows` | Framework fundamentals — traced steps, streaming, errors, long-running flows (no model) |
 | `context` | Pass context through `generate()`, flows, and tools |
 | `dynamic-tools` | Create a tool at runtime and trace plain functions |

--- a/py/samples/amazon-bedrock-sample/README.md
+++ b/py/samples/amazon-bedrock-sample/README.md
@@ -6,16 +6,16 @@ reranking through Genkit with Amazon Bedrock's Converse, ConverseStream, and
 InvokeModel APIs.
 
 You need an AWS account with Amazon Bedrock model access granted for the models
-the sample runs on startup:
+the CLI smoke run below uses:
 
 - `us.amazon.nova-lite-v1:0`
-- `us.meta.llama3-3-70b-instruct-v1:0`
-- `us.deepseek.r1-v1:0`
 - `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
 - `amazon.titan-embed-text-v2:0`
 
 The remaining models need one grant each, and only fail when you run their flow:
 
+- `us.meta.llama3-3-70b-instruct-v1:0` for `cat_profile`
+- `us.deepseek.r1-v1:0` for `reasoning`
 - `amazon.titan-embed-image-v1` for `embed_image`
 - `cohere.embed-english-v3` for `embed_batch` with `embedder` set to Cohere
 - `amazon.nova-2-multimodal-embeddings-v1:0` is offered in `us-east-1` only, and
@@ -25,7 +25,7 @@ The remaining models need one grant each, and only fail when you run their flow:
   not offered in `us-east-1`
 
 `describe_image`, `summarize_pdf` and `prompt_caching` need no grant beyond the
-startup list, since they run on models already on it: Nova Lite for
+smoke-run list, since they run on models already on it: Nova Lite for
 `describe_image`, and Claude for the other two.
 
 The Anthropic model additionally needs the account's one-time use-case
@@ -50,7 +50,7 @@ is offered in `us-east-1` only. In `us-east-1` the trade goes the other way:
 `generate_image` fails with `ValidationException: The provided model identifier
 is invalid`, which is Bedrock's way of saying the model is not offered in the
 calling region, and `amazon.rerank-v1:0` is unavailable, though
-`cohere.rerank-v3-5:0` works. A region set in `~/.aws/config` counts, so an
+`cohere.rerank-v3-5:0` works. A region set in `~/.aws/config` counts, so a
 `us-east-1` profile default quietly wins when no `AWS_REGION` is exported.
 
 Run the quick smoke test:
@@ -173,10 +173,10 @@ Only cache reads surface, because the plugin deliberately drops the write
 counter, so the evidence is the second call reporting `cached_content_tokens`
 that the first did not. Bedrock counts cached tokens separately from
 `inputTokens` rather than inside it, so the flow reports the uncached remainder
-under its own name and the manual only shows up in the total. A prefix below the
-model's minimum, roughly 1,000 tokens
-for Claude Sonnet, is silently not cached rather than rejected, which is why the
-sample's manual is padded out to about 2,000 tokens. Re-running inside the
+under its own name and the manual only shows up in the total. A prefix below
+the model's minimum, roughly 1,000 tokens for Claude Sonnet, is silently not
+cached rather than rejected, which is why the sample's manual is padded out to
+about 2,000 tokens. Re-running inside the
 cache's few-minute lifetime can show a read on the first call too, so the flow
 reports what the second call did and claims nothing about the first.
 

--- a/py/samples/amazon-bedrock-sample/README.md
+++ b/py/samples/amazon-bedrock-sample/README.md
@@ -155,8 +155,7 @@ accompanying text in the message, which the question supplies.
 
 Support for either kind of attachment is per model, not a plugin feature, which
 is why `summarize_pdf` asks Claude rather than the Nova Lite default that
-`describe_image` uses; Claude is also the model the Go plugin's own document
-example runs on.
+`describe_image` uses.
 
 Both assets are inline constants in the sample, so there are no asset files to
 keep around: a 64x48 PNG of three horizontal bands, and a one-page PDF holding

--- a/py/samples/amazon-bedrock-sample/README.md
+++ b/py/samples/amazon-bedrock-sample/README.md
@@ -1,8 +1,9 @@
 # Amazon Bedrock
 
 Run text generation, streaming, structured output, tool calling, reasoning,
-and embeddings through Genkit with Amazon Bedrock's Converse, ConverseStream,
-and InvokeModel APIs.
+prompt caching, image and document input, embeddings, image generation, and
+reranking through Genkit with Amazon Bedrock's Converse, ConverseStream, and
+InvokeModel APIs.
 
 You need an AWS account with Amazon Bedrock model access granted for the models
 the sample runs on startup:
@@ -13,16 +14,24 @@ the sample runs on startup:
 - `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
 - `amazon.titan-embed-text-v2:0`
 
-The other embedders need one grant each, and only fail when you run their flow:
+The remaining models need one grant each, and only fail when you run their flow:
 
 - `amazon.titan-embed-image-v1` for `embed_image`
 - `cohere.embed-english-v3` for `embed_batch` with `embedder` set to Cohere
 - `amazon.nova-2-multimodal-embeddings-v1:0` is offered in `us-east-1` only, and
   fails everywhere else however you invoke it
+- `stability.sd3-5-large-v1:0` for `generate_image`, offered in `us-west-2` only
+- `cohere.rerank-v3-5:0` for `rerank`; `amazon.rerank-v1:0` works too, but is
+  not offered in `us-east-1`
+
+`describe_image`, `summarize_pdf` and `prompt_caching` need no grant beyond the
+startup list, since they run on models already on it: Nova Lite for
+`describe_image`, and Claude for the other two.
 
 The Anthropic model additionally needs the account's one-time use-case
 agreement (Bedrock console, Model access, Anthropic use case details); the
-`thinking` flow fails with `ResourceNotFoundException` until it is granted.
+`thinking`, `thinking_stream`, `summarize_pdf` and `prompt_caching` flows fail
+with `ResourceNotFoundException` until it is granted.
 
 Credentials come from the standard AWS chain; environment variables, an
 `AWS_PROFILE` (including SSO profiles after `aws sso login`), or instance
@@ -31,8 +40,18 @@ the active profile:
 
 ```bash
 export AWS_PROFILE=my-profile
-export AWS_REGION=us-east-1
+export AWS_REGION=us-west-2
 ```
+
+`us-west-2` runs the most flows: it is the only region with active
+text-to-image models, and it has both rerank models. The one flow it cannot run
+is `embed_batch` switched to `amazon.nova-2-multimodal-embeddings-v1:0`, which
+is offered in `us-east-1` only. In `us-east-1` the trade goes the other way:
+`generate_image` fails with `ValidationException: The provided model identifier
+is invalid`, which is Bedrock's way of saying the model is not offered in the
+calling region, and `amazon.rerank-v1:0` is unavailable, though
+`cohere.rerank-v3-5:0` works. A region set in `~/.aws/config` counts, so an
+`us-east-1` profile default quietly wins when no `AWS_REGION` is exported.
 
 Run the quick smoke test:
 
@@ -61,6 +80,11 @@ Then open [http://localhost:4000](http://localhost:4000) and try:
 - `embed_batch`
 - `embed_similarity`
 - `embed_image`
+- `describe_image`
+- `summarize_pdf`
+- `prompt_caching`
+- `generate_image`
+- `rerank`
 
 The `*_stream` flows go through ConverseStream. Chunks are deltas rather than
 snapshots, so the Dev UI's streamed output is the concatenation of them; a tool
@@ -68,7 +92,7 @@ call is the exception, arriving whole in one chunk because its arguments come
 over the wire as JSON fragments.
 
 The plugin resolves any Bedrock model ID, inference profile, or ARN on demand,
-so the Dev UI model runner also works with models beyond the four declared
+so the Dev UI model runner also works with models beyond the five declared
 ones.
 
 Bedrock has no constrained-decoding mode, so structured output is carried by
@@ -114,3 +138,69 @@ be invoked directly with a raw request — useful for a model no flow covers:
 The response is the raw vector, which is why the flows above summarize instead.
 Declaring an embedder costs nothing at startup: no call is made until a flow or
 the Dev UI runs one.
+
+## Vision and documents
+
+Media rides along on a Converse prompt as a data URL. `describe_image` attaches
+a PNG and asks a question about it, and `summarize_pdf` does the same with a
+PDF. Remote `http(s)` URLs are refused rather than fetched, so the bytes have to
+be in the request; the MIME type is read off the data URL when the media part
+carries none of its own.
+
+The MIME type is what decides the rest. A document MIME type becomes a Converse
+`document` block rather than an `image` block, so attaching a CSV or a
+spreadsheet is this same code path: the plugin accepts pdf, csv, doc, docx, xls,
+xlsx, html, txt and md. Bedrock parses the document server-side, and wants
+accompanying text in the message, which the question supplies.
+
+Support for either kind of attachment is per model, not a plugin feature, which
+is why `summarize_pdf` asks Claude rather than the Nova Lite default that
+`describe_image` uses; Claude is also the model the Go plugin's own document
+example runs on.
+
+Both assets are inline constants in the sample, so there are no asset files to
+keep around: a 64x48 PNG of three horizontal bands, and a one-page PDF holding
+three lines of text.
+
+## Prompt caching
+
+`prompt_caching` puts two unrelated questions to the same large system prompt.
+The cache point goes after the static prefix it should cache, and that prefix
+has to be byte-identical between calls to hit, which is why the support manual
+is a module-level constant rather than something the flow rebuilds per call.
+
+Only cache reads surface, because the plugin deliberately drops the write
+counter, so the evidence is the second call reporting `cached_content_tokens`
+that the first did not. Bedrock counts cached tokens separately from
+`inputTokens` rather than inside it, so the flow reports the uncached remainder
+under its own name and the manual only shows up in the total. A prefix below the
+model's minimum, roughly 1,000 tokens
+for Claude Sonnet, is silently not cached rather than rejected, which is why the
+sample's manual is padded out to about 2,000 tokens. Re-running inside the
+cache's few-minute lifetime can show a read on the first call too, so the flow
+reports what the second call did and claims nothing about the first.
+
+## Image generation
+
+Image models go through InvokeModel, but they are ordinary Genkit model actions,
+so `generate_image` gets its result back as a media part holding a data URL. The
+flow returns a size summary rather than the base64 itself, which is unreadable
+in the Dev UI, and the image is visible on the model action in the Dev UI trace.
+
+The two image families take incompatible request bodies and the plugin routes on
+the model ID, so the flow's `aspect_ratio` and `output_format` inputs are
+Stability fields. The Amazon family, Nova Canvas and Titan Image, reads only
+`imageGenerationConfig` and silently ignores them. Image models never stream.
+
+## Reranking
+
+Reranking is a method on the plugin instance rather than a registered Genkit
+action, because Genkit Python has no reranker primitive to register against.
+That is why the sample keeps a reference to the `Bedrock` it passed to `Genkit`;
+`rerank` is the only flow that needs it.
+
+Results come back in the service's own descending-relevance order and are
+neither re-sorted nor truncated locally, so what the flow prints is what Bedrock
+returned. Each ranked document carries the input document's content verbatim
+with a fresh score, and the input document's own metadata is dropped. A `top_n`
+of 0 or less means all of the documents.

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -14,17 +14,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Amazon Bedrock samples for the Converse, ConverseStream, and embedding paths.
+"""Amazon Bedrock samples for every surface the plugin exposes.
 
 Needs AWS credentials and a region (``AWS_REGION`` or ``~/.aws/config``) with
 model access granted for the models below. The flows named ``*_stream`` go
-through ConverseStream; the ``embed_*`` flows go through InvokeModel; the rest
-are a single Converse call.
+through ConverseStream; ``embed_*``, ``generate_image`` and ``rerank`` go
+through InvokeModel; the rest are Converse calls. ``describe_image`` and
+``summarize_pdf`` attach media to a Converse prompt, and ``prompt_caching``
+reuses a cached system prompt across two calls.
+
+``us-west-2`` is the region that runs all of these; see the README for the
+per-model exceptions.
 """
 
 import math
 
-from genkit_amazon_bedrock import Bedrock, ModelDefinition
+from genkit_amazon_bedrock import Bedrock, BedrockRerankOptions, ModelDefinition, cache_point_part
 from pydantic import BaseModel, Field
 
 from genkit import (
@@ -35,6 +40,7 @@ from genkit import (
     Media,
     MediaPart,
     ModelResponse,
+    Part,
     ReasoningPart,
     TextPart,
 )
@@ -47,6 +53,8 @@ TITAN_EMBED = 'amazon.titan-embed-text-v2:0'
 TITAN_EMBED_IMAGE = 'amazon.titan-embed-image-v1'
 COHERE_EMBED = 'cohere.embed-english-v3'
 NOVA_EMBED = 'amazon.nova-2-multimodal-embeddings-v1:0'
+STABILITY_IMAGE = 'stability.sd3-5-large-v1:0'
+COHERE_RERANK = 'cohere.rerank-v3-5:0'
 
 # The smallest PNG Titan accepts (1x1 pixel), inline so the multimodal flow
 # needs no asset file. Titan wants raw base64 in the request body; the plugin
@@ -55,22 +63,101 @@ PNG_1X1_DATA_URL = (
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
 )
 
-# Declaring an embedder costs nothing at startup: no AWS call happens until a flow runs one,
-# so a missing model-access grant only surfaces when you use it.
-ai = Genkit(
-    plugins=[
-        Bedrock(
-            models=[
-                ModelDefinition(name='us.amazon.nova-lite-v1:0'),
-                ModelDefinition(name='us.meta.llama3-3-70b-instruct-v1:0'),
-                ModelDefinition(name='us.deepseek.r1-v1:0'),
-                ModelDefinition(name='us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
-            ],
-            embedders=[TITAN_EMBED, TITAN_EMBED_IMAGE, COHERE_EMBED, NOVA_EMBED],
-        )
-    ],
-    model=NOVA,
+# A 64x48 PNG of three horizontal bands (red, white, blue). Big enough for a
+# model to describe, unlike the 1x1 pixel above, and small enough to inline.
+STRIPES_PNG_DATA_URL = (
+    'data:image/png;base64,'
+    'iVBORw0KGgoAAAANSUhEUgAAAEAAAAAwCAIAAAAuKetIAAAATklEQVR42u3PMQ0AMAwEsWAKksIOiNLoXg7ZXvLpCLhud/QFAAAAAAAA'
+    'AAAAALAGvPAAAAAAAAAAAAAAAPaAPhM9AAAAAAAAAAAAAMD6DyqspTygWsHeAAAAAElFTkSuQmCC'
 )
+
+# A one-page PDF holding three lines of text, inline for the same reason.
+MEMO_PDF_DATA_URL = (
+    'data:application/pdf;base64,'
+    'JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1Bh'
+    'Z2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVk'
+    'aWFCb3ggWzAgMCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA1IDAgUiA+PiA+PiAvQ29udGVudHMgNCAwIFIgPj4K'
+    'ZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCAxNTAgPj4Kc3RyZWFtCkJUCi9GMSAxNCBUZgoxIDAgMCAxIDcyIDcyMCBUbQoxOCBUTAoo'
+    'R2Vua2l0IEJlZHJvY2sgc2FtcGxlIG1lbW8pIFRqClQqCihUaGUgb2ZmaWNlIGtldHRsZSBpcyBicm9rZW4uKSBUagpUKgooVGVhIHNl'
+    'cnZpY2UgcmVzdW1lcyBvbiBGcmlkYXkuKSBUagpUKgpFVAplbmRzdHJlYW0KZW5kb2JqCjUgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1'
+    'YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhIC9FbmNvZGluZyAvV2luQW5zaUVuY29kaW5nID4+CmVuZG9iagp4cmVmCjAg'
+    'NgowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAw'
+    'IG4gCjAwMDAwMDAyNDEgMDAwMDAgbiAKMDAwMDAwMDQ0MiAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDYgL1Jvb3QgMSAwIFIgPj4K'
+    'c3RhcnR4cmVmCjUzOQolJUVPRgo='
+)
+
+# Facts the prompt_caching questions are answered from.
+_MANUAL_ARTICLES = [
+    (
+        'Returns and refunds',
+        'Kettles, toasters, blenders and other small kitchen appliances may be returned within 30 days of '
+        'delivery for a full refund, whether or not the box has been opened. Furniture and mattresses have a '
+        '100-night trial instead. Refunds are issued to the original payment method within five business days '
+        'of the return arriving at the warehouse.',
+    ),
+    (
+        'Shipping destinations',
+        'We ship to Canada, Mexico, Ireland, Germany, Japan and Australia. Domestic orders over 50 dollars '
+        'ship free; international orders are quoted at checkout and are shipped on a delivered-duty-paid '
+        'basis, so no customs charges are collected on arrival.',
+    ),
+    (
+        'Warranty',
+        'Every appliance carries a two-year warranty against manufacturing defects, extended to five years '
+        'for the Heirloom range. Accidental damage is not covered. A warranty claim needs the order number '
+        'and a photograph of the serial-number plate.',
+    ),
+]
+
+# Padding: a prompt below the minimum cacheable size (roughly 1,000 tokens for
+# Claude Sonnet) is silently not cached.
+_MANUAL_REGIONS = ['North America', 'Ireland', 'Germany', 'Japan', 'Australia']
+_MANUAL_TIERS = [
+    ('Standard', '3 to 6 business days', 'no signature required'),
+    ('Express', '1 to 2 business days', 'signature required on delivery'),
+    ('Freight', '7 to 21 business days', 'a two-person delivery team and an appointment window'),
+]
+
+
+def _support_manual() -> str:
+    """Build the static system prompt the caching flow reuses across calls."""
+    sections = [
+        'You are the support assistant for Kettle & Crate, a home goods retailer. Answer only from the '
+        'manual below, in one or two sentences, and say so plainly when the manual does not cover the '
+        'question.',
+    ]
+    for title, body in _MANUAL_ARTICLES:
+        sections.append(f'{title}\n{body}')
+    for region in _MANUAL_REGIONS:
+        for tier, window, note in _MANUAL_TIERS:
+            sections.append(
+                f'{tier} delivery, {region}\n'
+                f'{tier} delivery to {region} arrives in {window} and requires {note}. Orders placed after '
+                f'14:00 local time enter the next working day. Tracking is emailed when the parcel leaves the '
+                f'warehouse and again on the morning of delivery. A missed delivery is held at the local depot '
+                f'for ten days before it is returned to us, and a redelivery can be booked once at no charge. '
+                f'Damage in transit must be reported within 48 hours of delivery with photographs of both the '
+                f'packaging and the item.'
+            )
+    return '\n\n'.join(sections)
+
+
+CACHED_SYSTEM_PROMPT = _support_manual()
+
+# Declaring a model or embedder costs nothing at startup: no AWS call happens until a flow runs
+# one, so a missing model-access grant only surfaces when you use it. The plugin instance is kept
+# because rerank is a method on it rather than a registered action.
+bedrock = Bedrock(
+    models=[
+        ModelDefinition(name='us.amazon.nova-lite-v1:0'),
+        ModelDefinition(name='us.meta.llama3-3-70b-instruct-v1:0'),
+        ModelDefinition(name='us.deepseek.r1-v1:0'),
+        ModelDefinition(name='us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+        ModelDefinition(name=STABILITY_IMAGE, type='image'),
+    ],
+    embedders=[TITAN_EMBED, TITAN_EMBED_IMAGE, COHERE_EMBED, NOVA_EMBED],
+)
+ai = Genkit(plugins=[bedrock], model=NOVA)
 
 
 class TopicInput(BaseModel):
@@ -140,6 +227,79 @@ class MultimodalEmbedInput(BaseModel):
 
     text: str = Field(default='a white square', description='Caption embedded alongside the image')
     image_data_url: str = Field(default=PNG_1X1_DATA_URL, description='PNG or JPEG image as a data URL')
+
+
+class VisionInput(BaseModel):
+    """Input for the image-description flow."""
+
+    question: str = Field(
+        default='What does this image look like? Answer in one sentence.',
+        description='Question to ask about the image',
+    )
+    image_data_url: str = Field(
+        default=STRIPES_PNG_DATA_URL,
+        description='PNG, JPEG, GIF or WebP image as a data URL; remote URLs are rejected',
+    )
+
+
+class PdfInput(BaseModel):
+    """Input for the document-summary flow."""
+
+    question: str = Field(
+        default='What does this document say? Answer in one sentence.',
+        description='Question to ask about the document',
+    )
+    pdf_data_url: str = Field(
+        default=MEMO_PDF_DATA_URL,
+        description='PDF as a data URL; csv, docx, xlsx, html, txt and md work the same way',
+    )
+
+
+class CacheInput(BaseModel):
+    """Input for the prompt-caching flow."""
+
+    first_question: str = Field(
+        default='What is the return window for a kettle?',
+        description='Asked on the first call, which writes the cache',
+    )
+    second_question: str = Field(
+        default='Which countries do you ship to?',
+        description='Asked on the second call, which should read the cache',
+    )
+
+
+class ImageInput(BaseModel):
+    """Input for the text-to-image flow."""
+
+    prompt: str = Field(
+        default='A tabby cat asleep on a sunlit windowsill, watercolour.',
+        description='Text-to-image prompt',
+    )
+    model: str = Field(
+        default=STABILITY_IMAGE,
+        description='Bedrock image model ID; the active text-to-image models are offered in us-west-2 only',
+    )
+    aspect_ratio: str = Field(default='1:1', description="Stability aspect ratio, e.g. '16:9'")
+    output_format: str = Field(default='png', description='Stability output format: png, jpeg or webp')
+
+
+class RerankInput(BaseModel):
+    """Input for the rerank flow."""
+
+    model: str = Field(
+        default=COHERE_RERANK,
+        description='Bedrock rerank model ID; amazon.rerank-v1:0 is not offered in us-east-1',
+    )
+    query: str = Field(default='How do I configure authentication for Bedrock?', description='Query to rank against')
+    documents: list[str] = Field(
+        default=[
+            'Configure AWS credentials with environment variables, a shared credentials file, or AWS SSO.',
+            'Nova Canvas returns generated images as base64-encoded PNG data.',
+            'Model access is granted per account and region in the Bedrock console.',
+        ],
+        description='Documents to rank; only the first answers the default query',
+    )
+    top_n: int = Field(default=0, description='How many ranked documents to return; 0 or less means all of them')
 
 
 @ai.tool()
@@ -404,6 +564,151 @@ async def embed_image(data: MultimodalEmbedInput) -> dict[str, object]:
     }
 
 
+@ai.flow()
+async def describe_image(data: VisionInput) -> str:
+    """Ask a multimodal model about an image attached to the prompt.
+
+    Genkit carries the image as a data URL; the plugin decodes it to raw bytes
+    because boto3 base64-encodes the field itself, so passing base64 through
+    would double-encode it. Remote http(s) URLs are refused rather than
+    fetched, and the MIME type is read from the data URL when the media part
+    does not carry one.
+    """
+    response = await ai.generate(
+        prompt=[
+            Part(root=MediaPart(media=Media(url=data.image_data_url))),
+            Part(root=TextPart(text=data.question)),
+        ]
+    )
+    return response.text
+
+
+@ai.flow()
+async def summarize_pdf(data: PdfInput) -> str:
+    """Ask a model about a PDF attached to the prompt.
+
+    A media part whose MIME type is a document type becomes a Converse
+    ``document`` block rather than an ``image`` block, so attaching a
+    spreadsheet or a CSV is this same code path. Bedrock parses the document
+    server-side, and requires accompanying text in the message, which the
+    question supplies. Claude is used rather than the default Nova because
+    document support is per model, and it is the model the Go plugin's own
+    document example runs on.
+    """
+    response = await ai.generate(
+        model=CLAUDE,
+        prompt=[
+            Part(root=MediaPart(media=Media(url=data.pdf_data_url))),
+            Part(root=TextPart(text=data.question)),
+        ],
+        config={'maxTokens': 512},
+    )
+    return response.text
+
+
+@ai.flow()
+async def prompt_caching(data: CacheInput) -> dict[str, object]:
+    """Reuse a cached system prompt across two calls.
+
+    The cache point goes after the static prefix it should cache, and the
+    prefix has to be byte-identical between calls to hit, which is why the
+    manual is a module-level constant. Only cache reads surface:
+    ``cacheReadInputTokens`` becomes ``cached_content_tokens`` while the write
+    counter is deliberately dropped, so the evidence is the second call
+    reporting cached tokens the first did not. ``input_tokens`` counts only the
+    uncached remainder, which is why it stays small on both calls and the
+    manual shows up in ``total_tokens`` instead.
+    """
+    system = [Part(root=TextPart(text=CACHED_SYSTEM_PROMPT)), cache_point_part()]
+    first = await ai.generate(model=CLAUDE, system=system, prompt=data.first_question, config={'maxTokens': 512})
+    second = await ai.generate(model=CLAUDE, system=system, prompt=data.second_question, config={'maxTokens': 512})
+    return {
+        'model': CLAUDE,
+        'system_prompt_chars': len(CACHED_SYSTEM_PROMPT),
+        'calls': [
+            {
+                'question': question,
+                'answer': response.text,
+                'uncached_input_tokens': _token_count(response, 'input_tokens'),
+                'cached_content_tokens': _token_count(response, 'cached_content_tokens'),
+                'total_tokens': _token_count(response, 'total_tokens'),
+            }
+            for question, response in ((data.first_question, first), (data.second_question, second))
+        ],
+        # Only the second call is claimed: a re-run inside the cache's
+        # few-minute lifetime reads the cache the previous run wrote.
+        'cache_read_on_second_call': bool(second.usage and second.usage.cached_content_tokens),
+    }
+
+
+@ai.flow()
+async def generate_image(data: ImageInput) -> dict[str, object]:
+    """Generate an image through InvokeModel.
+
+    Image models are ordinary Genkit model actions, so the image comes back as
+    a media part holding a data URL; the summary below is returned instead of
+    the base64, which is unreadable in the Dev UI, and the image itself is on
+    the model action's trace. The two families take incompatible bodies and the
+    plugin routes on the model ID: the flat fields below are Stability's, and
+    the Amazon family reads only ``imageGenerationConfig``. Nothing streams.
+    """
+    response = await ai.generate(
+        model=f'bedrock/{data.model}',
+        prompt=data.prompt,
+        config={'aspect_ratio': data.aspect_ratio, 'output_format': data.output_format},
+    )
+    media = response.media
+    if not media:
+        raise RuntimeError(f'Bedrock returned no images for {data.model}.')
+    url = media[0].url
+    _, _, payload = url.partition(',')
+    return {
+        'model': data.model,
+        'images': len(media),
+        'content_type': media[0].content_type,
+        'approx_kilobytes': round(len(payload) * 3 / 4 / 1024),
+        'data_url_preview': f'{url[:48]}...',
+    }
+
+
+@ai.flow()
+async def rerank(data: RerankInput) -> dict[str, object]:
+    """Score documents against a query with a Bedrock reranking model.
+
+    Reranking is a method on the plugin instance rather than a registered
+    action, because Genkit Python has no reranker primitive to register
+    against; that is why the sample keeps a reference to the ``Bedrock`` it
+    passed to ``Genkit``. Results arrive in the service's own
+    descending-relevance order and each carries a fresh score, with the input
+    document's content verbatim and its metadata dropped.
+    """
+    response = await bedrock.rerank(
+        data.model,
+        query=data.query,
+        documents=[Document.from_text(text) for text in data.documents],
+        options=BedrockRerankOptions(top_n=data.top_n),
+    )
+    return {
+        'model': data.model,
+        'query': data.query,
+        'ranked': [
+            {'text': _document_text(document.content), 'score': round(document.metadata.score, 5)}
+            for document in response.documents
+        ],
+    }
+
+
+def _document_text(content: list[DocumentPart]) -> str:
+    """Concatenate the text parts of a ranked document."""
+    return ''.join(part.root.text for part in content if isinstance(part.root, TextPart))
+
+
+def _token_count(response: ModelResponse, field: str) -> int | None:
+    """Read a token counter off a response as an int; they arrive as floats."""
+    value = getattr(response.usage, field, None) if response.usage else None
+    return int(value) if value is not None else None
+
+
 def _magnitude(vector: list[float]) -> float:
     """Euclidean length of a vector; stdlib math only, the sample has no numpy."""
     return math.sqrt(math.fsum(value * value for value in vector))
@@ -453,13 +758,16 @@ async def main() -> None:
         print(await haiku(TopicInput()))  # noqa: T201
         print(await haiku_stream(TopicInput()))  # noqa: T201
         print(await weather_report(CityInput()))  # noqa: T201
+        print(await describe_image(VisionInput()))  # noqa: T201
+        print(await summarize_pdf(PdfInput()))  # noqa: T201
         print(await embed_text(EmbedInput()))  # noqa: T201
         print(await embed_similarity(SimilarityInput()))  # noqa: T201
     except Exception as error:
         # Printed, not raised: in dev mode the Dev UI stays up either way.
         print(  # noqa: T201
-            f'Set AWS credentials and a region, and grant model access for {NOVA}, {LLAMA}, {DEEPSEEK}, and '
-            f'{TITAN_EMBED}, before running this sample.\n{error}'
+            f'Set AWS credentials and a region, and grant model access for {NOVA}, {CLAUDE} and {TITAN_EMBED}, '
+            f'before running this sample. Claude also needs the account one-time Anthropic use-case agreement; '
+            f'the other declared models are only used by flows the Dev UI runs.\n{error}'
         )
 
 

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -592,8 +592,7 @@ async def summarize_pdf(data: PdfInput) -> str:
     spreadsheet or a CSV is this same code path. Bedrock parses the document
     server-side, and requires accompanying text in the message, which the
     question supplies. Claude is used rather than the default Nova because
-    document support is per model, and it is the model the Go plugin's own
-    document example runs on.
+    document support is per model.
     """
     response = await ai.generate(
         model=CLAUDE,

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -700,7 +700,7 @@ async def rerank(data: RerankInput) -> dict[str, object]:
 
 def _document_text(content: list[DocumentPart]) -> str:
     """Concatenate the text parts of a ranked document."""
-    return ''.join(part.root.text for part in content if isinstance(part.root, TextPart))
+    return ''.join(part.root.text or '' for part in content if isinstance(part.root, TextPart))
 
 
 def _token_count(response: ModelResponse, field: str) -> int | None:


### PR DESCRIPTION
## Why

This is slice 8 of #5820, stacked on #6046

## Changes

The sample gains five flows, matching the Go repo's example coverage: describe_image, summarize_pdf, prompt_caching, generate_image, and rerank. Rerank is a method on the plugin instance (Python core has no reranker primitive), so the sample now keeps a reference to the Bedrock it passes to Genkit, the pattern the plugin README documents. The image and PDF inputs are inline constants (a 64x48 striped PNG, a 722-byte PDF). summarize_pdf runs on Claude since document support is per model, and Claude is what the Go plugin's own document example uses.

Three env-gated live tests cover the paths that had none: Converse image input, document input, and a cache read.

The plugin README gains AWS setup (model access, IAM, credentials), a plugin options table, inference profiles, prompt caching, and troubleshooting. The IAM policy adds the inference-profile resource the Go README omits; without it
every `us` model ID fails with AccessDeniedException. Troubleshooting also documents, verified live, that a model missing from the calling region fails as "ValidationException: The provided model identifier is invalid" on both Converse and InvokeModel, not as ResourceNotFoundException.

The sample README covers the new flows and now suggests us-west-2, as it is the only region with active text-to-image models, it has both rerank models, and it runs everything here except the us-east-1-only Nova 2 embedder. The sample
also gets its missing row in samples/README.md.

## Dev UI Screenshots
<img width="1005" height="424" alt="Screenshot 2026-08-13 at 10 42 11" src="https://github.com/user-attachments/assets/e1edcfe6-d725-4fe8-9b75-70af71268b1c" />
<img width="1004" height="703" alt="Screenshot 2026-08-13 at 10 44 23" src="https://github.com/user-attachments/assets/c559ffce-c3a9-4fa3-995a-2335e9077b5b" />
<img width="1000" height="700" alt="Screenshot 2026-08-13 at 10 44 52" src="https://github.com/user-attachments/assets/dfff6ab5-a6d7-4dad-8b22-20fd3769ee93" />
<img width="992" height="422" alt="Screenshot 2026-08-13 at 10 46 08" src="https://github.com/user-attachments/assets/a91345d9-5f3a-4cf0-8c70-f327e650ef6f" />
<img width="1009" height="633" alt="Screenshot 2026-08-13 at 11 08 31" src="https://github.com/user-attachments/assets/54eb893c-1242-4e4c-92ad-abb6c15ca948" />
