### PR TITLE
feat(js): enable OTel logs feature (remove GENKIT_OTEL_ENABLE_LOGS flag)

### DIFF
--- a/js/core/src/logging.ts
+++ b/js/core/src/logging.ts
@@ -56,10 +56,6 @@ class Logger {
     explicitBody?: string,
     explicitAttributes?: Record<string, any>
   ) {
-    if (process.env.GENKIT_OTEL_ENABLE_LOGS !== 'true') {
-      return;
-    }
-
     try {
       const currentLevel = getLogger().level;
       if (

--- a/js/core/src/tracing/node-telemetry-provider.ts
+++ b/js/core/src/tracing/node-telemetry-provider.ts
@@ -77,16 +77,14 @@ async function enableTelemetry(
   nodeOtelConfig.spanProcessors = processors;
 
   // Add LogRecordProcessors
-  if (process.env.GENKIT_OTEL_ENABLE_LOGS === 'true') {
-    const enableRealTimeTelemetry =
-      process.env.GENKIT_ENABLE_REALTIME_TELEMETRY === 'true';
-    const logExporter = new LogServerExporter();
-    const logProcessor: LogRecordProcessor =
-      isDevEnv() || enableRealTimeTelemetry
-        ? new SimpleLogRecordProcessor(logExporter)
-        : new BatchLogRecordProcessor(logExporter);
-    nodeOtelConfig.logRecordProcessor = logProcessor;
-  }
+  const enableRealTimeTelemetry =
+    process.env.GENKIT_ENABLE_REALTIME_TELEMETRY === 'true';
+  const logExporter = new LogServerExporter();
+  const logProcessor: LogRecordProcessor =
+    isDevEnv() || enableRealTimeTelemetry
+      ? new SimpleLogRecordProcessor(logExporter)
+      : new BatchLogRecordProcessor(logExporter);
+  nodeOtelConfig.logRecordProcessor = logProcessor;
 
   telemetrySDK = new NodeSDK(nodeOtelConfig);
   telemetrySDK.start();

--- a/js/core/src/tracing/node-telemetry-provider.ts
+++ b/js/core/src/tracing/node-telemetry-provider.ts
@@ -80,11 +80,19 @@ async function enableTelemetry(
   const enableRealTimeTelemetry =
     process.env.GENKIT_ENABLE_REALTIME_TELEMETRY === 'true';
   const logExporter = new LogServerExporter();
-  const logProcessor: LogRecordProcessor =
+  const defaultLogProcessor: LogRecordProcessor =
     isDevEnv() || enableRealTimeTelemetry
       ? new SimpleLogRecordProcessor(logExporter)
       : new BatchLogRecordProcessor(logExporter);
-  nodeOtelConfig.logRecordProcessor = logProcessor;
+
+  if (nodeOtelConfig.logRecordProcessor) {
+    nodeOtelConfig.logRecordProcessor = new MultiLogRecordProcessor([
+      nodeOtelConfig.logRecordProcessor,
+      defaultLogProcessor,
+    ]);
+  } else {
+    nodeOtelConfig.logRecordProcessor = defaultLogProcessor;
+  }
 
   telemetrySDK = new NodeSDK(nodeOtelConfig);
   telemetrySDK.start();
@@ -141,4 +149,22 @@ async function flushTracing() {
     promises.push(nodeOtelConfig.logRecordProcessor.forceFlush());
   }
   await Promise.all(promises);
+}
+
+class MultiLogRecordProcessor implements LogRecordProcessor {
+  constructor(private readonly processors: LogRecordProcessor[]) {}
+
+  async forceFlush(): Promise<void> {
+    await Promise.all(this.processors.map((p) => p.forceFlush()));
+  }
+
+  onEmit(logRecord: any, context?: any): void {
+    for (const processor of this.processors) {
+      processor.onEmit(logRecord, context);
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all(this.processors.map((p) => p.shutdown()));
+  }
 }


### PR DESCRIPTION
Remove the GENKIT_OTEL_ENABLE_LOGS feature flag. Also fixed a bug where we were unconditionally overwriting nodeOtelConfig.logRecordProcessor and losing any custom log record processors configured by the user in telemetryConfig.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
