### PR TITLE
fix(js/plugins/compat-oai): keep provider baseURL on request-scoped clients; expose DeepSeek reasoning config

### DIFF
--- a/js/plugins/compat-oai/src/deepseek/deepseek.ts
+++ b/js/plugins/compat-oai/src/deepseek/deepseek.ts
@@ -22,16 +22,44 @@ import {
   compatOaiModelRef,
 } from '../model.js';
 
+const DeepSeekReasoningEffortSchema = z
+  .enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
+  .describe(
+    'How much effort the model spends thinking before answering. ' +
+      'Sent as the top-level `reasoning_effort` request field.'
+  );
+const DeepSeekThinkingSchema = z
+  .object({
+    type: z.enum(['adaptive', 'enabled', 'disabled']),
+  })
+  .describe(
+    'Whether the model thinks before answering: always (enabled), ' +
+      'never (disabled), or as needed (adaptive).'
+  );
+
 /** DeepSeek Custom configuration schema. */
 export const DeepSeekChatCompletionConfigSchema =
   ChatCompletionCommonConfigSchema.extend({
     maxTokens: z.number().int().min(1).max(8192).optional(),
+    reasoningEffort: DeepSeekReasoningEffortSchema.optional(),
+    thinking: DeepSeekThinkingSchema.optional(),
   });
 
+interface DeepSeekRequestFieldsBeyondOpenAISdk {
+  reasoning_effort?: z.infer<typeof DeepSeekReasoningEffortSchema>;
+  thinking?: z.infer<typeof DeepSeekThinkingSchema>;
+}
+
 export const deepSeekRequestBuilder: ModelRequestBuilder = (req, params) => {
-  const { maxTokens } = req.config;
+  const { maxTokens, reasoningEffort, thinking } = req.config as z.infer<
+    typeof DeepSeekChatCompletionConfigSchema
+  >;
   // DeepSeek still uses max_tokens
   params.max_tokens = maxTokens;
+  Object.assign(params, {
+    reasoning_effort: reasoningEffort,
+    thinking,
+  } satisfies DeepSeekRequestFieldsBeyondOpenAISdk);
 };
 
 /** DeepSeek ModelRef helper, with DeepSeek specific config. */

--- a/js/plugins/compat-oai/src/deepseek/index.ts
+++ b/js/plugins/compat-oai/src/deepseek/index.ts
@@ -36,6 +36,8 @@ import {
 
 export type DeepSeekPluginOptions = Omit<PluginOptions, 'name' | 'baseURL'>;
 
+export const DEEPSEEK_BASE_URL = 'https://api.deepseek.com';
+
 function createResolver(pluginOptions: PluginOptions) {
   return async (client: OpenAI, actionType: ActionType, actionName: string) => {
     if (actionType === 'model') {
@@ -86,12 +88,14 @@ export function deepSeekPlugin(
         'Please pass in the API key or set the DEEPSEEK_API_KEY environment variable.',
     });
   }
-  const pluginOptions = { name: 'deepseek', ...options };
-  return openAICompatible({
-    name: 'deepseek',
-    baseURL: 'https://api.deepseek.com',
-    apiKey,
+  const pluginOptions: PluginOptions = {
     ...options,
+    name: 'deepseek',
+    baseURL: DEEPSEEK_BASE_URL,
+    apiKey,
+  };
+  return openAICompatible({
+    ...pluginOptions,
     initializer: async (client) => {
       return Object.values(SUPPORTED_DEEPSEEK_MODELS).map((modelRef) =>
         defineCompatOpenAIModel({

--- a/js/plugins/compat-oai/src/utils.ts
+++ b/js/plugins/compat-oai/src/utils.ts
@@ -37,6 +37,7 @@ export function maybeCreateRequestScopedOpenAIClient(
   return new OpenAI({
     // if pluginOptions are not passed in we attempt to get options from the default client.
     ...(pluginOptions ?? defaultClient['_options']),
+    baseURL: pluginOptions?.baseURL ?? defaultClient.baseURL,
     apiKey: requestApiKey,
   });
 }

--- a/js/plugins/compat-oai/src/xai/index.ts
+++ b/js/plugins/compat-oai/src/xai/index.ts
@@ -41,6 +41,8 @@ import {
 
 export type XAIPluginOptions = Omit<PluginOptions, 'name' | 'baseURL'>;
 
+export const XAI_BASE_URL = 'https://api.x.ai/v1';
+
 function createResolver(pluginOptions: PluginOptions) {
   return async (client: OpenAI, actionType: ActionType, actionName: string) => {
     if (actionType === 'model') {
@@ -96,12 +98,14 @@ export function xAIPlugin(options?: XAIPluginOptions): GenkitPluginV2 {
         'Please pass in the API key or set the XAI_API_KEY environment variable.',
     });
   }
-  const pluginOptions = { name: 'xai', ...options };
-  return openAICompatible({
-    name: 'xai',
-    baseURL: 'https://api.x.ai/v1',
-    apiKey,
+  const pluginOptions: PluginOptions = {
     ...options,
+    name: 'xai',
+    baseURL: XAI_BASE_URL,
+    apiKey,
+  };
+  return openAICompatible({
+    ...pluginOptions,
     initializer: async (client) => {
       const models = [] as ResolvableAction[];
       models.push(

--- a/js/plugins/compat-oai/tests/request_scoped_client_test.ts
+++ b/js/plugins/compat-oai/tests/request_scoped_client_test.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { genkit } from 'genkit';
+import type { PluginOptions } from '../src';
+import { DEEPSEEK_BASE_URL, deepSeek } from '../src/deepseek';
+import { XAI_BASE_URL, xAI } from '../src/xai';
+
+type PluginFetch = NonNullable<PluginOptions['fetch']>;
+type PluginFetchResponse = Awaited<ReturnType<PluginFetch>>;
+
+const asPluginFetchResponse = (res: Response): PluginFetchResponse =>
+  res as unknown as PluginFetchResponse;
+
+describe('request-scoped clients keep the provider base URL', () => {
+  function recordingFetch(seen: string[]): PluginFetch {
+    return async (url) => {
+      seen.push(String(url));
+      return asPluginFetchResponse(
+        new Response(
+          JSON.stringify({
+            id: 'test',
+            object: 'chat.completion',
+            created: 0,
+            model: 'test-model',
+            choices: [
+              {
+                index: 0,
+                finish_reason: 'stop',
+                message: { role: 'assistant', content: 'ok' },
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      );
+    };
+  }
+
+  const cases = [
+    {
+      provider: 'deepseek',
+      baseURL: DEEPSEEK_BASE_URL,
+      model: 'deepseek/deepseek-chat',
+      plugin: (fetch: PluginFetch) => deepSeek({ apiKey: 'plugin-key', fetch }),
+    },
+    {
+      provider: 'xai',
+      baseURL: XAI_BASE_URL,
+      model: 'xai/grok-3',
+      plugin: (fetch: PluginFetch) => xAI({ apiKey: 'plugin-key', fetch }),
+    },
+  ];
+
+  for (const { provider, baseURL, model, plugin } of cases) {
+    it(`${provider}: a per-call apiKey does not redirect the request to OpenAI`, async () => {
+      const seen: string[] = [];
+      const ai = genkit({ plugins: [plugin(recordingFetch(seen))] });
+
+      await ai.generate({
+        model,
+        prompt: 'hi',
+        config: { apiKey: 'scoped-key' },
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toContain(new URL(baseURL).host);
+      expect(seen[0]).not.toContain('api.openai.com');
+    });
+
+    it(`${provider}: without a per-call apiKey the default client is used`, async () => {
+      const seen: string[] = [];
+      const ai = genkit({ plugins: [plugin(recordingFetch(seen))] });
+
+      await ai.generate({ model, prompt: 'hi' });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toContain(new URL(baseURL).host);
+    });
+  }
+});

--- a/js/plugins/compat-oai/tests/utils_test.ts
+++ b/js/plugins/compat-oai/tests/utils_test.ts
@@ -56,6 +56,46 @@ describe('modelName', () => {
   });
 });
 
+describe('maybeCreateRequestScopedOpenAIClient', () => {
+  const defaultClient = new OpenAI({
+    apiKey: 'plugin-key',
+    baseURL: 'https://provider.example/v1',
+  });
+  const request: GenerateRequest = {
+    messages: [],
+    config: { apiKey: 'scoped-key' },
+  };
+
+  it('returns the default client when no per-request apiKey is given', () => {
+    expect(
+      maybeCreateRequestScopedOpenAIClient(
+        { name: 'provider' },
+        { messages: [] },
+        defaultClient
+      )
+    ).toBe(defaultClient);
+  });
+
+  it('keeps the default client baseURL when pluginOptions omit it', () => {
+    const client = maybeCreateRequestScopedOpenAIClient(
+      { name: 'provider' },
+      request,
+      defaultClient
+    );
+    expect(client.baseURL).toBe('https://provider.example/v1');
+    expect(client.apiKey).toBe('scoped-key');
+  });
+
+  it('prefers an explicit pluginOptions baseURL', () => {
+    const client = maybeCreateRequestScopedOpenAIClient(
+      { name: 'provider', baseURL: 'https://override.example/v1' },
+      request,
+      defaultClient
+    );
+    expect(client.baseURL).toBe('https://override.example/v1');
+  });
+});
+
 // TODO, actionName
 
 describe('maybeCreateRequestScopedOpenAIClient', () => {


### PR DESCRIPTION
## Bug 1: per-call `config.apiKey` sends DeepSeek/xAI requests (and the key) to api.openai.com

Request-scoped clients — created when a call supplies `config.apiKey` — are rebuilt from the `pluginOptions` object, which `deepSeekPlugin` and `xAIPlugin` (identical code pattern) passed without `baseURL`:

```ts
const pluginOptions = { name: 'deepseek', ...options }; // no baseURL
```

The rebuilt client therefore fell back to the OpenAI SDK default, so the request — carrying the caller's DeepSeek/xAI API key — was sent to `https://api.openai.com`. Besides failing, this leaks the provider key to a third party.

**Fix, two layers:**
1. Both affected plugins now derive the `openAICompatible` arguments and `pluginOptions` from one object that always carries the provider `baseURL`, so the two can't drift. `DEEPSEEK_BASE_URL` / `XAI_BASE_URL` are exported and used by the regression test.
2. `maybeCreateRequestScopedOpenAIClient` is hardened to inherit the default client's `baseURL` when `pluginOptions` omit it — a request-scoped client can never silently point at a different host than the client it derives from, closing this bug class for future plugins too.

**Tests:** `request_scoped_client_test.ts` drives the real plugins with a recording `fetch` (without the fix: `https://api.openai.com/v1/chat/completions`; with it: the provider host), and `utils_test.ts` covers the client-rebuild guard directly. Also verified live against the real DeepSeek API: plugin constructed with a bogus key, real key on `config.apiKey`, request succeeds against `api.deepseek.com`.

## Bug 2: DeepSeek config schema has no reasoning controls

The response side already surfaces `reasoning_content`, but `DeepSeekChatCompletionConfigSchema` exposed no way to control it. This adds `reasoningEffort` and `thinking` to the schema and request builder, with `.describe()` docs surfaced in the Dev UI.

DeepSeek's own docs contradict each other on where `reasoning_effort` lives (API reference says nested under `thinking`, reasoning guide says top-level), so the enums were verified against the API's request validation, empirically:

- `reasoning_effort` (top-level): `none | minimal | low | medium | high | xhigh | max` — nested inside `thinking` it is silently ignored
- `thinking.type`: `adaptive | enabled | disabled`

The extra fields are typed via a schema-inferred interface and applied with a `satisfies`-checked `Object.assign` — no `any` casts (per review feedback). Validated live: `reasoningEffort` scales reasoning token usage; `thinking: { type: 'disabled' }` yields no reasoning content.

## Checklist
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested: 7 new unit tests (104 total pass in compat-oai), plus live validation against the real DeepSeek and OpenAI APIs
- [x] Docs updated: new config fields carry `.describe()` documentation (Dev UI); the genkit.dev DeepSeek integration page lives outside this repo and can be updated once this merges