### PR TITLE
feat(go/plugins/googlegenai): add `gemini-3.7-flash`

### DIFF
--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -165,7 +165,7 @@ Genkit automatically discovers available models supported by the [Go GenAI SDK](
 
 Commonly used models include:
 
-- **Gemini Series**: `gemini-flash-latest`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`
+- **Gemini Series**: `gemini-flash-latest`, `gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`
 - **Imagen Series**: `imagen-4.0-generate-001`
 - **Veo Series**: `veo-3.1-generate-preview`
 

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -119,6 +119,7 @@ const (
 	geminiOmniFlashPreview = "gemini-omni-flash-preview"
 
 	gemini3FlashPreview    = "gemini-3-flash-preview"
+	gemini37Flash          = "gemini-3.7-flash"
 	gemini36Flash          = "gemini-3.6-flash"
 	gemini35Flash          = "gemini-3.5-flash"
 	gemini35FlashLite      = "gemini-3.5-flash-lite"
@@ -172,6 +173,7 @@ var (
 		gemini25Pro,
 		geminiOmniFlashPreview,
 		gemini3FlashPreview,
+		gemini37Flash,
 		gemini36Flash,
 		gemini35Flash,
 		gemini35FlashLite,
@@ -198,6 +200,7 @@ var (
 		gemini25Pro,
 		geminiOmniFlash,
 		gemini3FlashPreview,
+		gemini37Flash,
 		gemini36Flash,
 		gemini35Flash,
 		gemini35FlashLite,
@@ -262,6 +265,12 @@ var (
 		},
 		gemini3FlashPreview: {
 			Label:    "Gemini 3 Flash Preview",
+			Versions: []string{},
+			Supports: &Multimodal,
+			Stage:    ai.ModelStageStable,
+		},
+		gemini37Flash: {
+			Label:    "Gemini 3.7 Flash",
 			Versions: []string{},
 			Supports: &Multimodal,
 			Stage:    ai.ModelStageStable,

--- a/go/plugins/googlegenai/models_test.go
+++ b/go/plugins/googlegenai/models_test.go
@@ -145,7 +145,7 @@ func TestGeminiEmbedding2Registered(t *testing.T) {
 // from supportedGeminiModels still resolves, silently, to the unknown-model
 // fallback, which is labelled with the raw model ID.
 func TestNewlyRegisteredModels(t *testing.T) {
-	for _, name := range []string{gemini36Flash, gemini35FlashLite, gemini31ProPreview, gemini31FlashLiteImage} {
+	for _, name := range []string{gemini37Flash, gemini36Flash, gemini35FlashLite, gemini31ProPreview, gemini31FlashLiteImage} {
 		if got := ClassifyModel(name); got != ModelTypeGemini {
 			t.Errorf("ClassifyModel(%q) = %v, want ModelTypeGemini", name, got)
 		}


### PR DESCRIPTION
Adds `gemini-3.7-flash`, now GA on the Gemini API, to the curated Gemini catalog for both backends.

The ID already resolved before this change: `defaultGeminiOpts` serves any unrecognized `gemini-*` name. The catalog entry upgrades it from a raw-ID label at `ModelStageUnstable` to "Gemini 3.7 Flash" at `ModelStageStable`.

Verified live against the Gemini API: registers as `/model/googleai/gemini-3.7-flash`, generates, streams, calls tools with constrained output, and honors `ThinkingConfig.ThinkingLevel` (`HIGH` raised thoughts tokens from 70 to 1094 on the same prompt). The model returns frequent `503 UNAVAILABLE` right now, so those checks needed backoff. Go 1.26.3, `go test ./plugins/googlegenai/`: 104 tests pass.
