### PR TITLE
feat(go): stream logs to the Dev UI, overhaul logging, classify provider errors

### DIFF
--- a/go/GEMINI.md
+++ b/go/GEMINI.md
@@ -219,7 +219,7 @@ functions instead of mocking types.
 
 * **Library**: Use the `core/logger` package-level functions (`logger.Debug(ctx, ...)`, `logger.Info`, `logger.Warn`, `logger.Error`) whenever a `context.Context` is available; they use the context's logger and let handlers correlate records with the active trace span (Dev UI, Cloud Logging). Fall back to `log/slog` only where there is no context (package init, load-time code).
 * **Format**: Use structured logging keys and values. Messages are lowercase, stable phrases with no trailing punctuation; put variable data in attributes, never `fmt.Sprintf` into the message. Use `"error"` (not `"err"`) as the key for errors.
-* **Levels**: `Debug` for per-request detail (spans, model turns, tool runs); `Info` sparingly for one-time lifecycle events (init complete, server listening); `Warn` for misconfiguration, fallbacks, and skipped work; `Error` only where the error is not also returned to the caller (background goroutines, server handlers writing 500s). Never log-and-return the same error.
+* **Levels**: `Debug` for per-request detail (spans, model turns, tool runs, middleware hooks); `Info` sparingly for one-time lifecycle events (init complete, server listening); `Warn` for misconfiguration, fallbacks, and skipped work; `Error` only where the error is not also returned to the caller (background goroutines, server handlers writing 500s). Never log-and-return the same error.
 
 ### Licensing
 

--- a/go/GEMINI.md
+++ b/go/GEMINI.md
@@ -217,8 +217,9 @@ functions instead of mocking types.
 
 ### Logging
 
-* **Library**: Use `log/slog` (available in Go 1.21+) or the internal logger.
-* **Format**: Use structured logging keys and values.
+* **Library**: Use the `core/logger` package-level functions (`logger.Debug(ctx, ...)`, `logger.Info`, `logger.Warn`, `logger.Error`) whenever a `context.Context` is available; they use the context's logger and let handlers correlate records with the active trace span (Dev UI, Cloud Logging). Fall back to `log/slog` only where there is no context (package init, load-time code).
+* **Format**: Use structured logging keys and values. Messages are lowercase, stable phrases with no trailing punctuation; put variable data in attributes, never `fmt.Sprintf` into the message. Use `"error"` (not `"err"`) as the key for errors.
+* **Levels**: `Debug` for per-request detail (spans, model turns, tool runs); `Info` sparingly for one-time lifecycle events (init complete, server listening); `Warn` for misconfiguration, fallbacks, and skipped work; `Error` only where the error is not also returned to the caller (background goroutines, server handlers writing 500s). Never log-and-return the same error.
 
 ### Licensing
 

--- a/go/README.md
+++ b/go/README.md
@@ -822,6 +822,29 @@ genkit.DefineFlow(g, "processDocument",
 
 [See full example](samples/basic)
 
+### Logging
+
+Log through the context-aware logger (package `github.com/firebase/genkit/go/core/logger`) and records reach the terminal and, during development, the Dev UI attached to the trace span that emitted them:
+
+```go
+genkit.DefineFlow(g, "importDocuments",
+    func(ctx context.Context, source string) (int, error) {
+        logger.Info(ctx, "starting import", "source", source)
+
+        count, err := importAll(ctx, source)
+        if err != nil {
+            logger.Error(ctx, "import failed", "source", source, "error", err)
+            return 0, err
+        }
+
+        logger.Debug(ctx, "import finished", "documents", count)
+        return count, nil
+    },
+)
+```
+
+The terminal shows info and above by default; run with `GENKIT_LOG_LEVEL=debug` to also see Genkit's per-request detail (model calls, tool runs, span timings) there. The Dev UI always receives debug and above, so an interactive app can keep a quiet terminal while the full narrative lands in the trace viewer.
+
 ### Define Prompts
 
 Create reusable prompts with Handlebars templating:

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -323,7 +323,8 @@ func NewEvaluatorAction[Config any](
 						return result, nil
 					})
 				if err != nil {
-					logger.FromContext(ctx).Debug("EvaluatorAction", "err", err)
+					logger.Warn(ctx, "evaluation of test case failed, continuing with the rest",
+						"testCaseId", datapoint.TestCaseId, "error", err)
 					continue
 				}
 			}

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -1488,7 +1488,7 @@ func (rt *agentRuntime[State]) failedOutput(ctx context.Context, cause error) *A
 		// omit state (fail closed, no leak) rather than recurse. The original
 		// cause is what the caller needs and is preserved on Error above.
 		if state, err := rt.outboundState(ctx, rt.sess.lastGoodState); err != nil {
-			logger.FromContext(ctx).Error(
+			logger.Error(ctx,
 				"agent state transform failed shaping failed-output state; omitting state",
 				"error", err)
 		} else {
@@ -1625,8 +1625,8 @@ func (rt *agentRuntime[State]) runHeartbeat(ctx context.Context, snapshotID stri
 			return
 		case <-ticker.C:
 			if err := beatHeartbeat(ctx, rt.cfg.store, snapshotID); err != nil {
-				logger.FromContext(ctx).Debug("agent: heartbeat refresh failed",
-					"snapshotId", snapshotID, "err", err)
+				logger.Debug(ctx, "agent: heartbeat refresh failed",
+					"snapshotId", snapshotID, "error", err)
 			}
 		}
 	}
@@ -1762,8 +1762,8 @@ func (rt *agentRuntime[State]) finalizePendingSnapshot(
 			}, nil
 		})
 	if err != nil {
-		logger.FromContext(ctx).Error("agent: failed to finalize pending snapshot",
-			"snapshotId", pending.SnapshotID, "err", err)
+		logger.Error(ctx, "agent: failed to finalize pending snapshot",
+			"snapshotId", pending.SnapshotID, "error", err)
 	}
 }
 

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -425,9 +425,9 @@ func (s *SessionRunner[State]) snapshotTurnEnd(ctx context.Context, finishReason
 			}, nil
 		})
 	if err != nil {
-		logger.FromContext(ctx).Error("agent: failed to save snapshot",
+		logger.Error(ctx, "agent failed to save snapshot",
 			"parentId", parentID,
-			"err", err)
+			"error", err)
 		return ""
 	}
 
@@ -1016,7 +1016,7 @@ func (rt *agentRuntime[State]) takeFatal() error {
 // stream transform, both of which contain a panic in user code rather than let
 // it crash the process.
 func panicError(ctx context.Context, what string, rec any) error {
-	logger.FromContext(ctx).Error(what+" panicked", "panic", rec, "stack", string(debug.Stack()))
+	logger.Error(ctx, what+" panicked", "panic", rec, "stack", string(debug.Stack()))
 	return status.Errorf(status.ErrPanic, "%s panicked: %v", what, rec)
 }
 

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -193,16 +193,8 @@ type ModelOptions struct {
 func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 	a := core.NewStreamingActionOf(api.ActionTypeUtil, "generate", nil,
 		func(ctx context.Context, actionOpts *GenerateActionOptions, cb ModelStreamCallback) (resp *ModelResponse, err error) {
-			actionOptsBytes, _ := json.Marshal(actionOpts)
-			logger.FromContext(ctx).Debug("GenerateAction",
-				"input", actionOptsBytes)
-			defer func() {
-				respBytes, _ := json.Marshal(resp)
-				logger.FromContext(ctx).Debug("GenerateAction",
-					"output", respBytes,
-					"err", err)
-			}()
-
+			// The request and response are recorded on the action's trace span;
+			// no need to duplicate them here.
 			return GenerateWithRequest(ctx, r, actionOpts, nil, cb)
 		})
 	a.Register(r)
@@ -328,6 +320,7 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 	if opts.Model == "" {
 		if defaultModel, ok := r.LookupValue(api.DefaultModelKey).(string); ok && defaultModel != "" {
 			opts.Model = defaultModel
+			logger.Debug(ctx, "no model specified, using default model", "model", opts.Model)
 		}
 		if opts.Model == "" {
 			return nil, status.Errorf(status.ErrInvalidArgument, "ai.GenerateWithRequest: model is required")
@@ -449,7 +442,7 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 	var fn ModelFunc
 	if bm != nil {
 		if cb != nil {
-			logger.FromContext(ctx).Warn("background model does not support streaming", "model", bm.Name())
+			logger.Warn(ctx, "background model does not support streaming, ignoring stream callback", "model", bm.Name())
 		}
 		fn = backgroundModelToModelFn(bm.Start)
 	} else {
@@ -563,10 +556,17 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 				return generate(ctx, resumeReq, currentTurn+1, currentIndex)
 			}
 
+			logger.Debug(ctx, "calling model", "model", opts.Model, "turn", currentTurn, "messages", len(req.Messages))
 			resp, err := fn(ctx, req, wrappedCb)
 			if err != nil {
 				return nil, err
 			}
+
+			modelArgs := []any{"model", opts.Model, "turn", currentTurn, "finishReason", resp.FinishReason, "toolRequests", len(resp.ToolRequests())}
+			if resp.Usage != nil {
+				modelArgs = append(modelArgs, "inputTokens", resp.Usage.InputTokens, "outputTokens", resp.Usage.OutputTokens)
+			}
+			logger.Debug(ctx, "model responded", modelArgs...)
 
 			// Ensure all tool requests have unique refs for matching during resume.
 			ensureToolRequestRefs(resp.Message)
@@ -590,11 +590,15 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 					// enforced, so skipping it on an unclassified reason would
 					// silently drop validation for output the model may well
 					// have completed.
+					logger.Warn(ctx, "model finished abnormally, skipping output parsing",
+						"model", opts.Model,
+						"finishReason", resp.FinishReason,
+						"finishMessage", resp.FinishMessage)
 				default:
 					// This is legacy behavior. New format handlers should implement ParseMessage as a passthrough.
 					resp.Message, err = formatHandler.ParseMessage(resp.Message)
 					if err != nil {
-						logger.FromContext(ctx).Debug("model failed to generate output matching expected schema", "error", err.Error())
+						logger.Debug(ctx, "model output does not match the expected schema", "model", opts.Model, "error", err)
 						return nil, status.Errorf(status.ErrInvalidOutput, "model failed to generate output matching expected schema: %w", err)
 					}
 				}
@@ -613,6 +617,7 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 				return nil, err
 			}
 			if interruptMsg != nil {
+				logger.Debug(ctx, "generation paused by tool interrupts", "model", opts.Model, "turn", currentTurn)
 				resp.FinishReason = "interrupted"
 				resp.FinishMessage = "One or more tool calls resulted in interrupts."
 				resp.Message = interruptMsg
@@ -639,6 +644,15 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 			Callback:     middlewareCb,
 		})
 	}
+
+	logger.Debug(ctx, "generate request resolved",
+		"model", opts.Model,
+		"messages", len(req.Messages),
+		"tools", len(toolDefs),
+		"maxTurns", maxTurns,
+		"format", outputCfg.Format,
+		"constrained", outputCfg.Constrained,
+		"streaming", cb != nil)
 
 	return generate(ctx, req, 0, 0)
 }
@@ -1160,6 +1174,12 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 		return nil, nil, nil
 	}
 
+	toolNames := make([]string, 0, toolCount)
+	for _, p := range resp.ToolRequests() {
+		toolNames = append(toolNames, p.ToolRequest.Name)
+	}
+	logger.Debug(ctx, "executing tool requests", "tools", toolNames)
+
 	resultChan := make(chan result[*MultipartToolResponse], toolCount)
 	toolMsg := &Message{Role: RoleTool}
 	revisedMsg := clone(resp.Message)
@@ -1179,7 +1199,7 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 		streamMu.Lock()
 		defer streamMu.Unlock()
 		if err := cb(sendCtx, chunk); err != nil {
-			logger.FromContext(sendCtx).Debug("tool stream callback failed", "error", err)
+			logger.Debug(sendCtx, "tool stream callback failed, dropping chunk", "error", err)
 		}
 	}
 
@@ -1223,7 +1243,7 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 			if err != nil {
 				var tie *toolInterruptError
 				if errors.As(err, &tie) {
-					logger.FromContext(ctx).Debug("tool %q triggered an interrupt: %v", toolReq.Name, tie.Metadata)
+					logger.Debug(ctx, "tool triggered an interrupt", "tool", toolReq.Name)
 
 					newPart := clone(p)
 					if newPart.Metadata == nil {
@@ -1765,7 +1785,7 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 				if err != nil {
 					var tie *toolInterruptError
 					if errors.As(err, &tie) {
-						logger.FromContext(ctx).Debug("tool %q triggered an interrupt: %v", restartPart.ToolRequest.Name, tie.Metadata)
+						logger.Debug(ctx, "restarted tool triggered an interrupt", "tool", restartPart.ToolRequest.Name)
 
 						interruptPart := clone(p)
 						if interruptPart.Metadata == nil {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -26,6 +26,8 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/invopop/jsonschema"
@@ -357,10 +359,10 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 	}
 	var middlewareTools []Tool
 	for _, mw := range mws {
-		if mw == nil {
+		if mw.hooks == nil {
 			continue
 		}
-		for _, t := range mw.Tools {
+		for _, t := range mw.hooks.Tools {
 			if _, ok := toolDefMap[t.Name()]; ok {
 				return nil, status.Errorf(status.ErrInvalidArgument, "ai.GenerateWithRequest: tool %q is contributed by middleware but already declared elsewhere", t.Name())
 			}
@@ -650,52 +652,116 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 		})
 	}
 
-	logger.Debug(ctx, "generate request resolved",
+	resolvedArgs := []any{
 		"model", opts.Model,
 		"messages", len(req.Messages),
 		"tools", len(toolDefs),
 		"maxTurns", maxTurns,
 		"format", outputCfg.Format,
 		"constrained", outputCfg.Constrained,
-		"streaming", cb != nil)
+		"streaming", cb != nil,
+	}
+	if len(mws) > 0 {
+		resolvedArgs = append(resolvedArgs, "middleware", middlewareNames(mws))
+	}
+	logger.Debug(ctx, "generate request resolved", resolvedArgs...)
 
 	return generate(ctx, req, 0, 0)
 }
 
+// middlewareNames returns the names of the resolved middleware in chain
+// order, for the request-resolved log line.
+func middlewareNames(mws []namedHooks) []string {
+	names := make([]string, len(mws))
+	for i, mw := range mws {
+		names[i] = mw.name
+	}
+	return names
+}
+
+// hookLogArgs builds the attributes for the "middleware hook finished" log
+// record: the middleware and hook names, hook-specific extras, the duration,
+// whether the hook short-circuited the chain (returned without invoking
+// next), and any error it returned. Hooks have no spans of their own, so
+// these records are the only per-hook visibility.
+func hookLogArgs(name, hook string, start time.Time, nextCalled bool, err error, extra ...any) []any {
+	args := make([]any, 0, len(extra)+10)
+	args = append(args, "middleware", name, "hook", hook)
+	args = append(args, extra...)
+	args = append(args, "duration", time.Since(start).Round(time.Millisecond))
+	if !nextCalled {
+		args = append(args, "shortCircuited", true)
+	}
+	if err != nil {
+		args = append(args, "error", err)
+	}
+	return args
+}
+
 // buildGenerateChain composes the WrapGenerate hooks from mws (outer-to-inner)
-// around run. Middleware with a nil WrapGenerate hook is skipped.
-func buildGenerateChain(mws []*Hooks, run func(ctx context.Context, params *GenerateParams) (*ModelResponse, error)) func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
+// around run. Middleware with a nil WrapGenerate hook is skipped. When debug
+// logging is enabled, each hook invocation is bracketed by log records that
+// attribute the layer, its duration, and whether it short-circuited the chain.
+func buildGenerateChain(mws []namedHooks, run func(ctx context.Context, params *GenerateParams) (*ModelResponse, error)) func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
 	chain := run
 	for i := len(mws) - 1; i >= 0; i-- {
 		mw := mws[i]
-		if mw == nil || mw.WrapGenerate == nil {
+		if mw.hooks == nil || mw.hooks.WrapGenerate == nil {
 			continue
 		}
-		hook := mw.WrapGenerate
+		hook := mw.hooks.WrapGenerate
+		name := mw.name
 		next := chain
 		chain = func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
-			return hook(ctx, params, next)
+			if !logger.FromContext(ctx).Enabled(ctx, slog.LevelDebug) {
+				return hook(ctx, params, next)
+			}
+			logger.Debug(ctx, "middleware hook started", "middleware", name, "hook", "generate", "iteration", params.Iteration)
+			start := time.Now()
+			var nextCalled atomic.Bool
+			resp, err := hook(ctx, params, func(ctx context.Context, p *GenerateParams) (*ModelResponse, error) {
+				nextCalled.Store(true)
+				return next(ctx, p)
+			})
+			logger.Debug(ctx, "middleware hook finished",
+				hookLogArgs(name, "generate", start, nextCalled.Load(), err, "iteration", params.Iteration)...)
+			return resp, err
 		}
 	}
 	return chain
 }
 
 // buildModelChain composes the WrapModel hooks from mws (outer-to-inner)
-// around fn. Middleware with a nil WrapModel hook is skipped.
-func buildModelChain(mws []*Hooks, fn ModelFunc) ModelFunc {
+// around fn. Middleware with a nil WrapModel hook is skipped. Hook
+// invocations are logged as in [buildGenerateChain].
+func buildModelChain(mws []namedHooks, fn ModelFunc) ModelFunc {
 	chain := fn
 	for i := len(mws) - 1; i >= 0; i-- {
 		mw := mws[i]
-		if mw == nil || mw.WrapModel == nil {
+		if mw.hooks == nil || mw.hooks.WrapModel == nil {
 			continue
 		}
-		hook := mw.WrapModel
+		hook := mw.hooks.WrapModel
+		name := mw.name
 		next := chain
 		chain = func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
-			return hook(ctx, &ModelParams{Request: req, Callback: cb},
+			nextFn := func(ctx context.Context, params *ModelParams) (*ModelResponse, error) {
+				return next(ctx, params.Request, params.Callback)
+			}
+			if !logger.FromContext(ctx).Enabled(ctx, slog.LevelDebug) {
+				return hook(ctx, &ModelParams{Request: req, Callback: cb}, nextFn)
+			}
+			logger.Debug(ctx, "middleware hook started", "middleware", name, "hook", "model")
+			start := time.Now()
+			var nextCalled atomic.Bool
+			resp, err := hook(ctx, &ModelParams{Request: req, Callback: cb},
 				func(ctx context.Context, params *ModelParams) (*ModelResponse, error) {
-					return next(ctx, params.Request, params.Callback)
+					nextCalled.Store(true)
+					return nextFn(ctx, params)
 				})
+			logger.Debug(ctx, "middleware hook finished",
+				hookLogArgs(name, "model", start, nextCalled.Load(), err)...)
+			return resp, err
 		}
 	}
 	return chain
@@ -714,10 +780,10 @@ var toolRanKey = base.NewContextKey[*bool]()
 // invoke from concurrent goroutines; each invocation threads its own params
 // through the shared hook chain. When no WrapTool hooks are configured, the
 // tool is invoked directly without allocating a ToolParams wrapper.
-func buildToolRunner(mws []*Hooks) func(ctx context.Context, tool Tool, req *ToolRequest) (*MultipartToolResponse, error) {
+func buildToolRunner(mws []namedHooks) func(ctx context.Context, tool Tool, req *ToolRequest) (*MultipartToolResponse, error) {
 	hasHook := false
 	for _, mw := range mws {
-		if mw != nil && mw.WrapTool != nil {
+		if mw.hooks != nil && mw.hooks.WrapTool != nil {
 			hasHook = true
 			break
 		}
@@ -735,13 +801,26 @@ func buildToolRunner(mws []*Hooks) func(ctx context.Context, tool Tool, req *Too
 	}
 	for i := len(mws) - 1; i >= 0; i-- {
 		mw := mws[i]
-		if mw == nil || mw.WrapTool == nil {
+		if mw.hooks == nil || mw.hooks.WrapTool == nil {
 			continue
 		}
-		hook := mw.WrapTool
+		hook := mw.hooks.WrapTool
+		name := mw.name
 		next := chain
 		chain = func(ctx context.Context, params *ToolParams) (*MultipartToolResponse, error) {
-			return hook(ctx, params, next)
+			if !logger.FromContext(ctx).Enabled(ctx, slog.LevelDebug) {
+				return hook(ctx, params, next)
+			}
+			logger.Debug(ctx, "middleware hook started", "middleware", name, "hook", "tool", "tool", params.Tool.Name())
+			start := time.Now()
+			var nextCalled atomic.Bool
+			resp, err := hook(ctx, params, func(ctx context.Context, p *ToolParams) (*MultipartToolResponse, error) {
+				nextCalled.Store(true)
+				return next(ctx, p)
+			})
+			logger.Debug(ctx, "middleware hook finished",
+				hookLogArgs(name, "tool", start, nextCalled.Load(), err, "tool", params.Tool.Name())...)
+			return resp, err
 		}
 	}
 	return func(ctx context.Context, tool Tool, req *ToolRequest) (*MultipartToolResponse, error) {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1526,6 +1526,10 @@ func (mr *ModelResponse) Interrupts() []*Part {
 }
 
 // Media returns the media content of the [ModelResponse] as a string.
+//
+// Only the first media part is returned, and its content type is left behind,
+// so a response carrying more than one image, or one whose content type is
+// needed to render it, is better read with [ModelResponse.MediaParts].
 func (mr *ModelResponse) Media() string {
 	if mr == nil || mr.Message == nil {
 		return ""
@@ -1538,8 +1542,22 @@ func (mr *ModelResponse) Media() string {
 	return ""
 }
 
-// Text returns the text content of the ModelResponseChunk as a string.
-// It returns an empty string if there is no Content in the response chunk.
+// MediaParts returns every media part of the [ModelResponse], each carrying its
+// content type alongside its data. It returns nil if the response has none.
+//
+// A model that may answer with media often answers with media alone, so this
+// pairs with [ModelResponse.Text] rather than replacing it: the two read
+// disjoint halves of a response and either may come back empty.
+func (mr *ModelResponse) MediaParts() []*Part {
+	if mr == nil {
+		return nil
+	}
+	return mr.Message.MediaParts()
+}
+
+// Text returns the text content of the ModelResponseChunk as a string,
+// concatenating its text parts and skipping every other kind, as
+// [Message.Text] does. It returns an empty string if the chunk has none.
 // For the parsed structured output, use [ModelResponseChunk.Output] instead.
 func (c *ModelResponseChunk) Text() string {
 	if c == nil {
@@ -1547,7 +1565,7 @@ func (c *ModelResponseChunk) Text() string {
 	}
 	var sb strings.Builder
 	for _, p := range c.Content {
-		if p.IsText() || p.IsData() {
+		if p.IsText() {
 			sb.WriteString(p.Text)
 		}
 	}
@@ -1663,8 +1681,15 @@ func extractTypedOutput[Out any](o outputer) (Out, error) {
 	}
 }
 
-// Text returns the contents of a [Message] as a string. It
-// returns an empty string if the message has no content.
+// Text returns the textual contents of a [Message] as a string, concatenating
+// its text parts and skipping every other kind. It returns an empty string if
+// the message has none, which is what a message carrying only an image, only
+// raw data, or only a tool request comes back as; read those with
+// [Message.MediaParts] and ToolRequests instead.
+//
+// A data part is deliberately not text: it holds a blob, which the plugins
+// send as bytes and [plugins/internal/uri.Data] decodes as a data: URI, so
+// concatenating one here would splice base64 into prose.
 // If you want to get reasoning from the message, use Reasoning() instead.
 func (m *Message) Text() string {
 	if m == nil {
@@ -1673,16 +1698,36 @@ func (m *Message) Text() string {
 	if len(m.Content) == 0 {
 		return ""
 	}
+	// Single-part messages are the common case and skip the builder, but they
+	// are still filtered: a lone media part is not this message's text.
 	if len(m.Content) == 1 {
-		return m.Content[0].Text
+		if p := m.Content[0]; p.IsText() {
+			return p.Text
+		}
+		return ""
 	}
 	var sb strings.Builder
 	for _, p := range m.Content {
-		if p.IsText() || p.IsData() {
+		if p.IsText() {
 			sb.WriteString(p.Text)
 		}
 	}
 	return sb.String()
+}
+
+// MediaParts returns every media part of a [Message], each carrying its content
+// type alongside its data. It returns nil if the message has none.
+func (m *Message) MediaParts() []*Part {
+	if m == nil {
+		return nil
+	}
+	var parts []*Part
+	for _, p := range m.Content {
+		if p.IsMedia() {
+			parts = append(parts, p)
+		}
+	}
+	return parts
 }
 
 // NewResume constructs a [GenerateActionResume] from Part slices.

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
@@ -562,11 +563,15 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 				return nil, err
 			}
 
-			modelArgs := []any{"model", opts.Model, "turn", currentTurn, "finishReason", resp.FinishReason, "toolRequests", len(resp.ToolRequests())}
-			if resp.Usage != nil {
-				modelArgs = append(modelArgs, "inputTokens", resp.Usage.InputTokens, "outputTokens", resp.Usage.OutputTokens)
+			// ToolRequests allocates a scan of the message, so only build the
+			// log arguments when a handler accepts debug records.
+			if logger.FromContext(ctx).Enabled(ctx, slog.LevelDebug) {
+				modelArgs := []any{"model", opts.Model, "turn", currentTurn, "finishReason", resp.FinishReason, "toolRequests", len(resp.ToolRequests())}
+				if resp.Usage != nil {
+					modelArgs = append(modelArgs, "inputTokens", resp.Usage.InputTokens, "outputTokens", resp.Usage.OutputTokens)
+				}
+				logger.Debug(ctx, "model responded", modelArgs...)
 			}
-			logger.Debug(ctx, "model responded", modelArgs...)
 
 			// Ensure all tool requests have unique refs for matching during resume.
 			ensureToolRequestRefs(resp.Message)
@@ -1169,18 +1174,20 @@ type toolRunnerFunc = func(ctx context.Context, tool Tool, req *ToolRequest) (*M
 // either a new request to continue the conversation or nil if no tool requests
 // need handling.
 func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, resp *ModelResponse, cb ModelStreamCallback, messageIndex int, runTool toolRunnerFunc) (*ModelRequest, *Message, error) {
-	toolCount := len(resp.ToolRequests())
-	if toolCount == 0 {
+	toolRequests := resp.ToolRequests()
+	if len(toolRequests) == 0 {
 		return nil, nil, nil
 	}
 
-	toolNames := make([]string, 0, toolCount)
-	for _, p := range resp.ToolRequests() {
-		toolNames = append(toolNames, p.ToolRequest.Name)
+	if logger.FromContext(ctx).Enabled(ctx, slog.LevelDebug) {
+		toolNames := make([]string, 0, len(toolRequests))
+		for _, p := range toolRequests {
+			toolNames = append(toolNames, p.ToolRequest.Name)
+		}
+		logger.Debug(ctx, "executing tool requests", "tools", toolNames)
 	}
-	logger.Debug(ctx, "executing tool requests", "tools", toolNames)
 
-	resultChan := make(chan result[*MultipartToolResponse], toolCount)
+	resultChan := make(chan result[*MultipartToolResponse], len(toolRequests))
 	toolMsg := &Message{Role: RoleTool}
 	revisedMsg := clone(resp.Message)
 
@@ -1279,9 +1286,9 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 	// Tools run concurrently, so resultChan delivers responses in completion
 	// order. Collect them keyed by the request's position in the model message
 	// so they can be re-emitted in request order below.
-	toolRespByIndex := make(map[int]*Part, toolCount)
+	toolRespByIndex := make(map[int]*Part, len(toolRequests))
 	hasInterrupts := false
-	for range toolCount {
+	for range len(toolRequests) {
 		res := <-resultChan
 		if res.err != nil {
 			var tie *toolInterruptError

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2925,3 +2925,134 @@ func TestGenerateNoGoroutineLeak(t *testing.T) {
 
 	t.Fatalf("goroutines leaked: %d", runtime.NumGoroutine()-before)
 }
+
+func TestMessageText(t *testing.T) {
+	tests := []struct {
+		name    string
+		message *Message
+		want    string
+	}{
+		{
+			name:    "nil message",
+			message: nil,
+			want:    "",
+		},
+		{
+			name:    "no content",
+			message: &Message{Role: RoleModel},
+			want:    "",
+		},
+		{
+			name:    "lone text part",
+			message: NewModelTextMessage("hello"),
+			want:    "hello",
+		},
+		{
+			// A model allowed to answer with an image often answers with only
+			// an image. Its data is not the message's text.
+			name:    "lone media part",
+			message: NewMessage(RoleModel, nil, NewMediaPart("image/png", "iVBORw0KGgo=")),
+			want:    "",
+		},
+		{
+			// A data part carries a blob, which the plugins send as bytes.
+			// Concatenating it would splice base64 into the message's prose.
+			name:    "lone data part",
+			message: NewMessage(RoleModel, nil, NewDataPart("data:application/octet-stream;base64,AAAA")),
+			want:    "",
+		},
+		{
+			name: "data part alongside text",
+			message: NewMessage(RoleModel, nil,
+				NewTextPart("here is the blob"),
+				NewDataPart("data:application/octet-stream;base64,AAAA"),
+			),
+			want: "here is the blob",
+		},
+		{
+			name:    "lone reasoning part",
+			message: NewMessage(RoleModel, nil, NewReasoningPart("thinking", nil)),
+			want:    "",
+		},
+		{
+			name: "text alongside media",
+			message: NewMessage(RoleModel, nil,
+				NewTextPart("a drawing of a cat"),
+				NewMediaPart("image/png", "iVBORw0KGgo="),
+			),
+			want: "a drawing of a cat",
+		},
+		{
+			name: "text parts concatenate",
+			message: NewMessage(RoleModel, nil,
+				NewTextPart("one "),
+				NewTextPart("two"),
+			),
+			want: "one two",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.message.Text(); got != tt.want {
+				t.Errorf("Text() = %q, want %q", got, tt.want)
+			}
+			// ModelResponse.Text() reads through to the message, so the two
+			// must not disagree.
+			resp := &ModelResponse{Message: tt.message}
+			if got := resp.Text(); got != tt.want {
+				t.Errorf("ModelResponse.Text() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMediaParts(t *testing.T) {
+	t.Run("returns every media part with its content type", func(t *testing.T) {
+		resp := &ModelResponse{
+			Message: NewMessage(RoleModel, nil,
+				NewTextPart("two drawings"),
+				NewMediaPart("image/png", "first"),
+				NewMediaPart("image/jpeg", "second"),
+			),
+		}
+
+		parts := resp.MediaParts()
+
+		if len(parts) != 2 {
+			t.Fatalf("MediaParts() returned %d parts, want 2", len(parts))
+		}
+		for i, want := range []struct{ contentType, data string }{
+			{"image/png", "first"},
+			{"image/jpeg", "second"},
+		} {
+			if parts[i].ContentType != want.contentType || parts[i].Text != want.data {
+				t.Errorf("part %d = (%q, %q), want (%q, %q)",
+					i, parts[i].ContentType, parts[i].Text, want.contentType, want.data)
+			}
+		}
+		// Media returns only the first, which is why MediaParts exists.
+		if got := resp.Media(); got != "first" {
+			t.Errorf("Media() = %q, want %q", got, "first")
+		}
+	})
+
+	t.Run("returns nil when there is no media", func(t *testing.T) {
+		resp := &ModelResponse{Message: NewModelTextMessage("just text")}
+
+		if parts := resp.MediaParts(); parts != nil {
+			t.Errorf("MediaParts() = %v, want nil", parts)
+		}
+	})
+
+	t.Run("nil safe", func(t *testing.T) {
+		var resp *ModelResponse
+		if parts := resp.MediaParts(); parts != nil {
+			t.Errorf("MediaParts() on nil response = %v, want nil", parts)
+		}
+		var msg *Message
+		if parts := msg.MediaParts(); parts != nil {
+			t.Errorf("MediaParts() on nil message = %v, want nil", parts)
+		}
+	})
+}

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -239,16 +239,25 @@ func configsToRefs(configs []Middleware) ([]*MiddlewareRef, error) {
 	return refs, nil
 }
 
-// resolveRefs resolves [MiddlewareRef] entries to [Hooks] bundles. If
+// namedHooks pairs a middleware's registered name with the per-call [Hooks]
+// bundle it produced. Middleware gets no spans of its own (its hooks wrap
+// spans other actions create), so the name travels with the hooks to let the
+// chain builders attribute log records to the middleware that ran.
+type namedHooks struct {
+	name  string
+	hooks *Hooks
+}
+
+// resolveRefs resolves [MiddlewareRef] entries to named [Hooks] bundles. If
 // ref.Config is a [Middleware] value, its New method is invoked directly
 // (local fast path). Otherwise the descriptor is looked up in the registry
 // and its build closure is invoked with the marshaled config (JSON dispatch,
 // used for cross-runtime / Dev UI calls).
-func resolveRefs(ctx context.Context, r api.Registry, refs []*MiddlewareRef) ([]*Hooks, error) {
+func resolveRefs(ctx context.Context, r api.Registry, refs []*MiddlewareRef) ([]namedHooks, error) {
 	if len(refs) == 0 {
 		return nil, nil
 	}
-	bundles := make([]*Hooks, 0, len(refs))
+	bundles := make([]namedHooks, 0, len(refs))
 	for _, ref := range refs {
 		if mw, ok := ref.Config.(Middleware); ok {
 			h, err := mw.New(ctx)
@@ -258,7 +267,7 @@ func resolveRefs(ctx context.Context, r api.Registry, refs []*MiddlewareRef) ([]
 			if h == nil {
 				return nil, status.Errorf(status.ErrInternal, "ai: middleware %q returned nil hooks", ref.Name)
 			}
-			bundles = append(bundles, h)
+			bundles = append(bundles, namedHooks{name: ref.Name, hooks: h})
 			continue
 		}
 		d := LookupMiddleware(r, ref.Name)
@@ -280,7 +289,7 @@ func resolveRefs(ctx context.Context, r api.Registry, refs []*MiddlewareRef) ([]
 		if h == nil {
 			return nil, status.Errorf(status.ErrInternal, "ai: middleware %q factory returned nil", ref.Name)
 		}
-		bundles = append(bundles, h)
+		bundles = append(bundles, namedHooks{name: ref.Name, hooks: h})
 	}
 	return bundles, nil
 }

--- a/go/ai/middleware_test.go
+++ b/go/ai/middleware_test.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 )
 
@@ -1055,5 +1058,102 @@ func TestMiddlewareRefArg_NewErrors(t *testing.T) {
 	// of silently producing nil hooks.
 	if _, err := (middlewareRefArg{name: "x"}).New(testCtx); err == nil {
 		t.Fatal("expected middlewareRefArg.New to return an error")
+	}
+}
+
+// --- hook logging: runs are attributed and short-circuits flagged ---
+
+// hookLogRecorder is a slog.Handler that captures records at or above min.
+type hookLogRecorder struct {
+	min     slog.Level
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *hookLogRecorder) Enabled(_ context.Context, l slog.Level) bool { return l >= h.min }
+
+func (h *hookLogRecorder) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *hookLogRecorder) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *hookLogRecorder) WithGroup(string) slog.Handler      { return h }
+
+func TestMiddlewareHookLogging(t *testing.T) {
+	base := func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+		return &ModelResponse{}, nil
+	}
+	passThrough := namedHooks{name: "test/outer", hooks: &Hooks{
+		WrapModel: func(ctx context.Context, params *ModelParams, next ModelNext) (*ModelResponse, error) {
+			return next(ctx, params)
+		},
+	}}
+	shortCircuit := namedHooks{name: "test/inner", hooks: &Hooks{
+		WrapModel: func(ctx context.Context, params *ModelParams, next ModelNext) (*ModelResponse, error) {
+			return &ModelResponse{}, nil // resolves the call without invoking next
+		},
+	}}
+	chain := buildModelChain([]namedHooks{passThrough, shortCircuit}, base)
+
+	rec := &hookLogRecorder{min: slog.LevelDebug}
+	ctx := logger.WithContext(context.Background(), slog.New(rec))
+	if _, err := chain(ctx, &ModelRequest{}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	type entry struct {
+		msg, mw        string
+		shortCircuited bool
+	}
+	var got []entry
+	for _, r := range rec.records {
+		e := entry{msg: r.Message}
+		r.Attrs(func(a slog.Attr) bool {
+			switch a.Key {
+			case "middleware":
+				e.mw = a.Value.String()
+			case "shortCircuited":
+				e.shortCircuited = a.Value.Bool()
+			}
+			return true
+		})
+		got = append(got, e)
+	}
+	want := []entry{
+		{msg: "middleware hook started", mw: "test/outer"},
+		{msg: "middleware hook started", mw: "test/inner"},
+		{msg: "middleware hook finished", mw: "test/inner", shortCircuited: true},
+		{msg: "middleware hook finished", mw: "test/outer"},
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("hook log entries = %v, want %v", got, want)
+	}
+}
+
+func TestMiddlewareHookLoggingDisabled(t *testing.T) {
+	ran := false
+	base := func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+		ran = true
+		return &ModelResponse{}, nil
+	}
+	chain := buildModelChain([]namedHooks{{name: "test/mw", hooks: &Hooks{
+		WrapModel: func(ctx context.Context, params *ModelParams, next ModelNext) (*ModelResponse, error) {
+			return next(ctx, params)
+		},
+	}}}, base)
+
+	rec := &hookLogRecorder{min: slog.LevelInfo}
+	ctx := logger.WithContext(context.Background(), slog.New(rec))
+	if _, err := chain(ctx, &ModelRequest{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !ran {
+		t.Fatal("base model fn did not run")
+	}
+	if len(rec.records) != 0 {
+		t.Errorf("got %d log records with debug disabled, want 0", len(rec.records))
 	}
 }

--- a/go/ai/model_middleware.go
+++ b/go/ai/model_middleware.go
@@ -257,7 +257,7 @@ func validateSupport(model string, opts *ModelOptions) ModelMiddleware {
 			}
 
 			if opts.Stage == ModelStageDeprecated {
-				logger.FromContext(ctx).Warn("model is deprecated and may be removed in a future release", "model", model)
+				logger.Warn(ctx, "model is deprecated and may be removed in a future release", "model", model)
 			}
 
 			if (opts.Supports.Constrained == "" ||

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -341,7 +341,7 @@ func (p *prompt) Render(ctx context.Context, input any) (*GenerateActionOptions,
 	}
 
 	if len(p.Middleware) > 0 {
-		logger.FromContext(ctx).Warn(fmt.Sprintf("middleware set on prompt %q will be ignored during Prompt.Render", p.Name()))
+		logger.Warn(ctx, "middleware set on prompt is ignored during Prompt.Render, use Prompt.Execute to apply it", "prompt", p.Name())
 	}
 
 	// TODO: This is hacky; we should have a helper that fetches the metadata.
@@ -842,11 +842,11 @@ func LoadPromptDirFromFS(r api.Registry, fsys fs.FS, dir, namespace string) {
 				partialName := strings.TrimSuffix(filename[1:], ".prompt")
 				source, err := fs.ReadFile(fsys, filePath)
 				if err != nil {
-					slog.Error("Failed to read partial file", "error", err)
+					slog.Error("failed to read prompt partial file, skipping it", "file", filePath, "error", err)
 					continue
 				}
 				r.RegisterPartial(partialName, string(source))
-				slog.Debug("Registered Dotprompt partial", "name", partialName, "file", filePath)
+				slog.Debug("registered dotprompt partial", "partial", partialName, "file", filePath)
 			} else {
 				LoadPromptFromFS(r, fsys, dir, filename, namespace)
 			}
@@ -863,17 +863,17 @@ func LoadPromptFromFS(r api.Registry, fsys fs.FS, dir, filename, namespace strin
 	sourceFile := path.Join(dir, filename)
 	source, err := fs.ReadFile(fsys, sourceFile)
 	if err != nil {
-		slog.Error("Failed to read prompt file", "file", sourceFile, "error", err)
+		slog.Error("failed to read prompt file, skipping it", "file", sourceFile, "error", err)
 		return nil
 	}
 
 	p, err := LoadPromptFromSource(r, string(source), name, namespace)
 	if err != nil {
-		slog.Error("Failed to load prompt", "file", sourceFile, "error", err)
+		slog.Error("failed to load prompt file, skipping it", "file", sourceFile, "error", err)
 		return nil
 	}
 
-	slog.Debug("Registered Dotprompt", "name", p.Name(), "file", sourceFile)
+	slog.Debug("registered dotprompt", "prompt", p.Name(), "file", sourceFile)
 	return p
 }
 

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/core/api"
-	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/base"
@@ -244,13 +243,6 @@ func (a *Action[In, Out, Stream]) Run(ctx context.Context, input In, cb StreamCa
 // inject a per-call one-shot adapter; spanInit, when non-nil, is recorded as
 // the span's genkit:init attribute.
 func (a *Action[In, Out, Stream]) runWithTelemetry(ctx context.Context, input In, cb StreamCallback[Stream], fn StreamingFunc[In, Out, Stream], spanInit any) (output api.ActionRunResult[Out], err error) {
-	logger.FromContext(ctx).Debug("Action.Run", "name", a.Name())
-	defer func() {
-		logger.FromContext(ctx).Debug("Action.Run",
-			"name", a.Name(),
-			"err", err)
-	}()
-
 	var traceID string
 	var spanID string
 	o, err := tracing.RunInNewSpan(ctx, a.spanMetadata(ctx, spanInit), input,

--- a/go/core/flow.go
+++ b/go/core/flow.go
@@ -79,11 +79,40 @@ func NewStreamingFlow[In, Out, Stream any](name string, fn StreamingFunc[In, Out
 // Each call to Run results in a new step in the flow.
 // A step has its own span in the trace, and its result is cached so that if the flow
 // is restarted, f will not be called a second time.
+//
+// The step's context is not available to fn, so anything inside it that takes a
+// context and traces its own work, such as an HTTP client or a database call,
+// reports against the enclosing flow rather than against this step. Use
+// [RunWithContext] for those; keep Run for pure work that traces nothing.
 func Run[Out any](ctx context.Context, name string, fn func() (Out, error)) (Out, error) {
+	return runStep(ctx, "flow.Run", name, func(context.Context) (Out, error) { return fn() })
+}
+
+// RunWithContext is [Run] with the step's own context passed to fn.
+//
+// Work that fn starts with that context nests under the step in the trace
+// instead of under the flow, which is what makes a step's span cover the calls
+// it is timing:
+//
+//	file, err := core.RunWithContext(ctx, "upload-image", func(ctx context.Context) (*File, error) {
+//		return client.Files.Upload(ctx, path) // its spans nest under "upload-image"
+//	})
+//
+// Passing the enclosing context instead of the one supplied here is the whole
+// difference, and it is silent: the step still records the right duration while
+// the calls it made appear beside it rather than beneath it.
+func RunWithContext[Out any](ctx context.Context, name string, fn func(context.Context) (Out, error)) (Out, error) {
+	return runStep(ctx, "flow.RunWithContext", name, fn)
+}
+
+// runStep is the body shared by [Run] and [RunWithContext]. The caller name is
+// passed in so the "must be called from a flow" error names the function the
+// user actually called.
+func runStep[Out any](ctx context.Context, caller, name string, fn func(context.Context) (Out, error)) (Out, error) {
 	fc := flowContextKey.FromContext(ctx)
 	if fc == nil {
 		var z Out
-		return z, fmt.Errorf("flow.Run(%q): must be called from a flow", name)
+		return z, fmt.Errorf("%s(%q): must be called from a flow", caller, name)
 	}
 	spanMetadata := &tracing.SpanMetadata{
 		Name:    name,
@@ -91,7 +120,7 @@ func Run[Out any](ctx context.Context, name string, fn func() (Out, error)) (Out
 		Subtype: "flowStep",
 	}
 	return tracing.RunInNewSpan(ctx, spanMetadata, nil, func(ctx context.Context, _ any) (Out, error) {
-		o, err := fn()
+		o, err := fn(ctx)
 		if err != nil {
 			return base.Zero[Out](), err
 		}

--- a/go/core/flow_test.go
+++ b/go/core/flow_test.go
@@ -19,9 +19,13 @@ package core
 import (
 	"context"
 	"slices"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/registry"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestRunInFlow(t *testing.T) {
@@ -256,4 +260,104 @@ func TestFlowNameFromContextOutsideFlow(t *testing.T) {
 			t.Errorf("FlowNameFromContext outside flow = %q, want empty string", got)
 		}
 	})
+}
+
+// stepSpanCollector records finished spans so a test can assert on how they
+// nest. It is the same shape as the collector in ai/testutil_test.go, kept here
+// because tests live beside the file they cover.
+type stepSpanCollector struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (c *stepSpanCollector) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.spans = append(c.spans, spans...)
+	return nil
+}
+
+func (c *stepSpanCollector) Shutdown(context.Context) error { return nil }
+
+func (c *stepSpanCollector) byName(name string) sdktrace.ReadOnlySpan {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, s := range c.spans {
+		if s.Name() == name {
+			return s
+		}
+	}
+	return nil
+}
+
+func collectStepSpans(t *testing.T) *stepSpanCollector {
+	t.Helper()
+	c := &stepSpanCollector{}
+	sp := sdktrace.NewSimpleSpanProcessor(c)
+	tp := tracing.TracerProvider()
+	tp.RegisterSpanProcessor(sp)
+	t.Cleanup(func() { tp.UnregisterSpanProcessor(sp) })
+	return c
+}
+
+// TestRunWithContextNesting is the reason RunWithContext exists: work started
+// with the context it hands over belongs to the step, while work started with
+// the enclosing context escapes to the flow.
+func TestRunWithContextNesting(t *testing.T) {
+	r := registry.New()
+	c := collectStepSpans(t)
+
+	flow := defineFlow(r, "nesting", func(ctx context.Context, _ any) (int, error) {
+		// The step's own context reaches the callee, so its span nests.
+		if _, err := RunWithContext(ctx, "with-context", func(stepCtx context.Context) (int, error) {
+			return tracing.RunInNewSpan(stepCtx, &tracing.SpanMetadata{Name: "inner-nested"}, nil,
+				func(context.Context, any) (int, error) { return 1, nil })
+		}); err != nil {
+			return 0, err
+		}
+
+		// Run cannot pass the step context on, so a callee handed the flow's
+		// context reports against the flow instead.
+		if _, err := Run(ctx, "without-context", func() (int, error) {
+			return tracing.RunInNewSpan(ctx, &tracing.SpanMetadata{Name: "inner-escaped"}, nil,
+				func(context.Context, any) (int, error) { return 2, nil })
+		}); err != nil {
+			return 0, err
+		}
+		return 3, nil
+	})
+
+	if _, err := flow.Run(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	step := c.byName("with-context")
+	nested := c.byName("inner-nested")
+	escaped := c.byName("inner-escaped")
+	for name, s := range map[string]sdktrace.ReadOnlySpan{
+		"with-context": step, "inner-nested": nested, "inner-escaped": escaped,
+	} {
+		if s == nil {
+			t.Fatalf("span %q was not recorded", name)
+		}
+	}
+
+	if got, want := nested.Parent().SpanID(), step.SpanContext().SpanID(); got != want {
+		t.Errorf("inner-nested parent = %s, want the with-context step %s", got, want)
+	}
+	if got := escaped.Parent().SpanID(); got == c.byName("without-context").SpanContext().SpanID() {
+		t.Errorf("inner-escaped nested under its step, so Run now propagates context and this test is stale")
+	}
+}
+
+func TestRunWithContextOutsideFlow(t *testing.T) {
+	_, err := RunWithContext(context.Background(), "step", func(context.Context) (int, error) {
+		return 42, nil
+	})
+	if err == nil {
+		t.Fatal("expected an error when called outside a flow")
+	}
+	if !strings.Contains(err.Error(), "flow.RunWithContext") {
+		t.Errorf("error %q should name the function that was called", err)
+	}
 }

--- a/go/core/logger/doc.go
+++ b/go/core/logger/doc.go
@@ -17,94 +17,83 @@
 /*
 Package logger provides context-scoped structured logging for Genkit.
 
-This package wraps the standard library's [log/slog] package to provide
-context-aware logging throughout Genkit operations. Logs are automatically
-associated with the current action or flow context.
+This package wraps the standard library's [log/slog] package. Genkit itself
+logs through it, and application code inside flows and tools can use it to get
+the same behavior: logs flow through the process default logger, carry any
+attributes bound to the context's logger, and, during local development, are
+streamed to the Genkit Dev UI attached to the trace span that emitted them.
 
 # Usage
 
-Retrieve the logger from context within action or flow handlers:
+Log with the package-level functions, passing the context:
 
 	func myFlow(ctx context.Context, input string) (string, error) {
-		log := logger.FromContext(ctx)
-
-		log.Info("Processing input", "size", len(input))
-		log.Debug("Input details", "value", input)
+		logger.Info(ctx, "processing input", "size", len(input))
 
 		result, err := process(input)
 		if err != nil {
-			log.Error("Processing failed", "error", err)
+			logger.Error(ctx, "processing failed", "error", err)
 			return "", err
 		}
 
-		log.Info("Processing complete", "resultSize", len(result))
+		logger.Debug(ctx, "processing complete", "resultSize", len(result))
 		return result, nil
 	}
 
-# Log Levels
+Passing the context is what ties a record to its surroundings: the context
+carries the active trace span (for Dev UI and Cloud Logging correlation) and
+optionally a logger with pre-bound attributes. Equivalent behavior is
+available from any standard logger via the *Context methods, e.g.
+slog.InfoContext(ctx, ...).
 
-Control the global log level to filter output:
+# Log levels
 
-	// Show debug logs (verbose)
+The default minimum level for the console is Info, and the level only ever
+governs the console: during development the Dev UI receives every record at
+debug level and above regardless, so the terminal stays quiet while the full
+debug narrative lands in the trace viewer. To also see Genkit's per-request
+detail (action runs, model calls, tool loops) in the terminal, run with:
+
+	GENKIT_LOG_LEVEL=debug go run .
+
+or set the level programmatically:
+
 	logger.SetLevel(slog.LevelDebug)
 
-	// Show info and above (default)
-	logger.SetLevel(slog.LevelInfo)
+For an interactive CLI app whose terminal should stay pristine, run with
+GENKIT_LOG_LEVEL=warn to silence the startup info lines too; the Dev UI still
+receives everything.
 
-	// Show only warnings and errors
-	logger.SetLevel(slog.LevelWarn)
+[SetLevel] installs Genkit's console handler as the process default.
+Applications that configure their own [slog] handler should set that handler's
+level instead; Genkit respects a custom default handler and, if
+GENKIT_LOG_LEVEL is set, leaves it alone rather than replacing it.
 
-	// Show only errors
-	logger.SetLevel(slog.LevelError)
+# The Dev UI
 
-	// Get the current log level
-	level := logger.GetLevel()
+In the dev environment (GENKIT_ENV=dev, as set by `genkit start`), Genkit
+tees every record at debug level and above to the Dev UI's telemetry server
+in addition to the console, independent of the console level. Records logged
+with a context are attached to the trace span active at that moment and
+appear in the span's Logs panel in the trace viewer. Set
+GENKIT_OTEL_ENABLE_LOGS=false to turn this off.
 
-# Context Integration
+# Context integration
 
-The logger is automatically available in action and flow contexts. It
-inherits from the context passed to [genkit.Init] and flows through
-all nested operations.
+[FromContext] returns the logger stored in the context, or the process
+default. Store a derived logger with [WithContext] to bind attributes to
+everything logged downstream:
 
-For custom operations outside of actions/flows, attach a logger to context:
+	ctx = logger.WithContext(ctx, logger.FromContext(ctx).With("requestId", id))
 
-	log := slog.Default()
-	ctx = logger.WithContext(ctx, log)
+The package-level logging functions use the context's logger automatically,
+so code below the WithContext call needs no extra plumbing for its records to
+carry requestId.
 
-# slog Compatibility
+# Additional destinations
 
-The logger returned by [FromContext] is a standard [*slog.Logger] and
-supports all slog methods:
-
-	log := logger.FromContext(ctx)
-
-	// Structured logging with attributes
-	log.Info("User action",
-		"userId", userID,
-		"action", "login",
-		"duration", elapsed,
-	)
-
-	// Grouped attributes
-	log.Info("Request completed",
-		slog.Group("request",
-			"method", r.Method,
-			"path", r.URL.Path,
-		),
-		slog.Group("response",
-			"status", status,
-			"bytes", written,
-		),
-	)
-
-	// With pre-set attributes
-	requestLog := log.With("requestId", requestID)
-	requestLog.Info("Starting")
-	// ... later ...
-	requestLog.Info("Finished")
-
-This package is primarily used by Genkit internals but is useful for
-plugin developers who need consistent logging that integrates with
-Genkit's observability features.
+[AddHandler] tees the default logger's records to another [slog.Handler]
+without disturbing console output. Genkit uses it internally for the Dev UI
+export; applications can use it to mirror logs to a file or a test recorder.
 */
 package logger

--- a/go/core/logger/doc.go
+++ b/go/core/logger/doc.go
@@ -66,8 +66,8 @@ receives everything.
 
 [SetLevel] installs Genkit's console handler as the process default.
 Applications that configure their own [slog] handler should set that handler's
-level instead; Genkit respects a custom default handler and, if
-GENKIT_LOG_LEVEL is set, leaves it alone rather than replacing it.
+level instead: Genkit respects a custom default handler, so both SetLevel and
+GENKIT_LOG_LEVEL warn and leave it alone rather than replacing it.
 
 # The Dev UI
 
@@ -80,9 +80,11 @@ GENKIT_OTEL_ENABLE_LOGS=false to turn this off.
 
 # Context integration
 
-[FromContext] returns the logger stored in the context, or the process
-default. Store a derived logger with [WithContext] to bind attributes to
-everything logged downstream:
+[FromContext] returns the context's logger (or the process default) bound to
+that context, so records logged even through its plain methods (Info, Error,
+...) still carry the span that was active when the logger was obtained. Store
+a derived logger with [WithContext] to bind attributes to everything logged
+downstream:
 
 	ctx = logger.WithContext(ctx, logger.FromContext(ctx).With("requestId", id))
 

--- a/go/core/logger/logger.go
+++ b/go/core/logger/logger.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/firebase/genkit/go/internal/base"
+	otrace "go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -64,17 +65,29 @@ func isStdlibDefaultHandler(h slog.Handler) bool {
 }
 
 // SetLevel sets the minimum level of Genkit's console log handler and installs
-// it as the process-wide default logger, replacing the current one. Handlers
-// previously installed with [AddHandler] are preserved.
+// it as the process-wide default logger. Handlers previously installed with
+// [AddHandler] are preserved.
 //
-// Applications that manage their own [slog] handler should set their handler's
-// level directly instead of calling SetLevel.
+// A default handler the application installed itself (via [slog.SetDefault]
+// or [SetDefaultHandler]) is not Genkit's to manage: SetLevel records the
+// level for the managed console handler but leaves the application's handler
+// in place and warns, exactly as GENKIT_LOG_LEVEL does, since that handler's
+// own level is what governs output. Set the application handler's level
+// directly instead.
 func SetLevel(l slog.Level) {
 	mu.Lock()
-	defer mu.Unlock()
 	level.Set(l)
-	ensureConsole()
-	install(console)
+	custom := hasCustomDefaultLocked()
+	if !custom {
+		ensureConsole()
+		install(console)
+	}
+	mu.Unlock()
+	if custom {
+		// Logged after unlocking: the warning flows through the application's
+		// handler, which must be free to call back into this package.
+		slog.Warn("logger.SetLevel: the application installed its own default log handler; set its level directly", "level", l)
+	}
 }
 
 // ensureConsole creates the managed console handler if it does not exist yet.
@@ -127,11 +140,32 @@ func SetDefaultHandler(h slog.Handler) {
 func HasCustomDefault() bool {
 	mu.Lock()
 	defer mu.Unlock()
-	h := slog.Default().Handler()
-	if t, ok := h.(*teeHandler); ok {
-		h = t.handlers[0]
-	}
+	return hasCustomDefaultLocked()
+}
+
+// hasCustomDefaultLocked is [HasCustomDefault] for callers already holding mu.
+func hasCustomDefaultLocked() bool {
+	h := baseHandler(slog.Default().Handler())
 	return !isStdlibDefaultHandler(h) && h != console
+}
+
+// baseHandler strips the composition layers this package wraps around a base
+// handler: the tee that install builds, and the context binding [FromContext]
+// applies (in case an application handed a FromContext logger to
+// slog.SetDefault). What remains is the handler whose identity decides
+// whether the base is the stdlib default, the managed console, or
+// application-owned.
+func baseHandler(h slog.Handler) slog.Handler {
+	for {
+		switch v := h.(type) {
+		case *teeHandler:
+			h = v.handlers[0]
+		case *ctxHandler:
+			h = v.inner
+		default:
+			return h
+		}
+	}
 }
 
 // currentBase returns the handler that console output should continue to flow
@@ -142,10 +176,7 @@ func HasCustomDefault() bool {
 // carried over so the substitution does not change verbosity. Callers must
 // hold mu.
 func currentBase() slog.Handler {
-	h := slog.Default().Handler()
-	if t, ok := h.(*teeHandler); ok {
-		h = t.handlers[0]
-	}
+	h := baseHandler(slog.Default().Handler())
 	if isStdlibDefaultHandler(h) {
 		if console == nil {
 			seedLevelFromStdlib(h)
@@ -186,13 +217,73 @@ func install(base slog.Handler) {
 	slog.SetDefault(slog.New(&teeHandler{handlers: handlers}))
 }
 
-// FromContext returns the Logger in ctx, or the default Logger
-// if there is none.
+// FromContext returns the logger carried by ctx, or the process default
+// logger if there is none, bound to ctx: records logged even through the
+// returned logger's context-free methods (Info, Error, ...) reach the handler
+// carrying ctx, where those methods would otherwise hand the handler a
+// background context. The binding is what lets a context-aware handler, such
+// as the one that streams logs to the Dev UI, correlate such records with the
+// span that was active when the logger was obtained. A context passed
+// explicitly at the call site (InfoContext, Log) wins whenever it carries a
+// span of its own.
 func FromContext(ctx context.Context) *slog.Logger {
+	h := fromContext(ctx).Handler()
+	if c, ok := h.(*ctxHandler); ok {
+		h = c.inner // rebind to ctx rather than nest bindings
+	}
+	return slog.New(&ctxHandler{ctx: ctx, inner: h})
+}
+
+// fromContext returns the logger carried by ctx, or the process default,
+// without the context binding [FromContext] adds. The package-level logging
+// functions use it because they pass the call-site context through
+// explicitly, which makes the binding redundant work.
+func fromContext(ctx context.Context) *slog.Logger {
 	if l := loggerKey.FromContext(ctx); l != nil {
 		return l
 	}
 	return slog.Default()
+}
+
+// ctxHandler binds a context to a handler. slog's context-free logging
+// methods hand handlers context.Background(), stripping the trace span that
+// context-aware handlers correlate records by; the bound context fills that
+// gap.
+type ctxHandler struct {
+	ctx   context.Context
+	inner slog.Handler
+}
+
+// resolve picks the context the inner handler sees: the call-site context
+// when it carries a span, since a log statement under a deeper span must
+// attribute to that span, and the bound context otherwise.
+func (h *ctxHandler) resolve(ctx context.Context) context.Context {
+	if h.ctx == nil || otrace.SpanContextFromContext(ctx).IsValid() {
+		return ctx
+	}
+	return h.ctx
+}
+
+func (h *ctxHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.inner.Enabled(h.resolve(ctx), l)
+}
+
+func (h *ctxHandler) Handle(ctx context.Context, r slog.Record) error {
+	return h.inner.Handle(h.resolve(ctx), r)
+}
+
+func (h *ctxHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return &ctxHandler{ctx: h.ctx, inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *ctxHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &ctxHandler{ctx: h.ctx, inner: h.inner.WithGroup(name)}
 }
 
 // WithContext returns a copy of ctx carrying l. [FromContext] and the
@@ -212,20 +303,20 @@ func WithContext(ctx context.Context, l *slog.Logger) context.Context {
 // [WithContext]) and pass ctx through to the handler, which is what lets a
 // context-aware handler correlate the record with the active trace span.
 func Debug(ctx context.Context, msg string, args ...any) {
-	FromContext(ctx).Log(ctx, slog.LevelDebug, msg, args...)
+	fromContext(ctx).Log(ctx, slog.LevelDebug, msg, args...)
 }
 
 // Info logs at slog.LevelInfo using the logger in ctx. See [Debug].
 func Info(ctx context.Context, msg string, args ...any) {
-	FromContext(ctx).Log(ctx, slog.LevelInfo, msg, args...)
+	fromContext(ctx).Log(ctx, slog.LevelInfo, msg, args...)
 }
 
 // Warn logs at slog.LevelWarn using the logger in ctx. See [Debug].
 func Warn(ctx context.Context, msg string, args ...any) {
-	FromContext(ctx).Log(ctx, slog.LevelWarn, msg, args...)
+	fromContext(ctx).Log(ctx, slog.LevelWarn, msg, args...)
 }
 
 // Error logs at slog.LevelError using the logger in ctx. See [Debug].
 func Error(ctx context.Context, msg string, args ...any) {
-	FromContext(ctx).Log(ctx, slog.LevelError, msg, args...)
+	fromContext(ctx).Log(ctx, slog.LevelError, msg, args...)
 }

--- a/go/core/logger/logger.go
+++ b/go/core/logger/logger.go
@@ -51,11 +51,16 @@ var (
 // the log package's mutex. It is detected by type rather than by capturing
 // slog.Default() at package initialization, since another package's init can
 // legitimately install a custom default before this package initializes, and
-// that handler must not be mistaken for the stdlib one. A test pins the type
-// name against stdlib renames.
+// that handler must not be mistaken for the stdlib one. The type is matched
+// by package path and name, which are exact where Type.String's short-name
+// form could collide with a third-party package also called slog. A test
+// pins the identification against stdlib renames.
 func isStdlibDefaultHandler(h slog.Handler) bool {
 	t := reflect.TypeOf(h)
-	return t != nil && t.String() == "*slog.defaultHandler"
+	if t == nil || t.Kind() != reflect.Pointer {
+		return false
+	}
+	return t.Elem().PkgPath() == "log/slog" && t.Elem().Name() == "defaultHandler"
 }
 
 // SetLevel sets the minimum level of Genkit's console log handler and installs
@@ -81,10 +86,9 @@ func ensureConsole() {
 }
 
 // GetLevel returns the level most recently passed to [SetLevel], or
-// slog.LevelInfo if SetLevel has not been called.
+// slog.LevelInfo if SetLevel has not been called. slog.LevelVar is safe for
+// concurrent use, so no lock is needed.
 func GetLevel() slog.Level {
-	mu.Lock()
-	defer mu.Unlock()
 	return level.Level()
 }
 
@@ -100,28 +104,73 @@ func AddHandler(h slog.Handler) {
 	mu.Lock()
 	defer mu.Unlock()
 	sinks = append(sinks, h)
-	base := console
-	if base == nil {
-		base = currentBase()
+	install(currentBase())
+}
+
+// SetDefaultHandler installs h as the base handler of the process-wide
+// default logger, replacing the current base while keeping every sink
+// registered with [AddHandler]. Components that bring their own destination
+// handler (for example a plugin that ships logs to a cloud service) should
+// use this instead of [slog.SetDefault], which would silently disconnect the
+// registered sinks, including dev-mode streaming to the Dev UI.
+func SetDefaultHandler(h slog.Handler) {
+	mu.Lock()
+	defer mu.Unlock()
+	install(h)
+}
+
+// HasCustomDefault reports whether the process-wide default logger is built
+// on a handler the application installed itself, rather than the stdlib
+// default handler or the managed console handler this package installs.
+// Genkit uses it to decide whether console logging configuration (such as the
+// GENKIT_LOG_LEVEL environment variable) is Genkit's to apply.
+func HasCustomDefault() bool {
+	mu.Lock()
+	defer mu.Unlock()
+	h := slog.Default().Handler()
+	if t, ok := h.(*teeHandler); ok {
+		h = t.handlers[0]
 	}
-	install(base)
+	return !isStdlibDefaultHandler(h) && h != console
 }
 
 // currentBase returns the handler that console output should continue to flow
 // through: the current default handler, unwrapped if it is a tee this package
 // installed earlier (so re-installation never nests tees). The stdlib default
 // handler is substituted with the managed console handler, since teeing it
-// would deadlock (see [isStdlibDefaultHandler]). Callers must hold mu.
+// would deadlock (see [isStdlibDefaultHandler]); its effective level is
+// carried over so the substitution does not change verbosity. Callers must
+// hold mu.
 func currentBase() slog.Handler {
 	h := slog.Default().Handler()
 	if t, ok := h.(*teeHandler); ok {
 		h = t.handlers[0]
 	}
 	if isStdlibDefaultHandler(h) {
+		if console == nil {
+			seedLevelFromStdlib(h)
+		}
 		ensureConsole()
 		return console
 	}
 	return h
+}
+
+// seedLevelFromStdlib copies the stdlib default handler's effective minimum
+// level into the managed level, so substituting the managed console for that
+// handler preserves verbosity raised with [slog.SetLogLoggerLevel] (which has
+// no getter; the handler is probed through Enabled instead). It runs only
+// before the console handler exists, so an explicit [SetLevel] always wins.
+// Callers must hold mu.
+func seedLevelFromStdlib(h slog.Handler) {
+	ctx := context.Background()
+	for _, l := range []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError} {
+		if h.Enabled(ctx, l) {
+			level.Set(l)
+			return
+		}
+	}
+	level.Set(slog.LevelError + 1)
 }
 
 // install makes base, teed with any registered sinks, the default slog

--- a/go/core/logger/logger.go
+++ b/go/core/logger/logger.go
@@ -27,27 +27,105 @@ import (
 )
 
 var (
-	logLevel  = slog.LevelDebug
-	mu        sync.RWMutex
+	mu sync.Mutex
+	// level is the minimum level for the console handler that SetLevel manages.
+	// The zero value is slog.LevelInfo, which is also the effective minimum of
+	// the stdlib default handler that is in place before SetLevel is called.
+	level slog.LevelVar
+	// console is the handler SetLevel installs, created on first use and wired
+	// to level so later SetLevel calls only adjust the level.
+	console slog.Handler
+	// sinks are additional handlers installed by AddHandler. Records logged
+	// through the default logger are delivered to every sink whose Enabled
+	// accepts them, alongside the console handler.
+	sinks     []slog.Handler
 	loggerKey = base.NewContextKey[*slog.Logger]()
+	// initialDefaultHandler is the stdlib default handler that is in place
+	// before anyone calls slog.SetDefault. It is not a real sink: it writes
+	// through the log package, whose output slog.SetDefault redirects back to
+	// the current default slog handler. Making it a member of an installed
+	// tee would therefore re-enter the tee on every record and deadlock on
+	// the log package's mutex, so it is detected and substituted instead.
+	initialDefaultHandler = slog.Default().Handler()
 )
 
-// SetLevel sets the global log level
-func SetLevel(level slog.Level) {
+// SetLevel sets the minimum level of Genkit's console log handler and installs
+// it as the process-wide default logger, replacing the current one. Handlers
+// previously installed with [AddHandler] are preserved.
+//
+// Applications that manage their own [slog] handler should set their handler's
+// level directly instead of calling SetLevel.
+func SetLevel(l slog.Level) {
 	mu.Lock()
 	defer mu.Unlock()
-	logLevel = level
-	h := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: logLevel,
-	}))
-	slog.SetDefault(h)
+	level.Set(l)
+	ensureConsole()
+	install(console)
 }
 
-// GetLevel gets the current global log level
+// ensureConsole creates the managed console handler if it does not exist yet.
+// Callers must hold mu.
+func ensureConsole() {
+	if console == nil {
+		console = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: &level})
+	}
+}
+
+// GetLevel returns the level most recently passed to [SetLevel], or
+// slog.LevelInfo if SetLevel has not been called.
 func GetLevel() slog.Level {
-	mu.RLock()
-	defer mu.RUnlock()
-	return logLevel
+	mu.Lock()
+	defer mu.Unlock()
+	return level.Level()
+}
+
+// AddHandler registers h as an additional destination for records logged
+// through the default logger: every record whose level passes h's Enabled
+// method is handed to h in addition to the current default handler. Genkit
+// uses this in dev mode to stream logs to the Dev UI; applications can use it
+// to mirror logs to a file or a test recorder.
+//
+// The registration survives [SetLevel], but a later call to [slog.SetDefault]
+// replaces the composed handler entirely.
+func AddHandler(h slog.Handler) {
+	mu.Lock()
+	defer mu.Unlock()
+	sinks = append(sinks, h)
+	base := console
+	if base == nil {
+		base = currentBase()
+	}
+	install(base)
+}
+
+// currentBase returns the handler that console output should continue to flow
+// through: the current default handler, unwrapped if it is a tee this package
+// installed earlier (so re-installation never nests tees). The stdlib default
+// handler is substituted with the managed console handler, since teeing it
+// would deadlock (see initialDefaultHandler). Callers must hold mu.
+func currentBase() slog.Handler {
+	h := slog.Default().Handler()
+	if t, ok := h.(*teeHandler); ok {
+		h = t.handlers[0]
+	}
+	if h == initialDefaultHandler {
+		ensureConsole()
+		return console
+	}
+	return h
+}
+
+// install makes base, teed with any registered sinks, the default slog
+// handler. Callers must hold mu.
+func install(base slog.Handler) {
+	if len(sinks) == 0 {
+		slog.SetDefault(slog.New(base))
+		return
+	}
+	handlers := make([]slog.Handler, 0, len(sinks)+1)
+	handlers = append(handlers, base)
+	handlers = append(handlers, sinks...)
+	slog.SetDefault(slog.New(&teeHandler{handlers: handlers}))
 }
 
 // FromContext returns the Logger in ctx, or the default Logger
@@ -57,4 +135,39 @@ func FromContext(ctx context.Context) *slog.Logger {
 		return l
 	}
 	return slog.Default()
+}
+
+// WithContext returns a copy of ctx carrying l. [FromContext] and the
+// package-level logging functions use l for anything logged under the
+// returned context, so attributes bound with l.With flow to every log
+// statement downstream:
+//
+//	ctx = logger.WithContext(ctx, logger.FromContext(ctx).With("requestId", id))
+func WithContext(ctx context.Context, l *slog.Logger) context.Context {
+	return loggerKey.NewContext(ctx, l)
+}
+
+// Debug logs at slog.LevelDebug using the logger in ctx.
+//
+// The package-level logging functions are the preferred way to log within
+// Genkit: they use the context's logger (with any attributes bound via
+// [WithContext]) and pass ctx through to the handler, which is what lets a
+// context-aware handler correlate the record with the active trace span.
+func Debug(ctx context.Context, msg string, args ...any) {
+	FromContext(ctx).Log(ctx, slog.LevelDebug, msg, args...)
+}
+
+// Info logs at slog.LevelInfo using the logger in ctx. See [Debug].
+func Info(ctx context.Context, msg string, args ...any) {
+	FromContext(ctx).Log(ctx, slog.LevelInfo, msg, args...)
+}
+
+// Warn logs at slog.LevelWarn using the logger in ctx. See [Debug].
+func Warn(ctx context.Context, msg string, args ...any) {
+	FromContext(ctx).Log(ctx, slog.LevelWarn, msg, args...)
+}
+
+// Error logs at slog.LevelError using the logger in ctx. See [Debug].
+func Error(ctx context.Context, msg string, args ...any) {
+	FromContext(ctx).Log(ctx, slog.LevelError, msg, args...)
 }

--- a/go/core/logger/logger.go
+++ b/go/core/logger/logger.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"reflect"
 	"sync"
 
 	"github.com/firebase/genkit/go/internal/base"
@@ -40,14 +41,22 @@ var (
 	// accepts them, alongside the console handler.
 	sinks     []slog.Handler
 	loggerKey = base.NewContextKey[*slog.Logger]()
-	// initialDefaultHandler is the stdlib default handler that is in place
-	// before anyone calls slog.SetDefault. It is not a real sink: it writes
-	// through the log package, whose output slog.SetDefault redirects back to
-	// the current default slog handler. Making it a member of an installed
-	// tee would therefore re-enter the tee on every record and deadlock on
-	// the log package's mutex, so it is detected and substituted instead.
-	initialDefaultHandler = slog.Default().Handler()
 )
+
+// isStdlibDefaultHandler reports whether h is the standard library's default
+// slog handler, detected by its (unexported) type. That handler is not a real
+// sink: it writes through the log package, whose output slog.SetDefault
+// redirects back to the current default slog handler, so making it a member
+// of an installed tee would re-enter the tee on every record and deadlock on
+// the log package's mutex. It is detected by type rather than by capturing
+// slog.Default() at package initialization, since another package's init can
+// legitimately install a custom default before this package initializes, and
+// that handler must not be mistaken for the stdlib one. A test pins the type
+// name against stdlib renames.
+func isStdlibDefaultHandler(h slog.Handler) bool {
+	t := reflect.TypeOf(h)
+	return t != nil && t.String() == "*slog.defaultHandler"
+}
 
 // SetLevel sets the minimum level of Genkit's console log handler and installs
 // it as the process-wide default logger, replacing the current one. Handlers
@@ -102,13 +111,13 @@ func AddHandler(h slog.Handler) {
 // through: the current default handler, unwrapped if it is a tee this package
 // installed earlier (so re-installation never nests tees). The stdlib default
 // handler is substituted with the managed console handler, since teeing it
-// would deadlock (see initialDefaultHandler). Callers must hold mu.
+// would deadlock (see [isStdlibDefaultHandler]). Callers must hold mu.
 func currentBase() slog.Handler {
 	h := slog.Default().Handler()
 	if t, ok := h.(*teeHandler); ok {
 		h = t.handlers[0]
 	}
-	if h == initialDefaultHandler {
+	if isStdlibDefaultHandler(h) {
 		ensureConsole()
 		return console
 	}

--- a/go/core/logger/logger_test.go
+++ b/go/core/logger/logger_test.go
@@ -22,6 +22,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	otrace "go.opentelemetry.io/otel/trace"
 )
 
 // recordHandler collects records for assertions.
@@ -75,15 +77,94 @@ func resetGlobalState(t *testing.T) {
 func TestWithContext(t *testing.T) {
 	resetGlobalState(t)
 
-	h := newRecordHandler(slog.LevelDebug)
-	l := slog.New(h)
-	ctx := WithContext(context.Background(), l)
+	stored := newRecordHandler(slog.LevelDebug)
+	ctx := WithContext(context.Background(), slog.New(stored))
+	def := newRecordHandler(slog.LevelDebug)
+	slog.SetDefault(slog.New(def))
 
-	if got := FromContext(ctx); got != l {
-		t.Errorf("FromContext returned %v, want the logger from WithContext", got)
+	FromContext(ctx).Info("stored")
+	FromContext(context.Background()).Info("default")
+
+	if got := stored.messages(); !slices.Equal(got, []string{"stored"}) {
+		t.Errorf("stored logger messages = %v, want [stored]", got)
 	}
-	if got := FromContext(context.Background()); got != slog.Default() {
-		t.Errorf("FromContext without a logger returned %v, want slog.Default()", got)
+	if got := def.messages(); !slices.Equal(got, []string{"default"}) {
+		t.Errorf("default logger messages = %v, want [default]", got)
+	}
+}
+
+// spanHandler records the span context carried by each record's context.
+type spanHandler struct {
+	spans *[]otrace.SpanContext
+}
+
+func (h *spanHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *spanHandler) Handle(ctx context.Context, _ slog.Record) error {
+	*h.spans = append(*h.spans, otrace.SpanContextFromContext(ctx))
+	return nil
+}
+
+func (h *spanHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *spanHandler) WithGroup(string) slog.Handler      { return h }
+
+func spanContext(id byte) otrace.SpanContext {
+	return otrace.NewSpanContext(otrace.SpanContextConfig{
+		TraceID: otrace.TraceID{id},
+		SpanID:  otrace.SpanID{id},
+	})
+}
+
+func TestFromContextBindsSpan(t *testing.T) {
+	resetGlobalState(t)
+
+	var spans []otrace.SpanContext
+	slog.SetDefault(slog.New(&spanHandler{spans: &spans}))
+
+	scA, scB := spanContext(1), spanContext(2)
+	ctxA := otrace.ContextWithSpanContext(context.Background(), scA)
+	ctxB := otrace.ContextWithSpanContext(context.Background(), scB)
+
+	l := FromContext(ctxA)
+	l.Info("context-free")                          // bound context supplies span A
+	l.InfoContext(ctxB, "explicit span")            // call-site span B wins
+	l.InfoContext(context.Background(), "spanless") // bound span A fills in
+
+	// Re-fetching a stored bound logger under a new context rebinds it to
+	// that context rather than nesting a stale binding.
+	FromContext(WithContext(ctxB, l)).Info("rebound")
+
+	want := []otrace.SpanContext{scA, scB, scA, scB}
+	if len(spans) != len(want) {
+		t.Fatalf("got %d records, want %d", len(spans), len(want))
+	}
+	for i := range want {
+		if !spans[i].Equal(want[i]) {
+			t.Errorf("record %d span = %v, want %v", i, spans[i], want[i])
+		}
+	}
+}
+
+func TestFromContextKeepsBoundAttrs(t *testing.T) {
+	resetGlobalState(t)
+
+	h := newRecordHandler(slog.LevelDebug)
+	slog.SetDefault(slog.New(h))
+
+	FromContext(context.Background()).With("requestId", "r1").Info("m")
+
+	if len(*h.records) != 1 {
+		t.Fatalf("got %d records, want 1", len(*h.records))
+	}
+	found := false
+	(*h.records)[0].Attrs(func(a slog.Attr) bool {
+		if a.Key == "requestId" {
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Error("record lost the attribute bound with With")
 	}
 }
 
@@ -224,6 +305,26 @@ func TestAddHandlerKeepsCustomDefaultAfterSetLevel(t *testing.T) {
 
 	if got := custom.messages(); !slices.Equal(got, []string{"kept"}) {
 		t.Errorf("custom handler messages = %v, want [kept]", got)
+	}
+}
+
+func TestSetLevelKeepsCustomDefault(t *testing.T) {
+	resetGlobalState(t)
+
+	custom := newRecordHandler(slog.LevelInfo)
+	SetDefaultHandler(custom)
+	SetLevel(slog.LevelDebug)
+
+	slog.Info("still through custom")
+
+	// The application's handler stays the default; SetLevel warns through it
+	// instead of replacing it with the managed console.
+	msgs := custom.messages()
+	if len(msgs) != 2 || !strings.Contains(msgs[0], "SetLevel") || msgs[1] != "still through custom" {
+		t.Errorf("custom handler messages = %v, want the SetLevel warning followed by [still through custom]", msgs)
+	}
+	if got := GetLevel(); got != slog.LevelDebug {
+		t.Errorf("GetLevel = %v, want %v", got, slog.LevelDebug)
 	}
 }
 

--- a/go/core/logger/logger_test.go
+++ b/go/core/logger/logger_test.go
@@ -209,6 +209,83 @@ func TestCustomDefaultInstalledBeforeAddHandlerIsKept(t *testing.T) {
 	}
 }
 
+func TestAddHandlerKeepsCustomDefaultAfterSetLevel(t *testing.T) {
+	resetGlobalState(t)
+
+	// SetLevel creates the managed console; a custom default installed
+	// afterwards must still be the base AddHandler tees onto, not the stale
+	// managed console.
+	SetLevel(slog.LevelInfo)
+	custom := newRecordHandler(slog.LevelInfo)
+	slog.SetDefault(slog.New(custom))
+	AddHandler(newRecordHandler(slog.LevelDebug))
+
+	slog.Info("kept")
+
+	if got := custom.messages(); !slices.Equal(got, []string{"kept"}) {
+		t.Errorf("custom handler messages = %v, want [kept]", got)
+	}
+}
+
+func TestSetDefaultHandlerPreservesSinks(t *testing.T) {
+	resetGlobalState(t)
+
+	sink := newRecordHandler(slog.LevelDebug)
+	AddHandler(sink)
+	replacement := newRecordHandler(slog.LevelInfo)
+	SetDefaultHandler(replacement)
+
+	slog.Info("to both")
+
+	if got := replacement.messages(); !slices.Equal(got, []string{"to both"}) {
+		t.Errorf("replacement messages = %v, want [to both]", got)
+	}
+	if got := sink.messages(); !slices.Equal(got, []string{"to both"}) {
+		t.Errorf("sink messages = %v, want [to both]", got)
+	}
+}
+
+func TestHasCustomDefault(t *testing.T) {
+	resetGlobalState(t)
+
+	if HasCustomDefault() {
+		t.Error("HasCustomDefault = true with the stdlib default handler")
+	}
+	SetLevel(slog.LevelInfo)
+	if HasCustomDefault() {
+		t.Error("HasCustomDefault = true with the managed console installed")
+	}
+	AddHandler(newRecordHandler(slog.LevelDebug))
+	if HasCustomDefault() {
+		t.Error("HasCustomDefault = true with the managed console teed with a sink")
+	}
+	slog.SetDefault(slog.New(newRecordHandler(slog.LevelInfo)))
+	if !HasCustomDefault() {
+		t.Error("HasCustomDefault = false after the application installed its own handler")
+	}
+	// A component-supplied base handler also counts as custom: console
+	// configuration such as GENKIT_LOG_LEVEL must not clobber it.
+	SetDefaultHandler(newRecordHandler(slog.LevelInfo))
+	if !HasCustomDefault() {
+		t.Error("HasCustomDefault = false after SetDefaultHandler installed a component handler")
+	}
+}
+
+func TestStdlibLogLoggerLevelCarriesOver(t *testing.T) {
+	resetGlobalState(t)
+
+	// Verbosity raised on the stdlib default handler via SetLogLoggerLevel
+	// must survive its substitution with the managed console.
+	prev := slog.SetLogLoggerLevel(slog.LevelDebug)
+	t.Cleanup(func() { slog.SetLogLoggerLevel(prev) })
+
+	AddHandler(newRecordHandler(slog.LevelDebug))
+
+	if got := GetLevel(); got != slog.LevelDebug {
+		t.Errorf("GetLevel = %v, want %v (seeded from SetLogLoggerLevel)", got, slog.LevelDebug)
+	}
+}
+
 func TestAddHandlerTwiceDoesNotNest(t *testing.T) {
 	resetGlobalState(t)
 

--- a/go/core/logger/logger_test.go
+++ b/go/core/logger/logger_test.go
@@ -163,10 +163,17 @@ func TestSetLevelPreservesSinks(t *testing.T) {
 func TestAddHandlerOverStdlibDefault(t *testing.T) {
 	resetGlobalState(t)
 
-	// The process default is the stdlib handler here (resetGlobalState
-	// restored it). Teeing that handler back in would re-enter the tee
-	// through the log package on every record and deadlock, so AddHandler
-	// must substitute the managed console handler.
+	// Canary for the type-name detection: the process default here is the
+	// stdlib handler (resetGlobalState restored it). If this fails on a Go
+	// upgrade, the stdlib renamed its default handler type and
+	// isStdlibDefaultHandler must learn the new name.
+	if !isStdlibDefaultHandler(slog.Default().Handler()) {
+		t.Fatalf("isStdlibDefaultHandler does not recognize the process default handler (%T)", slog.Default().Handler())
+	}
+
+	// Teeing the stdlib handler back in would re-enter the tee through the
+	// log package on every record and deadlock, so AddHandler must
+	// substitute the managed console handler.
 	sink := newRecordHandler(slog.LevelDebug)
 	AddHandler(sink)
 
@@ -181,8 +188,24 @@ func TestAddHandlerOverStdlibDefault(t *testing.T) {
 	if !ok {
 		t.Fatalf("default handler is %T, want *teeHandler", slog.Default().Handler())
 	}
-	if tee.handlers[0] == initialDefaultHandler {
+	if isStdlibDefaultHandler(tee.handlers[0]) {
 		t.Error("tee kept the stdlib default handler as its console member")
+	}
+}
+
+func TestCustomDefaultInstalledBeforeAddHandlerIsKept(t *testing.T) {
+	resetGlobalState(t)
+
+	// A custom default handler must never be mistaken for the stdlib one and
+	// substituted away, no matter when it was installed.
+	custom := newRecordHandler(slog.LevelInfo)
+	slog.SetDefault(slog.New(custom))
+	AddHandler(newRecordHandler(slog.LevelDebug))
+
+	slog.Info("kept")
+
+	if got := custom.messages(); !slices.Equal(got, []string{"kept"}) {
+		t.Errorf("custom handler messages = %v, want [kept]", got)
 	}
 }
 

--- a/go/core/logger/logger_test.go
+++ b/go/core/logger/logger_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// recordHandler collects records for assertions.
+type recordHandler struct {
+	level   slog.Level
+	records *[]slog.Record
+	attrs   []slog.Attr
+}
+
+func newRecordHandler(level slog.Level) *recordHandler {
+	return &recordHandler{level: level, records: &[]slog.Record{}}
+}
+
+func (h *recordHandler) Enabled(ctx context.Context, l slog.Level) bool { return l >= h.level }
+
+func (h *recordHandler) Handle(ctx context.Context, r slog.Record) error {
+	nr := r.Clone()
+	nr.AddAttrs(h.attrs...)
+	*h.records = append(*h.records, nr)
+	return nil
+}
+
+func (h *recordHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &recordHandler{level: h.level, records: h.records, attrs: append(slices.Clip(h.attrs), attrs...)}
+}
+
+func (h *recordHandler) WithGroup(name string) slog.Handler { return h }
+
+func (h *recordHandler) messages() []string {
+	var msgs []string
+	for _, r := range *h.records {
+		msgs = append(msgs, r.Message)
+	}
+	return msgs
+}
+
+// resetGlobalState restores the package and slog globals a test mutates.
+func resetGlobalState(t *testing.T) {
+	t.Helper()
+	prev := slog.Default()
+	t.Cleanup(func() {
+		mu.Lock()
+		sinks = nil
+		console = nil
+		level.Set(slog.LevelInfo)
+		mu.Unlock()
+		slog.SetDefault(prev)
+	})
+}
+
+func TestWithContext(t *testing.T) {
+	resetGlobalState(t)
+
+	h := newRecordHandler(slog.LevelDebug)
+	l := slog.New(h)
+	ctx := WithContext(context.Background(), l)
+
+	if got := FromContext(ctx); got != l {
+		t.Errorf("FromContext returned %v, want the logger from WithContext", got)
+	}
+	if got := FromContext(context.Background()); got != slog.Default() {
+		t.Errorf("FromContext without a logger returned %v, want slog.Default()", got)
+	}
+}
+
+func TestPackageLevelHelpers(t *testing.T) {
+	resetGlobalState(t)
+
+	h := newRecordHandler(slog.LevelDebug)
+	ctx := WithContext(context.Background(), slog.New(h))
+
+	Debug(ctx, "debug msg", "k", 1)
+	Info(ctx, "info msg")
+	Warn(ctx, "warn msg")
+	Error(ctx, "error msg")
+
+	want := []string{"debug msg", "info msg", "warn msg", "error msg"}
+	if got := h.messages(); !slices.Equal(got, want) {
+		t.Errorf("messages = %v, want %v", got, want)
+	}
+	wantLevels := []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError}
+	for i, r := range *h.records {
+		if r.Level != wantLevels[i] {
+			t.Errorf("record %d level = %v, want %v", i, r.Level, wantLevels[i])
+		}
+	}
+}
+
+func TestHelpersUseDefaultWithoutContextLogger(t *testing.T) {
+	resetGlobalState(t)
+
+	h := newRecordHandler(slog.LevelDebug)
+	slog.SetDefault(slog.New(h))
+
+	Info(context.Background(), "through default")
+
+	if got := h.messages(); !slices.Equal(got, []string{"through default"}) {
+		t.Errorf("messages = %v, want [through default]", got)
+	}
+}
+
+func TestAddHandlerTees(t *testing.T) {
+	resetGlobalState(t)
+
+	console := newRecordHandler(slog.LevelInfo)
+	slog.SetDefault(slog.New(console))
+	sink := newRecordHandler(slog.LevelDebug)
+	AddHandler(sink)
+
+	slog.Info("visible to both")
+	slog.Debug("sink only")
+
+	if got := console.messages(); !slices.Equal(got, []string{"visible to both"}) {
+		t.Errorf("console messages = %v, want [visible to both]", got)
+	}
+	if got := sink.messages(); !slices.Equal(got, []string{"visible to both", "sink only"}) {
+		t.Errorf("sink messages = %v, want both records", got)
+	}
+}
+
+func TestSetLevelPreservesSinks(t *testing.T) {
+	resetGlobalState(t)
+
+	sink := newRecordHandler(slog.LevelDebug)
+	AddHandler(sink)
+	SetLevel(slog.LevelWarn)
+
+	if got := GetLevel(); got != slog.LevelWarn {
+		t.Errorf("GetLevel = %v, want %v", got, slog.LevelWarn)
+	}
+
+	slog.Debug("after set level")
+
+	if got := sink.messages(); !slices.Equal(got, []string{"after set level"}) {
+		t.Errorf("sink messages = %v, want [after set level]", got)
+	}
+}
+
+func TestAddHandlerOverStdlibDefault(t *testing.T) {
+	resetGlobalState(t)
+
+	// The process default is the stdlib handler here (resetGlobalState
+	// restored it). Teeing that handler back in would re-enter the tee
+	// through the log package on every record and deadlock, so AddHandler
+	// must substitute the managed console handler.
+	sink := newRecordHandler(slog.LevelDebug)
+	AddHandler(sink)
+
+	// Completing at all is the regression check: with the stdlib handler as
+	// a tee member this call would deadlock on the log package's mutex.
+	slog.Info("no deadlock")
+
+	if got := sink.messages(); !slices.Equal(got, []string{"no deadlock"}) {
+		t.Errorf("sink messages = %v, want [no deadlock]", got)
+	}
+	tee, ok := slog.Default().Handler().(*teeHandler)
+	if !ok {
+		t.Fatalf("default handler is %T, want *teeHandler", slog.Default().Handler())
+	}
+	if tee.handlers[0] == initialDefaultHandler {
+		t.Error("tee kept the stdlib default handler as its console member")
+	}
+}
+
+func TestAddHandlerTwiceDoesNotNest(t *testing.T) {
+	resetGlobalState(t)
+
+	console := newRecordHandler(slog.LevelInfo)
+	slog.SetDefault(slog.New(console))
+	AddHandler(newRecordHandler(slog.LevelDebug))
+	AddHandler(newRecordHandler(slog.LevelDebug))
+
+	slog.Info("once")
+
+	if got := console.messages(); !slices.Equal(got, []string{"once"}) {
+		t.Errorf("console messages = %v, want exactly one record", got)
+	}
+}
+
+func TestTeeWithAttrsAndGroups(t *testing.T) {
+	resetGlobalState(t)
+
+	sink := newRecordHandler(slog.LevelDebug)
+	tee := &teeHandler{handlers: []slog.Handler{sink}}
+	l := slog.New(tee).With("bound", "yes")
+
+	l.Info("with attrs", "k", "v")
+
+	if len(*sink.records) != 1 {
+		t.Fatalf("got %d records, want 1", len(*sink.records))
+	}
+	var keys []string
+	(*sink.records)[0].Attrs(func(a slog.Attr) bool {
+		keys = append(keys, a.Key)
+		return true
+	})
+	joined := strings.Join(keys, ",")
+	if !strings.Contains(joined, "bound") || !strings.Contains(joined, "k") {
+		t.Errorf("record attrs = %v, want bound and k", keys)
+	}
+}

--- a/go/core/logger/tee.go
+++ b/go/core/logger/tee.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logger
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// teeHandler fans each record out to every member handler that accepts its
+// level. handlers[0] is the console handler; the rest are sinks registered
+// with [AddHandler].
+type teeHandler struct {
+	handlers []slog.Handler
+}
+
+func (t *teeHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	for _, h := range t.handlers {
+		if h.Enabled(ctx, l) {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *teeHandler) Handle(ctx context.Context, r slog.Record) error {
+	var errs []error
+	for _, h := range t.handlers {
+		// A record can be enabled for one member but not another (a sink that
+		// wants debug records while the console shows info), so each member
+		// gets its own Enabled check. Clone guards against a handler that
+		// retains or mutates the record.
+		if h.Enabled(ctx, r.Level) {
+			if err := h.Handle(ctx, r.Clone()); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (t *teeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return t
+	}
+	handlers := make([]slog.Handler, len(t.handlers))
+	for i, h := range t.handlers {
+		handlers[i] = h.WithAttrs(attrs)
+	}
+	return &teeHandler{handlers: handlers}
+}
+
+func (t *teeHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return t
+	}
+	handlers := make([]slog.Handler, len(t.handlers))
+	for i, h := range t.handlers {
+		handlers[i] = h.WithGroup(name)
+	}
+	return &teeHandler{handlers: handlers}
+}

--- a/go/core/status/status.go
+++ b/go/core/status/status.go
@@ -85,10 +85,34 @@ var httpCodeToName = map[int]Name{
 	http.StatusServiceUnavailable:  Unavailable,
 }
 
+// codeToName is the reverse of the gRPC code column above. Unlike the HTTP
+// column it is one-to-one, so it is derived from the canonical table rather
+// than restated, and cannot drift from it.
+var codeToName = func() map[int]Name {
+	m := make(map[int]Name, len(statuses))
+	for name, s := range statuses {
+		m[s.code] = name
+	}
+	return m
+}()
+
 // IsValid reports whether n is one of the canonical status names.
 func (n Name) IsValid() bool {
 	_, ok := statuses[n]
 	return ok
+}
+
+// FromCode returns the canonical status name for a gRPC integer code, or
+// Unknown if the code is not canonical. It is the reverse of [Name.Code].
+//
+// Like [FromHTTPCode], it is intended for plugins translating a provider's
+// error into a status middleware can reason about. Google APIs report a failed
+// long-running operation as a google.rpc.Status, whose code is numeric.
+func FromCode(code int) Name {
+	if n, ok := codeToName[code]; ok {
+		return n
+	}
+	return Unknown
 }
 
 // Code returns the gRPC integer code for n, or 2 (Unknown) if n is not

--- a/go/core/status/status_test.go
+++ b/go/core/status/status_test.go
@@ -63,6 +63,23 @@ func TestNameHTTPCode(t *testing.T) {
 	})
 }
 
+func TestFromCode(t *testing.T) {
+	// Every canonical name must survive the Code -> FromCode round trip; the
+	// reverse map is derived from the same table, so this pins that the codes
+	// really are one-to-one.
+	for name := range statuses {
+		if got := FromCode(name.Code()); got != name {
+			t.Errorf("FromCode(%d) = %v, want %v", name.Code(), got, name)
+		}
+	}
+	// A code outside the canonical range is Unknown, not a silent zero value.
+	for _, code := range []int{-1, 17, 99} {
+		if got := FromCode(code); got != Unknown {
+			t.Errorf("FromCode(%d) = %v, want %v", code, got, Unknown)
+		}
+	}
+}
+
 func TestFromHTTPCode(t *testing.T) {
 	tests := []struct {
 		code int

--- a/go/core/tracing/doc.go
+++ b/go/core/tracing/doc.go
@@ -95,10 +95,8 @@ Create spans with rich metadata for better observability:
 
 Extract trace context for correlation with external systems:
 
-	info := tracing.GetTraceInfo(ctx)
-	if info != nil {
-		log.Printf("TraceID: %s, SpanID: %s", info.TraceID, info.SpanID)
-	}
+	info := tracing.SpanTraceInfo(ctx)
+	log.Printf("TraceID: %s, SpanID: %s", info.TraceID, info.SpanID)
 
 This package is primarily intended for Genkit internals and advanced plugin
 development. Most application developers will interact with tracing through

--- a/go/core/tracing/log_export.go
+++ b/go/core/tracing/log_export.go
@@ -54,10 +54,16 @@ const (
 )
 
 // logExportDisabled reports whether the user explicitly opted out of log
-// export. The same variable gates the JS runtime's log export, but with an
-// opt-in default; Go exports whenever a telemetry server is configured, which
-// only the dev tooling does, so "false" is the only meaningful setting.
-var logExportDisabled = os.Getenv("GENKIT_OTEL_ENABLE_LOGS") == "false"
+// export via GENKIT_OTEL_ENABLE_LOGS. The same variable gates the JS
+// runtime's log export, but with an opt-in default; Go exports whenever a
+// telemetry server is configured, which only the dev tooling does, so a false
+// value is the only meaningful setting. It is read when export is enabled,
+// not at package initialization, so a value set programmatically before
+// genkit.Init (os.Setenv in main, t.Setenv in tests) is honored.
+func logExportDisabled() bool {
+	v, err := strconv.ParseBool(os.Getenv("GENKIT_OTEL_ENABLE_LOGS"))
+	return err == nil && !v
+}
 
 // logExporter converts slog records to OTLP-JSON log records and ships them
 // to the telemetry server from a single background worker.
@@ -67,12 +73,10 @@ type logExporter struct {
 	start   sync.Once
 	dropped atomic.Int64
 
-	// warnUnreachable and warnDropped each fire once so a dead telemetry
-	// server or a full queue is reported without flooding the console. The
-	// warnings themselves pass back through the export handler, but a second
-	// failure no longer logs, so there is no feedback loop.
-	warnUnreachable sync.Once
-	warnDropped     sync.Once
+	// warnDropped fires once so a full queue is reported without flooding the
+	// console. An unreachable server is reported through the package-wide
+	// [warnTelemetryUnreachable], shared with the trace export path.
+	warnDropped sync.Once
 }
 
 // exporter is the process-wide dev log exporter. Its handler is installed by
@@ -98,7 +102,7 @@ var diag = slog.New(slog.NewTextHandler(os.Stderr, nil))
 // Records reach the telemetry server only if a handler created by
 // [LogExportHandler] is registered, which genkit.Init does in dev mode.
 func EnableLogExport(url string) {
-	if url == "" || logExportDisabled {
+	if url == "" || logExportDisabled() {
 		return
 	}
 	exporter.client.Store(NewHTTPTelemetryClient(url))
@@ -150,9 +154,7 @@ func (e *logExporter) send(batch []otlpLogRecord) {
 			}},
 		}},
 	}); err != nil {
-		e.warnUnreachable.Do(func() {
-			diag.Warn("cannot reach telemetry server; logs will not appear in the Dev UI", "error", err)
-		})
+		warnTelemetryUnreachable(err)
 	}
 }
 
@@ -188,7 +190,7 @@ func (h *logExportHandler) Handle(ctx context.Context, r slog.Record) error {
 		SeverityNumber: severityNumber(r.Level),
 		SeverityText:   severityText(r.Level),
 		Body:           otlpStringValue(r.Message),
-		Attributes:     append([]otlpKeyValue{}, h.attrs...),
+		Attributes:     append(make([]otlpKeyValue, 0, len(h.attrs)+r.NumAttrs()), h.attrs...),
 	}
 	r.Attrs(func(a slog.Attr) bool {
 		rec.Attributes = appendOtlpAttr(rec.Attributes, h.prefix, a)

--- a/go/core/tracing/log_export.go
+++ b/go/core/tracing/log_export.go
@@ -1,0 +1,363 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tracing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"reflect"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/firebase/genkit/go/internal"
+	otrace "go.opentelemetry.io/otel/trace"
+)
+
+// The dev log exporter forwards slog records to the telemetry server used by
+// the Genkit Dev UI, correlated with the active trace span so each record
+// shows up in the UI on the span that emitted it. It is the log-side
+// counterpart of the trace exporters in this package and mirrors the JS
+// runtime's LogServerExporter, which POSTs the same OTLP-JSON payload to the
+// same /api/otlp endpoint.
+
+const (
+	// logQueueSize bounds the export queue. Logging never blocks: when the
+	// queue is full, records are dropped (and counted) rather than stalling
+	// the caller.
+	logQueueSize = 1024
+	// logBatchSize and logBatchDelay shape the batches: a batch is sent when
+	// it reaches logBatchSize records or when logBatchDelay has passed since
+	// its first record, whichever comes first.
+	logBatchSize  = 64
+	logBatchDelay = 100 * time.Millisecond
+	// logExportTimeout bounds a single POST to the telemetry server.
+	logExportTimeout = 10 * time.Second
+)
+
+// logExportDisabled reports whether the user explicitly opted out of log
+// export. The same variable gates the JS runtime's log export, but with an
+// opt-in default; Go exports whenever a telemetry server is configured, which
+// only the dev tooling does, so "false" is the only meaningful setting.
+var logExportDisabled = os.Getenv("GENKIT_OTEL_ENABLE_LOGS") == "false"
+
+// logExporter converts slog records to OTLP-JSON log records and ships them
+// to the telemetry server from a single background worker.
+type logExporter struct {
+	client  atomic.Pointer[httpTelemetryClient]
+	queue   chan otlpLogRecord
+	start   sync.Once
+	dropped atomic.Int64
+
+	// warnUnreachable and warnDropped each fire once so a dead telemetry
+	// server or a full queue is reported without flooding the console. The
+	// warnings themselves pass back through the export handler, but a second
+	// failure no longer logs, so there is no feedback loop.
+	warnUnreachable sync.Once
+	warnDropped     sync.Once
+}
+
+// exporter is the process-wide dev log exporter. Its handler is installed by
+// genkit.Init in dev mode; it stays inert until [EnableLogExport] gives it a
+// telemetry server to talk to.
+var exporter = &logExporter{queue: make(chan otlpLogRecord, logQueueSize)}
+
+// EnableLogExport starts forwarding log records to the telemetry server at
+// url, correlating each record with the active span at the time of logging.
+// It is called during dev-mode initialization, either with the value of
+// GENKIT_TELEMETRY_SERVER or with the URL the Genkit CLI supplies when it
+// notifies the reflection server. Calling it again replaces the destination;
+// an empty url is ignored. Setting GENKIT_OTEL_ENABLE_LOGS=false disables
+// export entirely.
+//
+// Records reach the telemetry server only if a handler created by
+// [LogExportHandler] is registered, which genkit.Init does in dev mode.
+func EnableLogExport(url string) {
+	if url == "" || logExportDisabled {
+		return
+	}
+	exporter.client.Store(NewHTTPTelemetryClient(url))
+	exporter.start.Do(func() { go exporter.run() })
+}
+
+// LogExportHandler returns a slog.Handler that forwards every record at
+// slog.LevelDebug or above to the telemetry server configured with
+// [EnableLogExport]. Until then the handler reports itself disabled and adds
+// no overhead. The handler never blocks: records beyond the export queue's
+// capacity are dropped.
+func LogExportHandler() slog.Handler {
+	return &logExportHandler{exporter: exporter}
+}
+
+// run is the export worker: it drains the queue into batches and POSTs them.
+func (e *logExporter) run() {
+	for first := range e.queue {
+		batch := []otlpLogRecord{first}
+		timer := time.NewTimer(logBatchDelay)
+	collect:
+		for len(batch) < logBatchSize {
+			select {
+			case rec := <-e.queue:
+				batch = append(batch, rec)
+			case <-timer.C:
+				break collect
+			}
+		}
+		timer.Stop()
+		e.send(batch)
+	}
+}
+
+// send delivers one batch to the telemetry server.
+func (e *logExporter) send(batch []otlpLogRecord) {
+	client := e.client.Load()
+	if client == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), logExportTimeout)
+	defer cancel()
+	if err := client.SaveLogs(ctx, &otlpLogsPayload{
+		ResourceLogs: []otlpResourceLogs{{
+			Resource: otlpResource{Attributes: []otlpKeyValue{}},
+			ScopeLogs: []otlpScopeLogs{{
+				Scope:      otlpScope{Name: "genkit-go", Version: internal.Version},
+				LogRecords: batch,
+			}},
+		}},
+	}); err != nil {
+		e.warnUnreachable.Do(func() {
+			slog.Warn("cannot reach telemetry server; logs will not appear in the Dev UI", "error", err)
+		})
+	}
+}
+
+// enqueue adds rec to the export queue without blocking, dropping it if the
+// queue is full.
+func (e *logExporter) enqueue(rec otlpLogRecord) {
+	select {
+	case e.queue <- rec:
+	default:
+		e.dropped.Add(1)
+		e.warnDropped.Do(func() {
+			slog.Warn("log export queue is full; dropping records from the Dev UI log view")
+		})
+	}
+}
+
+// logExportHandler is the slog.Handler side of the exporter. WithAttrs and
+// WithGroup accumulate into pre-converted attributes and a dotted key prefix,
+// since the telemetry server stores attributes as a flat list.
+type logExportHandler struct {
+	exporter *logExporter
+	attrs    []otlpKeyValue
+	prefix   string
+}
+
+func (h *logExportHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return level >= slog.LevelDebug && h.exporter.client.Load() != nil
+}
+
+func (h *logExportHandler) Handle(ctx context.Context, r slog.Record) error {
+	rec := otlpLogRecord{
+		TimeUnixNano:   strconv.FormatInt(r.Time.UnixNano(), 10),
+		SeverityNumber: severityNumber(r.Level),
+		SeverityText:   severityText(r.Level),
+		Body:           otlpStringValue(r.Message),
+		Attributes:     append([]otlpKeyValue{}, h.attrs...),
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.Attributes = appendOtlpAttr(rec.Attributes, h.prefix, a)
+		return true
+	})
+	// The span active when the log statement ran determines where the record
+	// appears in the Dev UI, which looks logs up by exact trace and span ID.
+	// A record logged outside any span is still stored, just not shown on a
+	// span.
+	if sc := otrace.SpanContextFromContext(ctx); sc.IsValid() {
+		rec.TraceID = sc.TraceID().String()
+		rec.SpanID = sc.SpanID().String()
+	}
+	h.exporter.enqueue(rec)
+	return nil
+}
+
+func (h *logExportHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	nh := &logExportHandler{exporter: h.exporter, prefix: h.prefix}
+	nh.attrs = append(append([]otlpKeyValue{}, h.attrs...), convertOtlpAttrs(h.prefix, attrs)...)
+	return nh
+}
+
+func (h *logExportHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &logExportHandler{exporter: h.exporter, attrs: h.attrs, prefix: h.prefix + name + "."}
+}
+
+// severityNumber maps a slog level to an OpenTelemetry severity number.
+// The ranges line up exactly: slog Debug (-4) through Error (+8) map to OTel
+// DEBUG (5) through ERROR (17) with a constant offset of 9.
+func severityNumber(level slog.Level) int {
+	return min(max(int(level)+9, 1), 24)
+}
+
+// severityText maps a slog level to the OTel severity text the Dev UI colors
+// by. In-between levels take the text of the level they are at or above.
+func severityText(level slog.Level) string {
+	switch {
+	case level >= slog.LevelError:
+		return "ERROR"
+	case level >= slog.LevelWarn:
+		return "WARN"
+	case level >= slog.LevelInfo:
+		return "INFO"
+	default:
+		return "DEBUG"
+	}
+}
+
+// OTLP-JSON wire types, matching the subset the telemetry server parses. The
+// server understands only string, int, and bool attribute values, so every
+// other kind is rendered to a string.
+
+type otlpLogsPayload struct {
+	ResourceLogs []otlpResourceLogs `json:"resourceLogs"`
+}
+
+type otlpResourceLogs struct {
+	Resource  otlpResource    `json:"resource"`
+	ScopeLogs []otlpScopeLogs `json:"scopeLogs"`
+}
+
+type otlpResource struct {
+	Attributes             []otlpKeyValue `json:"attributes"`
+	DroppedAttributesCount int            `json:"droppedAttributesCount"`
+}
+
+type otlpScopeLogs struct {
+	Scope      otlpScope       `json:"scope"`
+	LogRecords []otlpLogRecord `json:"logRecords"`
+}
+
+type otlpScope struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type otlpLogRecord struct {
+	TimeUnixNano   string         `json:"timeUnixNano"`
+	SeverityNumber int            `json:"severityNumber"`
+	SeverityText   string         `json:"severityText"`
+	Body           otlpValue      `json:"body"`
+	Attributes     []otlpKeyValue `json:"attributes"`
+	TraceID        string         `json:"traceId,omitempty"`
+	SpanID         string         `json:"spanId,omitempty"`
+}
+
+type otlpKeyValue struct {
+	Key   string    `json:"key"`
+	Value otlpValue `json:"value"`
+}
+
+type otlpValue struct {
+	StringValue *string `json:"stringValue,omitempty"`
+	IntValue    *int64  `json:"intValue,omitempty"`
+	BoolValue   *bool   `json:"boolValue,omitempty"`
+}
+
+func otlpStringValue(s string) otlpValue { return otlpValue{StringValue: &s} }
+
+func convertOtlpAttrs(prefix string, attrs []slog.Attr) []otlpKeyValue {
+	var kvs []otlpKeyValue
+	for _, a := range attrs {
+		kvs = appendOtlpAttr(kvs, prefix, a)
+	}
+	return kvs
+}
+
+// appendOtlpAttr converts one slog attribute (flattening groups into dotted
+// keys) and appends the result to kvs.
+func appendOtlpAttr(kvs []otlpKeyValue, prefix string, a slog.Attr) []otlpKeyValue {
+	v := a.Value.Resolve()
+	if a.Key == "" && v.Kind() != slog.KindGroup {
+		return kvs
+	}
+	key := prefix + a.Key
+	switch v.Kind() {
+	case slog.KindGroup:
+		groupPrefix := prefix
+		if a.Key != "" {
+			groupPrefix += a.Key + "."
+		}
+		for _, ga := range v.Group() {
+			kvs = appendOtlpAttr(kvs, groupPrefix, ga)
+		}
+		return kvs
+	case slog.KindString:
+		return append(kvs, otlpKeyValue{Key: key, Value: otlpStringValue(v.String())})
+	case slog.KindInt64:
+		n := v.Int64()
+		return append(kvs, otlpKeyValue{Key: key, Value: otlpValue{IntValue: &n}})
+	case slog.KindUint64:
+		if u := v.Uint64(); u <= uint64(1<<63-1) {
+			n := int64(u)
+			return append(kvs, otlpKeyValue{Key: key, Value: otlpValue{IntValue: &n}})
+		}
+		return append(kvs, otlpKeyValue{Key: key, Value: otlpStringValue(strconv.FormatUint(v.Uint64(), 10))})
+	case slog.KindBool:
+		b := v.Bool()
+		return append(kvs, otlpKeyValue{Key: key, Value: otlpValue{BoolValue: &b}})
+	default:
+		return append(kvs, otlpKeyValue{Key: key, Value: otlpStringValue(otlpRenderValue(v))})
+	}
+}
+
+// otlpRenderValue renders a value the wire format has no native type for.
+// Floats, durations, and times use their standard string forms; errors their
+// message; named string types their string value; everything else its JSON
+// form when it has one.
+func otlpRenderValue(v slog.Value) string {
+	switch v.Kind() {
+	case slog.KindFloat64:
+		return strconv.FormatFloat(v.Float64(), 'g', -1, 64)
+	case slog.KindDuration:
+		return v.Duration().String()
+	case slog.KindTime:
+		return v.Time().Format(time.RFC3339Nano)
+	default:
+		av := v.Any()
+		if err, ok := av.(error); ok {
+			return err.Error()
+		}
+		// A named string type (e.g. ai.FinishReason) has slog kind Any; JSON
+		// would wrap it in an extra pair of quotes.
+		if rv := reflect.ValueOf(av); rv.IsValid() && rv.Kind() == reflect.String {
+			return rv.String()
+		}
+		if b, err := json.Marshal(av); err == nil {
+			return string(b)
+		}
+		return fmt.Sprintf("%v", av)
+	}
+}

--- a/go/core/tracing/log_export.go
+++ b/go/core/tracing/log_export.go
@@ -80,6 +80,13 @@ type logExporter struct {
 // telemetry server to talk to.
 var exporter = &logExporter{queue: make(chan otlpLogRecord, logQueueSize)}
 
+// diag reports the exporter's own problems. It writes straight to stderr
+// rather than through the default logger: the default handler includes the
+// export handler itself, so an exporter warning routed through it would
+// re-enter the exporter. On the overflow path that re-entry is a deadlock
+// (enqueue's sync.Once would be entered recursively on the same goroutine).
+var diag = slog.New(slog.NewTextHandler(os.Stderr, nil))
+
 // EnableLogExport starts forwarding log records to the telemetry server at
 // url, correlating each record with the active span at the time of logging.
 // It is called during dev-mode initialization, either with the value of
@@ -144,7 +151,7 @@ func (e *logExporter) send(batch []otlpLogRecord) {
 		}},
 	}); err != nil {
 		e.warnUnreachable.Do(func() {
-			slog.Warn("cannot reach telemetry server; logs will not appear in the Dev UI", "error", err)
+			diag.Warn("cannot reach telemetry server; logs will not appear in the Dev UI", "error", err)
 		})
 	}
 }
@@ -157,7 +164,7 @@ func (e *logExporter) enqueue(rec otlpLogRecord) {
 	default:
 		e.dropped.Add(1)
 		e.warnDropped.Do(func() {
-			slog.Warn("log export queue is full; dropping records from the Dev UI log view")
+			diag.Warn("log export queue is full; dropping records from the Dev UI log view")
 		})
 	}
 }

--- a/go/core/tracing/log_export_test.go
+++ b/go/core/tracing/log_export_test.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tracing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	otrace "go.opentelemetry.io/otel/trace"
+)
+
+// startLogCollector runs a test telemetry server that accumulates OTLP log
+// records POSTed to /api/otlp and returns the exporter wired to it.
+func startLogCollector(t *testing.T) (*logExporter, func() []otlpLogRecord) {
+	t.Helper()
+	var mu sync.Mutex
+	var records []otlpLogRecord
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/otlp" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading body: %v", err)
+		}
+		var payload otlpLogsPayload
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Errorf("unmarshaling payload: %v", err)
+		}
+		mu.Lock()
+		for _, rl := range payload.ResourceLogs {
+			for _, sl := range rl.ScopeLogs {
+				if sl.Scope.Name != "genkit-go" {
+					t.Errorf("scope name = %q, want genkit-go", sl.Scope.Name)
+				}
+				records = append(records, sl.LogRecords...)
+			}
+		}
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	e := &logExporter{queue: make(chan otlpLogRecord, logQueueSize)}
+	e.client.Store(NewHTTPTelemetryClient(srv.URL))
+	go e.run()
+
+	return e, func() []otlpLogRecord {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]otlpLogRecord{}, records...)
+	}
+}
+
+// waitForRecords polls until the collector has at least n records.
+func waitForRecords(t *testing.T, collect func() []otlpLogRecord, n int) []otlpLogRecord {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if recs := collect(); len(recs) >= n {
+			return recs
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d log records, have %d", n, len(collect()))
+	return nil
+}
+
+// namedString exercises the named-string-type rendering path.
+type namedString string
+
+func attrMap(rec otlpLogRecord) map[string]otlpValue {
+	m := map[string]otlpValue{}
+	for _, kv := range rec.Attributes {
+		m[kv.Key] = kv.Value
+	}
+	return m
+}
+
+func TestLogExportHandler(t *testing.T) {
+	e, collect := startLogCollector(t)
+	l := slog.New(&logExportHandler{exporter: e})
+
+	sc := otrace.NewSpanContext(otrace.SpanContextConfig{
+		TraceID: otrace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		SpanID:  otrace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+	})
+	ctx := otrace.ContextWithSpanContext(context.Background(), sc)
+
+	l.Log(ctx, slog.LevelInfo, "correlated message",
+		"str", "value",
+		"num", 42,
+		"flag", true,
+		"pi", 3.5,
+		"took", 250*time.Millisecond,
+		"cause", errors.New("boom"),
+		"kind", namedString("stop"),
+		slog.Group("req", "id", 7),
+	)
+
+	recs := waitForRecords(t, collect, 1)
+	rec := recs[0]
+
+	if got, want := rec.TraceID, sc.TraceID().String(); got != want {
+		t.Errorf("traceId = %q, want %q", got, want)
+	}
+	if got, want := rec.SpanID, sc.SpanID().String(); got != want {
+		t.Errorf("spanId = %q, want %q", got, want)
+	}
+	if rec.SeverityText != "INFO" || rec.SeverityNumber != 9 {
+		t.Errorf("severity = %q/%d, want INFO/9", rec.SeverityText, rec.SeverityNumber)
+	}
+	if rec.Body.StringValue == nil || *rec.Body.StringValue != "correlated message" {
+		t.Errorf("body = %+v, want correlated message", rec.Body)
+	}
+	if rec.TimeUnixNano == "" || rec.TimeUnixNano == "0" {
+		t.Errorf("timeUnixNano = %q, want a real timestamp", rec.TimeUnixNano)
+	}
+
+	attrs := attrMap(rec)
+	if v := attrs["str"]; v.StringValue == nil || *v.StringValue != "value" {
+		t.Errorf(`attr str = %+v, want "value"`, v)
+	}
+	if v := attrs["num"]; v.IntValue == nil || *v.IntValue != 42 {
+		t.Errorf("attr num = %+v, want 42", v)
+	}
+	if v := attrs["flag"]; v.BoolValue == nil || !*v.BoolValue {
+		t.Errorf("attr flag = %+v, want true", v)
+	}
+	// The wire format has no float, duration, or error types; they render as strings.
+	if v := attrs["pi"]; v.StringValue == nil || *v.StringValue != "3.5" {
+		t.Errorf(`attr pi = %+v, want "3.5"`, v)
+	}
+	if v := attrs["took"]; v.StringValue == nil || *v.StringValue != "250ms" {
+		t.Errorf(`attr took = %+v, want "250ms"`, v)
+	}
+	if v := attrs["cause"]; v.StringValue == nil || *v.StringValue != "boom" {
+		t.Errorf(`attr cause = %+v, want "boom"`, v)
+	}
+	if v := attrs["kind"]; v.StringValue == nil || *v.StringValue != "stop" {
+		t.Errorf(`attr kind = %+v, want "stop" (named string type unwrapped)`, v)
+	}
+	if v := attrs["req.id"]; v.IntValue == nil || *v.IntValue != 7 {
+		t.Errorf("attr req.id = %+v, want 7 (group flattened)", v)
+	}
+}
+
+func TestLogExportHandlerWithoutSpan(t *testing.T) {
+	e, collect := startLogCollector(t)
+	l := slog.New(&logExportHandler{exporter: e})
+
+	l.Warn("unattached")
+
+	rec := waitForRecords(t, collect, 1)[0]
+	if rec.TraceID != "" || rec.SpanID != "" {
+		t.Errorf("traceId/spanId = %q/%q, want empty for a record logged outside a span", rec.TraceID, rec.SpanID)
+	}
+	if rec.SeverityText != "WARN" || rec.SeverityNumber != 13 {
+		t.Errorf("severity = %q/%d, want WARN/13", rec.SeverityText, rec.SeverityNumber)
+	}
+}
+
+func TestLogExportHandlerBoundAttrsAndGroups(t *testing.T) {
+	e, collect := startLogCollector(t)
+	base := slog.New(&logExportHandler{exporter: e})
+	l := base.With("bound", "b").WithGroup("g")
+
+	l.Error("grouped", "inner", 1)
+
+	rec := waitForRecords(t, collect, 1)[0]
+	attrs := attrMap(rec)
+	if v := attrs["bound"]; v.StringValue == nil || *v.StringValue != "b" {
+		t.Errorf("attr bound = %+v, want b", v)
+	}
+	if v := attrs["g.inner"]; v.IntValue == nil || *v.IntValue != 1 {
+		t.Errorf("attr g.inner = %+v, want 1 (group prefix applied)", v)
+	}
+	if rec.SeverityText != "ERROR" || rec.SeverityNumber != 17 {
+		t.Errorf("severity = %q/%d, want ERROR/17", rec.SeverityText, rec.SeverityNumber)
+	}
+}
+
+func TestLogExportHandlerDisabledWithoutClient(t *testing.T) {
+	e := &logExporter{queue: make(chan otlpLogRecord, 4)}
+	h := &logExportHandler{exporter: e}
+	if h.Enabled(context.Background(), slog.LevelError) {
+		t.Error("handler reports enabled with no telemetry client configured")
+	}
+}
+
+func TestLogExportBatching(t *testing.T) {
+	e, collect := startLogCollector(t)
+	l := slog.New(&logExportHandler{exporter: e})
+
+	const n = 10
+	for i := range n {
+		l.Info("batch item", "i", i)
+	}
+
+	recs := waitForRecords(t, collect, n)
+	if len(recs) != n {
+		t.Errorf("got %d records, want %d", len(recs), n)
+	}
+}

--- a/go/core/tracing/log_export_test.go
+++ b/go/core/tracing/log_export_test.go
@@ -210,6 +210,31 @@ func TestLogExportHandlerDisabledWithoutClient(t *testing.T) {
 	}
 }
 
+func TestLogExportDisabledByEnv(t *testing.T) {
+	// The opt-out is read when export is enabled, not at package init, so a
+	// value set with t.Setenv (or os.Setenv before genkit.Init) takes effect.
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"", false},
+		{"true", false},
+		{"1", false},
+		{"false", true},
+		{"0", true},
+		{"FALSE", true},
+		{"off", false}, // not a strconv.ParseBool value; export stays enabled
+	}
+	for _, c := range cases {
+		t.Run("value="+c.value, func(t *testing.T) {
+			t.Setenv("GENKIT_OTEL_ENABLE_LOGS", c.value)
+			if got := logExportDisabled(); got != c.want {
+				t.Errorf("logExportDisabled() with %q = %v, want %v", c.value, got, c.want)
+			}
+		})
+	}
+}
+
 func TestLogExportOverflowDoesNotDeadlock(t *testing.T) {
 	// A full queue with no worker draining it: enqueue must drop, and the
 	// drop warning must not travel back through the export handler. Before

--- a/go/core/tracing/log_export_test.go
+++ b/go/core/tracing/log_export_test.go
@@ -210,6 +210,37 @@ func TestLogExportHandlerDisabledWithoutClient(t *testing.T) {
 	}
 }
 
+func TestLogExportOverflowDoesNotDeadlock(t *testing.T) {
+	// A full queue with no worker draining it: enqueue must drop, and the
+	// drop warning must not travel back through the export handler. Before
+	// diag existed, slog.Warn inside warnDropped.Do re-entered enqueue on
+	// the same goroutine and recursed into the sync.Once, deadlocking.
+	e := &logExporter{queue: make(chan otlpLogRecord, 1)}
+	e.client.Store(NewHTTPTelemetryClient("http://127.0.0.1:1"))
+	l := slog.New(&logExportHandler{exporter: e})
+	// The re-entry only happens when the warning's logger routes back into
+	// the export handler, i.e. when it is part of the process default.
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(l)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 3 {
+			l.Info("overflow", "i", i)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("logging deadlocked on queue overflow")
+	}
+	if got := e.dropped.Load(); got != 2 {
+		t.Errorf("dropped = %d, want 2", got)
+	}
+}
+
 func TestLogExportBatching(t *testing.T) {
 	e, collect := startLogCollector(t)
 	l := slog.New(&logExportHandler{exporter: e})

--- a/go/core/tracing/realtime_span_processor.go
+++ b/go/core/tracing/realtime_span_processor.go
@@ -94,7 +94,7 @@ func (p *realtimeSpanProcessor) save(s sdktrace.ReadOnlySpan, async bool) {
 		// action context was canceled (the dev UI canceled the run, or the agent
 		// connection closed), and the final trace write must still land.
 		if err := p.client.Save(context.Background(), td); err != nil {
-			slog.Debug("realtime telemetry: failed to save trace", "error", err)
+			reportTraceSaveError(err)
 		}
 		return
 	}
@@ -112,7 +112,7 @@ func (p *realtimeSpanProcessor) save(s sdktrace.ReadOnlySpan, async bool) {
 	go func() {
 		defer p.wg.Done()
 		if err := p.client.Save(context.Background(), td); err != nil {
-			slog.Debug("realtime telemetry: failed to save trace", "error", err)
+			reportTraceSaveError(err)
 		}
 	}()
 }

--- a/go/core/tracing/telemetry.go
+++ b/go/core/tracing/telemetry.go
@@ -21,8 +21,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"sync"
 )
+
+// warnTraceExportOnce gates a single warning when trace export to the
+// telemetry server fails, so a dev session with a dead server hears about it
+// once instead of on every span.
+var warnTraceExportOnce sync.Once
+
+// reportTraceSaveError logs a trace-export failure: the first one loudly,
+// the rest at debug level.
+func reportTraceSaveError(err error) {
+	warnTraceExportOnce.Do(func() {
+		slog.Warn("cannot reach telemetry server; traces will not appear in the Dev UI", "error", err)
+	})
+	slog.Debug("failed to save trace to telemetry server", "error", err)
+}
 
 type TelemetryClient interface {
 	Save(ctx context.Context, trace *Data) error
@@ -72,14 +88,25 @@ func NewHTTPTelemetryClient(url string) *httpTelemetryClient {
 
 // Save saves the trace data by making a call to the telemetry server.
 func (c *httpTelemetryClient) Save(ctx context.Context, trace *Data) error {
+	return c.post(ctx, "/api/traces", trace)
+}
+
+// SaveLogs sends a batch of log records to the telemetry server, which
+// accepts them on its OTLP ingestion endpoint and serves them to the Dev UI.
+func (c *httpTelemetryClient) SaveLogs(ctx context.Context, logs *otlpLogsPayload) error {
+	return c.post(ctx, "/api/otlp", logs)
+}
+
+// post sends v as JSON to the telemetry server endpoint at path.
+func (c *httpTelemetryClient) post(ctx context.Context, path string, v any) error {
 	if c.url == "" {
 		return nil
 	}
-	body, err := json.Marshal(trace)
+	body, err := json.Marshal(v)
 	if err != nil {
-		return fmt.Errorf("failed to marshal trace data: %w", err)
+		return fmt.Errorf("failed to marshal telemetry data: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", c.url+"/api/traces", bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.url+path, bytes.NewBuffer(body))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/go/core/tracing/telemetry.go
+++ b/go/core/tracing/telemetry.go
@@ -26,17 +26,25 @@ import (
 	"sync"
 )
 
-// warnTraceExportOnce gates a single warning when trace export to the
-// telemetry server fails, so a dev session with a dead server hears about it
-// once instead of on every span.
-var warnTraceExportOnce sync.Once
+// warnTelemetryUnreachableOnce gates a single unreachable-server warning
+// shared by the trace and log export paths, so a dev session with a dead
+// telemetry server hears about it once instead of once per pipeline (or per
+// span).
+var warnTelemetryUnreachableOnce sync.Once
+
+// warnTelemetryUnreachable warns once that the telemetry server cannot be
+// reached. It writes through diag: export-pipeline diagnostics must stay off
+// the export path itself (see [diag]).
+func warnTelemetryUnreachable(err error) {
+	warnTelemetryUnreachableOnce.Do(func() {
+		diag.Warn("cannot reach telemetry server; traces and logs will not appear in the Dev UI", "error", err)
+	})
+}
 
 // reportTraceSaveError logs a trace-export failure: the first one loudly,
 // the rest at debug level.
 func reportTraceSaveError(err error) {
-	warnTraceExportOnce.Do(func() {
-		slog.Warn("cannot reach telemetry server; traces will not appear in the Dev UI", "error", err)
-	})
+	warnTelemetryUnreachable(err)
 	slog.Debug("failed to save trace to telemetry server", "error", err)
 }
 

--- a/go/core/tracing/tracing.go
+++ b/go/core/tracing/tracing.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/internal/base"
@@ -216,10 +217,6 @@ func RunInNewSpan[I, O any](
 	f func(context.Context, I) (O, error),
 ) (O, error) {
 	// TODO: support span links.
-	log := logger.FromContext(ctx)
-	log.Debug("span start", "name", metadata.Name)
-	defer log.Debug("span end", "name", metadata.Name)
-
 	if metadata == nil {
 		metadata = &SpanMetadata{}
 	}
@@ -295,6 +292,27 @@ func RunInNewSpan[I, O any](
 	defer span.End()
 	defer func() { span.SetAttributes(sm.attributes()...) }()
 	ctx = spanMetaKey.NewContext(ctx, sm)
+
+	// These logs run under the new span's context, so they land on this span
+	// in the Dev UI. The deferred one is registered after the span.End defer,
+	// so it fires first, while the span is still recording.
+	start := time.Now()
+	startArgs := []any{"name", metadata.Name}
+	if metadata.Type != "" {
+		startArgs = append(startArgs, "type", metadata.Type)
+	}
+	if metadata.Subtype != "" {
+		startArgs = append(startArgs, "subtype", metadata.Subtype)
+	}
+	logger.Debug(ctx, "span started", startArgs...)
+	defer func() {
+		endArgs := []any{"name", metadata.Name, "state", string(sm.State), "duration", time.Since(start).Round(time.Millisecond)}
+		if sm.Error != "" {
+			endArgs = append(endArgs, "error", sm.Error)
+		}
+		logger.Debug(ctx, "span finished", endArgs...)
+	}()
+
 	output, err := f(ctx, input)
 
 	if err != nil {

--- a/go/core/tracing/tracing.go
+++ b/go/core/tracing/tracing.go
@@ -20,6 +20,7 @@ package tracing
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"runtime"
 	"strings"
@@ -295,17 +296,26 @@ func RunInNewSpan[I, O any](
 
 	// These logs run under the new span's context, so they land on this span
 	// in the Dev UI. The deferred one is registered after the span.End defer,
-	// so it fires first, while the span is still recording.
+	// so it fires first, while the span is still recording. This is the
+	// hottest path in the framework, so the log arguments are only built when
+	// some handler accepts debug records (the console at GENKIT_LOG_LEVEL=
+	// debug, or the Dev UI export sink).
 	start := time.Now()
-	startArgs := []any{"name", metadata.Name}
-	if metadata.Type != "" {
-		startArgs = append(startArgs, "type", metadata.Type)
+	logDebug := logger.FromContext(ctx).Enabled(ctx, slog.LevelDebug)
+	if logDebug {
+		startArgs := []any{"name", metadata.Name}
+		if metadata.Type != "" {
+			startArgs = append(startArgs, "type", metadata.Type)
+		}
+		if metadata.Subtype != "" {
+			startArgs = append(startArgs, "subtype", metadata.Subtype)
+		}
+		logger.Debug(ctx, "span started", startArgs...)
 	}
-	if metadata.Subtype != "" {
-		startArgs = append(startArgs, "subtype", metadata.Subtype)
-	}
-	logger.Debug(ctx, "span started", startArgs...)
 	defer func() {
+		if !logDebug {
+			return
+		}
 		endArgs := []any{"name", metadata.Name, "state", string(sm.State), "duration", time.Since(start).Round(time.Millisecond)}
 		if sm.Error != "" {
 			endArgs = append(endArgs, "error", sm.Error)

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -550,8 +550,40 @@ func NewStreamingFlow[In, Out, Stream any](name string, fn core.StreamingFunc[In
 //			return response, nil
 //		},
 //	)
+//
+// The step's context is not available to `fn`, so anything inside it that takes
+// a context and traces its own work, such as an HTTP client or a database call,
+// reports against the enclosing flow rather than against this step. Use
+// [RunWithContext] for those; keep Run for pure work that traces nothing.
 func Run[Out any](ctx context.Context, name string, fn func() (Out, error)) (Out, error) {
 	return core.Run(ctx, name, fn)
+}
+
+// RunWithContext is [Run] with the step's own context passed to `fn`.
+//
+// Work that `fn` starts with that context nests under the step in the trace
+// instead of under the flow, which is what makes a step's span cover the calls
+// it is timing:
+//
+//	genkit.DefineFlow(g, "describe",
+//		func(ctx context.Context, path string) (string, error) {
+//			// The upload's own HTTP spans nest under "upload-image".
+//			file, err := genkit.RunWithContext(ctx, "upload-image",
+//				func(ctx context.Context) (*genai.File, error) {
+//					return client.Files.UploadFromPath(ctx, path, nil)
+//				})
+//			if err != nil {
+//				return "", err
+//			}
+//			// ... use file.URI in a request ...
+//		},
+//	)
+//
+// Passing the enclosing context instead of the one supplied here is the whole
+// difference, and it is silent: the step still records the right duration while
+// the calls it made appear beside it rather than beneath it.
+func RunWithContext[Out any](ctx context.Context, name string, fn func(context.Context) (Out, error)) (Out, error) {
+	return core.RunWithContext(ctx, name, fn)
 }
 
 // ListFlows returns a slice of all [api.Action] instances that represent

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -29,17 +29,56 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
+	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/base"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
 // genkitCtxKey is the context key for the Genkit instance.
 var genkitCtxKey = base.NewContextKey[*Genkit]()
+
+// initialSlogDefault is the process's default logger as of package
+// initialization. Comparing against it tells whether the application (or a
+// plugin) installed its own handler, in which case Genkit leaves the console
+// logging configuration alone.
+var initialSlogDefault = slog.Default()
+
+// configureLoggingOnce guards configureLogging: Init may run more than once
+// (commonly in tests), but log handlers must only be installed once.
+var configureLoggingOnce sync.Once
+
+// configureLogging applies GENKIT_LOG_LEVEL to the console handler and, in the
+// dev environment, installs the handler that streams logs to the Dev UI's
+// telemetry server, correlated with the active trace span.
+func configureLogging() {
+	if v := os.Getenv("GENKIT_LOG_LEVEL"); v != "" {
+		var lvl slog.Level
+		if err := lvl.UnmarshalText([]byte(v)); err != nil {
+			slog.Warn("ignoring invalid GENKIT_LOG_LEVEL", "value", v, "error", err)
+		} else if slog.Default() == initialSlogDefault {
+			logger.SetLevel(lvl)
+		} else {
+			// The application brought its own handler; its level is not ours
+			// to manage.
+			slog.Debug("ignoring GENKIT_LOG_LEVEL because a custom default logger is installed", "value", v)
+		}
+	}
+	if api.CurrentEnvironment() == api.EnvironmentDev {
+		logger.AddHandler(tracing.LogExportHandler())
+		// The CLI normally provides the telemetry server URL in the
+		// environment; when it arrives later via the reflection API instead,
+		// configureTelemetry enables export at that point.
+		tracing.EnableLogExport(os.Getenv("GENKIT_TELEMETRY_SERVER"))
+	}
+}
 
 // FromContext returns the [*Genkit] instance stored in the context.
 // This is set automatically by [Generate] and related functions, and seeded
@@ -241,6 +280,9 @@ func WithExperimental() GenkitOption {
 func Init(ctx context.Context, opts ...GenkitOption) *Genkit {
 	ctx, _ = signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 
+	configureLoggingOnce.Do(configureLogging)
+	start := time.Now()
+
 	gOpts := &genkitOptions{}
 	for _, opt := range opts {
 		if err := opt.apply(gOpts); err != nil {
@@ -252,6 +294,8 @@ func Init(ctx context.Context, opts ...GenkitOption) *Genkit {
 	g := &Genkit{reg: r}
 
 	for _, plugin := range gOpts.Plugins {
+		logger.Debug(ctx, "initializing plugin", "plugin", plugin.Name())
+		pluginStart := time.Now()
 		actions := plugin.Init(ctx)
 		for _, action := range actions {
 			action.Register(r)
@@ -267,6 +311,10 @@ func Init(ctx context.Context, opts ...GenkitOption) *Genkit {
 				d.Register(r)
 			}
 		}
+		logger.Debug(ctx, "initialized plugin",
+			"plugin", plugin.Name(),
+			"actions", len(actions),
+			"duration", time.Since(pluginStart).Round(time.Millisecond))
 	}
 
 	ai.ConfigureFormats(r)
@@ -298,8 +346,15 @@ func Init(ctx context.Context, opts ...GenkitOption) *Genkit {
 				if s := startReflectionServer(ctx, g, errCh, serverStartCh); s == nil {
 					return
 				}
+				// Wait for startup to succeed before draining errCh for
+				// runtime serve errors. Receiving from errCh right away would
+				// race the select below for a startup failure; if this
+				// goroutine won, the error would be logged instead of
+				// panicking and Init would block forever on channels nobody
+				// closes.
+				<-serverStartCh
 				if err := <-errCh; err != nil {
-					slog.Error("reflection server error", "err", err)
+					logger.Error(ctx, "reflection server error", "error", err)
 				}
 			}()
 		}
@@ -308,13 +363,26 @@ func Init(ctx context.Context, opts ...GenkitOption) *Genkit {
 		case err := <-errCh:
 			panic(fmt.Errorf("genkit.Init: reflection server startup failed: %w", err))
 		case <-serverStartCh:
-			slog.Debug("reflection server started successfully")
 		case <-ctx.Done():
 			panic(ctx.Err())
 		}
 	}
 
+	logger.Info(ctx, "Genkit initialized",
+		"env", api.CurrentEnvironment(),
+		"plugins", pluginNames(gOpts.Plugins),
+		"duration", time.Since(start).Round(time.Millisecond))
+
 	return g
+}
+
+// pluginNames returns the names of the given plugins for the init log line.
+func pluginNames(plugins []api.Plugin) []string {
+	names := make([]string, len(plugins))
+	for i, p := range plugins {
+		names[i] = p.Name()
+	}
+	return names
 }
 
 // RegisterAction registers a [api.Action] that was previously created by calling
@@ -1684,7 +1752,7 @@ func loadPromptDirOS(r api.Registry, dir, namespace string) {
 		if !useDefaultDir {
 			panic(fmt.Errorf("failed to resolve prompt directory %q: %w", dir, err))
 		}
-		slog.Debug("default prompt directory not found, skipping loading .prompt files", "dir", dir)
+		slog.Debug("default prompt directory not found, skipping prompt loading", "dir", dir)
 		return
 	}
 
@@ -1692,7 +1760,7 @@ func loadPromptDirOS(r api.Registry, dir, namespace string) {
 		if !useDefaultDir {
 			panic(fmt.Errorf("failed to resolve prompt directory %q: %w", dir, err))
 		}
-		slog.Debug("Default prompt directory not found, skipping loading .prompt files", "dir", dir)
+		slog.Debug("default prompt directory not found, skipping prompt loading", "dir", dir)
 		return
 	}
 

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -45,12 +45,6 @@ import (
 // genkitCtxKey is the context key for the Genkit instance.
 var genkitCtxKey = base.NewContextKey[*Genkit]()
 
-// initialSlogDefault is the process's default logger as of package
-// initialization. Comparing against it tells whether the application (or a
-// plugin) installed its own handler, in which case Genkit leaves the console
-// logging configuration alone.
-var initialSlogDefault = slog.Default()
-
 // configureLoggingOnce guards configureLogging: Init may run more than once
 // (commonly in tests), but log handlers must only be installed once.
 var configureLoggingOnce sync.Once
@@ -63,12 +57,13 @@ func configureLogging() {
 		var lvl slog.Level
 		if err := lvl.UnmarshalText([]byte(v)); err != nil {
 			slog.Warn("ignoring invalid GENKIT_LOG_LEVEL", "value", v, "error", err)
-		} else if slog.Default() == initialSlogDefault {
-			logger.SetLevel(lvl)
-		} else {
+		} else if logger.HasCustomDefault() {
 			// The application brought its own handler; its level is not ours
-			// to manage.
-			slog.Debug("ignoring GENKIT_LOG_LEVEL because a custom default logger is installed", "value", v)
+			// to manage. Warn rather than stay silent, since the user set the
+			// variable expecting an effect.
+			slog.Warn("ignoring GENKIT_LOG_LEVEL because the application installed its own default logger", "value", v)
+		} else {
+			logger.SetLevel(lvl)
 		}
 	}
 	if api.CurrentEnvironment() == api.EnvironmentDev {
@@ -336,33 +331,55 @@ func Init(ctx context.Context, opts ...GenkitOption) *Genkit {
 	if api.CurrentEnvironment() == api.EnvironmentDev {
 		errCh := make(chan error, 1)
 		serverStartCh := make(chan struct{})
+		// startupErrCh carries the startup outcome to the select below. The
+		// supervisor goroutine is the sole reader of errCh, so a post-startup
+		// serve error can never be mistaken for a startup failure here, and a
+		// startup failure never strands the supervisor waiting on a start
+		// signal that will not come.
+		startupErrCh := make(chan error, 1)
 
 		if v2URL := os.Getenv("GENKIT_REFLECTION_V2_SERVER"); v2URL != "" {
 			// V2: connect to the CLI's WebSocket server.
 			go startReflectionServerV2(ctx, g, reflectionServerV2Options{URL: v2URL}, errCh, serverStartCh)
 		} else {
-			// V1: start an HTTP reflection server.
-			go func() {
-				if s := startReflectionServer(ctx, g, errCh, serverStartCh); s == nil {
-					return
-				}
-				// Wait for startup to succeed before draining errCh for
-				// runtime serve errors. Receiving from errCh right away would
-				// race the select below for a startup failure; if this
-				// goroutine won, the error would be logged instead of
-				// panicking and Init would block forever on channels nobody
-				// closes.
-				<-serverStartCh
-				if err := <-errCh; err != nil {
-					logger.Error(ctx, "reflection server error", "error", err)
-				}
-			}()
+			// V1: start an HTTP reflection server. Startup errors arrive on
+			// errCh; success closes serverStartCh.
+			go startReflectionServer(ctx, g, errCh, serverStartCh)
 		}
 
+		go func() {
+			select {
+			case <-serverStartCh:
+				startupErrCh <- nil
+				select {
+				case err := <-errCh:
+					if err != nil {
+						logger.Error(ctx, "reflection server error", "error", err)
+					}
+				case <-ctx.Done():
+				}
+			case err := <-errCh:
+				// Both channels can be ready when the server fails right
+				// after starting; started-then-failed is a runtime error,
+				// not a startup failure.
+				select {
+				case <-serverStartCh:
+					startupErrCh <- nil
+					if err != nil {
+						logger.Error(ctx, "reflection server error", "error", err)
+					}
+				default:
+					startupErrCh <- err
+				}
+			case <-ctx.Done():
+			}
+		}()
+
 		select {
-		case err := <-errCh:
-			panic(fmt.Errorf("genkit.Init: reflection server startup failed: %w", err))
-		case <-serverStartCh:
+		case err := <-startupErrCh:
+			if err != nil {
+				panic(fmt.Errorf("genkit.Init: reflection server startup failed: %w", err))
+			}
 		case <-ctx.Done():
 			panic(ctx.Err())
 		}

--- a/go/genkit/reflection.go
+++ b/go/genkit/reflection.go
@@ -337,7 +337,10 @@ func wrapReflectionHandler(h func(w http.ResponseWriter, r *http.Request) error)
 
 		if err = h(w, r); err != nil {
 			errorResponse := toReflectionError(err)
-			w.WriteHeader(errorResponse.Code)
+			// The body's code is a canonical status code, not an HTTP one, so
+			// the transport status is derived from it rather than reused. Going
+			// through the code keeps the two from ever disagreeing.
+			w.WriteHeader(status.FromCode(errorResponse.Code).HTTPCode())
 			writeJSON(ctx, w, errorResponse)
 		}
 	}
@@ -356,7 +359,11 @@ type reflectionErrorDetails struct {
 type reflectionError struct {
 	Details *reflectionErrorDetails `json:"details,omitempty"`
 	Message string                  `json:"message"`
-	Code    int                     `json:"code"`
+	// Code is the canonical status code, the same numbering gRPC uses and the
+	// dev UI's Status schema validates against (INVALID_ARGUMENT is 3, not
+	// 400). It is not an HTTP status: callers needing one derive it with
+	// [status.FromCode] and [status.Name.HTTPCode].
+	Code int `json:"code"`
 }
 
 // setTraceID records traceID, allocating the details envelope when the error
@@ -382,7 +389,7 @@ func (re *reflectionError) setTraceID(traceID string) {
 func toReflectionError(err error) reflectionError {
 	e := status.Convert(err)
 	if e == nil {
-		return reflectionError{Code: status.Internal.HTTPCode(), Details: &reflectionErrorDetails{}}
+		return reflectionError{Code: status.Internal.Code(), Details: &reflectionErrorDetails{}}
 	}
 	// The deprecated core constructors recorded the stack under
 	// Details["stack"]; status.Errorf keeps it off the details map and formats
@@ -405,7 +412,7 @@ func toReflectionError(err error) reflectionError {
 	}
 	return reflectionError{
 		Details: details,
-		Code:    e.Status.HTTPCode(),
+		Code:    e.Status.Code(),
 		Message: e.Message,
 	}
 }

--- a/go/genkit/reflection.go
+++ b/go/genkit/reflection.go
@@ -172,6 +172,7 @@ func startReflectionServer(ctx context.Context, g *Genkit, errCh chan<- error, s
 			return
 		}
 
+		slog.Info("reflection server listening", "addr", s.Addr)
 		close(serverStartCh)
 
 		if err := s.Serve(listener); err != nil && err != http.ErrServerClosed {
@@ -321,14 +322,14 @@ func serveMux(g *Genkit, s *reflectionServer) *http.ServeMux {
 func wrapReflectionHandler(h func(w http.ResponseWriter, r *http.Request) error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		logger.FromContext(ctx).Debug("request start", "method", r.Method, "path", r.URL.Path)
+		logger.Debug(ctx, "reflection request started", "method", r.Method, "path", r.URL.Path)
 
 		var err error
 		defer func() {
 			if err != nil {
-				logger.FromContext(ctx).Error("request end", "err", err)
+				logger.Error(ctx, "reflection request failed", "method", r.Method, "path", r.URL.Path, "error", err)
 			} else {
-				logger.FromContext(ctx).Debug("request end")
+				logger.Debug(ctx, "reflection request finished", "method", r.Method, "path", r.URL.Path)
 			}
 		}()
 
@@ -432,7 +433,7 @@ func handleRunAction(g *Genkit, activeActions *activeActionsMap) func(w http.Res
 			return err
 		}
 
-		logger.FromContext(ctx).Debug("running action", "key", body.Key, "stream", stream)
+		logger.Debug(ctx, "running action from the Dev UI", "key", body.Key, "stream", stream)
 
 		// Create cancellable context for this action
 		actionCtx, cancel := context.WithCancel(ctx)
@@ -548,7 +549,7 @@ func handleRunAction(g *Genkit, activeActions *activeActionsMap) func(w http.Res
 
 				reflectErr, err := json.Marshal(refErr)
 				if err != nil {
-					logger.FromContext(ctx).Error("writing output", "err", err)
+					logger.Error(ctx, "failed to write reflection response", "error", err)
 					return nil
 				}
 				_, err = fmt.Fprintf(w, "{\"error\": %s }", reflectErr)
@@ -566,7 +567,7 @@ func handleRunAction(g *Genkit, activeActions *activeActionsMap) func(w http.Res
 
 			reflectErr, err := json.Marshal(errorResponse)
 			if err != nil {
-				logger.FromContext(ctx).Error("writing output", "err", err)
+				logger.Error(ctx, "failed to write reflection response", "error", err)
 				return nil
 			}
 
@@ -587,7 +588,7 @@ func handleRunAction(g *Genkit, activeActions *activeActionsMap) func(w http.Res
 			}
 			data, err := json.Marshal(finalResponse)
 			if err != nil {
-				logger.FromContext(ctx).Error("writing output", "err", err)
+				logger.Error(ctx, "failed to write reflection response", "error", err)
 				return nil
 			}
 
@@ -650,6 +651,7 @@ func configureTelemetry(url string) {
 		} else {
 			tracing.WriteTelemetryImmediate(client)
 		}
+		tracing.EnableLogExport(url)
 		slog.Debug("connected to telemetry server", "url", url, "realtime", realtime)
 	}
 }
@@ -670,7 +672,9 @@ func handleNotify() func(w http.ResponseWriter, r *http.Request) error {
 		configureTelemetry(body.TelemetryServerURL)
 
 		if body.ReflectionApiSpecVersion != internal.GENKIT_REFLECTION_API_SPEC_VERSION {
-			slog.Error("Genkit CLI version is not compatible with runtime library. Please use `genkit-cli` version compatible with runtime library version.")
+			slog.Warn("Genkit CLI version is not compatible with the runtime library, update genkit-cli to a compatible version",
+				"expectedSpecVersion", internal.GENKIT_REFLECTION_API_SPEC_VERSION,
+				"gotSpecVersion", body.ReflectionApiSpecVersion)
 		}
 
 		w.WriteHeader(http.StatusOK)
@@ -869,7 +873,7 @@ func writeJSON(ctx context.Context, w http.ResponseWriter, value any) error {
 	}
 	_, err = w.Write(data)
 	if err != nil {
-		logger.FromContext(ctx).Error("writing output", "err", err)
+		logger.Error(ctx, "failed to write reflection response", "error", err)
 	}
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()

--- a/go/genkit/reflection_test.go
+++ b/go/genkit/reflection_test.go
@@ -745,8 +745,10 @@ func TestRunActionWithInit(t *testing.T) {
 }
 
 // TestToReflectionError covers the envelope the reflection API answers a
-// failed run with: the HTTP code comes from the error's status however deeply
-// it is wrapped, and the details ride along only when the error carried them.
+// failed run with: the code is the canonical status code (the numbering the
+// dev UI's Status schema validates, not an HTTP status) taken from the error's
+// status however deeply it is wrapped, and the details ride along only when
+// the error carried them.
 func TestToReflectionError(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -758,28 +760,28 @@ func TestToReflectionError(t *testing.T) {
 		{
 			"classified error carries its stack",
 			status.Errorf(status.ErrInvalidInput, "invalid input to action %q: %w", "/tool/test", errors.New("value must be a number")),
-			http.StatusBadRequest,
+			status.InvalidArgument.Code(),
 			`invalid input to action "/tool/test": value must be a number`,
 			true,
 		},
 		{
 			"plain error is internal",
 			errors.New("plain error"),
-			http.StatusInternalServerError,
+			status.Internal.Code(),
 			"plain error",
 			false,
 		},
 		{
 			"status survives one fmt.Errorf",
 			fmt.Errorf("context: %w", status.Errorf(status.ErrNotFound, "not found")),
-			http.StatusNotFound,
+			status.NotFound.Code(),
 			"not found",
 			true,
 		},
 		{
 			"status survives two",
 			fmt.Errorf("layer2: %w", fmt.Errorf("layer1: %w", status.Errorf(status.ErrPermissionDenied, "denied"))),
-			http.StatusForbidden,
+			status.PermissionDenied.Code(),
 			"denied",
 			true,
 		},
@@ -832,6 +834,38 @@ func TestToReflectionError(t *testing.T) {
 			t.Errorf("an empty trace allocated details: %+v", re.Details)
 		}
 	})
+}
+
+// TestReflectionErrorCodeYieldsValidHTTPStatus pins the split between the two
+// numbering schemes the error envelope touches. The body's code is canonical
+// (INVALID_ARGUMENT is 3), while wrapReflectionHandler still has to put an HTTP
+// status on the response, which it derives from that code. Feeding a canonical
+// code straight to WriteHeader would panic, since 3 is not a valid HTTP status.
+func TestReflectionErrorCodeYieldsValidHTTPStatus(t *testing.T) {
+	tests := []struct {
+		err      error
+		wantHTTP int
+	}{
+		{status.Errorf(status.ErrInvalidArgument, "bad"), http.StatusBadRequest},
+		{status.Errorf(status.ErrNotFound, "missing"), http.StatusNotFound},
+		{status.Errorf(status.ErrPermissionDenied, "denied"), http.StatusForbidden},
+		{status.Errorf(status.ErrUnauthenticated, "who"), http.StatusUnauthorized},
+		{status.Errorf(status.ErrResourceExhausted, "slow down"), http.StatusTooManyRequests},
+		{errors.New("plain"), http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		re := toReflectionError(tt.err)
+		if re.Code < 0 || re.Code > 16 {
+			t.Errorf("Code = %d, want a canonical status code the dev UI's enum accepts", re.Code)
+		}
+		got := status.FromCode(re.Code).HTTPCode()
+		if got != tt.wantHTTP {
+			t.Errorf("HTTP status for code %d = %d, want %d", re.Code, got, tt.wantHTTP)
+		}
+		if got < 100 || got > 999 {
+			t.Errorf("HTTP status %d is outside the range WriteHeader accepts", got)
+		}
+	}
 }
 
 // TestRunActionPlainErrorResponse pins that an action failing with an error the

--- a/go/genkit/reflection_v2.go
+++ b/go/genkit/reflection_v2.go
@@ -187,7 +187,7 @@ func (s *reflectionServerV2) connect(ctx context.Context) error {
 	s.writeMu.Lock()
 	s.conn = conn
 	s.writeMu.Unlock()
-	slog.Debug("reflection V2: connected", "url", s.opts.URL)
+	slog.Info("reflection V2: connected to reflection server", "url", s.opts.URL)
 	return nil
 }
 
@@ -224,7 +224,7 @@ func (s *reflectionServerV2) session(ctx context.Context) {
 		}
 
 		if err := s.connect(ctx); err != nil {
-			slog.Debug("reflection V2: reconnect failed", "err", err)
+			slog.Debug("reflection V2: reconnect failed", "error", err)
 			attempt++
 			continue
 		}
@@ -251,13 +251,13 @@ func (s *reflectionServerV2) register(ctx context.Context) {
 
 	result, err := s.sendRequest(ctx, "register", params)
 	if err != nil {
-		slog.Error("reflection V2: register failed", "err", err)
+		slog.Error("reflection V2: register failed", "error", err)
 		return
 	}
 	var resp reflectionRegisterResponse
 	if len(result) > 0 {
 		if err := json.Unmarshal(result, &resp); err != nil {
-			slog.Error("reflection V2: invalid register response", "err", err)
+			slog.Error("reflection V2: invalid register response", "error", err)
 			return
 		}
 	}
@@ -277,7 +277,7 @@ func (s *reflectionServerV2) readLoop(ctx context.Context) {
 		var msg jsonRPCMessage
 		if err := wsjson.Read(ctx, s.conn, &msg); err != nil {
 			if ctx.Err() == nil && websocket.CloseStatus(err) == -1 {
-				slog.Debug("reflection V2: read error", "err", err)
+				slog.Debug("reflection V2: read error", "error", err)
 			}
 			return
 		}
@@ -584,7 +584,7 @@ func (s *reflectionServerV2) handleRunActionBidi(ctx context.Context, req *jsonR
 				continue
 			}
 			if err := s.sendStreamChunk(req.ID, chunk); err != nil {
-				slog.Debug("reflection V2: streamChunk send failed", "err", err)
+				slog.Debug("reflection V2: streamChunk send failed", "error", err)
 				forward = false
 			}
 		}
@@ -616,7 +616,7 @@ func (s *reflectionServerV2) handleRunActionBidi(ctx context.Context, req *jsonR
 func (s *reflectionServerV2) handleSendInputStreamChunk(req *jsonRPCMessage) {
 	var params ReflectionSendInputStreamChunkParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		slog.Debug("reflection V2: invalid sendInputStreamChunk params", "err", err)
+		slog.Debug("reflection V2: invalid sendInputStreamChunk params", "error", err)
 		return
 	}
 	session := s.lookupBidiSession(params.RequestID)
@@ -633,7 +633,7 @@ func (s *reflectionServerV2) handleSendInputStreamChunk(req *jsonRPCMessage) {
 func (s *reflectionServerV2) handleEndInputStream(req *jsonRPCMessage) {
 	var params ReflectionEndInputStreamParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		slog.Debug("reflection V2: invalid endInputStream params", "err", err)
+		slog.Debug("reflection V2: invalid endInputStream params", "error", err)
 		return
 	}
 	session := s.lookupBidiSession(params.RequestID)
@@ -736,7 +736,7 @@ func (s *bidiSession) run(conn api.BidiJSONConnection) {
 			return
 		}
 		if err := conn.Send(ev.chunk); err != nil {
-			slog.Debug("reflection V2: bidi Send failed", "err", err)
+			slog.Debug("reflection V2: bidi Send failed", "error", err)
 		}
 	}
 }
@@ -842,7 +842,7 @@ func (s *reflectionServerV2) sendRunActionError(id string, err error, traceID st
 func (s *reflectionServerV2) handleConfigure(req *jsonRPCMessage) {
 	var params ReflectionConfigureParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		slog.Error("reflection V2: invalid configure params", "err", err)
+		slog.Error("reflection V2: invalid configure params", "error", err)
 		return
 	}
 	configureTelemetry(params.TelemetryServerURL)
@@ -878,7 +878,7 @@ func (s *reflectionServerV2) handleCancelAction(req *jsonRPCMessage) {
 // the read loop will detect a broken connection on its next read.
 func (s *reflectionServerV2) sendResponse(id string, result any) {
 	if err := s.send(&jsonRPCResponse{JSONRPC: "2.0", Result: result, ID: id}); err != nil {
-		slog.Error("reflection V2: failed to send response", "err", err, "id", id)
+		slog.Error("reflection V2: failed to send response", "error", err, "id", id)
 	}
 }
 
@@ -889,7 +889,7 @@ func (s *reflectionServerV2) sendErrorResponse(id string, code int, message stri
 		Error:   &jsonRPCError{Code: code, Message: message, Data: data},
 		ID:      id,
 	}); err != nil {
-		slog.Error("reflection V2: failed to send error response", "err", err, "id", id)
+		slog.Error("reflection V2: failed to send error response", "error", err, "id", id)
 	}
 }
 

--- a/go/genkit/servers.go
+++ b/go/genkit/servers.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -135,15 +136,26 @@ func HandlerFunc(a api.Action, opts ...HandlerOption) func(http.ResponseWriter, 
 // wrapHandler wraps an HTTP handler function with common logging and error handling.
 func wrapHandler(h func(http.ResponseWriter, *http.Request) error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		log := slog.Default().With("reqID", requestID.Add(1))
-		log.Debug("request start", "method", r.Method, "path", r.URL.Path)
+		log := slog.Default().With("reqId", requestID.Add(1))
+		// Carry the request-scoped logger in the context so everything logged
+		// while handling this request (including inside flows and tools) is
+		// tagged with the same reqId.
+		r = r.WithContext(logger.WithContext(r.Context(), log))
+		ctx := r.Context()
+
+		start := time.Now()
+		logger.Debug(ctx, "request started", "method", r.Method, "path", r.URL.Path)
 
 		var err error
 		defer func() {
 			if err != nil {
-				log.Error("request end", "err", err)
+				logger.Error(ctx, "request failed",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"duration", time.Since(start).Round(time.Millisecond),
+					"error", err)
 			} else {
-				log.Debug("request end")
+				logger.Debug(ctx, "request finished", "duration", time.Since(start).Round(time.Millisecond))
 			}
 		}()
 
@@ -276,7 +288,7 @@ func applyContextProviders(ctx context.Context, r *http.Request, providers []cor
 			Input:   input,
 		})
 		if err != nil {
-			logger.FromContext(ctx).Error("error providing action context from request", "err", err)
+			logger.Error(ctx, "context provider rejected the request", "error", err)
 			return ctx, err
 		}
 
@@ -310,7 +322,7 @@ func runWithStreaming(ctx context.Context, w http.ResponseWriter, run runJSONFun
 		// The SSE frame carries only the redacted message and this function
 		// returns nil, so wrapHandler never sees the error: this log is the
 		// only server-side record of the real failure.
-		slog.ErrorContext(ctx, "streaming flow failed", "err", err)
+		logger.Error(ctx, "streaming flow failed", "error", err)
 		if werr := writeSSEError(w, err); werr != nil {
 			return werr
 		}
@@ -369,7 +381,7 @@ func runWithDurableStreaming(ctx context.Context, w http.ResponseWriter, run run
 		// As in runWithStreaming: the wire carries only the redacted message
 		// and wrapHandler never sees the error, so log the real failure here.
 		// The durable record is no substitute: it expires with the stream.
-		slog.ErrorContext(durableCtx, "streaming flow failed", "err", err)
+		logger.Error(durableCtx, "streaming flow failed", "error", err)
 		durableStream.Error(durableCtx, err)
 		select {
 		case <-clientGone:

--- a/go/internal/metrics/metrics.go
+++ b/go/internal/metrics/metrics.go
@@ -40,7 +40,7 @@ var fetchInstruments = sync.OnceValue(func() *metricInstruments {
 	insts, err := initInstruments()
 	if err != nil {
 		// Do not stop the program because we can't collect metrics.
-		slog.Default().Error("metric initialization failed; no metrics will be collected", "err", err)
+		slog.Error("metric initialization failed, no metrics will be collected", "error", err)
 		return nil
 	}
 	return insts

--- a/go/internal/registry/registry.go
+++ b/go/internal/registry/registry.go
@@ -108,7 +108,7 @@ func (r *Registry) RegisterPlugin(name string, p api.Plugin) {
 		panic(fmt.Sprintf("plugin %q is already registered", name))
 	}
 	r.plugins[name] = p
-	slog.Debug("RegisterPlugin", "name", name)
+	slog.Debug("registered plugin", "plugin", name)
 }
 
 // RegisterAction records the action in the registry.
@@ -121,7 +121,7 @@ func (r *Registry) RegisterAction(key string, action api.Action) {
 		panic(fmt.Sprintf("action %q is already registered", key))
 	}
 	r.actions[key] = action
-	slog.Debug("RegisterAction", "key", key)
+	slog.Debug("registered action", "key", key)
 }
 
 // RegisterSchema records a JSON schema (as a map[string]any) in the registry.
@@ -133,7 +133,7 @@ func (r *Registry) RegisterSchema(name string, schema map[string]any) {
 		panic(fmt.Sprintf("schema %q is already registered", name))
 	}
 	r.schemas[name] = schema
-	slog.Debug("RegisterSchema", "name", name)
+	slog.Debug("registered schema", "schema", name)
 }
 
 // LookupSchema returns a JSON schema (as a map[string]any) for the given name.
@@ -181,7 +181,7 @@ func (r *Registry) RegisterValue(name string, value any) {
 		panic(fmt.Sprintf("value %q is already registered", name))
 	}
 	r.values[name] = value
-	slog.Debug("RegisterValue", "name", name)
+	slog.Debug("registered value", "name", name)
 }
 
 // LookupValue returns the value for the given name.
@@ -241,7 +241,7 @@ func (r *Registry) ResolveAction(key string) api.Action {
 
 	typ, provider, name := api.ParseKey(key)
 	if typ == "" || name == "" {
-		slog.Debug("ResolveAction: failed to parse action key", "key", key)
+		slog.Debug("cannot resolve action with malformed key", "key", key)
 		return nil
 	}
 

--- a/go/internal/version.go
+++ b/go/internal/version.go
@@ -16,8 +16,58 @@
 
 package internal
 
-// Version is the current tagged release of this module.
-// That is, it should match the value of the latest `go/v*` git tag.
-const Version = "1.4.0"
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// modulePath is this module's path, as it appears in the go.mod of programs
+// that depend on Genkit.
+const modulePath = "github.com/firebase/genkit/go"
+
+// Version is the version of the Genkit module the running program was built
+// against, without the "v" prefix (e.g. "1.11.0"). It is read from the
+// binary's embedded build info, so it tracks the version in the program's
+// go.mod rather than a hardcoded value. It is "dev" when Genkit is built from
+// source: from within this repository or through a directory replace
+// directive.
+var Version = versionFromBuildInfo(buildInfo())
 
 const GENKIT_REFLECTION_API_SPEC_VERSION = 1
+
+// buildInfo returns the running binary's build info, or nil if the binary
+// was built without module support.
+func buildInfo() *debug.BuildInfo {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+	return info
+}
+
+// versionFromBuildInfo extracts the Genkit module's version from build info.
+// Genkit normally appears among the dependencies with the version its go.mod
+// requires; when it is the main module instead (tests and samples in this
+// repository), or when a replace directive points at a source checkout, there
+// is no release version to report and the version is "dev".
+func versionFromBuildInfo(info *debug.BuildInfo) string {
+	if info == nil {
+		return "dev"
+	}
+	for _, dep := range info.Deps {
+		if dep.Path != modulePath {
+			continue
+		}
+		m := dep
+		if dep.Replace != nil {
+			// A module replacement carries the replacement's version; a
+			// directory replacement has none.
+			m = dep.Replace
+		}
+		if v, ok := strings.CutPrefix(m.Version, "v"); ok {
+			return v
+		}
+		return "dev"
+	}
+	return "dev"
+}

--- a/go/internal/version_test.go
+++ b/go/internal/version_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestVersionFromBuildInfo(t *testing.T) {
+	tests := []struct {
+		name string
+		info *debug.BuildInfo
+		want string
+	}{
+		{
+			name: "no build info",
+			info: nil,
+			want: "dev",
+		},
+		{
+			name: "genkit is the main module",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: "(devel)"},
+			},
+			want: "dev",
+		},
+		{
+			name: "genkit is a dependency",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/app"},
+				Deps: []*debug.Module{
+					{Path: "example.com/other", Version: "v2.0.0"},
+					{Path: modulePath, Version: "v1.11.0"},
+				},
+			},
+			want: "1.11.0",
+		},
+		{
+			name: "genkit is a dependency at a pseudo-version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/app"},
+				Deps: []*debug.Module{
+					{Path: modulePath, Version: "v1.11.1-0.20260810123456-abcdef123456"},
+				},
+			},
+			want: "1.11.1-0.20260810123456-abcdef123456",
+		},
+		{
+			name: "genkit replaced by a source checkout",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/app"},
+				Deps: []*debug.Module{
+					{
+						Path:    modulePath,
+						Version: "v1.11.0",
+						Replace: &debug.Module{Path: "../genkit/go", Version: "(devel)"},
+					},
+				},
+			},
+			want: "dev",
+		},
+		{
+			name: "genkit replaced by another module version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/app"},
+				Deps: []*debug.Module{
+					{
+						Path:    modulePath,
+						Version: "v1.11.0",
+						Replace: &debug.Module{Path: "example.com/fork/genkit/go", Version: "v1.2.3"},
+					},
+				},
+			},
+			want: "1.2.3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := versionFromBuildInfo(tt.info); got != tt.want {
+				t.Errorf("versionFromBuildInfo() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionInRepo(t *testing.T) {
+	// Within this repository Genkit is the main module, so the resolved
+	// version must be the source fallback.
+	if Version != "dev" {
+		t.Errorf("Version = %q, want %q when built from source", Version, "dev")
+	}
+}

--- a/go/plugins/anthropic/anthropic.go
+++ b/go/plugins/anthropic/anthropic.go
@@ -18,7 +18,6 @@ package anthropic
 
 import (
 	"context"
-	"errors"
 	"os"
 	"regexp"
 	"sync"
@@ -29,6 +28,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/internal"
 	ant "github.com/firebase/genkit/go/plugins/internal/anthropic"
@@ -207,7 +207,7 @@ func (a *Anthropic) DefineModel(g *genkit.Genkit, id string, opts *ai.ModelOptio
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if !a.initted {
-		return nil, errors.New("anthropic plugin not initialized")
+		return nil, status.Errorf(status.ErrFailedPrecondition, "anthropic plugin not initialized")
 	}
 
 	// Trim before resolving, so a prefixed ID still hits supportedModels.

--- a/go/plugins/anthropic/anthropic.go
+++ b/go/plugins/anthropic/anthropic.go
@@ -19,7 +19,6 @@ package anthropic
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"os"
 	"regexp"
 	"sync"
@@ -29,6 +28,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/internal"
 	ant "github.com/firebase/genkit/go/plugins/internal/anthropic"
@@ -167,7 +167,7 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 func (a *Anthropic) ListActions(ctx context.Context) []api.ActionDesc {
 	models, err := a.discoveredModels(ctx)
 	if err != nil {
-		slog.Error("unable to list anthropic models from Anthropic API", "error", err)
+		logger.Error(ctx, "unable to list anthropic models from Anthropic API", "error", err)
 		return nil
 	}
 

--- a/go/plugins/anthropic/models.go
+++ b/go/plugins/anthropic/models.go
@@ -22,6 +22,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/plugins/internal"
+	ant "github.com/firebase/genkit/go/plugins/internal/anthropic"
 )
 
 // Capability sets shared by the entries below. claudeSupports is what every
@@ -108,7 +109,7 @@ func listModels(ctx context.Context, client *anthropic.Client) ([]string, error)
 	}
 
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return nil, ant.WrapAPIError(err)
 	}
 
 	return models, nil

--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -404,7 +404,7 @@ func listClaudeModels(ctx context.Context, client *openai.Client) ([]string, err
 			path += "&after_id=" + url.QueryEscape(after)
 		}
 		if err := client.Get(ctx, path, nil, &page); err != nil {
-			return nil, err
+			return nil, compat_oai.WrapAPIError(err)
 		}
 		for _, m := range page.Data {
 			models = append(models, m.ID)

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"maps"
 	"math"
 	"slices"
@@ -483,7 +482,7 @@ func (o *OpenAICompatible) newEmbedder(provider, id string, embedOpts *ai.Embedd
 
 		embeddingResp, err := o.clientForKey(config.APIKey).Embeddings.New(ctx, params)
 		if err != nil {
-			return nil, err
+			return nil, WrapAPIError(err)
 		}
 
 		resp := &ai.EmbedResponse{}
@@ -518,10 +517,10 @@ func embeddingFloats(emb openai.Embedding) ([]float32, error) {
 	}
 	data, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return nil, fmt.Errorf("compat_oai: decoding base64 embedding: %w", err)
+		return nil, status.Errorf(status.ErrInvalidOutput, "compat_oai: decoding base64 embedding: %w", err)
 	}
 	if len(data)%4 != 0 {
-		return nil, fmt.Errorf("compat_oai: base64 embedding has %d bytes, want a multiple of 4", len(data))
+		return nil, status.Errorf(status.ErrInvalidOutput, "compat_oai: base64 embedding has %d bytes, want a multiple of 4", len(data))
 	}
 	embedding := make([]float32, len(data)/4)
 	for i := range embedding {
@@ -723,7 +722,7 @@ func listOpenAIModels(ctx context.Context, client *openai.Client) ([]string, err
 		models = append(models, m.ID)
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return nil, WrapAPIError(err)
 	}
 
 	return models, nil

--- a/go/plugins/compat_oai/errors.go
+++ b/go/plugins/compat_oai/errors.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compat_oai
+
+import (
+	"errors"
+
+	"github.com/openai/openai-go"
+
+	"github.com/firebase/genkit/go/core/status"
+)
+
+// WrapAPIError wraps an error the OpenAI SDK returned for an HTTP response in
+// a [status.Error] carrying the status the server reported, so status-aware
+// middleware (retry, fallback, ...) can tell a rate limit from a request the
+// provider rejected. Without it every API failure is unclassified, which the
+// retry middleware treats as retryable: a 401 would be reissued unchanged
+// until the attempts ran out.
+//
+// It is exported for the provider packages built on this one, which reach the
+// SDK directly for model discovery.
+//
+// Values that are not an SDK API error pass through untouched. The SDK returns
+// transport failures unwrapped, and leaving those unclassified is the right
+// answer: a dial timeout really is worth retrying.
+func WrapAPIError(err error) error {
+	if err == nil {
+		return nil
+	}
+	// The SDK returns *openai.Error; a value-typed target would never match.
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+	return status.Errorf(status.Base(status.FromHTTPCode(apiErr.StatusCode)), "%w", err)
+}

--- a/go/plugins/compat_oai/errors_test.go
+++ b/go/plugins/compat_oai/errors_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compat_oai
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/openai/openai-go"
+
+	"github.com/firebase/genkit/go/core/status"
+)
+
+// apiError builds an SDK error the way the SDK does. Request and Response must
+// both be set: (*openai.Error).Error() dereferences them unconditionally, so a
+// zero value panics when formatted.
+func apiError(code int) *openai.Error {
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	return &openai.Error{
+		StatusCode: code,
+		Request:    req,
+		Response:   &http.Response{StatusCode: code},
+	}
+}
+
+func TestWrapAPIErrorNil(t *testing.T) {
+	if got := WrapAPIError(nil); got != nil {
+		t.Errorf("WrapAPIError(nil) = %v, want nil", got)
+	}
+}
+
+func TestWrapAPIErrorPassesThroughNonAPIError(t *testing.T) {
+	// The SDK returns transport failures unwrapped. Those stay unclassified,
+	// which the retry middleware treats as retryable: a dial timeout is worth
+	// another attempt.
+	plain := errors.New("dial tcp: i/o timeout")
+	got := WrapAPIError(plain)
+	if got != plain {
+		t.Errorf("WrapAPIError returned %v, want the original error unchanged", got)
+	}
+	if _, ok := status.Classified(got); ok {
+		t.Error("WrapAPIError classified an error that did not come from the API")
+	}
+}
+
+func TestWrapAPIErrorMapsHTTPStatus(t *testing.T) {
+	tests := []struct {
+		code int
+		want status.Name
+	}{
+		{http.StatusBadRequest, status.InvalidArgument},
+		{http.StatusUnauthorized, status.Unauthenticated},
+		{http.StatusForbidden, status.PermissionDenied},
+		{http.StatusNotFound, status.NotFound},
+		{http.StatusTooManyRequests, status.ResourceExhausted},
+		{http.StatusInternalServerError, status.Internal},
+		{http.StatusServiceUnavailable, status.Unavailable},
+	}
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.code), func(t *testing.T) {
+			s, ok := status.Classified(WrapAPIError(apiError(tt.code)))
+			if !ok {
+				t.Fatalf("WrapAPIError left a %d unclassified", tt.code)
+			}
+			if s != tt.want {
+				t.Errorf("status = %v, want %v", s, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapAPIErrorFindsWrappedAPIError(t *testing.T) {
+	// The SDK error is usually several frames below where it is returned, so
+	// classification has to survive the context callers wrap around it.
+	err := fmt.Errorf("failed to create completion: %w", apiError(http.StatusBadRequest))
+	if got := status.Of(WrapAPIError(err)); got != status.InvalidArgument {
+		t.Errorf("status = %v, want %v", got, status.InvalidArgument)
+	}
+}
+
+// TestWrapAPIErrorClientErrorsAreNotRetried pins the property that motivates
+// the wrapper: a request the provider rejected must not be reissued unchanged
+// by the retry middleware, whose default set is UNAVAILABLE, DEADLINE_EXCEEDED,
+// RESOURCE_EXHAUSTED, ABORTED, and INTERNAL.
+func TestWrapAPIErrorClientErrorsAreNotRetried(t *testing.T) {
+	retried := map[status.Name]bool{
+		status.Unavailable:       true,
+		status.DeadlineExceeded:  true,
+		status.ResourceExhausted: true,
+		status.Aborted:           true,
+		status.Internal:          true,
+	}
+	for _, code := range []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	} {
+		s, ok := status.Classified(WrapAPIError(apiError(code)))
+		if !ok {
+			t.Fatalf("a %d is unclassified, so retry would reissue it", code)
+		}
+		if retried[s] {
+			t.Errorf("a %d maps to %v, which the retry middleware reissues", code, s)
+		}
+	}
+	// A rate limit stays retryable: that one is worth waiting out.
+	if s, _ := status.Classified(WrapAPIError(apiError(http.StatusTooManyRequests))); !retried[s] {
+		t.Errorf("429 maps to %v, which retry does not reissue", s)
+	}
+}

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -454,13 +454,16 @@ func getResponseFormat(output *ai.ModelOutputConfig) openai.ChatCompletionNewPar
 	return format
 }
 
+// concatenateTextContent joins a message's text parts, matching [ai.Message.Text].
+// A data part is skipped rather than concatenated: it carries a blob, so writing
+// it here would put base64 in the outbound message content.
 func concatenateTextContent(parts []*ai.Part) string {
 	var content strings.Builder
 	for _, part := range parts {
 		if part == nil {
 			continue
 		}
-		if part.IsText() || part.IsData() {
+		if part.IsText() {
 			content.WriteString(part.Text)
 		}
 	}

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/base"
 	pluginjsonschema "github.com/firebase/genkit/go/plugins/internal/jsonschema"
 	"github.com/openai/openai-go"
@@ -224,7 +225,7 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		var err error
 		openaiConfig, err = base.MapToStruct[openai.ChatCompletionNewParams](normalizedConfig)
 		if err != nil {
-			g.err = fmt.Errorf("failed to convert config to openai.ChatCompletionNewParams: %w", err)
+			g.err = status.Errorf(status.ErrInvalidArgument, "failed to convert config to openai.ChatCompletionNewParams: %w", err)
 			return g
 		}
 		// Match the JS compat-oai adapter's config passthrough behavior. The
@@ -240,7 +241,7 @@ func (g *ModelGenerator) WithConfig(config any) *ModelGenerator {
 		}
 		openaiConfig.SetExtraFields(extraFields)
 	default:
-		g.err = fmt.Errorf("unexpected config type: %T", config)
+		g.err = status.Errorf(status.ErrInvalidArgument, "unexpected config type: %T", config)
 		return g
 	}
 
@@ -324,7 +325,7 @@ func (g *ModelGenerator) WithToolChoice(toolChoice ai.ToolChoice) *ModelGenerato
 	case ai.ToolChoiceAuto, ai.ToolChoiceNone, ai.ToolChoiceRequired:
 		g.request.ToolChoice.OfAuto = param.NewOpt(string(toolChoice))
 	default:
-		g.err = fmt.Errorf("unsupported tool choice: %q", toolChoice)
+		g.err = status.Errorf(status.ErrInvalidArgument, "unsupported tool choice: %q", toolChoice)
 	}
 
 	return g
@@ -390,7 +391,7 @@ func (g *ModelGenerator) Generate(ctx context.Context, req *ai.ModelRequest, han
 	}
 
 	if len(g.messages) == 0 {
-		return nil, fmt.Errorf("no messages provided")
+		return nil, status.Errorf(status.ErrInvalidArgument, "no messages provided")
 	}
 	g.request.Messages = g.messages
 
@@ -557,8 +558,10 @@ func (g *ModelGenerator) generateStream(ctx context.Context, req *ai.ModelReques
 		}
 	}
 
+	// NewStreaming defers its HTTP error to the stream, so a 4xx on the
+	// request that opened it surfaces here rather than at the call.
 	if err := stream.Err(); err != nil {
-		return nil, fmt.Errorf("stream error: %w", err)
+		return nil, fmt.Errorf("stream error: %w", WrapAPIError(err))
 	}
 
 	if usageSeen {
@@ -631,7 +634,7 @@ func extractReasoningContent(raw string) string {
 // convertChatCompletionToModelResponse converts openai.ChatCompletion to ai.ModelResponse
 func convertChatCompletionToModelResponse(completion *openai.ChatCompletion) (*ai.ModelResponse, error) {
 	if len(completion.Choices) == 0 {
-		return nil, fmt.Errorf("no choices in completion")
+		return nil, status.Errorf(status.ErrInvalidOutput, "no choices in completion")
 	}
 
 	choice := completion.Choices[0]
@@ -770,7 +773,7 @@ func addCustomTokens(usage *ai.GenerationUsage, name string, count int) {
 func (g *ModelGenerator) generateComplete(ctx context.Context, req *ai.ModelRequest) (*ai.ModelResponse, error) {
 	completion, err := g.client.Chat.Completions.New(ctx, *g.request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create completion: %w", err)
+		return nil, fmt.Errorf("failed to create completion: %w", WrapAPIError(err))
 	}
 
 	resp, err := convertChatCompletionToModelResponse(completion)
@@ -826,7 +829,7 @@ func convertToolCall(part *ai.Part) (*openai.ChatCompletionMessageToolCallParam,
 func jsonStringToMap(jsonString string) (map[string]any, error) {
 	var result map[string]any
 	if err := json.Unmarshal([]byte(jsonString), &result); err != nil {
-		return nil, fmt.Errorf("unmarshal failed to parse json string %s: %w", jsonString, err)
+		return nil, status.Errorf(status.ErrInvalidOutput, "unmarshal failed to parse json string %s: %w", jsonString, err)
 	}
 	return result, nil
 }
@@ -834,7 +837,7 @@ func jsonStringToMap(jsonString string) (map[string]any, error) {
 func anyToJSONString(data any) (string, error) {
 	jsonBytes, err := json.Marshal(data)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal any to JSON string: data, %#v %w", data, err)
+		return "", status.Errorf(status.ErrInvalidArgument, "failed to marshal any to JSON string: data %#v: %w", data, err)
 	}
 	return string(jsonBytes), nil
 }

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -501,16 +501,19 @@ func TestWithParams(t *testing.T) {
 	}
 }
 
-func TestConcatenateContentSkipsNilParts(t *testing.T) {
+// Only text parts become message content. A data part carries a blob, so
+// concatenating it would put base64 on the wire; this matches [ai.Message.Text].
+func TestConcatenateContentSkipsNonTextParts(t *testing.T) {
 	parts := []*ai.Part{
 		nil,
 		ai.NewTextPart("visible"),
 		ai.NewReasoningPart("thought", nil),
 		nil,
-		ai.NewDataPart(" data"),
+		ai.NewDataPart("data:application/octet-stream;base64,AAAA"),
+		ai.NewMediaPart("image/png", "data:image/png;base64,AAAA"),
 	}
-	if got := concatenateTextContent(parts); got != "visible data" {
-		t.Errorf("concatenateTextContent() = %q, want %q", got, "visible data")
+	if got := concatenateTextContent(parts); got != "visible" {
+		t.Errorf("concatenateTextContent() = %q, want %q", got, "visible")
 	}
 	if got := concatenateReasoningContent(parts); got != "thought" {
 		t.Errorf("concatenateReasoningContent() = %q, want %q", got, "thought")

--- a/go/plugins/evaluators/evaluators.go
+++ b/go/plugins/evaluators/evaluators.go
@@ -125,8 +125,8 @@ func configureRegexEvaluator() ai.Evaluator {
 			}
 		} else {
 			// Mark as failed if output is not string type
-			logger.FromContext(ctx).Debug("genkitEval",
-				"regex", fmt.Sprintf("Failed regex evaluation, as output is not string api. TestCaseId: %s", dataPoint.TestCaseId))
+			logger.Debug(ctx, "regex evaluation failed, output is not a string",
+				"testCaseId", dataPoint.TestCaseId)
 			score = ai.Score{
 				Score:  false,
 				Status: ai.ScoreStatusFail.String(),

--- a/go/plugins/firebase/retriever.go
+++ b/go/plugins/firebase/retriever.go
@@ -24,6 +24,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -47,7 +48,7 @@ type RetrieverOptions struct {
 }
 
 // Convert a Firestore document snapshot to a Genkit Document object.
-func convertToDoc(docSnapshots []*firestore.DocumentSnapshot, contentField string, metadataFields []string) []*ai.Document {
+func convertToDoc(ctx context.Context, docSnapshots []*firestore.DocumentSnapshot, contentField string, metadataFields []string) []*ai.Document {
 	var documents []*ai.Document // Prepare the documents to return in the response
 
 	for _, result := range docSnapshots {
@@ -56,7 +57,8 @@ func convertToDoc(docSnapshots []*firestore.DocumentSnapshot, contentField strin
 		// Ensure content field exists and is of type string
 		content, ok := data[contentField].(string)
 		if !ok {
-			fmt.Printf("Content field %s missing or not a string in document %s", contentField, result.Ref.ID)
+			logger.Warn(ctx, "firebase: skipping document with a missing or non-string content field",
+				"contentField", contentField, "document", result.Ref.ID)
 			continue
 		}
 
@@ -126,7 +128,7 @@ func defineFirestoreRetriever(g *genkit.Genkit, cfg RetrieverOptions, client *fi
 		}
 
 		// Convert Firestore documents to Genkit documents
-		documents := convertToDoc(results, cfg.ContentField, cfg.MetadataFields)
+		documents := convertToDoc(ctx, results, cfg.ContentField, cfg.MetadataFields)
 		return &ai.RetrieverResponse{Documents: documents}, nil
 	}
 

--- a/go/plugins/googlecloud/googlecloud.go
+++ b/go/plugins/googlecloud/googlecloud.go
@@ -32,6 +32,7 @@ import (
 	"cloud.google.com/go/logging"
 	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
 	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
+	corelogger "github.com/firebase/genkit/go/core/logger"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
@@ -246,9 +247,11 @@ func setupGCPLogger(projectID string, level slog.Leveler, credentials *google.Cr
 	if err != nil {
 		return fmt.Errorf("failed to create logging client: %w", err)
 	}
-	// Set up error handling for async logging failures with recursive recovery
+	// Set up error handling for async logging failures with recursive recovery.
+	// SetDefaultHandler (rather than slog.SetDefault) keeps sinks registered
+	// with logger.AddHandler attached, such as dev-mode Dev UI log streaming.
 	c.OnError = func(err error) {
-		slog.SetDefault(stderrLogger)
+		corelogger.SetDefaultHandler(stderrLogger.Handler())
 		stderrLogger.Warn("Unable to send logs to Google Cloud", "error", err)
 		if loggingDenied(err) {
 			showLoggingInstructionsOnce.Do(func() {
@@ -269,7 +272,7 @@ func setupGCPLogger(projectID string, level slog.Leveler, credentials *google.Cr
 		*/
 	}
 	logger := c.Logger("genkit_log")
-	slog.SetDefault(slog.New(newHandler(level, logger.Log, projectID)))
+	corelogger.SetDefaultHandler(newHandler(level, logger.Log, projectID))
 	return nil
 }
 

--- a/go/plugins/googlegenai/cache.go
+++ b/go/plugins/googlegenai/cache.go
@@ -187,7 +187,10 @@ func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
 			if t <= 0 {
 				return nil, status.Errorf(status.ErrInvalidArgument, "invalid cache ttlSeconds, expected a positive number of whole seconds, got %v", tv)
 			}
-			if m.Text() == "" {
+			// Any content is cacheable, not just text: a long video or PDF is
+			// what caching pays off for most, and [ai.Message.Text] reports a
+			// message holding only media as empty.
+			if len(m.Content) == 0 {
 				return nil, status.Errorf(status.ErrInvalidArgument, "no content to cache, message is empty")
 			}
 			return &cacheSettings{

--- a/go/plugins/googlegenai/cache.go
+++ b/go/plugins/googlegenai/cache.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
 	"google.golang.org/genai"
 )
 
@@ -59,7 +60,7 @@ func handleCache(
 	}
 	// index out of bounds
 	if cs.endIndex < 0 || cs.endIndex >= len(request.Messages) {
-		return nil, fmt.Errorf("end of cached contents, index %d is invalid", cs.endIndex)
+		return nil, status.Errorf(status.ErrInvalidArgument, "end of cached contents, index %d is invalid", cs.endIndex)
 	}
 
 	// since context caching is only available for specific model versions, we
@@ -80,11 +81,11 @@ func handleCache(
 		cache, err = lookupCache(ctx, client, cs.name)
 		if err != nil {
 			// TODO: if cache expired or not found, create a fresh one
-			return nil, fmt.Errorf("cache lookup error, got %v", err)
+			return nil, fmt.Errorf("cache lookup error: %w", wrapAPIError(err))
 		}
 		// make sure the cache contents matches the request messages hash
 		if cache.DisplayName != hash {
-			return nil, fmt.Errorf("invalid cache name: hash mismatch between cached content and request messages")
+			return nil, status.Errorf(status.ErrInvalidArgument, "invalid cache name: hash mismatch between cached content and request messages")
 		}
 
 		return cache, nil
@@ -97,7 +98,7 @@ func handleCache(
 			Contents:    messages,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("cache creation error, got %v", err)
+			return nil, fmt.Errorf("cache creation error: %w", wrapAPIError(err))
 		}
 	}
 
@@ -128,11 +129,11 @@ func messagesToCache(m []*ai.Message, cacheEndIdx int) ([]*genai.Content, error)
 // are being provided in the request
 func validateContextCacheRequest(request *ai.ModelRequest, modelVersion string) error {
 	if len(request.Tools) > 0 {
-		return fmt.Errorf("%s", invalidArgMessages.tools)
+		return status.Errorf(status.ErrInvalidArgument, "%s", invalidArgMessages.tools)
 	}
 	for _, m := range request.Messages {
 		if m.Role == ai.RoleSystem {
-			return fmt.Errorf("%s", invalidArgMessages.systemPrompt)
+			return status.Errorf(status.ErrInvalidArgument, "%s", invalidArgMessages.systemPrompt)
 		}
 	}
 
@@ -163,7 +164,7 @@ func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
 
 		c, ok := cacheVal.(map[string]any)
 		if !ok {
-			return nil, fmt.Errorf("cache metadata should be map but got: %T", cacheVal)
+			return nil, status.Errorf(status.ErrInvalidArgument, "cache metadata should be map but got: %T", cacheVal)
 		}
 
 		// cache name should be only used to indicate the request already
@@ -181,13 +182,13 @@ func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
 		if tv, ok := c["ttlSeconds"]; ok {
 			t, isNum := castToInt64(tv)
 			if !isNum {
-				return nil, fmt.Errorf("invalid type for cache ttlSeconds, expected a number, got %T", tv)
+				return nil, status.Errorf(status.ErrInvalidArgument, "invalid type for cache ttlSeconds, expected a number, got %T", tv)
 			}
 			if t <= 0 {
-				return nil, fmt.Errorf("invalid cache ttlSeconds, expected a positive number of whole seconds, got %v", tv)
+				return nil, status.Errorf(status.ErrInvalidArgument, "invalid cache ttlSeconds, expected a positive number of whole seconds, got %v", tv)
 			}
 			if m.Text() == "" {
-				return nil, fmt.Errorf("no content to cache, message is empty")
+				return nil, status.Errorf(status.ErrInvalidArgument, "no content to cache, message is empty")
 			}
 			return &cacheSettings{
 				ttl:      int(t),
@@ -196,7 +197,7 @@ func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
 			}, nil
 		}
 
-		return nil, fmt.Errorf("invalid cache metadata, expected ttlSeconds or name, got: %v", c)
+		return nil, status.Errorf(status.ErrInvalidArgument, "invalid cache metadata, expected ttlSeconds or name, got: %v", c)
 	}
 	return nil, nil
 }
@@ -204,7 +205,7 @@ func findCacheMarker(request *ai.ModelRequest) (*cacheSettings, error) {
 // lookupCache retrieves a *genai.CachedContent from a given cache name
 func lookupCache(ctx context.Context, client *genai.Client, name string) (*genai.CachedContent, error) {
 	if name == "" {
-		return nil, fmt.Errorf("empty cache name detected")
+		return nil, status.Errorf(status.ErrInvalidArgument, "empty cache name detected")
 	}
 
 	return client.Caches.Get(ctx, name, nil)

--- a/go/plugins/googlegenai/cache_test.go
+++ b/go/plugins/googlegenai/cache_test.go
@@ -62,6 +62,31 @@ func TestGetContentForCache_NoContentToCache(t *testing.T) {
 	}
 }
 
+// A long video or PDF is what caching pays off for most, and such a message
+// holds no text at all, so the marker has to look at content rather than text.
+func TestFindCacheMarker_MediaOnlyMessage(t *testing.T) {
+	req := &ai.ModelRequest{
+		Messages: []*ai.Message{
+			ai.NewMessage(ai.RoleUser, nil, ai.NewMediaPart("video/mp4", "data:video/mp4;base64,AAAA")).WithCacheTTL(360),
+			ai.NewUserTextMessage("Summarize the video."),
+		},
+	}
+
+	settings, err := findCacheMarker(req)
+	if err != nil {
+		t.Fatalf("findCacheMarker rejected a media-only message: %v", err)
+	}
+	if settings == nil {
+		t.Fatal("findCacheMarker returned no settings")
+	}
+	if settings.ttl != 360 {
+		t.Errorf("ttl = %d, want 360", settings.ttl)
+	}
+	if settings.endIndex != 0 {
+		t.Errorf("endIndex = %d, want 0", settings.endIndex)
+	}
+}
+
 func TestGetContentForCache_Invalid(t *testing.T) {
 	req := &ai.ModelRequest{
 		Messages: []*ai.Message{

--- a/go/plugins/googlegenai/errors_test.go
+++ b/go/plugins/googlegenai/errors_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
 	"google.golang.org/genai"
 )
 
@@ -237,5 +239,91 @@ func TestWrapAPIError_AttachesRetryAfterDetails(t *testing.T) {
 	}
 	if got, want := ge.Details["retryAfterMs"], int64(3000); got != want {
 		t.Fatalf("Details[retryAfterMs] = %v (%T), want %v", got, got, want)
+	}
+}
+
+// TestRequestShapingErrorsAreNotRetryable covers the request-shaping failures
+// this package raises before any HTTP call. Each is deterministic in its input,
+// so reissuing it would fail identically; classifying them keeps the retry
+// middleware, whose default set is UNAVAILABLE, DEADLINE_EXCEEDED,
+// RESOURCE_EXHAUSTED, ABORTED, and INTERNAL, from spending its budget on a
+// request that can never succeed. An unclassified error is retried regardless
+// of that list, which is what these guard.
+func TestRequestShapingErrorsAreNotRetryable(t *testing.T) {
+	retried := map[status.Name]bool{
+		status.Unavailable:       true,
+		status.DeadlineExceeded:  true,
+		status.ResourceExhausted: true,
+		status.Aborted:           true,
+		status.Internal:          true,
+	}
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "invalid tool name",
+			call: func() error {
+				_, err := toGeminiTools([]*ai.ToolDefinition{{Name: "not a valid name!"}})
+				return err
+			},
+		},
+		{
+			name: "schema missing type",
+			call: func() error {
+				_, err := toGeminiSchema(map[string]any{}, map[string]any{"description": "no type"})
+				return err
+			},
+		},
+		{
+			name: "schema type not a string",
+			call: func() error {
+				_, err := toGeminiSchema(map[string]any{}, map[string]any{"type": 42})
+				return err
+			},
+		},
+		{
+			name: "cache metadata not a map",
+			call: func() error {
+				_, err := findCacheMarker(&ai.ModelRequest{Messages: []*ai.Message{
+					{Role: ai.RoleUser, Metadata: map[string]any{"cache": "not a map"}},
+				}})
+				return err
+			},
+		},
+		{
+			name: "cache ttl not a number",
+			call: func() error {
+				_, err := findCacheMarker(&ai.ModelRequest{Messages: []*ai.Message{
+					{Role: ai.RoleUser, Metadata: map[string]any{"cache": map[string]any{"ttlSeconds": "soon"}}},
+				}})
+				return err
+			},
+		},
+		{
+			name: "tools with context caching",
+			call: func() error {
+				return validateContextCacheRequest(&ai.ModelRequest{
+					Tools: []*ai.ToolDefinition{{Name: "someTool"}},
+				}, "gemini-flash-latest")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			s, ok := status.Classified(err)
+			if !ok {
+				t.Fatalf("error is unclassified, so retry would reissue it: %v", err)
+			}
+			if retried[s] {
+				t.Errorf("error maps to %v, which the retry middleware reissues: %v", s, err)
+			}
+		})
 	}
 }

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -19,7 +19,6 @@ package googlegenai
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -156,7 +155,7 @@ func generate(
 	cb func(context.Context, *ai.ModelResponseChunk) error,
 ) (*ai.ModelResponse, error) {
 	if model == "" {
-		return nil, errors.New("model not provided")
+		return nil, status.Errorf(status.ErrInvalidArgument, "model not provided")
 	}
 	model = resolveVertexModelName(client, model)
 
@@ -175,7 +174,7 @@ func generate(
 		return nil, err
 	}
 	if len(contents) == 0 {
-		return nil, fmt.Errorf("at least one message is required in generate request")
+		return nil, status.Errorf(status.ErrInvalidArgument, "at least one message is required in generate request")
 	}
 
 	// Send out the actual request.
@@ -253,7 +252,7 @@ func generate(
 		// A stream can end without yielding a chunk: the SDK only logs a
 		// scanner failure rather than surfacing it, so an empty or truncated
 		// 2xx body reaches here with no error to report.
-		return nil, errors.New("model stream returned no responses")
+		return nil, status.Errorf(status.ErrUnavailable, "model stream returned no responses")
 	}
 
 	// Fold the stream back into a single response: one candidate carrying the
@@ -567,7 +566,7 @@ func translateCandidate(cand *genai.Candidate) (*ai.ModelResponse, error) {
 		// failing the request; a candidate with neither content nor a finish
 		// reason is malformed.
 		if m.FinishReason == "" {
-			return nil, fmt.Errorf("no valid candidates were found in the generate response")
+			return nil, status.Errorf(status.ErrInternal, "no valid candidates were found in the generate response")
 		}
 		msg.Role = ai.RoleModel
 		m.Message = msg
@@ -663,7 +662,7 @@ func translateResponse(resp *genai.GenerateContentResponse) (*ai.ModelResponse, 
 			Message:       &ai.Message{Role: ai.RoleModel},
 		}
 	default:
-		return nil, errors.New("model returned no candidates")
+		return nil, status.Errorf(status.ErrInternal, "model returned no candidates")
 	}
 
 	if r.Usage == nil {
@@ -772,7 +771,7 @@ func toGeminiPart(p *ai.Part) (*genai.Part, error) {
 		}
 		return fc, nil
 	default:
-		return nil, fmt.Errorf("unknown part in the request: %q", p.Kind)
+		return nil, status.Errorf(status.ErrInvalidArgument, "unknown part in the request: %q", p.Kind)
 	}
 
 	// Restore ThoughtSignature if present in metadata.

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -5,7 +5,6 @@ package googlegenai
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -18,6 +17,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/internal"
 
@@ -47,7 +47,7 @@ func displayName(provider string) string {
 // video fields and can only fail at the API.
 func rejectBackgroundModel(provider, id string) error {
 	if ClassifyModel(id).ActionType() == api.ActionTypeBackgroundModel {
-		return fmt.Errorf("%s: %q is a background model; generate with it directly instead of defining it as a model", provider, id)
+		return status.Errorf(status.ErrInvalidArgument, "%s: %q is a background model; generate with it directly instead of defining it as a model", provider, id)
 	}
 	return nil
 }
@@ -413,7 +413,7 @@ func (ga *GoogleAI) Client() (*genai.Client, error) {
 	ga.mu.Lock()
 	defer ga.mu.Unlock()
 	if !ga.initted {
-		return nil, errors.New("GoogleAI plugin not initialized")
+		return nil, status.Errorf(status.ErrFailedPrecondition, "GoogleAI plugin not initialized")
 	}
 	return ga.gclient, nil
 }
@@ -424,7 +424,7 @@ func (v *VertexAI) Client() (*genai.Client, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if !v.initted {
-		return nil, errors.New("VertexAI plugin not initialized")
+		return nil, status.Errorf(status.ErrFailedPrecondition, "VertexAI plugin not initialized")
 	}
 	return v.gclient, nil
 }
@@ -441,7 +441,7 @@ func (ga *GoogleAI) DefineModel(g *genkit.Genkit, id string, opts *ai.ModelOptio
 	ga.mu.Lock()
 	defer ga.mu.Unlock()
 	if !ga.initted {
-		return nil, errors.New("GoogleAI plugin not initialized")
+		return nil, status.Errorf(status.ErrFailedPrecondition, "GoogleAI plugin not initialized")
 	}
 	id = internal.TrimProvider(googleAIProvider, id)
 	if err := rejectBackgroundModel(googleAIProvider, id); err != nil {
@@ -457,7 +457,7 @@ func (ga *GoogleAI) DefineModel(g *genkit.Genkit, id string, opts *ai.ModelOptio
 		return nil, err
 	}
 	if _, known := models[id]; !known && !c.modelOverridden(id) {
-		return nil, fmt.Errorf("GoogleAI: called with unknown model %q and nil ModelOptions", id)
+		return nil, status.Errorf(status.ErrInvalidArgument, "called with unknown model %q and nil ModelOptions", id)
 	}
 
 	return newModel(ga.gclient, id, c.modelOptions(id)), nil
@@ -478,7 +478,7 @@ func (v *VertexAI) DefineModel(g *genkit.Genkit, id string, opts *ai.ModelOption
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if !v.initted {
-		return nil, errors.New("VertexAI plugin not initialized")
+		return nil, status.Errorf(status.ErrFailedPrecondition, "VertexAI plugin not initialized")
 	}
 	id = internal.TrimProvider(vertexAIProvider, id)
 	if err := rejectBackgroundModel(vertexAIProvider, id); err != nil {
@@ -495,7 +495,7 @@ func (v *VertexAI) DefineModel(g *genkit.Genkit, id string, opts *ai.ModelOption
 			return nil, err
 		}
 		if _, known := models[id]; !known {
-			return nil, fmt.Errorf("VertexAI: called with unknown model %q and nil ModelOptions", id)
+			return nil, status.Errorf(status.ErrInvalidArgument, "called with unknown model %q and nil ModelOptions", id)
 		}
 	}
 
@@ -512,7 +512,7 @@ func (ga *GoogleAI) DefineEmbedder(g *genkit.Genkit, id string, embedOpts *ai.Em
 	ga.mu.Lock()
 	defer ga.mu.Unlock()
 	if !ga.initted {
-		return nil, errors.New("GoogleAI plugin not initialized")
+		return nil, status.Errorf(status.ErrFailedPrecondition, "GoogleAI plugin not initialized")
 	}
 	id = internal.TrimProvider(googleAIProvider, id)
 	if embedOpts == nil {
@@ -530,7 +530,7 @@ func (v *VertexAI) DefineEmbedder(g *genkit.Genkit, id string, embedOpts *ai.Emb
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if !v.initted {
-		return nil, errors.New("VertexAI plugin not initialized")
+		return nil, status.Errorf(status.ErrFailedPrecondition, "VertexAI plugin not initialized")
 	}
 	id = internal.TrimProvider(vertexAIProvider, id)
 	if embedOpts == nil {

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -326,7 +326,7 @@ func (v *VertexAI) Init(ctx context.Context) []api.Action {
 			// key in these variables is not valid for Vertex AI and fails
 			// each request with PERMISSION_DENIED, so name where the key
 			// came from.
-			logger.FromContext(ctx).Info("Vertex AI: using Express Mode API key from environment", "variable", keySource)
+			logger.Info(ctx, "Vertex AI: using Express Mode API key from environment", "variable", keySource)
 		}
 		gc.APIKey = apiKey
 		gc.HTTPClient = httpClientOrDefault(v.HTTPClient)

--- a/go/plugins/googlegenai/imagen.go
+++ b/go/plugins/googlegenai/imagen.go
@@ -19,11 +19,11 @@ package googlegenai
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 
 	"google.golang.org/genai"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
 )
 
 // translateImagenCandidates translates the image generation response to [*ai.ModelResponse]
@@ -64,11 +64,11 @@ func generateImage(
 		}
 	}
 	if userPrompt == "" {
-		return nil, fmt.Errorf("error generating images: empty prompt detected")
+		return nil, status.Errorf(status.ErrInvalidArgument, "empty prompt detected")
 	}
 
 	if cb != nil {
-		return nil, fmt.Errorf("streaming mode not supported for image generation")
+		return nil, status.Errorf(status.ErrUnimplemented, "streaming mode not supported for image generation")
 	}
 
 	resp, err := client.Models.GenerateImages(ctx, model, userPrompt, gic)

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/plugins/internal"
 	"google.golang.org/genai"
 )
@@ -542,7 +543,7 @@ func listModels(provider string) (map[string]ai.ModelOptions, error) {
 	case vertexAIProvider:
 		names = vertexAIModels
 	default:
-		return nil, fmt.Errorf("unknown provider detected %s", provider)
+		return nil, status.Errorf(status.ErrInvalidArgument, "unknown provider detected %s", provider)
 	}
 
 	models := make(map[string]ai.ModelOptions, len(names))
@@ -569,7 +570,7 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 
 	for item, err := range client.Models.All(ctx) {
 		if err != nil {
-			return genaiModels{}, fmt.Errorf("failed to list models: %w", err)
+			return genaiModels{}, fmt.Errorf("failed to list models: %w", wrapAPIError(err))
 		}
 
 		name := strings.TrimPrefix(item.Name, "publishers/google/")

--- a/go/plugins/googlegenai/schema.go
+++ b/go/plugins/googlegenai/schema.go
@@ -5,10 +5,10 @@ package googlegenai
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/firebase/genkit/go/core/status"
 	"google.golang.org/genai"
 )
 
@@ -23,7 +23,7 @@ func toGeminiSchema(originalSchema map[string]any, genkitSchema map[string]any) 
 	if v, ok := genkitSchema["$ref"]; ok {
 		ref, ok := v.(string)
 		if !ok {
-			return nil, fmt.Errorf("invalid $ref value: not a string")
+			return nil, status.Errorf(status.ErrInvalidSchema, "invalid $ref value: not a string")
 		}
 		s, err := resolveRef(originalSchema, ref)
 		if err != nil {
@@ -66,7 +66,7 @@ func toGeminiSchema(originalSchema map[string]any, genkitSchema map[string]any) 
 	schema := &genai.Schema{}
 	typeVal, ok := genkitSchema["type"]
 	if !ok {
-		return nil, fmt.Errorf("schema is missing the 'type' field: %#v", genkitSchema)
+		return nil, status.Errorf(status.ErrInvalidSchema, "schema is missing the 'type' field: %#v", genkitSchema)
 	}
 
 	// JSON Schema 2020-12 allows "type" to be an array of types, e.g.
@@ -83,14 +83,14 @@ func toGeminiSchema(originalSchema map[string]any, genkitSchema map[string]any) 
 		for _, t := range tv {
 			s, isString := t.(string)
 			if !isString {
-				return nil, fmt.Errorf("schema 'type' array contains non-string element of type %T", t)
+				return nil, status.Errorf(status.ErrInvalidSchema, "schema 'type' array contains non-string element of type %T", t)
 			}
 			typeList = append(typeList, s)
 		}
 	case []string:
 		typeList = tv
 	default:
-		return nil, fmt.Errorf("schema 'type' field is not a string, but %T", typeVal)
+		return nil, status.Errorf(status.ErrInvalidSchema, "schema 'type' field is not a string, but %T", typeVal)
 	}
 	for _, s := range typeList {
 		if s == "null" {
@@ -98,7 +98,7 @@ func toGeminiSchema(originalSchema map[string]any, genkitSchema map[string]any) 
 			continue
 		}
 		if typeStr != "" {
-			return nil, fmt.Errorf("schema 'type' array contains multiple non-null types: %v", typeList)
+			return nil, status.Errorf(status.ErrInvalidSchema, "schema 'type' array contains multiple non-null types: %v", typeList)
 		}
 		typeStr = s
 	}
@@ -119,7 +119,7 @@ func toGeminiSchema(originalSchema map[string]any, genkitSchema map[string]any) 
 	case "array":
 		schema.Type = genai.TypeArray
 	default:
-		return nil, fmt.Errorf("schema type %q not allowed", typeStr)
+		return nil, status.Errorf(status.ErrInvalidSchema, "schema type %q not allowed", typeStr)
 	}
 	if v, ok := genkitSchema["required"]; ok {
 		schema.Required = castToStringArray(v)
@@ -198,7 +198,7 @@ func resolveRef(originalSchema map[string]any, ref string) (map[string]any, erro
 			return def, nil
 		}
 	}
-	return nil, fmt.Errorf("unable to resolve schema reference")
+	return nil, status.Errorf(status.ErrInvalidSchema, "unable to resolve schema reference %q", ref)
 }
 
 // castToStringArray converts either []any or []string to []string, filtering non-strings.

--- a/go/plugins/googlegenai/tools.go
+++ b/go/plugins/googlegenai/tools.go
@@ -4,12 +4,12 @@
 package googlegenai
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 	"google.golang.org/genai"
 )
@@ -26,7 +26,7 @@ func toGeminiTools(inTools []*ai.ToolDefinition) ([]*genai.Tool, error) {
 
 	for _, t := range inTools {
 		if !validToolName(t.Name) {
-			return nil, fmt.Errorf(`invalid tool name: %q, must start with a letter or an underscore, must be alphanumeric, underscores, dots or dashes with a max length of 64 chars`, t.Name)
+			return nil, status.Errorf(status.ErrInvalidArgument, `invalid tool name: %q, must start with a letter or an underscore, must be alphanumeric, underscores, dots or dashes with a max length of 64 chars`, t.Name)
 		}
 		inputSchema, err := toGeminiSchema(t.InputSchema, t.InputSchema)
 		if err != nil {
@@ -71,7 +71,7 @@ func toGeminiFunctionResponsePart(parts []*ai.Part) ([]*genai.FunctionResponsePa
 			}
 			frp = append(frp, genai.NewFunctionResponsePartFromURI(p.Text, p.ContentType))
 		default:
-			return nil, fmt.Errorf("unsupported function response part type: %d", p.Kind)
+			return nil, status.Errorf(status.ErrInvalidArgument, "unsupported function response part type: %d", p.Kind)
 		}
 	}
 	return frp, nil
@@ -128,7 +128,7 @@ func toGeminiToolChoice(toolConfig *genai.ToolConfig, toolChoice ai.ToolChoice, 
 	case ai.ToolChoiceNone:
 		mode = genai.FunctionCallingConfigModeNone
 	default:
-		return nil, fmt.Errorf("tool choice mode %q not supported", toolChoice)
+		return nil, status.Errorf(status.ErrInvalidArgument, "tool choice mode %q not supported", toolChoice)
 	}
 
 	var toolNames []string

--- a/go/plugins/googlegenai/veo.go
+++ b/go/plugins/googlegenai/veo.go
@@ -28,6 +28,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 )
 
@@ -49,7 +50,7 @@ func newVeoModel(
 		// Extract text prompt from the request
 		prompt := extractTextFromRequest(req)
 		if prompt == "" {
-			return nil, fmt.Errorf("no text prompt found in request")
+			return nil, status.Errorf(status.ErrInvalidArgument, "no text prompt found in request")
 		}
 
 		video := extractVeoVideoFromRequest(req)
@@ -214,12 +215,15 @@ func fromVeoOperation(veoOp *genai.GenerateVideosOperation) *ai.ModelOperation {
 		}
 	}
 
-	// Handle error cases
+	// Handle error cases. veoOp.Error is a google.rpc.Status, so it carries the
+	// canonical code alongside the message; classifying with it is what lets a
+	// caller tell a rejected prompt from a transient backend failure.
 	if veoOp.Error != nil {
+		sentinel := status.Base(veoOperationStatus(veoOp.Error))
 		if errorMsg, ok := veoOp.Error["message"].(string); ok {
-			operation.Error = fmt.Errorf("%s", errorMsg)
+			operation.Error = status.Errorf(sentinel, "%s", errorMsg)
 		} else {
-			operation.Error = fmt.Errorf("operation error: %v", veoOp.Error)
+			operation.Error = status.Errorf(sentinel, "operation error: %v", veoOp.Error)
 		}
 		return operation
 	}
@@ -296,4 +300,20 @@ func checkVeoOperation(ctx context.Context, client *genai.Client, ops *core.Oper
 		Name: ops.ID,
 	}
 	return client.Operations.GetVideosOperation(ctx, genaiOps, nil)
+}
+
+// veoOperationStatus reads the canonical status out of the google.rpc.Status
+// map a failed Veo operation carries. The code field is a gRPC status code,
+// numeric over the wire but a float64 (or json.Number) once decoded into a
+// map. An absent or unrecognized code answers Internal, which is what an
+// unexplained backend failure is.
+func veoOperationStatus(opErr map[string]any) status.Name {
+	code, ok := castToInt64(opErr["code"])
+	if !ok {
+		return status.Internal
+	}
+	if n := status.FromCode(int(code)); n != status.Unknown {
+		return n
+	}
+	return status.Internal
 }

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -230,7 +230,7 @@ func Generate(
 	if cb == nil {
 		msg, err := client.Messages.New(ctx, *req)
 		if err != nil {
-			return nil, err
+			return nil, WrapAPIError(err)
 		}
 
 		r, err := toGenkitResponse(msg)
@@ -291,13 +291,16 @@ func Generate(
 			}
 		}
 		if err := stream.Err(); err != nil {
-			return nil, err
+			return nil, WrapAPIError(err)
 		}
 		// The loop only returns from the message_stop case. Falling out of it
 		// means the stream ended early without one, and the SDK reports no
 		// error for a body that simply stops, so say so rather than returning
 		// a nil response the caller would dereference.
-		return nil, fmt.Errorf("anthropic stream ended without a message_stop event")
+		// Internal, not InvalidArgument: a body that stops early is usually a
+		// truncated response rather than a bad request, so this stays in the
+		// set the retry middleware reissues.
+		return nil, status.Errorf(status.ErrInternal, "anthropic stream ended without a message_stop event")
 	}
 }
 
@@ -310,7 +313,7 @@ func toAnthropicRole(role ai.Role) (anthropic.MessageParamRole, error) {
 	case ai.RoleTool:
 		return anthropic.MessageParamRoleAssistant, nil
 	default:
-		return "", fmt.Errorf("unknown role given: %q", role)
+		return "", status.Errorf(status.ErrInvalidArgument, "unknown role given: %q", role)
 	}
 }
 
@@ -434,10 +437,10 @@ func toAnthropicTools(provider string, tools []*ai.ToolDefinition) ([]anthropic.
 
 	for _, t := range tools {
 		if t.Name == "" {
-			return nil, fmt.Errorf("tool name is required")
+			return nil, status.Errorf(status.ErrInvalidArgument, "tool name is required")
 		}
 		if !regex.MatchString(t.Name) {
-			return nil, fmt.Errorf("tool name must match regex: %s", ToolNameRegex)
+			return nil, status.Errorf(status.ErrInvalidArgument, "tool name %q must match regex: %s", t.Name, ToolNameRegex)
 		}
 
 		inputSchema := t.InputSchema
@@ -460,7 +463,7 @@ func toAnthropicTools(provider string, tools []*ai.ToolDefinition) ([]anthropic.
 
 		schema, err := base.MapToStruct[anthropic.ToolInputSchemaParam](inputSchema)
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse tool input schema: %w", err)
+			return nil, status.Errorf(status.ErrInvalidArgument, "unable to parse input schema for tool %q: %w", t.Name, err)
 		}
 
 		// ToolInputSchemaParam struct doesn't have AdditionalProperties field,
@@ -552,7 +555,7 @@ func toAnthropicToolResultBlock(toolResp *ai.ToolResponse) (anthropic.ContentBlo
 	if toolResp.Output != nil || len(toolResp.Content) == 0 {
 		output, err := json.Marshal(toolResp.Output)
 		if err != nil {
-			return anthropic.ContentBlockParamUnion{}, fmt.Errorf("unable to parse tool response, err: %w", err)
+			return anthropic.ContentBlockParamUnion{}, status.Errorf(status.ErrInvalidArgument, "unable to marshal response of tool %q: %w", toolResp.Name, err)
 		}
 		content = append(content, anthropic.ToolResultBlockParamContentUnion{
 			OfText: &anthropic.TextBlockParam{Text: string(output)},

--- a/go/plugins/internal/anthropic/anthropic_test.go
+++ b/go/plugins/internal/anthropic/anthropic_test.go
@@ -347,7 +347,7 @@ func TestToAnthropicTools(t *testing.T) {
 					Description: "my tool description",
 				},
 			},
-			expectedErr: "tool name must match regex",
+			expectedErr: "must match regex",
 		},
 	}
 

--- a/go/plugins/internal/anthropic/errors.go
+++ b/go/plugins/internal/anthropic/errors.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package anthropic
+
+import (
+	"errors"
+
+	"github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/firebase/genkit/go/core/status"
+)
+
+// WrapAPIError wraps an error the Anthropic SDK returned for an HTTP response
+// in a [status.Error] carrying the status the server reported, so status-aware
+// middleware (retry, fallback, ...) can tell a rate limit from a malformed
+// request. Without it every API failure is unclassified, which the retry
+// middleware treats as retryable: a 400 would be reissued unchanged until the
+// attempts ran out.
+//
+// Values that are not an SDK API error pass through untouched. Those are
+// transport failures the SDK does not wrap, and leaving them unclassified is
+// the right answer: a connection reset really is worth retrying.
+func WrapAPIError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr *anthropic.Error
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+	return status.Errorf(status.Base(status.FromHTTPCode(apiErr.StatusCode)), "%w", err)
+}

--- a/go/plugins/internal/anthropic/errors_test.go
+++ b/go/plugins/internal/anthropic/errors_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package anthropic
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/firebase/genkit/go/core/status"
+)
+
+func TestWrapAPIErrorNil(t *testing.T) {
+	if got := WrapAPIError(nil); got != nil {
+		t.Errorf("WrapAPIError(nil) = %v, want nil", got)
+	}
+}
+
+func TestWrapAPIErrorPassesThroughNonAPIError(t *testing.T) {
+	// A transport failure the SDK does not wrap stays unclassified, which the
+	// retry middleware treats as retryable. That is the wanted behavior: a
+	// connection reset is worth another attempt.
+	plain := errors.New("connection reset by peer")
+	got := WrapAPIError(plain)
+	if got != plain {
+		t.Errorf("WrapAPIError returned %v, want the original error unchanged", got)
+	}
+	if _, ok := status.Classified(got); ok {
+		t.Error("WrapAPIError classified an error that did not come from the API")
+	}
+}
+
+func TestWrapAPIErrorMapsHTTPStatus(t *testing.T) {
+	tests := []struct {
+		code int
+		want status.Name
+	}{
+		{400, status.InvalidArgument},
+		{401, status.Unauthenticated},
+		{403, status.PermissionDenied},
+		{404, status.NotFound},
+		{429, status.ResourceExhausted},
+		{500, status.Internal},
+		{503, status.Unavailable},
+		{529, status.Internal}, // Anthropic's "overloaded"; any unmapped 5xx is Internal
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprint(tt.code), func(t *testing.T) {
+			got := WrapAPIError(&anthropic.Error{StatusCode: tt.code})
+			s, ok := status.Classified(got)
+			if !ok {
+				t.Fatalf("WrapAPIError left a %d API error unclassified", tt.code)
+			}
+			if s != tt.want {
+				t.Errorf("status = %v, want %v", s, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapAPIErrorFindsWrappedAPIError(t *testing.T) {
+	// Classification must survive the context wrapping callers add, since the
+	// SDK error is often several frames below where it is returned.
+	err := fmt.Errorf("generating content: %w", &anthropic.Error{StatusCode: 400})
+	if got := status.Of(WrapAPIError(err)); got != status.InvalidArgument {
+		t.Errorf("status = %v, want %v", got, status.InvalidArgument)
+	}
+}
+
+// TestWrapAPIErrorClientErrorsAreNotRetried pins the property that motivates
+// the wrapper: a request the server rejected must not be reissued unchanged by
+// the retry middleware, whose default set is UNAVAILABLE, DEADLINE_EXCEEDED,
+// RESOURCE_EXHAUSTED, ABORTED, and INTERNAL.
+func TestWrapAPIErrorClientErrorsAreNotRetried(t *testing.T) {
+	retried := map[status.Name]bool{
+		status.Unavailable:       true,
+		status.DeadlineExceeded:  true,
+		status.ResourceExhausted: true,
+		status.Aborted:           true,
+		status.Internal:          true,
+	}
+	for _, code := range []int{400, 401, 403, 404} {
+		s, ok := status.Classified(WrapAPIError(&anthropic.Error{StatusCode: code}))
+		if !ok {
+			t.Fatalf("a %d API error is unclassified, so retry would reissue it", code)
+		}
+		if retried[s] {
+			t.Errorf("a %d API error maps to %v, which the retry middleware reissues", code, s)
+		}
+	}
+}

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -238,7 +238,7 @@ func Index(ctx context.Context, docs []*ai.Document, ds *DocStore) error {
 			return err
 		}
 		if _, ok := ds.Data[id]; ok {
-			logger.FromContext(ctx).Debug("localvec skipping document because already present", "id", id)
+			logger.Debug(ctx, "localvec: skipping document already present in the index", "id", id)
 			continue
 		}
 

--- a/go/plugins/mcp/client.go
+++ b/go/plugins/mcp/client.go
@@ -112,7 +112,7 @@ func (c *GenkitMCPClient) connect(options MCPClientOptions) error {
 	if c.server != nil {
 		if err := c.server.Client.Close(); err != nil {
 			ctx := context.Background()
-			logger.FromContext(ctx).Warn("Error closing previous MCP transport", "client", c.options.Name, "error", err)
+			logger.Warn(ctx, "error closing previous MCP transport", "client", c.options.Name, "error", err)
 		}
 	}
 
@@ -237,7 +237,7 @@ func (c *GenkitMCPClient) Reenable() {
 // Restart restarts the transport connection
 func (c *GenkitMCPClient) Restart(ctx context.Context) error {
 	if err := c.Disconnect(); err != nil {
-		logger.FromContext(ctx).Warn("Error closing MCP transport during restart", "client", c.options.Name, "error", err)
+		logger.Warn(ctx, "error closing MCP transport during restart", "client", c.options.Name, "error", err)
 	}
 	return c.connect(c.options)
 }

--- a/go/plugins/mcp/host.go
+++ b/go/plugins/mcp/host.go
@@ -69,7 +69,7 @@ func NewMCPHost(g *genkit.Genkit, options MCPHostOptions) (*MCPHost, error) {
 	ctx := context.Background()
 	for _, serverConfig := range options.MCPServers {
 		if err := host.Connect(ctx, g, serverConfig.Name, serverConfig.Config); err != nil {
-			logger.FromContext(ctx).Error("Failed to connect to MCP server", "server", serverConfig.Name, "host", host.name, "error", err)
+			logger.Error(ctx, "failed to connect to MCP server, continuing with the others", "server", serverConfig.Name, "host", host.name, "error", err)
 			// Continue with other servers
 		}
 	}
@@ -83,11 +83,11 @@ func (h *MCPHost) Connect(ctx context.Context, g *genkit.Genkit, serverName stri
 	// If a client with this name already exists, disconnect it first
 	if existingClient, exists := h.clients[serverName]; exists {
 		if err := existingClient.Disconnect(); err != nil {
-			logger.FromContext(ctx).Warn("Error disconnecting existing MCP client", "server", serverName, "host", h.name, "error", err)
+			logger.Warn(ctx, "error disconnecting existing MCP client", "server", serverName, "host", h.name, "error", err)
 		}
 	}
 
-	logger.FromContext(ctx).Info("Connecting to MCP server", "server", serverName, "host", h.name)
+	logger.Debug(ctx, "connecting to MCP server", "server", serverName, "host", h.name)
 
 	// Set the server name in the config
 	if config.Name == "" {
@@ -112,7 +112,7 @@ func (h *MCPHost) Disconnect(ctx context.Context, serverName string) error {
 		return fmt.Errorf("no client found with name '%s'", serverName)
 	}
 
-	logger.FromContext(ctx).Info("Disconnecting MCP server", "server", serverName, "host", h.name)
+	logger.Debug(ctx, "disconnecting MCP server", "server", serverName, "host", h.name)
 
 	err := client.Disconnect()
 	delete(h.clients, serverName)
@@ -126,7 +126,7 @@ func (h *MCPHost) Reconnect(ctx context.Context, serverName string) error {
 		return fmt.Errorf("no client found with name '%s'", serverName)
 	}
 
-	logger.FromContext(ctx).Info("Reconnecting MCP server", "server", serverName, "host", h.name)
+	logger.Debug(ctx, "reconnecting MCP server", "server", serverName, "host", h.name)
 	return client.Restart(ctx)
 }
 
@@ -141,7 +141,7 @@ func (h *MCPHost) GetActiveTools(ctx context.Context, gk *genkit.Genkit) ([]ai.T
 
 		tools, err := client.GetActiveTools(ctx, gk)
 		if err != nil {
-			logger.FromContext(ctx).Error("Error fetching tools from MCP client", "client", name, "host", h.name, "error", err)
+			logger.Error(ctx, "failed to fetch tools from MCP client, skipping it", "client", name, "host", h.name, "error", err)
 			continue
 		}
 
@@ -162,7 +162,7 @@ func (h *MCPHost) GetActiveResources(ctx context.Context) ([]ai.Resource, error)
 
 		resources, err := client.GetActiveResources(ctx)
 		if err != nil {
-			logger.FromContext(ctx).Error("Error fetching resources from MCP client", "client", name, "host", h.name, "error", err)
+			logger.Error(ctx, "failed to fetch resources from MCP client, skipping it", "client", name, "host", h.name, "error", err)
 			continue
 		}
 		allResources = append(allResources, resources...)

--- a/go/plugins/mcp/host.go
+++ b/go/plugins/mcp/host.go
@@ -87,7 +87,7 @@ func (h *MCPHost) Connect(ctx context.Context, g *genkit.Genkit, serverName stri
 		}
 	}
 
-	logger.Debug(ctx, "connecting to MCP server", "server", serverName, "host", h.name)
+	logger.Info(ctx, "connecting to MCP server", "server", serverName, "host", h.name)
 
 	// Set the server name in the config
 	if config.Name == "" {
@@ -112,7 +112,7 @@ func (h *MCPHost) Disconnect(ctx context.Context, serverName string) error {
 		return fmt.Errorf("no client found with name '%s'", serverName)
 	}
 
-	logger.Debug(ctx, "disconnecting MCP server", "server", serverName, "host", h.name)
+	logger.Info(ctx, "disconnecting MCP server", "server", serverName, "host", h.name)
 
 	err := client.Disconnect()
 	delete(h.clients, serverName)
@@ -126,7 +126,7 @@ func (h *MCPHost) Reconnect(ctx context.Context, serverName string) error {
 		return fmt.Errorf("no client found with name '%s'", serverName)
 	}
 
-	logger.Debug(ctx, "reconnecting MCP server", "server", serverName, "host", h.name)
+	logger.Info(ctx, "reconnecting MCP server", "server", serverName, "host", h.name)
 	return client.Restart(ctx)
 }
 

--- a/go/plugins/mcp/server.go
+++ b/go/plugins/mcp/server.go
@@ -95,7 +95,7 @@ func (s *GenkitMCPServer) setup() error {
 	// Register resources with the MCP server
 	for _, resourceAction := range resourceActions {
 		if err := s.registerResourceWithMCP(resourceAction); err != nil {
-			slog.Warn("Failed to register resource", "resource", resourceAction.Desc().Name, "error", err)
+			slog.Warn("failed to register resource with the MCP server, skipping it", "resource", resourceAction.Desc().Name, "error", err)
 		}
 	}
 

--- a/go/plugins/middleware/fallback.go
+++ b/go/plugins/middleware/fallback.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
 )
@@ -97,6 +98,9 @@ func (f *Fallback) wrapModel(ctx context.Context, params *ai.ModelParams, next a
 	lastErr := err
 	for _, ref := range f.Models {
 		name := ref.Name()
+		// A fallback reroutes the request to a different (billed) model, so it
+		// warrants more than debug visibility.
+		logger.Warn(ctx, "model call failed, falling back", "model", name, "error", lastErr)
 		m := genkit.LookupModel(genkit.FromContext(ctx), name)
 		if m == nil {
 			return nil, status.Errorf(ai.ErrModelNotFound, "fallback: model %q not found", name)

--- a/go/plugins/middleware/filesystem.go
+++ b/go/plugins/middleware/filesystem.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 )
 
@@ -210,6 +211,7 @@ func (f *Filesystem) New(ctx context.Context) (*ai.Hooks, error) {
 		mu.Unlock()
 
 		if len(queued) > 0 {
+			logger.Debug(ctx, "filesystem middleware injecting queued messages", "messages", len(queued))
 			if params.Callback != nil {
 				for _, msg := range queued {
 					if err := params.Callback(ctx, &ai.ModelResponseChunk{
@@ -241,6 +243,10 @@ func (f *Filesystem) New(ctx context.Context) (*ai.Hooks, error) {
 			return nil, err
 		}
 
+		// The error is deliberately not propagated: the model sees the failure
+		// as a user message on the next turn and can self-correct, so this log
+		// is the only direct record of the original error.
+		logger.Debug(ctx, "filesystem tool failed, converting to user message", "tool", params.Tool.Name(), "error", err)
 		enqueueParts(ai.NewTextPart(fmt.Sprintf("Tool %q failed: %v", params.Tool.Name(), err)))
 		return &ai.MultipartToolResponse{
 			Output: "Tool call failed; see user message below for details.",

--- a/go/plugins/middleware/retry.go
+++ b/go/plugins/middleware/retry.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/status"
 )
 
@@ -158,6 +159,12 @@ func (r *Retry) wrapModel(ctx context.Context, params *ai.ModelParams, next ai.M
 			jitter := time.Duration(float64(time.Second) * math.Pow(2, float64(attempt)) * rand.Float64())
 			delay += jitter
 		}
+
+		logger.Debug(ctx, "model call failed, retrying",
+			"attempt", attempt+1,
+			"maxRetries", maxRetries,
+			"delay", delay.Round(time.Millisecond),
+			"error", err)
 
 		// Bail out if the caller disconnected mid-backoff; no reason to wait
 		// out the delay (or issue another retry) for a caller who has left.

--- a/go/plugins/middleware/skills.go
+++ b/go/plugins/middleware/skills.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/goccy/go-yaml"
 )
 
@@ -88,10 +89,16 @@ func (s *Skills) Name() string { return provider + "/skills" }
 // once per [ai.Generate] call; the result is captured in the returned hooks
 // so WrapGenerate and the use_skill tool agree on the same skill set.
 func (s *Skills) New(ctx context.Context) (*ai.Hooks, error) {
-	info, err := scanSkills(s.paths())
+	info, err := scanSkills(ctx, s.paths(), len(s.SkillPaths) > 0)
 	if err != nil {
 		return nil, err
 	}
+	names := make([]string, 0, len(info))
+	for name := range info {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	logger.Debug(ctx, "skills middleware scanned", "skills", names)
 
 	useSkill := ai.NewTool(
 		useSkillToolName,
@@ -135,16 +142,27 @@ func (s *Skills) paths() []string {
 
 // scanSkills enumerates SKILL.md files under each path and returns a map keyed
 // by the skill's directory name. Missing or unreadable paths are skipped,
-// matching the JS implementation.
-func scanSkills(paths []string) (map[string]skillInfo, error) {
+// matching the JS implementation; a skipped path is a warning when the caller
+// configured it explicitly (a likely misconfiguration) and debug noise when it
+// is only the unset default.
+func scanSkills(ctx context.Context, paths []string, explicit bool) (map[string]skillInfo, error) {
 	result := make(map[string]skillInfo)
+	skipped := func(p string, err error) {
+		if explicit {
+			logger.Warn(ctx, "skills path could not be read, skipping", "path", p, "error", err)
+		} else {
+			logger.Debug(ctx, "skills path could not be read, skipping", "path", p, "error", err)
+		}
+	}
 	for _, p := range paths {
 		abs, err := filepath.Abs(p)
 		if err != nil {
+			skipped(p, err)
 			continue
 		}
 		entries, err := os.ReadDir(abs)
 		if err != nil {
+			skipped(abs, err)
 			continue
 		}
 		for _, entry := range entries {

--- a/go/plugins/middleware/tool_approval.go
+++ b/go/plugins/middleware/tool_approval.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/logger"
 )
 
 // ToolApproval is a middleware that interrupts tool execution unless the tool
@@ -75,6 +76,7 @@ func (t *ToolApproval) wrapTool(ctx context.Context, params *ai.ToolParams, next
 
 	// No span is emitted here: the generate engine attributes a hook that
 	// short-circuits the tool to the tool itself in traces.
+	logger.Debug(ctx, "tool held for approval", "tool", name)
 	return nil, ai.NewToolInterruptError(map[string]any{
 		"message": "Tool not in approved list: " + name,
 	})

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"regexp"
 	"slices"
@@ -35,6 +34,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/internal"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
@@ -520,7 +520,7 @@ func (o *Ollama) newModel(name string, opts ai.ModelOptions) ai.Model {
 func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 	models, err := o.listLocalModels(ctx)
 	if err != nil {
-		slog.Error("unable to list ollama models", "error", err)
+		logger.Error(ctx, "unable to list ollama models", "error", err)
 		return nil
 	}
 
@@ -558,7 +558,7 @@ scheduleQueries:
 			modelSupports := &defaultOllamaSupports
 			if err != nil {
 				if ctx.Err() == nil {
-					slog.Warn("unable to detect ollama model capabilities", "model", m.Name, "error", err)
+					logger.Warn(ctx, "unable to detect ollama model capabilities", "model", m.Name, "error", err)
 				}
 			} else {
 				modelSupports = modelSupportsFromCapabilities(caps)
@@ -571,7 +571,7 @@ scheduleQueries:
 	}
 	wg.Wait()
 	if err := ctx.Err(); err != nil {
-		slog.Warn("ollama model discovery canceled", "error", err)
+		logger.Warn(ctx, "ollama model discovery canceled", "error", err)
 		return nil
 	}
 

--- a/go/plugins/pinecone/pinecone.go
+++ b/go/plugins/pinecone/pinecone.go
@@ -39,6 +39,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/firebase/genkit/go/core/logger"
 )
 
 // Set pineconeDebug to true to dump data sent to and received from the server.
@@ -388,7 +390,7 @@ func (c *client) postData(ctx context.Context, url string, post, result any) err
 				return err
 			}
 			b := buf.Bytes()
-			fmt.Printf("pinecone: post to %s: %s\n", url, b)
+			logger.Debug(ctx, "pinecone: request", "url", url, "body", string(b))
 			if _, err := httpWriter.Write(b); err != nil {
 				return err
 			}
@@ -434,7 +436,7 @@ func (c *client) postData(ctx context.Context, url string, post, result any) err
 		if err != nil {
 			return err
 		}
-		fmt.Printf("pinecone: reply from %s: %s\n", url, data)
+		logger.Debug(ctx, "pinecone: response", "url", url, "body", string(data))
 		r = bytes.NewReader(data)
 	}
 

--- a/go/plugins/pinecone/pinecone.go
+++ b/go/plugins/pinecone/pinecone.go
@@ -43,7 +43,9 @@ import (
 	"github.com/firebase/genkit/go/core/logger"
 )
 
-// Set pineconeDebug to true to dump data sent to and received from the server.
+// Set pineconeDebug to true to dump data sent to and received from the
+// server. The dumps are logged at debug level, so also run with
+// GENKIT_LOG_LEVEL=debug (or a debug-level handler) to see them.
 const pineconeDebug = false
 
 // apiServer is the Pinecone API server.

--- a/go/plugins/server/server.go
+++ b/go/plugins/server/server.go
@@ -25,7 +25,12 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
+
+// shutdownTimeout bounds the graceful drain of in-flight requests after an
+// interrupt, matching the reflection server's shutdown timeout.
+const shutdownTimeout = 5 * time.Second
 
 // Start starts a new HTTP server and manages its lifecycle.
 // This is a convenience function since Go does not manage interrupt signals directly.
@@ -53,7 +58,14 @@ func Start(ctx context.Context, addr string, mux *http.ServeMux) error {
 		return err
 	case <-ctx.Done():
 		slog.Info("server shutting down", "addr", addr)
-		if err := srv.Shutdown(ctx); err != nil {
+		// Stop intercepting signals so a second interrupt kills the process
+		// immediately instead of being swallowed while requests drain.
+		cancel()
+		// ctx is already canceled here; Shutdown needs a fresh context or it
+		// returns immediately without draining in-flight requests.
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancelShutdown()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
 			return fmt.Errorf("failed to shutdown server: %w", err)
 		}
 	}

--- a/go/plugins/server/server.go
+++ b/go/plugins/server/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -40,6 +41,7 @@ func Start(ctx context.Context, addr string, mux *http.ServeMux) error {
 	errChan := make(chan error, 1)
 
 	go func() {
+		slog.Info("server listening", "addr", addr)
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errChan <- fmt.Errorf("server error: %w", err)
 		}
@@ -50,6 +52,7 @@ func Start(ctx context.Context, addr string, mux *http.ServeMux) error {
 	case err := <-errChan:
 		return err
 	case <-ctx.Done():
+		slog.Info("server shutting down", "addr", addr)
 		if err := srv.Shutdown(ctx); err != nil {
 			return fmt.Errorf("failed to shutdown server: %w", err)
 		}

--- a/go/plugins/vertexai/vectorsearch/bigquery.go
+++ b/go/plugins/vertexai/vectorsearch/bigquery.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math/rand"
 	"time"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/logger"
 	"google.golang.org/api/iterator"
 )
 
@@ -61,7 +61,6 @@ func GetBigQueryDocumentRetriever(bqClient *bigquery.Client, datasetID, tableID 
 
 		it, err := q.Read(ctx)
 		if err != nil {
-			log.Printf("Failed to execute BigQuery query: %v", err)
 			return nil, fmt.Errorf("failed to query BigQuery: %w", err)
 		}
 
@@ -73,17 +72,18 @@ func GetBigQueryDocumentRetriever(bqClient *bigquery.Client, datasetID, tableID 
 				break
 			}
 			if err != nil {
-				log.Printf("Error reading BigQuery row: %v", err)
 				return nil, fmt.Errorf("error reading BigQuery row: %w", err)
 			}
 
 			var doc ai.Document
 
 			if err := json.Unmarshal([]byte(row.Content), &doc.Content); err != nil {
-				log.Printf("Failed to parse content for document ID %s: %v", row.ID, err)
+				logger.Warn(ctx, "vectorsearch: returning document with unparsable content",
+					"document", row.ID, "error", err)
 			}
 			if err := json.Unmarshal([]byte(row.Metadata), &doc.Metadata); err != nil {
-				log.Printf("Failed to parse metadata for document ID %s: %v", row.ID, err)
+				logger.Warn(ctx, "vectorsearch: returning document with unparsable metadata",
+					"document", row.ID, "error", err)
 			}
 			documents = append(documents, &doc)
 		}
@@ -126,10 +126,7 @@ func GetBigQueryDocumentIndexer(bqClient *bigquery.Client, datasetID, tableID st
 			rows = append(rows, row)
 		}
 
-		// Log rows for debugging.
-		for _, row := range rows {
-			log.Printf("Inserting row: %+v", row)
-		}
+		logger.Debug(ctx, "vectorsearch: inserting rows into BigQuery", "rows", len(rows), "dataset", datasetID, "table", tableID)
 
 		// Insert rows into the BigQuery table.
 		inserter := bqClient.Dataset(datasetID).Table(tableID).Inserter()

--- a/go/plugins/vertexai/vectorsearch/firestore.go
+++ b/go/plugins/vertexai/vectorsearch/firestore.go
@@ -17,10 +17,10 @@ package vectorsearch
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"cloud.google.com/go/firestore"
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/googleapis/gax-go/v2/apierror"
 )
 
@@ -32,26 +32,29 @@ func GetFirestoreDocumentRetriever(db *firestore.Client, collectionName string) 
 		docs := []*ai.Document{}
 		for _, neighbor := range neighbors {
 			if neighbor.Datapoint.DatapointId == "" {
-				log.Printf("Skipping neighbor with empty or nil DatapointId: %+v", neighbor)
+				logger.Debug(ctx, "vectorsearch: skipping neighbor with an empty datapoint ID")
 				continue
 			}
 
 			docRef := db.Collection(collectionName).Doc(neighbor.Datapoint.DatapointId)
 			docSnapshot, err := docRef.Get(ctx)
 			if err != nil {
-				// Log the error but continue to try other neighbors.
-				log.Printf("Failed to get document %s from Firestore: %v", neighbor.Datapoint.DatapointId, err)
+				// Continue to try other neighbors on failure.
+				logger.Warn(ctx, "vectorsearch: skipping document that could not be fetched from Firestore",
+					"document", neighbor.Datapoint.DatapointId, "error", err)
 				continue
 			}
 
 			if !docSnapshot.Exists() {
-				log.Printf("Document %s does not exist in collection %s. Skipping.", neighbor.Datapoint.DatapointId, collectionName)
+				logger.Warn(ctx, "vectorsearch: skipping document missing from Firestore collection",
+					"document", neighbor.Datapoint.DatapointId, "collection", collectionName)
 				continue
 			}
 
 			var firestoreData ai.Document
 			if err := docSnapshot.DataTo(&firestoreData); err != nil {
-				log.Printf("Failed to unmarshal document data for ID %s: %v", neighbor.Datapoint.DatapointId, err)
+				logger.Warn(ctx, "vectorsearch: skipping document whose data could not be unmarshaled",
+					"document", neighbor.Datapoint.DatapointId, "error", err)
 				continue
 			}
 
@@ -80,8 +83,10 @@ func GetFirestoreDocumentIndexer(db *firestore.Client, collectionName string) Do
 
 		// Commit the batch operation.
 		if _, err := batch.Commit(ctx); err != nil {
+			// The wrapped error carries the message; the API error details
+			// are only available here, so log them before returning.
 			if apiErr, ok := err.(*apierror.APIError); ok {
-				log.Printf("Firestore API Error: %v, DebugInfo: %v", apiErr, apiErr.Details())
+				logger.Debug(ctx, "vectorsearch: Firestore batch commit failed", "details", fmt.Sprintf("%v", apiErr.Details()))
 			}
 			return nil, fmt.Errorf("failed to commit Firestore batch: %w", err)
 		}

--- a/go/plugins/vertexai/vectorsearch/firestore.go
+++ b/go/plugins/vertexai/vectorsearch/firestore.go
@@ -21,7 +21,6 @@ import (
 	"cloud.google.com/go/firestore"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/logger"
-	"github.com/googleapis/gax-go/v2/apierror"
 )
 
 // GetFirestoreDocumentRetriever creates a Firestore Document Retriever.
@@ -81,13 +80,9 @@ func GetFirestoreDocumentIndexer(db *firestore.Client, collectionName string) Do
 			ids = append(ids, docRef.ID)
 		}
 
-		// Commit the batch operation.
+		// Commit the batch operation. APIError's Error() includes its
+		// details, so the wrapped error carries the full diagnostics.
 		if _, err := batch.Commit(ctx); err != nil {
-			// The wrapped error carries the message; the API error details
-			// are only available here, so log them before returning.
-			if apiErr, ok := err.(*apierror.APIError); ok {
-				logger.Debug(ctx, "vectorsearch: Firestore batch commit failed", "details", fmt.Sprintf("%v", apiErr.Details()))
-			}
 			return nil, fmt.Errorf("failed to commit Firestore batch: %w", err)
 		}
 

--- a/go/samples/basic-agents/banker.go
+++ b/go/samples/basic-agents/banker.go
@@ -135,7 +135,7 @@ func defineBankerAgent(g *genkit.Genkit) *aix.Agent[any] {
 			}, nil
 		})
 
-	return genkitx.DefinePromptAgent[any](g, name,
+	return genkitx.DefinePromptAgent(g, name,
 		aix.WithSessionStore(mustStore[any](name)),
 		aix.WithDescription[any]("Money transfer assistant (interruptible tool + human approval)"),
 	)

--- a/go/samples/basic-agents/main.go
+++ b/go/samples/basic-agents/main.go
@@ -100,7 +100,7 @@ import (
 // pirate, coder, and orchestrator agents reference it directly; the chef and
 // banker agents set the same model in their .prompt frontmatter.
 var flashModel = googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
-	ThinkingConfig: &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelMinimal},
+	ThinkingConfig: &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelMedium},
 })
 
 func main() {

--- a/go/samples/basic-agents/prompts/banker.prompt
+++ b/go/samples/basic-agents/prompts/banker.prompt
@@ -2,7 +2,7 @@
 model: googleai/gemini-flash-latest
 config:
   thinkingConfig:
-    thinkingLevel: MINIMAL
+    thinkingLevel: MEDIUM
 tools:
   - transferMoney
 ---

--- a/go/samples/basic-agents/prompts/chef.prompt
+++ b/go/samples/basic-agents/prompts/chef.prompt
@@ -2,7 +2,7 @@
 model: googleai/gemini-flash-latest
 config:
   thinkingConfig:
-    thinkingLevel: MINIMAL
+    thinkingLevel: MEDIUM
 input:
   schema: ChatPromptInput
   default:


### PR DESCRIPTION
Adds trace-correlated log streaming to the Dev UI and rebuilds framework logging around it: a context-first API, one level taxonomy across core, genkit, ai, and the plugins, and a dev-mode exporter that ships every record at debug and above to the telemetry server, attached to the span that emitted it. The ingestion side already exists (from #4981); this makes Go the first runtime to feed it by default, matching the JS exporter's wire format. A companion Dev UI change, genkit-ai/genkit-ui#2041, renders each record's attributes inline in that panel.

<img width="1053" height="967" alt="image" src="https://github.com/user-attachments/assets/1a9c154b-4643-41a2-bc96-fdba9280d0e7" />

## Logs reach the Dev UI attached to their span

```go
logger.Info(ctx, "looking up weather", "city", city)
```

In dev, a slog handler converts each record to OTLP-JSON, stamps the trace and span IDs from ctx, and a background worker batches and POSTs them. It never blocks: bounded queue, drop-and-count on overflow, one warning if the server is unreachable. Export turns on whenever a telemetry server URL is configured; `GENKIT_OTEL_ENABLE_LOGS=false` turns it off. JS reads the same variable but exports only on an explicit `true`, which the CLI never sets.

Console level and export are independent: the terminal shows info and above (`GENKIT_LOG_LEVEL`, `logger.SetLevel`), while the Dev UI always receives debug and above, so an interactive app keeps a quiet terminal while the full narrative lands in the trace viewer.

## Context-first logging API

**Before:** the helper resolved a logger nothing ever put in a context, and dropped ctx, so no handler could correlate a record with the active span:

```go
logger.FromContext(ctx).Debug("Action.Run", "name", a.Name())
```

**After:** package-level functions take ctx and hand it to the handler, and `FromContext` returns a logger bound to its context, so the old shape correlates too:

```go
logger.Debug(ctx, "span started", "name", name, "type", "action")
ctx = logger.WithContext(ctx, logger.FromContext(ctx).With("reqId", id))
```

```go
// Added
logger.Debug(ctx, msg, args...)   logger.Info(ctx, msg, args...)
logger.Warn(ctx, msg, args...)    logger.Error(ctx, msg, args...)
logger.WithContext(ctx, l)        logger.AddHandler(h)
logger.SetDefaultHandler(h)       logger.HasCustomDefault()
tracing.EnableLogExport(url)      tracing.LogExportHandler()
```

`AddHandler` tees a handler onto the default logger and survives `SetLevel`, which previously clobbered the default unconditionally. `SetLevel` and `GENKIT_LOG_LEVEL` now leave an application-installed handler in place and warn. `SetDefaultHandler` swaps the base while keeping sinks, so googlecloud's Cloud Logging handler no longer disconnects Dev UI streaming.

`AddHandler` substitutes Genkit's console when it would otherwise capture the stdlib default handler, which is not a real sink: it writes through the `log` package, whose output `slog.SetDefault` redirects back, so teeing it deadlocks on `log`'s mutex.

## One taxonomy across the framework

Debug carries the per-request narrative: span start and finish, the resolved generate request, each model turn with finish reason and token counts, tool batches, and middleware hooks. Middleware gets no spans of its own, so each hook is bracketed by debug records carrying the middleware name, duration, and whether it short-circuited the chain. Info is rare lifecycle. Warn is misconfiguration and skipped work, and a model finishing abnormally now warns instead of passing silently. Error is reserved for errors not also returned to the caller, so nothing is double-reported. This diverges from JS deliberately, which has no framework `info` and is silent out of the box. Hot paths build debug arguments only when a handler accepts them, so production pays one `Enabled` check per span.

## Provider errors carry a status, so retries mean something

`middleware.Retry` reissues any error nothing in its chain classified, whatever status set it is configured with, so a request that could never succeed was retried through the whole backoff schedule:

```go
return nil, fmt.Errorf("at least one message is required in generate request") // retried 3x
```

The larger half was the SDK boundary. Only googlegenai wrapped what its SDK returns for an HTTP response, so across the Anthropic and OpenAI-compatible families every provider 400, 401, 403, and 404 was retried. Both SDKs expose `StatusCode` on their error type, so each family gets a `WrapAPIError` mirroring googlegenai's, applied at all 13 boundaries where an SDK error escapes. Transport failures stay unclassified, since a dial timeout is worth retrying. Three sites also dropped a status the server had already sent, including two googlegenai cache paths that flattened theirs with `%v`.

The remaining 59 sites are request-shaping failures deterministic in their input, now `InvalidArgument`, `InvalidSchema`, or `Unimplemented`. Failures a retry can fix keep a retryable status on purpose: an empty stream is `Unavailable`, a truncated one `Internal`.

Classifying these surfaced a bug they had masked. The reflection error envelope carries a code the dev UI validates against its `Status` schema, canonical numbering where `INVALID_ARGUMENT` is 3, and `toReflectionError` filled it with the HTTP status, so every classified failure went out outside that enum and the UI had no status to render. Reflection v2, JS, and the cancellation path beside it all send canonical codes. That field also fed `WriteHeader`, where a canonical code would panic, so the transport status is now derived from it.

## A step can own its context, and text means text

```go
out, err := genkit.RunWithContext(ctx, "fetch", func(ctx context.Context) (string, error) { ... })
```

`Run` hands its callback no context, so work the callback starts nests beside the enclosing flow instead of under the step. `RunWithContext` gives the step its own; `Run` keeps its signature for pure work. `MediaParts`, on `Message` and `ModelResponse`, returns every media part with its content type, where `Media` returns only the first and leaves the type behind.

`Message.Text` and `ModelResponseChunk.Text` now concatenate text parts only. A data part carries a blob the plugins send as bytes, so counting one as text spliced base64 into prose. This matches JS, where text and data are separate fields, and the `accumulate` and `splitTextParts` helpers, which already filtered this way.

## Reported version tracks the module

`internal.Version` was a hand-bumped constant sitting at 1.4.0 with 1.11 released. It now resolves from the binary's embedded build info, or `dev` when Genkit is the main module, and runtime files, `x-genkit-version` headers, and googlecloud `sourceVersion` follow.

## Init no longer hangs when reflection startup fails

The V1 reflection launcher and Init's startup select both received from the same one-shot error channel, so a startup failure was a race: if the launcher won, it swallowed the error and Init blocked forever. A supervisor goroutine now owns the channel and hands Init a dedicated startup verdict.

## What this does not do

- **No CLI changes, and the Logs panel stays experiment-gated**: enable `otel_logs` at `/lab`. Un-gating it and having the CLI set `GENKIT_OTEL_ENABLE_LOGS` for JS are tools-repo follow-ups.
- **No googlecloud rework**: it keeps its Cloud Logging pipeline; only the handler installation goes through `logger.SetDefaultHandler`.
- **No exporter flush on exit**: records inside the 100ms batch window are lost when a short-lived process exits, and draining needs a shutdown hook the framework lacks.
- **Records logged outside any span** are exported and stored but not shown, since the UI only lists logs per span.
