### PR TITLE
fix(js): omit config when version is undefined

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -651,11 +651,11 @@ export async function toGenerateActionOptions<
     tools,
     resources,
     toolChoice: options.toolChoice,
-    config: {
+    config: stripUndefinedOptions({
       version: resolvedModel?.version,
       ...stripUndefinedOptions(resolvedModel?.config),
       ...stripUndefinedOptions(options.config),
-    },
+    }),
     output: options.output && {
       ...options.output,
       format: options.output.format,


### PR DESCRIPTION
The current assignment to config.version will always cause the below `if (Object.keys(param.config).length === 0` to fail, as this causes `Object.keys` to always return an array starting with `'version'`

Description here... Help the reviewer by:
 - linking to an issue that includes more details
 - if it's a new feature include samples of how to use the new feature
 - (optional if issue link is provided) if you fixed a bug include basic bug details

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
