### PR TITLE
feat(py): add agents conformance test harness

### DIFF
--- a/docs/agents-conformance-testing.md
+++ b/docs/agents-conformance-testing.md
@@ -49,8 +49,8 @@ Sends inputs to the agent via its bidirectional streaming interface (e.g.
 | `expectOutput` | Object | Expected fields on the `AgentOutput`. See [Output Assertions](#output-assertions). |
 | `expectError` | Object | Optional. Asserts the turn *throws* (rather than resolving with a graceful `finishReason: 'failed'` output). Used for API-misuse cases (e.g. sending `state` to a server-managed agent). Fields: `status` (matched exactly) and `message` (matched as a substring). Mutually exclusive with `expectOutput`. |
 | `captureSnapshotId` | `string` | Optional. Stores `output.snapshotId` under this name for use in later steps via `{{name}}`. |
-
 | `captureState` | `string` | Optional. Stores `output.state` under this name for use in later steps via `{{name}}`. |
+| `captureSessionId` | `string` | Optional. Stores `output.state.sessionId` under this name for use in later steps via `{{name}}`. |
 
 #### `getSnapshotData`
 
@@ -75,11 +75,11 @@ Aborts an agent by snapshot ID.
 |-------|------|-------------|
 | `type` | `"abort"` | Required. |
 | `snapshotId` | `string` | The snapshot ID to abort. Supports `{{name}}` references. |
-| `expectPreviousStatus` | `string` | Expected previous status before abort (e.g. `"pending"`, `"done"`). |
+| `expectPreviousStatus` | `string` | Expected previous status before abort (e.g. `"pending"`, `"completed"`). YAML `~` means absent. |
 
 #### `waitUntilCompleted`
 
-Polls a snapshot until it reaches a terminal status (`done`, `failed`, or
+Polls a snapshot until it reaches a terminal status (`completed`, `failed`, or
 `aborted`).
 
 | Field | Type | Description |
@@ -99,6 +99,7 @@ Used in `expectOutput` for `send` steps.
 |-------|------|-------------|
 | `message` | `MessageData` | If present, `output.message` must deep-equal this value. |
 | `hasSnapshotId` | `boolean` | If `true`, asserts `output.snapshotId` is a non-empty string. |
+| `hasSessionId` | `boolean` | If `true`, asserts `output.state.sessionId` is a non-empty string. |
 | `stateContains` | `SessionState` (partial) | If present, asserts that `output.state` contains (at minimum) these fields. Uses "contains" / subset matching — the actual state may have additional fields. |
 | `artifactsContain` | `Artifact[]` | If present, asserts that `output.artifacts` contains (at minimum) these entries. |
 | `finishReason` | `string` | If present, `output.finishReason` must equal this value exactly (e.g. `stop` on a normal completion, `interrupted` on a tool pause, `failed` on a graceful failure). |
@@ -113,7 +114,7 @@ steps.
 | Field | Type | Description |
 |-------|------|-------------|
 | `parentId` | `string` | Expected `parentId`. Supports `{{name}}` references. |
-| `status` | `string` | Expected `status` (e.g. `"done"`, `"pending"`, `"failed"`, `"aborted"`). |
+| `status` | `string` | Expected `status` (e.g. `"completed"`, `"pending"`, `"failed"`, `"aborted"`). |
 | `finishReason` | `string` | Expected `snapshot.finishReason` (e.g. `failed`). Distinct from `status` — a failed run records `finishReason: failed` in addition to `status: failed`. |
 | `hasSessionId` | `boolean` | If `true`, asserts `snapshot.state.sessionId` is a non-empty string. |
 | `stateContains` | `SessionState` (partial) | Subset match on `snapshot.state`. |
@@ -130,6 +131,7 @@ values:
 
 - `captureSnapshotId: snap1` → captures `output.snapshotId` as `snap1`
 - `captureState: state1` → captures `output.state` as `state1`
+- `captureSessionId: sess1` → captures `output.state.sessionId` as `sess1`
 
 These can be used anywhere a `snapshotId` or `state` is expected in subsequent
 steps:
@@ -154,6 +156,7 @@ Only simple `{{name}}` syntax is supported — no dot-paths or expressions.
 | `artifactsContain` | **Partial**: each specified artifact must be present (matched by name). |
 | `message` | **Strict**: deep-equality on the message object. |
 | `hasSnapshotId` | **Boolean**: asserts presence of a non-empty string. |
+| `hasSessionId` | **Boolean**: asserts `state.sessionId` is a non-empty string. |
 
 ---
 
@@ -233,9 +236,19 @@ cd js/ai
 npx tsx --test tests/agents_spec_test.ts
 ```
 
-### Go ⏳
+### Python ✅
 
-_(Coming soon — implement a Go harness that reads the same YAML spec.)_
+```bash
+cd py
+uv run pytest packages/genkit/tests/genkit/ai/agent_conformance_test.py
+```
+
+### Go ✅
+
+```bash
+cd go
+go test ./ai/exp/ -run TestAgentConformance
+```
 
 ---
 

--- a/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
@@ -52,13 +52,11 @@ from genkit._core._typing import (
     AgentInit,
     AgentInput,
     AgentResult,
-    AgentStreamChunk,
     Artifact,
     MessageData,
     Part,
     Role,
     TextPart,
-    TurnEnd,
 )
 from genkit.agent import Agent
 
@@ -409,24 +407,12 @@ def assert_chunks(*, actual_chunks: list[Any], expected_chunks: list[Any]) -> No
             assert 'turnEnd' in got, f'Chunk {i}: expected turnEnd, got {got!r}'
             turn_end = expected['turnEnd']
             if isinstance(turn_end, dict) and 'finishReason' in turn_end:
-                # Pydantic json dumps drop None even when the field was set, so
-                # omitted vs null is model_fields_set, not exclude_unset.
+                # Omitted and explicit-null serialize the same (the key is
+                # dropped), so treat them as one optional field.
                 te_model = actual_chunks[i].turn_end
                 want_fr = turn_end['finishReason']
-                if want_fr is None:
-                    set_null = (
-                        te_model is not None
-                        and 'finish_reason' in te_model.model_fields_set
-                        and te_model.finish_reason is None
-                    )
-                    assert set_null, (
-                        f'Chunk {i}: expected turnEnd.finishReason null, '
-                        f'fields_set={getattr(te_model, "model_fields_set", None)!r} '
-                        f'value={getattr(te_model, "finish_reason", None)!r}'
-                    )
-                else:
-                    got_fr = te_model.finish_reason if te_model is not None else None
-                    assert got_fr == want_fr, f'Chunk {i}: expected turnEnd.finishReason {want_fr!r}, got {got_fr!r}'
+                got_fr = te_model.finish_reason if te_model is not None else None
+                assert got_fr == want_fr, f'Chunk {i}: expected turnEnd.finishReason {want_fr!r}, got {got_fr!r}'
         elif 'modelChunk' in expected:
             assert_contains(
                 actual=got.get('modelChunk'), expected=expected['modelChunk'], path=f'chunk[{i}].modelChunk'
@@ -804,17 +790,3 @@ def test_snapshot_error_contains_is_exact_message() -> None:
         snap={'error': {'status': 'INTERNAL', 'message': 'intentional failure'}},
         expect={'errorContains': {'message': 'intentional failure'}},
     )
-
-
-def test_assert_chunks_pins_null_finish_reason() -> None:
-    chunks = [AgentStreamChunk(turn_end=TurnEnd(finish_reason=AgentFinishReason.STOP))]
-    with pytest.raises(AssertionError, match='finishReason'):
-        assert_chunks(actual_chunks=chunks, expected_chunks=[{'turnEnd': {'finishReason': None}}])
-    assert_chunks(actual_chunks=chunks, expected_chunks=[{'turnEnd': {}}])
-
-    omitted = [AgentStreamChunk(turn_end=TurnEnd())]
-    with pytest.raises(AssertionError, match='finishReason null'):
-        assert_chunks(actual_chunks=omitted, expected_chunks=[{'turnEnd': {'finishReason': None}}])
-
-    explicit_null = [AgentStreamChunk(turn_end=TurnEnd.model_validate({'finishReason': None}))]
-    assert_chunks(actual_chunks=explicit_null, expected_chunks=[{'turnEnd': {'finishReason': None}}])

--- a/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
@@ -907,6 +907,7 @@ def test_abort_keeps_explicit_null_previous_status() -> None:
     assert 'expectPreviousStatus' in dumped
     assert dumped['expectPreviousStatus'] is None
     resolved = resolve_step(step=step, captures={})
+    assert isinstance(resolved, AbortStep)
     assert field_was_set(model=resolved, name='expect_previous_status')
     assert resolved.expect_previous_status is None
 

--- a/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
@@ -30,12 +30,13 @@ import json
 import pathlib
 import re
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeVar
 
 import pytest
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from pydantic.alias_generators import to_camel
 
 from genkit._ai._agents._runtime import SessionRunner
@@ -82,17 +83,61 @@ def spec_path() -> pathlib.Path:
 
 
 class SpecModel(BaseModel):
-    model_config = ConfigDict(extra='ignore', populate_by_name=True, alias_generator=to_camel)
+    # Forbid unknown keys so a typo in agent.yaml fails at load, not as a skip.
+    model_config = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
+
+
+class SpecInit(SpecModel):
+    """Send init. ``state`` stays untyped — it can be an object or ``{{state1}}``."""
+
+    session_id: str | None = None
+    snapshot_id: str | None = None
+    state: Any | None = None
+
+
+class SpecInput(SpecModel):
+    detach: bool | None = None
+    message: dict[str, Any] | None = None
+    resume: dict[str, Any] | None = None
+
+
+class TurnEndExpect(SpecModel):
+    finish_reason: str | None = None
+    snapshot_id: str | None = None
+
+
+class ExpectChunk(SpecModel):
+    turn_end: TurnEndExpect | None = None
+    model_chunk: dict[str, Any] | None = None
+    artifact: dict[str, Any] | None = None
+    custom_patch: Any | None = None
+
+    @model_validator(mode='after')
+    def exactly_one_payload(self) -> ExpectChunk:
+        kinds = [n for n in ('turn_end', 'model_chunk', 'artifact', 'custom_patch') if n in self.model_fields_set]
+        if len(kinds) != 1:
+            raise ValueError('expectChunks item must have exactly one of turnEnd, modelChunk, artifact, customPatch')
+        return self
+
+
+class PartialState(SpecModel):
+    """Subset match on session state. Extra keys are allowed so the spec can grow."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    session_id: str | None = None
+    messages: list[Any] | None = None
+    custom: Any | None = None
+    artifacts: list[Any] | None = None
 
 
 class OutputAssertions(SpecModel):
-    message: Any | None = None
+    message: dict[str, Any] | None = None
     has_snapshot_id: bool | None = None
     has_session_id: bool | None = None
-    state_contains: Any | None = None
-    artifacts_contain: list[Any] | None = None
+    state_contains: PartialState | None = None
+    artifacts_contain: list[dict[str, Any]] | None = None
     finish_reason: str | None = None
-    error_contains: Any | None = None
+    error_contains: dict[str, Any] | None = None
 
 
 class SnapshotAssertions(SpecModel):
@@ -100,8 +145,8 @@ class SnapshotAssertions(SpecModel):
     status: str | None = None
     finish_reason: str | None = None
     has_session_id: bool | None = None
-    state_contains: Any | None = None
-    error_contains: Any | None = None
+    state_contains: PartialState | None = None
+    error_contains: dict[str, Any] | None = None
 
 
 class SendExpectError(SpecModel):
@@ -111,11 +156,11 @@ class SendExpectError(SpecModel):
 
 class SendStep(SpecModel):
     type: Literal['send']
-    init: Any | None = None
-    inputs: list[Any] | None = None
-    model_responses: list[Any] | None = None
-    stream_chunks: list[list[Any]] | None = None
-    expect_chunks: list[Any] | None = None
+    init: SpecInit | None = None
+    inputs: list[SpecInput] | None = None
+    model_responses: list[dict[str, Any]] | None = None
+    stream_chunks: list[list[dict[str, Any]]] | None = None
+    expect_chunks: list[ExpectChunk] | None = None
     expect_output: OutputAssertions | None = None
     expect_error: SendExpectError | None = None
     capture_snapshot_id: str | None = None
@@ -312,6 +357,14 @@ def assert_pinned_scalar(*, live: Any, expect_model: BaseModel, name: str, path:
     assert got == want, f'{path}: expected {want!r}, got {got!r}'
 
 
+def assert_has_id(*, actual: Any, want: bool, path: str) -> None:  # noqa: ANN401
+    present = isinstance(actual, str) and bool(actual)
+    if want:
+        assert present, f'Expected {path} to be a non-empty string, got: {actual!r}'
+    else:
+        assert not present, f'Expected {path} to be absent, got: {actual!r}'
+
+
 # ---------------------------------------------------------------------------
 # Harness setup
 # ---------------------------------------------------------------------------
@@ -333,6 +386,24 @@ class RestartOutput(BaseModel):
     result: str
 
 
+@dataclass(frozen=True)
+class PromptAgentDef:
+    name: str
+    tools: tuple[str, ...] = ()
+    store: bool = False
+
+
+PROMPT_AGENTS = (
+    PromptAgentDef(name='promptAgent'),
+    PromptAgentDef(name='promptAgentWithStore', store=True),
+    PromptAgentDef(name='promptAgentWithTools', tools=('testTool',)),
+    PromptAgentDef(name='promptAgentWithInterrupt', tools=('interruptTool',), store=True),
+    PromptAgentDef(name='promptAgentWithRestartTool', tools=('restartTool',), store=True),
+)
+
+TurnBody = Callable[[SessionRunner, ActionRunContext, AgentInput, TurnContext], Awaitable[None]]
+
+
 @dataclass
 class Harness:
     ai: Genkit
@@ -344,9 +415,13 @@ def setup_harness() -> Harness:
     ai = Genkit()
     pm, _ = define_programmable_model(ai)
     h = Harness(ai=ai, pm=pm)
+    _register_tools(ai=ai)
+    _register_prompt_agents(ai=ai, agents=h.agents)
+    _register_custom_agents(ai=ai, agents=h.agents)
+    return h
 
-    # --- Tools ---
 
+def _register_tools(*, ai: Genkit) -> None:
     @ai.tool(name='testTool', description='A simple test tool')
     async def test_tool(_: dict) -> str:  # noqa: ARG001
         return 'tool called'
@@ -366,70 +441,86 @@ def setup_harness() -> Harness:
             raise Interrupt({'requiresConfirmation': True})
         return RestartOutput(result=f'confirmed: {input.action}')
 
-    # --- Prompt-backed agents ---
 
-    h.agents['promptAgent'] = ai.define_agent(
-        name='promptAgent',
-        model='programmableModel',
-        config={'temperature': 1},
-    )
-    h.agents['promptAgentWithStore'] = ai.define_agent(
-        name='promptAgentWithStore',
-        model='programmableModel',
-        config={'temperature': 1},
-        store=InMemorySessionStore(),
-    )
-    h.agents['promptAgentWithTools'] = ai.define_agent(
-        name='promptAgentWithTools',
-        model='programmableModel',
-        config={'temperature': 1},
-        tools=['testTool'],
-    )
-    h.agents['promptAgentWithInterrupt'] = ai.define_agent(
-        name='promptAgentWithInterrupt',
-        model='programmableModel',
-        config={'temperature': 1},
-        tools=['interruptTool'],
-        store=InMemorySessionStore(),
-    )
-    h.agents['promptAgentWithRestartTool'] = ai.define_agent(
-        name='promptAgentWithRestartTool',
-        model='programmableModel',
-        config={'temperature': 1},
-        tools=['restartTool'],
-        store=InMemorySessionStore(),
-    )
+def _register_prompt_agents(*, ai: Genkit, agents: dict[str, Agent]) -> None:
+    for spec in PROMPT_AGENTS:
+        agents[spec.name] = ai.define_agent(
+            name=spec.name,
+            model='programmableModel',
+            config={'temperature': 1},
+            tools=list(spec.tools) if spec.tools else None,
+            store=InMemorySessionStore() if spec.store else None,
+        )
 
-    # --- Custom agents ---
 
-    def run_turns(*, turn_body):  # noqa: ANN001, ANN202 - AgentFn factory
-        """Wrap a per-turn body into the canonical custom AgentFn shape."""
+def _run_turns(*, turn_body: TurnBody) -> Callable[[SessionRunner, ActionRunContext], Awaitable[AgentResult]]:
+    """Wrap a per-turn body into the canonical custom AgentFn shape."""
 
-        async def agent_fn(session_runner: SessionRunner, ctx: ActionRunContext) -> AgentResult:
-            async def handle_turn(inp: AgentInput, turn_ctx: TurnContext) -> TurnResult | None:
-                await turn_body(session_runner, ctx, inp, turn_ctx)
-                return TurnResult(finish_reason=AgentFinishReason.STOP)
+    async def agent_fn(session_runner: SessionRunner, ctx: ActionRunContext) -> AgentResult:
+        async def handle_turn(inp: AgentInput, turn_ctx: TurnContext) -> TurnResult | None:
+            await turn_body(session_runner, ctx, inp, turn_ctx)
+            return TurnResult(finish_reason=AgentFinishReason.STOP)
 
-            await session_runner.run(handle_turn)
-            return await session_runner.result()
+        await session_runner.run(handle_turn)
+        return await session_runner.result()
 
-        return agent_fn
+    return agent_fn
 
-    # customAgentBlocking: server-managed, blocks until the abort signal fires.
-    async def blocking_turn(sr: SessionRunner, ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
-        await ctx.abort_signal.wait()
-        await sr.add_messages([_model_text(text='unblocked')])
 
-    h.agents['customAgentBlocking'] = ai.define_custom_agent(
-        name='customAgentBlocking',
-        fn=run_turns(turn_body=blocking_turn),
-        store=InMemorySessionStore(),
-    )
+async def _blocking_turn(sr: SessionRunner, ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+    await ctx.abort_signal.wait()
+    await sr.add_messages([_model_text(text='unblocked')])
 
-    # customAgentFailing: server-managed; the turn raises on purpose.
-    # Raise inside the turn callback so run() records last_turn_error, then
-    # return session_runner.result() so an attached caller gets a graceful
-    # failed output. The snapshot write comes from that recorded error.
+
+async def _artifacts_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+    await sr.add_artifacts([Artifact(name='doc1', parts=[Part(root=TextPart(text='v1'))])])
+    await sr.add_artifacts([Artifact(name='doc1', parts=[Part(root=TextPart(text='v2'))])])
+    await sr.add_artifacts([Artifact(name='doc2', parts=[Part(root=TextPart(text='other'))])])
+    await sr.add_messages([_model_text(text='done')])
+
+
+async def _counter_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+    prev = await sr.get_custom() or {}
+    counter = (prev.get('counter') or 0) + 1
+    await sr.update_custom(lambda _prev: {'counter': counter})
+    await sr.add_messages([_model_text(text='done')])
+
+
+async def _multi_custom_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+    # First patch is a whole-doc replace; later ones are incremental diffs.
+    await sr.update_custom(lambda _prev: {'counter': 1, 'status': 'working'})
+    await sr.update_custom(lambda prev: {**(prev or {}), 'counter': 2})
+    await sr.update_custom(lambda prev: {**(prev or {}), 'status': 'done'})
+    await sr.add_messages([_model_text(text='done')])
+
+
+async def _artifacts_store_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+    existing = await sr.get_artifacts()
+    count = len(existing) + 1
+    await sr.add_artifacts([Artifact(name=f'doc{count}', parts=[Part(root=TextPart(text=f'content{count}'))])])
+    await sr.add_messages([_model_text(text='done')])
+
+
+CUSTOM_TURN_AGENTS: tuple[tuple[str, TurnBody, bool], ...] = (
+    ('customAgentBlocking', _blocking_turn, True),
+    ('customAgentWithArtifacts', _artifacts_turn, False),
+    ('customAgentWithCustomState', _counter_turn, False),
+    ('customAgentWithMultiCustomState', _multi_custom_turn, False),
+    ('customAgentWithArtifactsStore', _artifacts_store_turn, True),
+    ('customAgentWithCustomStateStore', _counter_turn, True),
+)
+
+
+def _register_custom_agents(*, ai: Genkit, agents: dict[str, Agent]) -> None:
+    for name, turn, store in CUSTOM_TURN_AGENTS:
+        agents[name] = ai.define_custom_agent(
+            name=name,
+            fn=_run_turns(turn_body=turn),
+            store=InMemorySessionStore() if store else None,
+        )
+
+    # Raise inside the turn so run() records last_turn_error, then return
+    # result() so an attached caller gets a graceful failed output.
     async def failing_agent_fn(session_runner: SessionRunner, _ctx: ActionRunContext) -> AgentResult:
         async def handle_turn(_inp: AgentInput, _tc: TurnContext) -> TurnResult | None:
             raise RuntimeError('intentional failure')
@@ -437,73 +528,11 @@ def setup_harness() -> Harness:
         await session_runner.run(handle_turn)
         return await session_runner.result()
 
-    h.agents['customAgentFailing'] = ai.define_custom_agent(
+    agents['customAgentFailing'] = ai.define_custom_agent(
         name='customAgentFailing',
         fn=failing_agent_fn,
         store=InMemorySessionStore(),
     )
-
-    # customAgentWithArtifacts: client-managed, adds and updates artifacts.
-    async def artifacts_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
-        await sr.add_artifacts([Artifact(name='doc1', parts=[Part(root=TextPart(text='v1'))])])
-        await sr.add_artifacts([Artifact(name='doc1', parts=[Part(root=TextPart(text='v2'))])])
-        await sr.add_artifacts([Artifact(name='doc2', parts=[Part(root=TextPart(text='other'))])])
-        await sr.add_messages([_model_text(text='done')])
-
-    h.agents['customAgentWithArtifacts'] = ai.define_custom_agent(
-        name='customAgentWithArtifacts',
-        fn=run_turns(turn_body=artifacts_turn),
-    )
-
-    # customAgentWithCustomState: client-managed, increments a counter per turn.
-    async def counter_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
-        prev = await sr.get_custom() or {}
-        counter = (prev.get('counter') or 0) + 1
-        await sr.update_custom(lambda _prev: {'counter': counter})
-        await sr.add_messages([_model_text(text='done')])
-
-    h.agents['customAgentWithCustomState'] = ai.define_custom_agent(
-        name='customAgentWithCustomState',
-        fn=run_turns(turn_body=counter_turn),
-    )
-
-    # customAgentWithMultiCustomState: several sequential custom-state updates
-    # within one turn (first patch = whole-doc replace, then incremental diffs).
-    async def multi_custom_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
-        await sr.update_custom(lambda _prev: {'counter': 1, 'status': 'working'})
-        await sr.update_custom(lambda prev: {**(prev or {}), 'counter': 2})
-        await sr.update_custom(lambda prev: {**(prev or {}), 'status': 'done'})
-        await sr.add_messages([_model_text(text='done')])
-
-    h.agents['customAgentWithMultiCustomState'] = ai.define_custom_agent(
-        name='customAgentWithMultiCustomState',
-        fn=run_turns(turn_body=multi_custom_turn),
-    )
-
-    # customAgentWithArtifactsStore: server-managed, adds a numbered artifact
-    # on each invocation.
-    async def artifacts_store_turn(
-        sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext
-    ) -> None:
-        existing = await sr.get_artifacts()
-        count = len(existing) + 1
-        await sr.add_artifacts([Artifact(name=f'doc{count}', parts=[Part(root=TextPart(text=f'content{count}'))])])
-        await sr.add_messages([_model_text(text='done')])
-
-    h.agents['customAgentWithArtifactsStore'] = ai.define_custom_agent(
-        name='customAgentWithArtifactsStore',
-        fn=run_turns(turn_body=artifacts_store_turn),
-        store=InMemorySessionStore(),
-    )
-
-    # customAgentWithCustomStateStore: server-managed counter.
-    h.agents['customAgentWithCustomStateStore'] = ai.define_custom_agent(
-        name='customAgentWithCustomStateStore',
-        fn=run_turns(turn_body=counter_turn),
-        store=InMemorySessionStore(),
-    )
-
-    return h
 
 
 # ---------------------------------------------------------------------------
@@ -527,38 +556,35 @@ def program_model(*, pm: ProgrammableModel, step: SendStep) -> None:
         ]
 
 
-def assert_chunks(*, actual_chunks: list[Any], expected_chunks: list[Any]) -> None:
+def assert_chunks(*, actual_chunks: list[Any], expected_chunks: list[ExpectChunk]) -> None:
     """Strict ordered chunk comparison per the spec's expectChunks contract."""
     actual = [dump(model=c) for c in actual_chunks]
+    expected_dump = [dump(model=c) for c in expected_chunks]
     assert len(actual) == len(expected_chunks), (
         f'Expected {len(expected_chunks)} chunks, got {len(actual)}.\n'
         f'  Actual: {actual!r}\n'
-        f'  Expected: {expected_chunks!r}'
+        f'  Expected: {expected_dump!r}'
     )
     for i, expected in enumerate(expected_chunks):
         got = actual[i]
-        if 'turnEnd' in expected:
+        if field_was_set(model=expected, name='turn_end'):
             # turnEnd carries a dynamic snapshotId; only assert presence, plus
             # finishReason exactly when the spec pins it (key present, including YAML ~).
             assert 'turnEnd' in got, f'Chunk {i}: expected turnEnd, got {got!r}'
-            turn_end = expected['turnEnd']
-            if isinstance(turn_end, dict) and 'finishReason' in turn_end:
+            turn_end = expected.turn_end
+            if turn_end is not None and field_was_set(model=turn_end, name='finish_reason'):
                 te_model = actual_chunks[i].turn_end
-                want_fr = turn_end['finishReason']
+                want_fr = turn_end.finish_reason
                 got_fr = wire_scalar(live=te_model.finish_reason if te_model is not None else None)
                 assert got_fr == want_fr, f'Chunk {i}: expected turnEnd.finishReason {want_fr!r}, got {got_fr!r}'
-        elif 'modelChunk' in expected:
-            assert_contains(
-                actual=got.get('modelChunk'), expected=expected['modelChunk'], path=f'chunk[{i}].modelChunk'
-            )
-        elif 'artifact' in expected:
-            assert_contains(actual=got.get('artifact'), expected=expected['artifact'], path=f'chunk[{i}].artifact')
-        elif 'customPatch' in expected:
-            assert_contains(
-                actual=got.get('customPatch'), expected=expected['customPatch'], path=f'chunk[{i}].customPatch'
-            )
+        elif field_was_set(model=expected, name='model_chunk'):
+            assert_contains(actual=got.get('modelChunk'), expected=expected.model_chunk, path=f'chunk[{i}].modelChunk')
+        elif field_was_set(model=expected, name='artifact'):
+            assert_contains(actual=got.get('artifact'), expected=expected.artifact, path=f'chunk[{i}].artifact')
         else:
-            assert_contains(actual=got, expected=expected, path=f'chunk[{i}]')
+            assert_contains(
+                actual=got.get('customPatch'), expected=expected.custom_patch, path=f'chunk[{i}].customPatch'
+            )
 
 
 def assert_output(*, output: AgentOutput, expect: OutputAssertions) -> None:
@@ -568,21 +594,16 @@ def assert_output(*, output: AgentOutput, expect: OutputAssertions) -> None:
         # spec that pins only content still matches a live message that has role.
         assert_contains(actual=out.get('message'), expected=expect.message, path='output.message')
 
-    if expect.has_snapshot_id:
-        assert isinstance(out.get('snapshotId'), str) and out['snapshotId'], (
-            f'Expected output to have a snapshotId, got: {out.get("snapshotId")!r}'
-        )
+    if field_was_set(model=expect, name='has_snapshot_id'):
+        assert_has_id(actual=out.get('snapshotId'), want=bool(expect.has_snapshot_id), path='output.snapshotId')
 
-    if expect.has_session_id:
-        state = out.get('state')
-        assert state, 'Expected output to have state for sessionId check'
-        assert isinstance(state.get('sessionId'), str) and state['sessionId'], (
-            f'Expected output.state to have a sessionId, got: {state.get("sessionId")!r}'
-        )
+    if field_was_set(model=expect, name='has_session_id'):
+        state = out.get('state') or {}
+        assert_has_id(actual=state.get('sessionId'), want=bool(expect.has_session_id), path='output.state.sessionId')
 
     if expect.state_contains is not None:
         assert out.get('state') is not None, 'Expected output to have state'
-        assert_contains(actual=out['state'], expected=expect.state_contains, path='output.state')
+        assert_contains(actual=out['state'], expected=dump(model=expect.state_contains), path='output.state')
 
     if expect.artifacts_contain is not None:
         artifacts = out.get('artifacts')
@@ -628,13 +649,15 @@ def assert_snapshot(*, snap: SessionSnapshotSchema, expect: SnapshotAssertions) 
         name='finish_reason',
         path='snapshot.finishReason',
     )
-    if expect.has_session_id:
+    if field_was_set(model=expect, name='has_session_id'):
         state = dumped.get('state') or {}
-        assert isinstance(state.get('sessionId'), str) and state['sessionId'], (
-            f'Expected snapshot.state to have a sessionId, got: {state.get("sessionId")!r}'
+        assert_has_id(
+            actual=state.get('sessionId'),
+            want=bool(expect.has_session_id),
+            path='snapshot.state.sessionId',
         )
     if expect.state_contains is not None:
-        assert_contains(actual=dumped.get('state'), expected=expect.state_contains, path='snapshot.state')
+        assert_contains(actual=dumped.get('state'), expected=dump(model=expect.state_contains), path='snapshot.state')
     if expect.error_contains is not None:
         err = dumped.get('error')
         assert err, 'Expected snapshot to have error'
@@ -651,7 +674,9 @@ async def _close_quietly(*, conn: Any) -> None:  # noqa: ANN401
 
 
 def _thrown_message(*, thrown: BaseException) -> str:
-    """The string the caller sees, including a ``STATUS: `` prefix on GenkitError."""
+    """``STATUS: text`` for a GenkitError — the status prefix, not a cause suffix."""
+    if isinstance(thrown, GenkitError):
+        return f'{thrown.status}: {thrown.original_message}'
     return str(thrown)
 
 
@@ -676,11 +701,15 @@ async def execute_send(*, agent: Agent, pm: ProgrammableModel, step: SendStep, c
 
     async def run_turn() -> tuple[list[Any], AgentOutput]:
         conn = await agent.stream_bidi(
-            validate_wire(model_type=AgentInit, data=resolved.init or {}, path='init'),
+            validate_wire(
+                model_type=AgentInit,
+                data=dump(model=resolved.init) if resolved.init is not None else {},
+                path='init',
+            ),
         )
         try:
             for i, inp in enumerate(resolved.inputs or []):
-                await conn.send(validate_wire(model_type=AgentInput, data=inp, path=f'inputs[{i}]'))
+                await conn.send(validate_wire(model_type=AgentInput, data=dump(model=inp), path=f'inputs[{i}]'))
             await conn.close()
             chunks = [c async for c in conn.receive()]
             output = await conn.output()
@@ -829,6 +858,8 @@ async def test_agent_conformance(spec_test: SpecTest) -> None:
                 await execute_wait_until_completed(agent=agent, step=step, captures=captures)
             else:
                 raise AssertionError(f'Unknown step type: {type(step).__name__}')
+        except AssertionError:
+            raise
         except Exception as e:
             raise AssertionError(f'{label} in test {spec_test.name!r} failed: {e}') from e
 
@@ -847,6 +878,25 @@ def test_spec_suite_rejects_unknown_step_type() -> None:
         SpecSuite.model_validate({'tests': [{'name': 't', 'agent': 'a', 'steps': ['send']}]})
     with pytest.raises(ValidationError):
         SpecSuite.model_validate({'tests': ['foo']})
+
+
+def test_spec_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError, match='hasSnapshatId'):
+        OutputAssertions.model_validate({'hasSnapshatId': True})
+
+
+def test_expect_chunk_requires_exactly_one_payload() -> None:
+    ExpectChunk.model_validate({'turnEnd': {'finishReason': 'stop'}})
+    with pytest.raises(ValidationError, match='exactly one'):
+        ExpectChunk.model_validate({})
+    with pytest.raises(ValidationError, match='exactly one'):
+        ExpectChunk.model_validate({'turnEnd': {}, 'modelChunk': {'role': 'model'}})
+
+
+def test_spec_init_keeps_template_state() -> None:
+    init = SpecInit.model_validate({'snapshotId': '{{snap1}}', 'state': '{{state1}}'})
+    assert init.snapshot_id == '{{snap1}}'
+    assert init.state == '{{state1}}'
 
 
 def test_abort_keeps_explicit_null_previous_status() -> None:
@@ -898,6 +948,15 @@ def test_lookup_expect_error_rejects_mapping() -> None:
 def test_thrown_message_includes_status_prefix() -> None:
     err = GenkitError(status='NOT_FOUND', message='branching session')
     assert _thrown_message(thrown=err) == 'NOT_FOUND: branching session'
+    wrapped = GenkitError(status='NOT_FOUND', message='branching session', cause=RuntimeError('inner'))
+    assert _thrown_message(thrown=wrapped) == 'NOT_FOUND: branching session'
+    assert 'inner' not in _thrown_message(thrown=wrapped)
+
+
+def test_has_id_false_means_absent() -> None:
+    assert_has_id(actual=None, want=False, path='output.snapshotId')
+    with pytest.raises(AssertionError, match='absent'):
+        assert_has_id(actual='snap-1', want=False, path='output.snapshotId')
 
 
 def test_dump_keeps_explicit_null_and_drops_unset() -> None:

--- a/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
@@ -19,8 +19,7 @@
 Reads the shared spec from tests/specs/agent.yaml and executes each test case
 against harness-provided agent implementations. See
 docs/agents-conformance-testing.md for the full spec format reference and
-harness requirements. Mirrors js/ai/tests/agents_spec_test.ts and
-go/ai/exp/agents_conformance_test.go.
+harness requirements.
 """
 
 from __future__ import annotations
@@ -32,11 +31,12 @@ import pathlib
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Annotated, Any, Literal, TypeVar
 
 import pytest
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic.alias_generators import to_camel
 
 from genkit._ai._agents._runtime import SessionRunner
 from genkit._ai._agents._session_stores._inmemory_store import InMemorySessionStore
@@ -51,43 +51,127 @@ from genkit._core._typing import (
     AgentFinishReason,
     AgentInit,
     AgentInput,
+    AgentOutput,
     AgentResult,
     Artifact,
+    GenkitRuntimeError,
     MessageData,
     Part,
     Role,
+    SessionSnapshot as SessionSnapshotSchema,
     TextPart,
 )
 from genkit.agent import Agent
 
-SPEC_PATH = pathlib.Path(__file__).parent / '../../../../../../tests/specs/agent.yaml'
 TERMINAL_STATUSES = {'completed', 'failed', 'aborted'}
+DEFAULT_STEP_TIMEOUT_S = 5.0
 
 
-def _tests_from_suite(*, suite: Any) -> list[dict[str, Any]]:  # noqa: ANN401
-    if not isinstance(suite, dict):
-        raise AssertionError(f'agent.yaml must be a mapping, got {type(suite).__name__}')
-    tests = suite.get('tests')
-    assert isinstance(tests, list) and tests, 'agent.yaml contains no tests'
-    for i, t in enumerate(tests):
-        if not isinstance(t, dict):
-            raise AssertionError(f'agent.yaml tests[{i}] must be a mapping, got {type(t).__name__}')
-        assert isinstance(t.get('name'), str), f'spec test at tests[{i}] missing name'
-        assert isinstance(t.get('agent'), str), f'spec test {t.get("name")!r} missing agent'
-        steps = t.get('steps')
-        assert isinstance(steps, list), f'spec test {t.get("name")!r} missing steps'
-        for j, step in enumerate(steps):
-            if not isinstance(step, dict):
-                raise AssertionError(
-                    f'agent.yaml tests[{i}] ({t["name"]!r}) steps[{j}] must be a mapping, got {type(step).__name__}'
-                )
-    return tests
+def spec_path() -> pathlib.Path:
+    """Walk up from this file to the repo's tests/specs/agent.yaml."""
+    for parent in pathlib.Path(__file__).resolve().parents:
+        candidate = parent / 'tests' / 'specs' / 'agent.yaml'
+        if candidate.is_file():
+            return candidate
+    raise AssertionError('tests/specs/agent.yaml not found from agent_conformance_test.py')
 
 
-def load_spec() -> list[dict[str, Any]]:
-    with SPEC_PATH.open() as f:
-        suite = yaml.safe_load(f)
-    return _tests_from_suite(suite={} if suite is None else suite)
+# ---------------------------------------------------------------------------
+# Spec models (discriminated on step.type)
+# ---------------------------------------------------------------------------
+
+
+class SpecModel(BaseModel):
+    model_config = ConfigDict(extra='ignore', populate_by_name=True, alias_generator=to_camel)
+
+
+class OutputAssertions(SpecModel):
+    message: Any | None = None
+    has_snapshot_id: bool | None = None
+    has_session_id: bool | None = None
+    state_contains: Any | None = None
+    artifacts_contain: list[Any] | None = None
+    finish_reason: str | None = None
+    error_contains: Any | None = None
+
+
+class SnapshotAssertions(SpecModel):
+    parent_id: str | None = None
+    status: str | None = None
+    finish_reason: str | None = None
+    has_session_id: bool | None = None
+    state_contains: Any | None = None
+    error_contains: Any | None = None
+
+
+class SendExpectError(SpecModel):
+    status: str | None = None
+    message: str | None = None
+
+
+class SendStep(SpecModel):
+    type: Literal['send']
+    init: Any | None = None
+    inputs: list[Any] | None = None
+    model_responses: list[Any] | None = None
+    stream_chunks: list[list[Any]] | None = None
+    expect_chunks: list[Any] | None = None
+    expect_output: OutputAssertions | None = None
+    expect_error: SendExpectError | None = None
+    capture_snapshot_id: str | None = None
+    capture_state: str | None = None
+    capture_session_id: str | None = None
+
+
+class GetSnapshotDataStep(SpecModel):
+    type: Literal['getSnapshotData']
+    snapshot_id: str | None = None
+    session_id: str | None = None
+    expect_snapshot: SnapshotAssertions | None = None
+    expect_error: str | None = None
+
+
+class AbortStep(SpecModel):
+    type: Literal['abort']
+    snapshot_id: str
+    expect_previous_status: str | None = None
+
+
+class WaitUntilCompletedStep(SpecModel):
+    type: Literal['waitUntilCompleted']
+    snapshot_id: str
+    timeout_ms: float | None = None
+    expect_snapshot: SnapshotAssertions | None = None
+
+
+SpecStep = Annotated[
+    SendStep | GetSnapshotDataStep | AbortStep | WaitUntilCompletedStep,
+    Field(discriminator='type'),
+]
+
+
+class SpecTest(SpecModel):
+    name: str
+    description: str | None = None
+    agent: str
+    steps: list[SpecStep]
+
+
+class SpecSuite(SpecModel):
+    tests: list[SpecTest]
+
+
+def load_spec() -> list[SpecTest]:
+    path = spec_path()
+    with path.open() as f:
+        raw = yaml.safe_load(f)
+    try:
+        suite = SpecSuite.model_validate({} if raw is None else raw)
+    except ValidationError as e:
+        raise AssertionError(f'agent.yaml: {e}') from e
+    if not suite.tests:
+        raise AssertionError('agent.yaml contains no tests')
+    return suite.tests
 
 
 SPEC_TESTS = load_spec()
@@ -124,6 +208,16 @@ def resolve_templates(*, value: Any, captures: dict[str, Any]) -> Any:
     if isinstance(value, dict):
         return {k: resolve_templates(value=v, captures=captures) for k, v in value.items()}
     return value
+
+
+def resolve_step(*, step: SpecStep, captures: dict[str, Any]) -> SpecStep:
+    """Apply ``{{name}}`` captures, keeping explicit YAML nulls (including ``~``)."""
+    raw = step.model_dump(by_alias=True, exclude_unset=True)
+    resolved = resolve_templates(value=raw, captures=captures)
+    try:
+        return type(step).model_validate(resolved)
+    except ValidationError as e:
+        raise AssertionError(f'spec step after template resolve: {e}') from e
 
 
 # ---------------------------------------------------------------------------
@@ -178,8 +272,44 @@ def assert_contains_subsequence(*, actual: list[Any], expected: list[Any], path:
 
 
 def dump(*, model: BaseModel) -> dict[str, Any]:
-    """Serialize a wire model to its camelCase JSON form for spec comparison."""
-    return model.model_dump(by_alias=True, exclude_none=True, mode='json')
+    """Serialize a wire model to its camelCase JSON form for spec comparison.
+
+    Unset fields stay off the object. A field that was set to null stays null,
+    so a spec can tell "not present" from an explicit ``~``. Wire models
+    default to dropping nulls, so this has to opt out.
+    """
+    return model.model_dump(by_alias=True, exclude_unset=True, exclude_none=False, mode='json')
+
+
+WireT = TypeVar('WireT', bound=BaseModel)
+
+
+def validate_wire(*, model_type: type[WireT], data: Any, path: str) -> WireT:  # noqa: ANN401
+    """Build a runtime wire object; name the YAML path if the shape is wrong."""
+    try:
+        return model_type.model_validate(data)
+    except ValidationError as e:
+        raise AssertionError(f'{path}: {e}') from e
+
+
+def field_was_set(*, model: BaseModel, name: str) -> bool:
+    return name in model.model_fields_set
+
+
+def wire_scalar(*, live: Any) -> Any:  # noqa: ANN401
+    if live is None:
+        return None
+    value = getattr(live, 'value', None)
+    return value if isinstance(value, str) else live
+
+
+def assert_pinned_scalar(*, live: Any, expect_model: BaseModel, name: str, path: str) -> None:  # noqa: ANN401
+    """If the spec pinned this field (including YAML ~), compare the live value."""
+    if not field_was_set(model=expect_model, name=name):
+        return
+    want = getattr(expect_model, name)
+    got = wire_scalar(live=live)
+    assert got == want, f'{path}: expected {want!r}, got {got!r}'
 
 
 # ---------------------------------------------------------------------------
@@ -297,10 +427,9 @@ def setup_harness() -> Harness:
     )
 
     # customAgentFailing: server-managed; the turn raises on purpose.
-    # Raise inside the turn callback, then return session_runner.result().
-    # run() records the failure on the session and returns, so a detached
-    # client can still read status=failed and the error from the snapshot.
-    # Re-raising after run() fails the invocation and skips that write.
+    # Raise inside the turn callback so run() records last_turn_error, then
+    # return session_runner.result() so an attached caller gets a graceful
+    # failed output. The snapshot write comes from that recorded error.
     async def failing_agent_fn(session_runner: SessionRunner, _ctx: ActionRunContext) -> AgentResult:
         async def handle_turn(_inp: AgentInput, _tc: TurnContext) -> TurnResult | None:
             raise RuntimeError('intentional failure')
@@ -382,13 +511,20 @@ def setup_harness() -> Harness:
 # ---------------------------------------------------------------------------
 
 
-def program_model(*, pm: ProgrammableModel, step: dict[str, Any]) -> None:
+def program_model(*, pm: ProgrammableModel, step: SendStep) -> None:
     pm.reset()
-    responses = step.get('modelResponses') or []
-    pm.responses = [ModelResponse.model_validate(r) for r in responses]
-    stream_chunks = step.get('streamChunks')
-    if stream_chunks:
-        pm.chunks = [[ModelResponseChunk.model_validate(c) for c in group] for group in stream_chunks]
+    responses = step.model_responses or []
+    pm.responses = [
+        validate_wire(model_type=ModelResponse, data=r, path=f'modelResponses[{i}]') for i, r in enumerate(responses)
+    ]
+    if step.stream_chunks:
+        pm.chunks = [
+            [
+                validate_wire(model_type=ModelResponseChunk, data=c, path=f'streamChunks[{i}][{j}]')
+                for j, c in enumerate(group)
+            ]
+            for i, group in enumerate(step.stream_chunks)
+        ]
 
 
 def assert_chunks(*, actual_chunks: list[Any], expected_chunks: list[Any]) -> None:
@@ -407,11 +543,9 @@ def assert_chunks(*, actual_chunks: list[Any], expected_chunks: list[Any]) -> No
             assert 'turnEnd' in got, f'Chunk {i}: expected turnEnd, got {got!r}'
             turn_end = expected['turnEnd']
             if isinstance(turn_end, dict) and 'finishReason' in turn_end:
-                # Omitted and explicit-null serialize the same (the key is
-                # dropped), so treat them as one optional field.
                 te_model = actual_chunks[i].turn_end
                 want_fr = turn_end['finishReason']
-                got_fr = te_model.finish_reason if te_model is not None else None
+                got_fr = wire_scalar(live=te_model.finish_reason if te_model is not None else None)
                 assert got_fr == want_fr, f'Chunk {i}: expected turnEnd.finishReason {want_fr!r}, got {got_fr!r}'
         elif 'modelChunk' in expected:
             assert_contains(
@@ -427,43 +561,48 @@ def assert_chunks(*, actual_chunks: list[Any], expected_chunks: list[Any]) -> No
             assert_contains(actual=got, expected=expected, path=f'chunk[{i}]')
 
 
-def assert_output(*, out: dict[str, Any], expect: dict[str, Any]) -> None:
-    if expect.get('message') is not None:
-        assert_contains(actual=out.get('message'), expected=expect['message'], path='output.message')
+def assert_output(*, output: AgentOutput, expect: OutputAssertions) -> None:
+    out = dump(model=output)
+    if expect.message is not None:
+        # Contains / subsequence — extra keys and extra parts are allowed, so a
+        # spec that pins only content still matches a live message that has role.
+        assert_contains(actual=out.get('message'), expected=expect.message, path='output.message')
 
-    if expect.get('hasSnapshotId'):
+    if expect.has_snapshot_id:
         assert isinstance(out.get('snapshotId'), str) and out['snapshotId'], (
             f'Expected output to have a snapshotId, got: {out.get("snapshotId")!r}'
         )
 
-    if expect.get('hasSessionId'):
+    if expect.has_session_id:
         state = out.get('state')
         assert state, 'Expected output to have state for sessionId check'
         assert isinstance(state.get('sessionId'), str) and state['sessionId'], (
             f'Expected output.state to have a sessionId, got: {state.get("sessionId")!r}'
         )
 
-    if expect.get('stateContains') is not None:
+    if expect.state_contains is not None:
         assert out.get('state') is not None, 'Expected output to have state'
-        assert_contains(actual=out['state'], expected=expect['stateContains'], path='output.state')
+        assert_contains(actual=out['state'], expected=expect.state_contains, path='output.state')
 
-    if expect.get('artifactsContain') is not None:
+    if expect.artifacts_contain is not None:
         artifacts = out.get('artifacts')
         assert artifacts is not None, 'Expected output to have artifacts'
-        for expected_art in expect['artifactsContain']:
+        for expected_art in expect.artifacts_contain:
             found = next((a for a in artifacts if a.get('name') == expected_art.get('name')), None)
             assert found is not None, f'Expected artifact {expected_art.get("name")!r} not found in output'
             assert_contains(actual=found, expected=expected_art, path=f'artifact({expected_art.get("name")})')
 
-    if 'finishReason' in expect:
-        assert out.get('finishReason') == expect['finishReason'], (
-            f'Expected output.finishReason {expect["finishReason"]!r}, got {out.get("finishReason")!r}'
-        )
+    assert_pinned_scalar(
+        live=output.finish_reason,
+        expect_model=expect,
+        name='finish_reason',
+        path='output.finishReason',
+    )
 
-    if expect.get('errorContains') is not None:
+    if expect.error_contains is not None:
         err = out.get('error')
         assert err, f'Expected output to have an error, got: {err!r}'
-        want = expect['errorContains']
+        want = expect.error_contains
         if 'status' in want:
             assert err.get('status') == want['status'], (
                 f'Expected output.error.status {want["status"]!r}, got {err.get("status")!r}'
@@ -474,32 +613,34 @@ def assert_output(*, out: dict[str, Any], expect: dict[str, Any]) -> None:
             )
 
 
-def assert_snapshot(*, snap: dict[str, Any], expect: dict[str, Any]) -> None:
-    if 'parentId' in expect:
-        assert snap.get('parentId') == expect['parentId'], (
-            f'Expected parentId {expect["parentId"]!r}, got {snap.get("parentId")!r}'
-        )
-    if 'status' in expect:
-        assert snap.get('status') == expect['status'], (
-            f'Expected status {expect["status"]!r}, got {snap.get("status")!r}'
-        )
-    if 'finishReason' in expect:
-        assert snap.get('finishReason') == expect['finishReason'], (
-            f'Expected snapshot.finishReason {expect["finishReason"]!r}, got {snap.get("finishReason")!r}'
-        )
-    if expect.get('hasSessionId'):
-        state = snap.get('state') or {}
+def assert_snapshot(*, snap: SessionSnapshotSchema, expect: SnapshotAssertions) -> None:
+    dumped = dump(model=snap)
+    assert_pinned_scalar(live=snap.parent_id, expect_model=expect, name='parent_id', path='snapshot.parentId')
+    assert_pinned_scalar(
+        live=snap.status.value if snap.status is not None else None,
+        expect_model=expect,
+        name='status',
+        path='snapshot.status',
+    )
+    assert_pinned_scalar(
+        live=snap.finish_reason,
+        expect_model=expect,
+        name='finish_reason',
+        path='snapshot.finishReason',
+    )
+    if expect.has_session_id:
+        state = dumped.get('state') or {}
         assert isinstance(state.get('sessionId'), str) and state['sessionId'], (
             f'Expected snapshot.state to have a sessionId, got: {state.get("sessionId")!r}'
         )
-    if expect.get('stateContains') is not None:
-        assert_contains(actual=snap.get('state'), expected=expect['stateContains'], path='snapshot.state')
-    if expect.get('errorContains') is not None:
-        err = snap.get('error')
+    if expect.state_contains is not None:
+        assert_contains(actual=dumped.get('state'), expected=expect.state_contains, path='snapshot.state')
+    if expect.error_contains is not None:
+        err = dumped.get('error')
         assert err, 'Expected snapshot to have error'
-        # Snapshot error is subset/contains (scalar fields exact), same as JS.
+        # Snapshot errorContains is subset matching (a string field is exact).
         # Output errorContains is different: status exact, message substring.
-        assert_contains(actual=err, expected=expect['errorContains'], path='snapshot.error')
+        assert_contains(actual=err, expected=expect.error_contains, path='snapshot.error')
 
 
 async def _close_quietly(*, conn: Any) -> None:  # noqa: ANN401
@@ -509,119 +650,97 @@ async def _close_quietly(*, conn: Any) -> None:  # noqa: ANN401
         await conn.close()
 
 
-def _require_send_expect_error(*, value: Any) -> dict[str, Any]:  # noqa: ANN401
-    if not isinstance(value, dict):
-        raise AssertionError(
-            f'send expectError must be a mapping with optional status/message, got {type(value).__name__}: {value!r}'
-        )
-    if not value:
-        raise AssertionError('send expectError must include status and/or message, got {}')
-    for key in ('status', 'message'):
-        if key in value and not isinstance(value[key], str):
-            raise AssertionError(
-                f'send expectError.{key} must be a string, got {type(value[key]).__name__}: {value[key]!r}'
-            )
-    return value
-
-
-def _require_lookup_expect_error(*, value: Any) -> str:  # noqa: ANN401
-    if not isinstance(value, str) or not value:
-        raise AssertionError(
-            f'getSnapshotData expectError must be a non-empty string substring, got {type(value).__name__}: {value!r}'
-        )
-    return value
-
-
 def _thrown_message(*, thrown: BaseException) -> str:
-    """Return the error's message field, not ``str(exc)`` (which prefixes status)."""
-    return getattr(thrown, 'original_message', None) or getattr(thrown, 'message', None) or str(thrown)
+    """The string the caller sees, including a ``STATUS: `` prefix on GenkitError."""
+    return str(thrown)
 
 
-def _assert_expect_error(*, thrown: BaseException | None, expect_err: dict[str, Any]) -> None:
+def _assert_expect_error(*, thrown: BaseException | None, expect_err: SendExpectError) -> None:
     assert thrown is not None, 'Expected the turn to throw an error, but it resolved successfully.'
-    if 'status' in expect_err:
+    if expect_err.status is not None:
         status = getattr(thrown, 'status', None)
-        assert status == expect_err['status'], (
-            f'Expected thrown error.status {expect_err["status"]!r}, got {status!r} (message: {thrown})'
+        assert status == expect_err.status, (
+            f'Expected thrown error.status {expect_err.status!r}, got {status!r} (message: {thrown})'
         )
-    if 'message' in expect_err:
+    if expect_err.message is not None:
         thrown_msg = _thrown_message(thrown=thrown)
-        assert expect_err['message'] in thrown_msg, (
-            f'Expected thrown error.message to contain {expect_err["message"]!r}, got: {thrown_msg!r}'
+        assert expect_err.message in thrown_msg, (
+            f'Expected thrown error.message to contain {expect_err.message!r}, got: {thrown_msg!r}'
         )
 
 
-async def execute_send(*, agent: Agent, pm: ProgrammableModel, step: dict[str, Any], captures: dict[str, Any]) -> None:
-    resolved = resolve_templates(value=step, captures=captures)
+async def execute_send(*, agent: Agent, pm: ProgrammableModel, step: SendStep, captures: dict[str, Any]) -> None:
+    resolved = resolve_step(step=step, captures=captures)
+    assert isinstance(resolved, SendStep)
     program_model(pm=pm, step=resolved)
+
+    async def run_turn() -> tuple[list[Any], AgentOutput]:
+        conn = await agent.stream_bidi(
+            validate_wire(model_type=AgentInit, data=resolved.init or {}, path='init'),
+        )
+        try:
+            for i, inp in enumerate(resolved.inputs or []):
+                await conn.send(validate_wire(model_type=AgentInput, data=inp, path=f'inputs[{i}]'))
+            await conn.close()
+            chunks = [c async for c in conn.receive()]
+            output = await conn.output()
+            return chunks, output
+        finally:
+            await _close_quietly(conn=conn)
 
     # expectError: the turn throws (API misuse) rather than resolving with a
     # graceful finishReason='failed' output. Cover stream_bidi / send as well
     # as receive / output — an init rejection can surface before the stream.
-    if 'expectError' in resolved:
-        expect_err = _require_send_expect_error(value=resolved['expectError'])
+    if field_was_set(model=resolved, name='expect_error'):
         thrown: BaseException | None = None
-        conn = None
         try:
-            conn = await agent.stream_bidi(AgentInit.model_validate(resolved.get('init') or {}))
-            for inp in resolved.get('inputs') or []:
-                await conn.send(AgentInput.model_validate(inp))
-            await conn.close()
-            async for _chunk in conn.receive():
-                pass
-            await conn.output()
+            await asyncio.wait_for(run_turn(), timeout=DEFAULT_STEP_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            raise AssertionError(f'send step timed out after {DEFAULT_STEP_TIMEOUT_S}s') from None
         except Exception as e:  # noqa: BLE001 - spec asserts on the raised error
             thrown = e
-        finally:
-            await _close_quietly(conn=conn)
-        _assert_expect_error(thrown=thrown, expect_err=expect_err)
+        _assert_expect_error(thrown=thrown, expect_err=resolved.expect_error or SendExpectError())
         return
 
-    conn = None
     try:
-        conn = await agent.stream_bidi(AgentInit.model_validate(resolved.get('init') or {}))
-        for inp in resolved.get('inputs') or []:
-            await conn.send(AgentInput.model_validate(inp))
-        await conn.close()
-
-        chunks = [c async for c in conn.receive()]
-        output = await conn.output()
-    finally:
-        await _close_quietly(conn=conn)
+        chunks, output = await asyncio.wait_for(run_turn(), timeout=DEFAULT_STEP_TIMEOUT_S)
+    except asyncio.TimeoutError:
+        raise AssertionError(f'send step timed out after {DEFAULT_STEP_TIMEOUT_S}s') from None
     out = dump(model=output)
 
-    if resolved.get('expectChunks') is not None:
-        assert_chunks(actual_chunks=chunks, expected_chunks=resolved['expectChunks'])
+    if resolved.expect_chunks is not None:
+        assert_chunks(actual_chunks=chunks, expected_chunks=resolved.expect_chunks)
 
-    if resolved.get('expectOutput') is not None:
-        assert_output(out=out, expect=resolved['expectOutput'])
+    if resolved.expect_output is not None:
+        assert_output(output=output, expect=resolved.expect_output)
 
-    # Captures for subsequent steps (use the unresolved step so capture names
-    # are never themselves template-substituted).
-    if step.get('captureSnapshotId'):
+    # Capture names come from the unresolved step so they are never themselves
+    # template-substituted.
+    if step.capture_snapshot_id:
         assert out.get('snapshotId'), (
-            f'captureSnapshotId {step["captureSnapshotId"]!r} requested but output has no snapshotId'
+            f'captureSnapshotId {step.capture_snapshot_id!r} requested but output has no snapshotId'
         )
-        captures[step['captureSnapshotId']] = out['snapshotId']
-    if step.get('captureState'):
-        assert out.get('state'), f'captureState {step["captureState"]!r} requested but output has no state'
-        captures[step['captureState']] = out['state']
-    if step.get('captureSessionId'):
+        captures[step.capture_snapshot_id] = out['snapshotId']
+    if step.capture_state:
+        assert out.get('state'), f'captureState {step.capture_state!r} requested but output has no state'
+        captures[step.capture_state] = out['state']
+    if step.capture_session_id:
         state = out.get('state') or {}
         assert state.get('sessionId'), (
-            f'captureSessionId {step["captureSessionId"]!r} requested but output has no state.sessionId'
+            f'captureSessionId {step.capture_session_id!r} requested but output has no state.sessionId'
         )
-        captures[step['captureSessionId']] = state['sessionId']
+        captures[step.capture_session_id] = state['sessionId']
 
 
-async def execute_get_snapshot_data(*, agent: Agent, step: dict[str, Any], captures: dict[str, Any]) -> None:
-    resolved = resolve_templates(value=step, captures=captures)
-    snapshot_id = resolved.get('snapshotId')
-    session_id = resolved.get('sessionId')
+async def execute_get_snapshot_data(*, agent: Agent, step: GetSnapshotDataStep, captures: dict[str, Any]) -> None:
+    resolved = resolve_step(step=step, captures=captures)
+    assert isinstance(resolved, GetSnapshotDataStep)
+    snapshot_id = resolved.snapshot_id
+    session_id = resolved.session_id
     assert bool(snapshot_id) != bool(session_id), 'getSnapshotData step requires exactly one of snapshotId or sessionId'
 
-    if 'expectError' in resolved:
-        expect_err = _require_lookup_expect_error(value=resolved['expectError'])
+    if field_was_set(model=resolved, name='expect_error'):
+        expect_err = resolved.expect_error or ''
         try:
             snap = await agent.get_snapshot_data(snapshot_id=snapshot_id, session_id=session_id)
         except Exception as e:  # noqa: BLE001 - spec asserts on the raised error
@@ -640,46 +759,47 @@ async def execute_get_snapshot_data(*, agent: Agent, step: dict[str, Any], captu
     snap = await agent.get_snapshot_data(snapshot_id=snapshot_id, session_id=session_id)
     assert snap is not None, f'Snapshot not found for snapshotId={snapshot_id!r} sessionId={session_id!r}'
 
-    if resolved.get('expectSnapshot') is not None:
-        assert_snapshot(snap=dump(model=snap), expect=resolved['expectSnapshot'])
+    if resolved.expect_snapshot is not None:
+        assert_snapshot(snap=snap, expect=resolved.expect_snapshot)
 
 
-async def execute_abort(*, agent: Agent, step: dict[str, Any], captures: dict[str, Any]) -> None:
-    resolved = resolve_templates(value=step, captures=captures)
-    snapshot_id = resolved.get('snapshotId')
-    assert snapshot_id, 'abort step requires snapshotId'
+async def execute_abort(*, agent: Agent, step: AbortStep, captures: dict[str, Any]) -> None:
+    resolved = resolve_step(step=step, captures=captures)
+    assert isinstance(resolved, AbortStep)
+    assert resolved.snapshot_id, 'abort step requires snapshotId'
 
-    previous = await agent.abort_snapshot_data(snapshot_id)
+    previous = await agent.abort_snapshot_data(resolved.snapshot_id)
     previous_str = previous.value if previous is not None else None
 
     # The key being present (even as YAML ~ / null) means we should assert.
-    if 'expectPreviousStatus' in resolved:
-        expected = resolved['expectPreviousStatus']
-        assert previous_str == expected, f'Expected previous status {expected!r}, got {previous_str!r}'
+    if field_was_set(model=resolved, name='expect_previous_status'):
+        assert previous_str == resolved.expect_previous_status, (
+            f'Expected previous status {resolved.expect_previous_status!r}, got {previous_str!r}'
+        )
 
 
-async def execute_wait_until_completed(*, agent: Agent, step: dict[str, Any], captures: dict[str, Any]) -> None:
-    resolved = resolve_templates(value=step, captures=captures)
-    snapshot_id = resolved.get('snapshotId')
-    assert snapshot_id, 'waitUntilCompleted step requires snapshotId'
-    timeout_s = (resolved.get('timeoutMs') or 5000) / 1000.0
+async def execute_wait_until_completed(*, agent: Agent, step: WaitUntilCompletedStep, captures: dict[str, Any]) -> None:
+    resolved = resolve_step(step=step, captures=captures)
+    assert isinstance(resolved, WaitUntilCompletedStep)
+    assert resolved.snapshot_id, 'waitUntilCompleted step requires snapshotId'
+    timeout_s = (resolved.timeout_ms or 5000) / 1000.0
 
     deadline = time.monotonic() + timeout_s
     snap = None
     while time.monotonic() < deadline:
-        snap = await agent.get_snapshot_data(snapshot_id=snapshot_id)
+        snap = await agent.get_snapshot_data(snapshot_id=resolved.snapshot_id)
         if snap is not None and snap.status is not None and snap.status.value in TERMINAL_STATUSES:
             break
         await asyncio.sleep(0.1)
 
-    assert snap is not None, f'Snapshot {snapshot_id!r} not found after waiting'
+    assert snap is not None, f'Snapshot {resolved.snapshot_id!r} not found after waiting'
     status = snap.status.value if snap.status is not None else None
     assert status in TERMINAL_STATUSES, (
-        f'Snapshot {snapshot_id!r} did not reach terminal status within {timeout_s}s. Status: {status!r}'
+        f'Snapshot {resolved.snapshot_id!r} did not reach terminal status within {timeout_s}s. Status: {status!r}'
     )
 
-    if resolved.get('expectSnapshot') is not None:
-        assert_snapshot(snap=dump(model=snap), expect=resolved['expectSnapshot'])
+    if resolved.expect_snapshot is not None:
+        assert_snapshot(snap=snap, expect=resolved.expect_snapshot)
 
 
 # ---------------------------------------------------------------------------
@@ -688,53 +808,57 @@ async def execute_wait_until_completed(*, agent: Agent, step: dict[str, Any], ca
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('spec_test', SPEC_TESTS, ids=[t['name'] for t in SPEC_TESTS])
-async def test_agent_conformance(spec_test: dict[str, Any]) -> None:
+@pytest.mark.parametrize('spec_test', SPEC_TESTS, ids=[t.name for t in SPEC_TESTS])
+async def test_agent_conformance(spec_test: SpecTest) -> None:
     harness = setup_harness()
-    agent = harness.agents.get(spec_test['agent'])
-    assert agent is not None, f'Unknown agent {spec_test["agent"]!r} in test {spec_test["name"]!r}'
+    agent = harness.agents.get(spec_test.agent)
+    assert agent is not None, f'Unknown agent {spec_test.agent!r} in test {spec_test.name!r}'
 
     captures: dict[str, Any] = {}
 
-    for i, step in enumerate(spec_test['steps']):
-        label = f'step[{i}]'
+    for i, step in enumerate(spec_test.steps):
+        label = f'step[{i}] ({step.type})'
         try:
-            if not isinstance(step, dict):
-                raise AssertionError(f'step must be a mapping, got {type(step).__name__}')
-            step_type = step.get('type')
-            label = f'step[{i}] ({step_type})'
-            if step_type == 'send':
+            if isinstance(step, SendStep):
                 await execute_send(agent=agent, pm=harness.pm, step=step, captures=captures)
-            elif step_type == 'getSnapshotData':
+            elif isinstance(step, GetSnapshotDataStep):
                 await execute_get_snapshot_data(agent=agent, step=step, captures=captures)
-            elif step_type == 'abort':
+            elif isinstance(step, AbortStep):
                 await execute_abort(agent=agent, step=step, captures=captures)
-            elif step_type == 'waitUntilCompleted':
+            elif isinstance(step, WaitUntilCompletedStep):
                 await execute_wait_until_completed(agent=agent, step=step, captures=captures)
             else:
-                raise AssertionError(f'Unknown step type: {step_type!r}')
+                raise AssertionError(f'Unknown step type: {type(step).__name__}')
         except Exception as e:
-            raise AssertionError(f'{label} in test {spec_test["name"]!r} failed: {e}') from e
+            raise AssertionError(f'{label} in test {spec_test.name!r} failed: {e}') from e
 
 
 def test_assert_contains_none_is_noop() -> None:
-    """A null expected value means "not specified", matching the other harnesses."""
+    """A null expected value means the spec did not pin that field."""
     assert_contains(actual={'x': 1}, expected=None)
     assert_contains(actual=None, expected=None)
     assert_contains(actual=[1, 2], expected=None)
 
 
-def test_tests_from_suite_rejects_non_mapping() -> None:
-    with pytest.raises(AssertionError, match='must be a mapping, got list'):
-        _tests_from_suite(suite=['foo'])
-    with pytest.raises(AssertionError, match='must be a mapping, got bool'):
-        _tests_from_suite(suite=False)
-    with pytest.raises(AssertionError, match='contains no tests'):
-        _tests_from_suite(suite={})
-    with pytest.raises(AssertionError, match=r'tests\[0\] must be a mapping'):
-        _tests_from_suite(suite={'tests': ['foo']})
-    with pytest.raises(AssertionError, match=r'steps\[0\] must be a mapping'):
-        _tests_from_suite(suite={'tests': [{'name': 't', 'agent': 'a', 'steps': ['send']}]})
+def test_spec_suite_rejects_unknown_step_type() -> None:
+    with pytest.raises(ValidationError):
+        SpecSuite.model_validate({'tests': [{'name': 't', 'agent': 'a', 'steps': [{'type': 'nope'}]}]})
+    with pytest.raises(ValidationError):
+        SpecSuite.model_validate({'tests': [{'name': 't', 'agent': 'a', 'steps': ['send']}]})
+    with pytest.raises(ValidationError):
+        SpecSuite.model_validate({'tests': ['foo']})
+
+
+def test_abort_keeps_explicit_null_previous_status() -> None:
+    step = AbortStep.model_validate({'type': 'abort', 'snapshotId': 'x', 'expectPreviousStatus': None})
+    assert field_was_set(model=step, name='expect_previous_status')
+    assert step.expect_previous_status is None
+    dumped = step.model_dump(by_alias=True, exclude_unset=True)
+    assert 'expectPreviousStatus' in dumped
+    assert dumped['expectPreviousStatus'] is None
+    resolved = resolve_step(step=step, captures={})
+    assert field_was_set(model=resolved, name='expect_previous_status')
+    assert resolved.expect_previous_status is None
 
 
 def test_resolve_templates_inline_object_is_json() -> None:
@@ -745,48 +869,67 @@ def test_resolve_templates_inline_object_is_json() -> None:
     assert got == 'seeded-{"sessionId":"abc","custom":{"counter":1}}'
 
 
-def test_assert_expect_error_matches_message_not_status_prefix() -> None:
+def test_assert_expect_error_matches_status_prefixed_message() -> None:
     err = GenkitError(status='FAILED_PRECONDITION', message="Cannot send 'state' to agent")
     _assert_expect_error(
         thrown=err,
-        expect_err={'status': 'FAILED_PRECONDITION', 'message': "Cannot send 'state'"},
+        expect_err=SendExpectError(status='FAILED_PRECONDITION', message="Cannot send 'state'"),
     )
+    # The status name is in the string the caller sees, so a spec can search for it.
+    _assert_expect_error(thrown=err, expect_err=SendExpectError(message='FAILED_PRECONDITION'))
     with pytest.raises(AssertionError, match='error.message'):
-        _assert_expect_error(thrown=err, expect_err={'message': 'FAILED_PRECONDITION'})
+        _assert_expect_error(thrown=err, expect_err=SendExpectError(message='NOT_THIS'))
 
 
 def test_send_expect_error_rejects_string() -> None:
-    with pytest.raises(AssertionError, match='must be a mapping'):
-        _require_send_expect_error(value="Cannot send 'state' to agent")
-    with pytest.raises(AssertionError, match='must include status and/or message'):
-        _require_send_expect_error(value={})
-    with pytest.raises(AssertionError, match='status must be a string'):
-        _require_send_expect_error(value={'status': None})
+    with pytest.raises(ValidationError):
+        SendStep.model_validate({'type': 'send', 'expectError': "Cannot send 'state' to agent"})
 
 
 def test_lookup_expect_error_rejects_mapping() -> None:
-    with pytest.raises(AssertionError, match='must be a non-empty string'):
-        _require_lookup_expect_error(value={'status': 'NOT_FOUND', 'message': 'not found'})
-    with pytest.raises(AssertionError, match='must be a non-empty string'):
-        _require_lookup_expect_error(value='')
+    with pytest.raises(ValidationError):
+        GetSnapshotDataStep.model_validate({
+            'type': 'getSnapshotData',
+            'snapshotId': 's',
+            'expectError': {'status': 'NOT_FOUND', 'message': 'not found'},
+        })
 
 
-def test_thrown_message_skips_status_prefix() -> None:
+def test_thrown_message_includes_status_prefix() -> None:
     err = GenkitError(status='NOT_FOUND', message='branching session')
-    assert _thrown_message(thrown=err) == 'branching session'
-    assert 'NOT_FOUND' not in _thrown_message(thrown=err)
+    assert _thrown_message(thrown=err) == 'NOT_FOUND: branching session'
+
+
+def test_dump_keeps_explicit_null_and_drops_unset() -> None:
+    pinned = SessionSnapshotSchema(snapshot_id='s', created_at='t', finish_reason=None)
+    dumped = dump(model=pinned)
+    assert 'finishReason' in dumped
+    assert dumped['finishReason'] is None
+    omitted = SessionSnapshotSchema(snapshot_id='s', created_at='t')
+    assert 'finishReason' not in dump(model=omitted)
 
 
 def test_snapshot_error_contains_is_exact_message() -> None:
     """Snapshot errorContains uses subset matching; a string field is exact."""
-    wrapped = {'error': {'message': 'background: intentional failure (wrapped)'}}
+
+    def snap(*, message: str, status: str | None = None) -> SessionSnapshotSchema:
+        return SessionSnapshotSchema(
+            snapshot_id='s',
+            created_at='t',
+            error=GenkitRuntimeError(status=status, message=message),
+        )
+
+    wrapped = snap(message='background: intentional failure (wrapped)')
+    expect_partial = SnapshotAssertions.model_validate({'errorContains': {'message': 'intentional failure'}})
     with pytest.raises(AssertionError, match='snapshot.error.message'):
-        assert_snapshot(snap=wrapped, expect={'errorContains': {'message': 'intentional failure'}})
+        assert_snapshot(snap=wrapped, expect=expect_partial)
     assert_snapshot(
         snap=wrapped,
-        expect={'errorContains': {'message': 'background: intentional failure (wrapped)'}},
+        expect=SnapshotAssertions.model_validate({
+            'errorContains': {'message': 'background: intentional failure (wrapped)'}
+        }),
     )
     assert_snapshot(
-        snap={'error': {'status': 'INTERNAL', 'message': 'intentional failure'}},
-        expect={'errorContains': {'message': 'intentional failure'}},
+        snap=snap(message='intentional failure', status='INTERNAL'),
+        expect=SnapshotAssertions.model_validate({'errorContains': {'message': 'intentional failure'}}),
     )

--- a/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_conformance_test.py
@@ -1,0 +1,820 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent conformance test runner.
+
+Reads the shared spec from tests/specs/agent.yaml and executes each test case
+against harness-provided agent implementations. See
+docs/agents-conformance-testing.md for the full spec format reference and
+harness requirements. Mirrors js/ai/tests/agents_spec_test.ts and
+go/ai/exp/agents_conformance_test.go.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import pathlib
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import BaseModel
+
+from genkit._ai._agents._runtime import SessionRunner
+from genkit._ai._agents._session_stores._inmemory_store import InMemorySessionStore
+from genkit._ai._agents._types import TurnContext, TurnResult
+from genkit._ai._aio import Genkit
+from genkit._ai._testing import ProgrammableModel, define_programmable_model
+from genkit._ai._tools import Interrupt, ToolRunContext
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._model import ModelResponse, ModelResponseChunk
+from genkit._core._typing import (
+    AgentFinishReason,
+    AgentInit,
+    AgentInput,
+    AgentResult,
+    AgentStreamChunk,
+    Artifact,
+    MessageData,
+    Part,
+    Role,
+    TextPart,
+    TurnEnd,
+)
+from genkit.agent import Agent
+
+SPEC_PATH = pathlib.Path(__file__).parent / '../../../../../../tests/specs/agent.yaml'
+TERMINAL_STATUSES = {'completed', 'failed', 'aborted'}
+
+
+def _tests_from_suite(*, suite: Any) -> list[dict[str, Any]]:  # noqa: ANN401
+    if not isinstance(suite, dict):
+        raise AssertionError(f'agent.yaml must be a mapping, got {type(suite).__name__}')
+    tests = suite.get('tests')
+    assert isinstance(tests, list) and tests, 'agent.yaml contains no tests'
+    for i, t in enumerate(tests):
+        if not isinstance(t, dict):
+            raise AssertionError(f'agent.yaml tests[{i}] must be a mapping, got {type(t).__name__}')
+        assert isinstance(t.get('name'), str), f'spec test at tests[{i}] missing name'
+        assert isinstance(t.get('agent'), str), f'spec test {t.get("name")!r} missing agent'
+        steps = t.get('steps')
+        assert isinstance(steps, list), f'spec test {t.get("name")!r} missing steps'
+        for j, step in enumerate(steps):
+            if not isinstance(step, dict):
+                raise AssertionError(
+                    f'agent.yaml tests[{i}] ({t["name"]!r}) steps[{j}] must be a mapping, got {type(step).__name__}'
+                )
+    return tests
+
+
+def load_spec() -> list[dict[str, Any]]:
+    with SPEC_PATH.open() as f:
+        suite = yaml.safe_load(f)
+    return _tests_from_suite(suite={} if suite is None else suite)
+
+
+SPEC_TESTS = load_spec()
+
+
+# ---------------------------------------------------------------------------
+# Template resolution
+# ---------------------------------------------------------------------------
+
+_FULL_TEMPLATE = re.compile(r'^\{\{(\w+)\}\}$')
+_INLINE_TEMPLATE = re.compile(r'\{\{(\w+)\}\}')
+
+
+def resolve_templates(*, value: Any, captures: dict[str, Any]) -> Any:
+    """Recursively resolve ``{{name}}`` references using the captures map."""
+    if isinstance(value, str):
+        m = _FULL_TEMPLATE.match(value)
+        if m:
+            name = m.group(1)
+            if name not in captures:
+                raise AssertionError(f"Template reference '{{{{{name}}}}}' not found in captures")
+            return captures[name]
+
+        def sub(match: re.Match[str]) -> str:
+            name = match.group(1)
+            if name not in captures:
+                raise AssertionError(f"Template reference '{{{{{name}}}}}' not found in captures")
+            v = captures[name]
+            return v if isinstance(v, str) else json.dumps(v, separators=(',', ':'))
+
+        return _INLINE_TEMPLATE.sub(sub, value)
+    if isinstance(value, list):
+        return [resolve_templates(value=item, captures=captures) for item in value]
+    if isinstance(value, dict):
+        return {k: resolve_templates(value=v, captures=captures) for k, v in value.items()}
+    return value
+
+
+# ---------------------------------------------------------------------------
+# "Contains" assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_contains(*, actual: Any, expected: Any, path: str = '') -> None:
+    """Assert that ``actual`` contains all fields specified in ``expected``.
+
+    Dicts are matched key-by-key (extra keys in actual are allowed). Lists are
+    matched as an in-order (not necessarily contiguous) subsequence. Scalars
+    must match exactly.
+    """
+    if expected is None:
+        # A missing/null expected value is "not specified", not "must be null".
+        return
+
+    if isinstance(expected, list):
+        assert isinstance(actual, list), f'Expected list at {path}, got {type(actual).__name__}: {actual!r}'
+        assert_contains_subsequence(actual=actual, expected=expected, path=path)
+        return
+
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), f'Expected dict at {path}, got {type(actual).__name__}: {actual!r}'
+        for key, val in expected.items():
+            assert_contains(actual=actual.get(key), expected=val, path=f'{path}.{key}')
+        return
+
+    assert actual == expected, f'Mismatch at {path}: expected {expected!r}, got {actual!r}'
+
+
+def assert_contains_subsequence(*, actual: list[Any], expected: list[Any], path: str) -> None:
+    """Assert all ``expected`` items appear in ``actual`` in the same relative order."""
+    actual_idx = 0
+    for i, exp_item in enumerate(expected):
+        found = False
+        while actual_idx < len(actual):
+            try:
+                assert_contains(actual=actual[actual_idx], expected=exp_item, path=f'{path}[{actual_idx}]')
+                found = True
+                actual_idx += 1
+                break
+            except AssertionError:
+                actual_idx += 1
+        if not found:
+            raise AssertionError(
+                f'Expected item at {path}[{i}] not found in actual array.\n'
+                f'  Expected: {exp_item!r}\n'
+                f'  Actual array: {actual!r}'
+            )
+
+
+def dump(*, model: BaseModel) -> dict[str, Any]:
+    """Serialize a wire model to its camelCase JSON form for spec comparison."""
+    return model.model_dump(by_alias=True, exclude_none=True, mode='json')
+
+
+# ---------------------------------------------------------------------------
+# Harness setup
+# ---------------------------------------------------------------------------
+
+
+def _model_text(*, text: str) -> MessageData:
+    return MessageData(role=Role.MODEL, content=[Part(root=TextPart(text=text))])
+
+
+class InterruptQuery(BaseModel):
+    query: str
+
+
+class RestartInput(BaseModel):
+    action: str
+
+
+class RestartOutput(BaseModel):
+    result: str
+
+
+@dataclass
+class Harness:
+    ai: Genkit
+    pm: ProgrammableModel
+    agents: dict[str, Agent] = field(default_factory=dict)
+
+
+def setup_harness() -> Harness:
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+    h = Harness(ai=ai, pm=pm)
+
+    # --- Tools ---
+
+    @ai.tool(name='testTool', description='A simple test tool')
+    async def test_tool(_: dict) -> str:  # noqa: ARG001
+        return 'tool called'
+
+    # interruptTool always interrupts (human-in-the-loop checkpoint).
+    ai.define_interrupt(
+        name='interruptTool',
+        description='An interrupt tool',
+        input_schema=InterruptQuery,
+    )
+
+    # restartTool interrupts on first call, succeeds when restarted with
+    # resumed metadata.
+    @ai.tool(name='restartTool', description='A tool that requires confirmation before executing')
+    async def restart_tool(input: RestartInput, ctx: ToolRunContext) -> RestartOutput:  # noqa: A002
+        if not ctx.is_resumed():
+            raise Interrupt({'requiresConfirmation': True})
+        return RestartOutput(result=f'confirmed: {input.action}')
+
+    # --- Prompt-backed agents ---
+
+    h.agents['promptAgent'] = ai.define_agent(
+        name='promptAgent',
+        model='programmableModel',
+        config={'temperature': 1},
+    )
+    h.agents['promptAgentWithStore'] = ai.define_agent(
+        name='promptAgentWithStore',
+        model='programmableModel',
+        config={'temperature': 1},
+        store=InMemorySessionStore(),
+    )
+    h.agents['promptAgentWithTools'] = ai.define_agent(
+        name='promptAgentWithTools',
+        model='programmableModel',
+        config={'temperature': 1},
+        tools=['testTool'],
+    )
+    h.agents['promptAgentWithInterrupt'] = ai.define_agent(
+        name='promptAgentWithInterrupt',
+        model='programmableModel',
+        config={'temperature': 1},
+        tools=['interruptTool'],
+        store=InMemorySessionStore(),
+    )
+    h.agents['promptAgentWithRestartTool'] = ai.define_agent(
+        name='promptAgentWithRestartTool',
+        model='programmableModel',
+        config={'temperature': 1},
+        tools=['restartTool'],
+        store=InMemorySessionStore(),
+    )
+
+    # --- Custom agents ---
+
+    def run_turns(*, turn_body):  # noqa: ANN001, ANN202 - AgentFn factory
+        """Wrap a per-turn body into the canonical custom AgentFn shape."""
+
+        async def agent_fn(session_runner: SessionRunner, ctx: ActionRunContext) -> AgentResult:
+            async def handle_turn(inp: AgentInput, turn_ctx: TurnContext) -> TurnResult | None:
+                await turn_body(session_runner, ctx, inp, turn_ctx)
+                return TurnResult(finish_reason=AgentFinishReason.STOP)
+
+            await session_runner.run(handle_turn)
+            return await session_runner.result()
+
+        return agent_fn
+
+    # customAgentBlocking: server-managed, blocks until the abort signal fires.
+    async def blocking_turn(sr: SessionRunner, ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+        await ctx.abort_signal.wait()
+        await sr.add_messages([_model_text(text='unblocked')])
+
+    h.agents['customAgentBlocking'] = ai.define_custom_agent(
+        name='customAgentBlocking',
+        fn=run_turns(turn_body=blocking_turn),
+        store=InMemorySessionStore(),
+    )
+
+    # customAgentFailing: server-managed; the turn raises on purpose.
+    # Raise inside the turn callback, then return session_runner.result().
+    # run() records the failure on the session and returns, so a detached
+    # client can still read status=failed and the error from the snapshot.
+    # Re-raising after run() fails the invocation and skips that write.
+    async def failing_agent_fn(session_runner: SessionRunner, _ctx: ActionRunContext) -> AgentResult:
+        async def handle_turn(_inp: AgentInput, _tc: TurnContext) -> TurnResult | None:
+            raise RuntimeError('intentional failure')
+
+        await session_runner.run(handle_turn)
+        return await session_runner.result()
+
+    h.agents['customAgentFailing'] = ai.define_custom_agent(
+        name='customAgentFailing',
+        fn=failing_agent_fn,
+        store=InMemorySessionStore(),
+    )
+
+    # customAgentWithArtifacts: client-managed, adds and updates artifacts.
+    async def artifacts_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+        await sr.add_artifacts([Artifact(name='doc1', parts=[Part(root=TextPart(text='v1'))])])
+        await sr.add_artifacts([Artifact(name='doc1', parts=[Part(root=TextPart(text='v2'))])])
+        await sr.add_artifacts([Artifact(name='doc2', parts=[Part(root=TextPart(text='other'))])])
+        await sr.add_messages([_model_text(text='done')])
+
+    h.agents['customAgentWithArtifacts'] = ai.define_custom_agent(
+        name='customAgentWithArtifacts',
+        fn=run_turns(turn_body=artifacts_turn),
+    )
+
+    # customAgentWithCustomState: client-managed, increments a counter per turn.
+    async def counter_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+        prev = await sr.get_custom() or {}
+        counter = (prev.get('counter') or 0) + 1
+        await sr.update_custom(lambda _prev: {'counter': counter})
+        await sr.add_messages([_model_text(text='done')])
+
+    h.agents['customAgentWithCustomState'] = ai.define_custom_agent(
+        name='customAgentWithCustomState',
+        fn=run_turns(turn_body=counter_turn),
+    )
+
+    # customAgentWithMultiCustomState: several sequential custom-state updates
+    # within one turn (first patch = whole-doc replace, then incremental diffs).
+    async def multi_custom_turn(sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext) -> None:
+        await sr.update_custom(lambda _prev: {'counter': 1, 'status': 'working'})
+        await sr.update_custom(lambda prev: {**(prev or {}), 'counter': 2})
+        await sr.update_custom(lambda prev: {**(prev or {}), 'status': 'done'})
+        await sr.add_messages([_model_text(text='done')])
+
+    h.agents['customAgentWithMultiCustomState'] = ai.define_custom_agent(
+        name='customAgentWithMultiCustomState',
+        fn=run_turns(turn_body=multi_custom_turn),
+    )
+
+    # customAgentWithArtifactsStore: server-managed, adds a numbered artifact
+    # on each invocation.
+    async def artifacts_store_turn(
+        sr: SessionRunner, _ctx: ActionRunContext, _inp: AgentInput, _tc: TurnContext
+    ) -> None:
+        existing = await sr.get_artifacts()
+        count = len(existing) + 1
+        await sr.add_artifacts([Artifact(name=f'doc{count}', parts=[Part(root=TextPart(text=f'content{count}'))])])
+        await sr.add_messages([_model_text(text='done')])
+
+    h.agents['customAgentWithArtifactsStore'] = ai.define_custom_agent(
+        name='customAgentWithArtifactsStore',
+        fn=run_turns(turn_body=artifacts_store_turn),
+        store=InMemorySessionStore(),
+    )
+
+    # customAgentWithCustomStateStore: server-managed counter.
+    h.agents['customAgentWithCustomStateStore'] = ai.define_custom_agent(
+        name='customAgentWithCustomStateStore',
+        fn=run_turns(turn_body=counter_turn),
+        store=InMemorySessionStore(),
+    )
+
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Step executors
+# ---------------------------------------------------------------------------
+
+
+def program_model(*, pm: ProgrammableModel, step: dict[str, Any]) -> None:
+    pm.reset()
+    responses = step.get('modelResponses') or []
+    pm.responses = [ModelResponse.model_validate(r) for r in responses]
+    stream_chunks = step.get('streamChunks')
+    if stream_chunks:
+        pm.chunks = [[ModelResponseChunk.model_validate(c) for c in group] for group in stream_chunks]
+
+
+def assert_chunks(*, actual_chunks: list[Any], expected_chunks: list[Any]) -> None:
+    """Strict ordered chunk comparison per the spec's expectChunks contract."""
+    actual = [dump(model=c) for c in actual_chunks]
+    assert len(actual) == len(expected_chunks), (
+        f'Expected {len(expected_chunks)} chunks, got {len(actual)}.\n'
+        f'  Actual: {actual!r}\n'
+        f'  Expected: {expected_chunks!r}'
+    )
+    for i, expected in enumerate(expected_chunks):
+        got = actual[i]
+        if 'turnEnd' in expected:
+            # turnEnd carries a dynamic snapshotId; only assert presence, plus
+            # finishReason exactly when the spec pins it (key present, including YAML ~).
+            assert 'turnEnd' in got, f'Chunk {i}: expected turnEnd, got {got!r}'
+            turn_end = expected['turnEnd']
+            if isinstance(turn_end, dict) and 'finishReason' in turn_end:
+                # Pydantic json dumps drop None even when the field was set, so
+                # omitted vs null is model_fields_set, not exclude_unset.
+                te_model = actual_chunks[i].turn_end
+                want_fr = turn_end['finishReason']
+                if want_fr is None:
+                    set_null = (
+                        te_model is not None
+                        and 'finish_reason' in te_model.model_fields_set
+                        and te_model.finish_reason is None
+                    )
+                    assert set_null, (
+                        f'Chunk {i}: expected turnEnd.finishReason null, '
+                        f'fields_set={getattr(te_model, "model_fields_set", None)!r} '
+                        f'value={getattr(te_model, "finish_reason", None)!r}'
+                    )
+                else:
+                    got_fr = te_model.finish_reason if te_model is not None else None
+                    assert got_fr == want_fr, f'Chunk {i}: expected turnEnd.finishReason {want_fr!r}, got {got_fr!r}'
+        elif 'modelChunk' in expected:
+            assert_contains(
+                actual=got.get('modelChunk'), expected=expected['modelChunk'], path=f'chunk[{i}].modelChunk'
+            )
+        elif 'artifact' in expected:
+            assert_contains(actual=got.get('artifact'), expected=expected['artifact'], path=f'chunk[{i}].artifact')
+        elif 'customPatch' in expected:
+            assert_contains(
+                actual=got.get('customPatch'), expected=expected['customPatch'], path=f'chunk[{i}].customPatch'
+            )
+        else:
+            assert_contains(actual=got, expected=expected, path=f'chunk[{i}]')
+
+
+def assert_output(*, out: dict[str, Any], expect: dict[str, Any]) -> None:
+    if expect.get('message') is not None:
+        assert_contains(actual=out.get('message'), expected=expect['message'], path='output.message')
+
+    if expect.get('hasSnapshotId'):
+        assert isinstance(out.get('snapshotId'), str) and out['snapshotId'], (
+            f'Expected output to have a snapshotId, got: {out.get("snapshotId")!r}'
+        )
+
+    if expect.get('hasSessionId'):
+        state = out.get('state')
+        assert state, 'Expected output to have state for sessionId check'
+        assert isinstance(state.get('sessionId'), str) and state['sessionId'], (
+            f'Expected output.state to have a sessionId, got: {state.get("sessionId")!r}'
+        )
+
+    if expect.get('stateContains') is not None:
+        assert out.get('state') is not None, 'Expected output to have state'
+        assert_contains(actual=out['state'], expected=expect['stateContains'], path='output.state')
+
+    if expect.get('artifactsContain') is not None:
+        artifacts = out.get('artifacts')
+        assert artifacts is not None, 'Expected output to have artifacts'
+        for expected_art in expect['artifactsContain']:
+            found = next((a for a in artifacts if a.get('name') == expected_art.get('name')), None)
+            assert found is not None, f'Expected artifact {expected_art.get("name")!r} not found in output'
+            assert_contains(actual=found, expected=expected_art, path=f'artifact({expected_art.get("name")})')
+
+    if 'finishReason' in expect:
+        assert out.get('finishReason') == expect['finishReason'], (
+            f'Expected output.finishReason {expect["finishReason"]!r}, got {out.get("finishReason")!r}'
+        )
+
+    if expect.get('errorContains') is not None:
+        err = out.get('error')
+        assert err, f'Expected output to have an error, got: {err!r}'
+        want = expect['errorContains']
+        if 'status' in want:
+            assert err.get('status') == want['status'], (
+                f'Expected output.error.status {want["status"]!r}, got {err.get("status")!r}'
+            )
+        if 'message' in want:
+            assert want['message'] in (err.get('message') or ''), (
+                f'Expected output.error.message to contain {want["message"]!r}, got: {err.get("message")!r}'
+            )
+
+
+def assert_snapshot(*, snap: dict[str, Any], expect: dict[str, Any]) -> None:
+    if 'parentId' in expect:
+        assert snap.get('parentId') == expect['parentId'], (
+            f'Expected parentId {expect["parentId"]!r}, got {snap.get("parentId")!r}'
+        )
+    if 'status' in expect:
+        assert snap.get('status') == expect['status'], (
+            f'Expected status {expect["status"]!r}, got {snap.get("status")!r}'
+        )
+    if 'finishReason' in expect:
+        assert snap.get('finishReason') == expect['finishReason'], (
+            f'Expected snapshot.finishReason {expect["finishReason"]!r}, got {snap.get("finishReason")!r}'
+        )
+    if expect.get('hasSessionId'):
+        state = snap.get('state') or {}
+        assert isinstance(state.get('sessionId'), str) and state['sessionId'], (
+            f'Expected snapshot.state to have a sessionId, got: {state.get("sessionId")!r}'
+        )
+    if expect.get('stateContains') is not None:
+        assert_contains(actual=snap.get('state'), expected=expect['stateContains'], path='snapshot.state')
+    if expect.get('errorContains') is not None:
+        err = snap.get('error')
+        assert err, 'Expected snapshot to have error'
+        # Snapshot error is subset/contains (scalar fields exact), same as JS.
+        # Output errorContains is different: status exact, message substring.
+        assert_contains(actual=err, expected=expect['errorContains'], path='snapshot.error')
+
+
+async def _close_quietly(*, conn: Any) -> None:  # noqa: ANN401
+    if conn is None:
+        return
+    with contextlib.suppress(Exception):
+        await conn.close()
+
+
+def _require_send_expect_error(*, value: Any) -> dict[str, Any]:  # noqa: ANN401
+    if not isinstance(value, dict):
+        raise AssertionError(
+            f'send expectError must be a mapping with optional status/message, got {type(value).__name__}: {value!r}'
+        )
+    if not value:
+        raise AssertionError('send expectError must include status and/or message, got {}')
+    for key in ('status', 'message'):
+        if key in value and not isinstance(value[key], str):
+            raise AssertionError(
+                f'send expectError.{key} must be a string, got {type(value[key]).__name__}: {value[key]!r}'
+            )
+    return value
+
+
+def _require_lookup_expect_error(*, value: Any) -> str:  # noqa: ANN401
+    if not isinstance(value, str) or not value:
+        raise AssertionError(
+            f'getSnapshotData expectError must be a non-empty string substring, got {type(value).__name__}: {value!r}'
+        )
+    return value
+
+
+def _thrown_message(*, thrown: BaseException) -> str:
+    """Return the error's message field, not ``str(exc)`` (which prefixes status)."""
+    return getattr(thrown, 'original_message', None) or getattr(thrown, 'message', None) or str(thrown)
+
+
+def _assert_expect_error(*, thrown: BaseException | None, expect_err: dict[str, Any]) -> None:
+    assert thrown is not None, 'Expected the turn to throw an error, but it resolved successfully.'
+    if 'status' in expect_err:
+        status = getattr(thrown, 'status', None)
+        assert status == expect_err['status'], (
+            f'Expected thrown error.status {expect_err["status"]!r}, got {status!r} (message: {thrown})'
+        )
+    if 'message' in expect_err:
+        thrown_msg = _thrown_message(thrown=thrown)
+        assert expect_err['message'] in thrown_msg, (
+            f'Expected thrown error.message to contain {expect_err["message"]!r}, got: {thrown_msg!r}'
+        )
+
+
+async def execute_send(*, agent: Agent, pm: ProgrammableModel, step: dict[str, Any], captures: dict[str, Any]) -> None:
+    resolved = resolve_templates(value=step, captures=captures)
+    program_model(pm=pm, step=resolved)
+
+    # expectError: the turn throws (API misuse) rather than resolving with a
+    # graceful finishReason='failed' output. Cover stream_bidi / send as well
+    # as receive / output — an init rejection can surface before the stream.
+    if 'expectError' in resolved:
+        expect_err = _require_send_expect_error(value=resolved['expectError'])
+        thrown: BaseException | None = None
+        conn = None
+        try:
+            conn = await agent.stream_bidi(AgentInit.model_validate(resolved.get('init') or {}))
+            for inp in resolved.get('inputs') or []:
+                await conn.send(AgentInput.model_validate(inp))
+            await conn.close()
+            async for _chunk in conn.receive():
+                pass
+            await conn.output()
+        except Exception as e:  # noqa: BLE001 - spec asserts on the raised error
+            thrown = e
+        finally:
+            await _close_quietly(conn=conn)
+        _assert_expect_error(thrown=thrown, expect_err=expect_err)
+        return
+
+    conn = None
+    try:
+        conn = await agent.stream_bidi(AgentInit.model_validate(resolved.get('init') or {}))
+        for inp in resolved.get('inputs') or []:
+            await conn.send(AgentInput.model_validate(inp))
+        await conn.close()
+
+        chunks = [c async for c in conn.receive()]
+        output = await conn.output()
+    finally:
+        await _close_quietly(conn=conn)
+    out = dump(model=output)
+
+    if resolved.get('expectChunks') is not None:
+        assert_chunks(actual_chunks=chunks, expected_chunks=resolved['expectChunks'])
+
+    if resolved.get('expectOutput') is not None:
+        assert_output(out=out, expect=resolved['expectOutput'])
+
+    # Captures for subsequent steps (use the unresolved step so capture names
+    # are never themselves template-substituted).
+    if step.get('captureSnapshotId'):
+        assert out.get('snapshotId'), (
+            f'captureSnapshotId {step["captureSnapshotId"]!r} requested but output has no snapshotId'
+        )
+        captures[step['captureSnapshotId']] = out['snapshotId']
+    if step.get('captureState'):
+        assert out.get('state'), f'captureState {step["captureState"]!r} requested but output has no state'
+        captures[step['captureState']] = out['state']
+    if step.get('captureSessionId'):
+        state = out.get('state') or {}
+        assert state.get('sessionId'), (
+            f'captureSessionId {step["captureSessionId"]!r} requested but output has no state.sessionId'
+        )
+        captures[step['captureSessionId']] = state['sessionId']
+
+
+async def execute_get_snapshot_data(*, agent: Agent, step: dict[str, Any], captures: dict[str, Any]) -> None:
+    resolved = resolve_templates(value=step, captures=captures)
+    snapshot_id = resolved.get('snapshotId')
+    session_id = resolved.get('sessionId')
+    assert bool(snapshot_id) != bool(session_id), 'getSnapshotData step requires exactly one of snapshotId or sessionId'
+
+    if 'expectError' in resolved:
+        expect_err = _require_lookup_expect_error(value=resolved['expectError'])
+        try:
+            snap = await agent.get_snapshot_data(snapshot_id=snapshot_id, session_id=session_id)
+        except Exception as e:  # noqa: BLE001 - spec asserts on the raised error
+            thrown_msg = _thrown_message(thrown=e)
+            assert expect_err in thrown_msg, (
+                f'Expected getSnapshotData error.message to contain {expect_err!r}, got: {thrown_msg!r}'
+            )
+            return
+        if snap is None:
+            raise AssertionError(
+                f'Expected error containing {expect_err!r} but getSnapshotData returned None '
+                '(a miss is not a throw; branching reject must raise)'
+            )
+        raise AssertionError(f'Expected error containing {expect_err!r} but getSnapshotData succeeded')
+
+    snap = await agent.get_snapshot_data(snapshot_id=snapshot_id, session_id=session_id)
+    assert snap is not None, f'Snapshot not found for snapshotId={snapshot_id!r} sessionId={session_id!r}'
+
+    if resolved.get('expectSnapshot') is not None:
+        assert_snapshot(snap=dump(model=snap), expect=resolved['expectSnapshot'])
+
+
+async def execute_abort(*, agent: Agent, step: dict[str, Any], captures: dict[str, Any]) -> None:
+    resolved = resolve_templates(value=step, captures=captures)
+    snapshot_id = resolved.get('snapshotId')
+    assert snapshot_id, 'abort step requires snapshotId'
+
+    previous = await agent.abort_snapshot_data(snapshot_id)
+    previous_str = previous.value if previous is not None else None
+
+    # The key being present (even as YAML ~ / null) means we should assert.
+    if 'expectPreviousStatus' in resolved:
+        expected = resolved['expectPreviousStatus']
+        assert previous_str == expected, f'Expected previous status {expected!r}, got {previous_str!r}'
+
+
+async def execute_wait_until_completed(*, agent: Agent, step: dict[str, Any], captures: dict[str, Any]) -> None:
+    resolved = resolve_templates(value=step, captures=captures)
+    snapshot_id = resolved.get('snapshotId')
+    assert snapshot_id, 'waitUntilCompleted step requires snapshotId'
+    timeout_s = (resolved.get('timeoutMs') or 5000) / 1000.0
+
+    deadline = time.monotonic() + timeout_s
+    snap = None
+    while time.monotonic() < deadline:
+        snap = await agent.get_snapshot_data(snapshot_id=snapshot_id)
+        if snap is not None and snap.status is not None and snap.status.value in TERMINAL_STATUSES:
+            break
+        await asyncio.sleep(0.1)
+
+    assert snap is not None, f'Snapshot {snapshot_id!r} not found after waiting'
+    status = snap.status.value if snap.status is not None else None
+    assert status in TERMINAL_STATUSES, (
+        f'Snapshot {snapshot_id!r} did not reach terminal status within {timeout_s}s. Status: {status!r}'
+    )
+
+    if resolved.get('expectSnapshot') is not None:
+        assert_snapshot(snap=dump(model=snap), expect=resolved['expectSnapshot'])
+
+
+# ---------------------------------------------------------------------------
+# Test runner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('spec_test', SPEC_TESTS, ids=[t['name'] for t in SPEC_TESTS])
+async def test_agent_conformance(spec_test: dict[str, Any]) -> None:
+    harness = setup_harness()
+    agent = harness.agents.get(spec_test['agent'])
+    assert agent is not None, f'Unknown agent {spec_test["agent"]!r} in test {spec_test["name"]!r}'
+
+    captures: dict[str, Any] = {}
+
+    for i, step in enumerate(spec_test['steps']):
+        label = f'step[{i}]'
+        try:
+            if not isinstance(step, dict):
+                raise AssertionError(f'step must be a mapping, got {type(step).__name__}')
+            step_type = step.get('type')
+            label = f'step[{i}] ({step_type})'
+            if step_type == 'send':
+                await execute_send(agent=agent, pm=harness.pm, step=step, captures=captures)
+            elif step_type == 'getSnapshotData':
+                await execute_get_snapshot_data(agent=agent, step=step, captures=captures)
+            elif step_type == 'abort':
+                await execute_abort(agent=agent, step=step, captures=captures)
+            elif step_type == 'waitUntilCompleted':
+                await execute_wait_until_completed(agent=agent, step=step, captures=captures)
+            else:
+                raise AssertionError(f'Unknown step type: {step_type!r}')
+        except Exception as e:
+            raise AssertionError(f'{label} in test {spec_test["name"]!r} failed: {e}') from e
+
+
+def test_assert_contains_none_is_noop() -> None:
+    """A null expected value means "not specified", matching the other harnesses."""
+    assert_contains(actual={'x': 1}, expected=None)
+    assert_contains(actual=None, expected=None)
+    assert_contains(actual=[1, 2], expected=None)
+
+
+def test_tests_from_suite_rejects_non_mapping() -> None:
+    with pytest.raises(AssertionError, match='must be a mapping, got list'):
+        _tests_from_suite(suite=['foo'])
+    with pytest.raises(AssertionError, match='must be a mapping, got bool'):
+        _tests_from_suite(suite=False)
+    with pytest.raises(AssertionError, match='contains no tests'):
+        _tests_from_suite(suite={})
+    with pytest.raises(AssertionError, match=r'tests\[0\] must be a mapping'):
+        _tests_from_suite(suite={'tests': ['foo']})
+    with pytest.raises(AssertionError, match=r'steps\[0\] must be a mapping'):
+        _tests_from_suite(suite={'tests': [{'name': 't', 'agent': 'a', 'steps': ['send']}]})
+
+
+def test_resolve_templates_inline_object_is_json() -> None:
+    got = resolve_templates(
+        value='seeded-{{state1}}',
+        captures={'state1': {'sessionId': 'abc', 'custom': {'counter': 1}}},
+    )
+    assert got == 'seeded-{"sessionId":"abc","custom":{"counter":1}}'
+
+
+def test_assert_expect_error_matches_message_not_status_prefix() -> None:
+    err = GenkitError(status='FAILED_PRECONDITION', message="Cannot send 'state' to agent")
+    _assert_expect_error(
+        thrown=err,
+        expect_err={'status': 'FAILED_PRECONDITION', 'message': "Cannot send 'state'"},
+    )
+    with pytest.raises(AssertionError, match='error.message'):
+        _assert_expect_error(thrown=err, expect_err={'message': 'FAILED_PRECONDITION'})
+
+
+def test_send_expect_error_rejects_string() -> None:
+    with pytest.raises(AssertionError, match='must be a mapping'):
+        _require_send_expect_error(value="Cannot send 'state' to agent")
+    with pytest.raises(AssertionError, match='must include status and/or message'):
+        _require_send_expect_error(value={})
+    with pytest.raises(AssertionError, match='status must be a string'):
+        _require_send_expect_error(value={'status': None})
+
+
+def test_lookup_expect_error_rejects_mapping() -> None:
+    with pytest.raises(AssertionError, match='must be a non-empty string'):
+        _require_lookup_expect_error(value={'status': 'NOT_FOUND', 'message': 'not found'})
+    with pytest.raises(AssertionError, match='must be a non-empty string'):
+        _require_lookup_expect_error(value='')
+
+
+def test_thrown_message_skips_status_prefix() -> None:
+    err = GenkitError(status='NOT_FOUND', message='branching session')
+    assert _thrown_message(thrown=err) == 'branching session'
+    assert 'NOT_FOUND' not in _thrown_message(thrown=err)
+
+
+def test_snapshot_error_contains_is_exact_message() -> None:
+    """Snapshot errorContains uses subset matching; a string field is exact."""
+    wrapped = {'error': {'message': 'background: intentional failure (wrapped)'}}
+    with pytest.raises(AssertionError, match='snapshot.error.message'):
+        assert_snapshot(snap=wrapped, expect={'errorContains': {'message': 'intentional failure'}})
+    assert_snapshot(
+        snap=wrapped,
+        expect={'errorContains': {'message': 'background: intentional failure (wrapped)'}},
+    )
+    assert_snapshot(
+        snap={'error': {'status': 'INTERNAL', 'message': 'intentional failure'}},
+        expect={'errorContains': {'message': 'intentional failure'}},
+    )
+
+
+def test_assert_chunks_pins_null_finish_reason() -> None:
+    chunks = [AgentStreamChunk(turn_end=TurnEnd(finish_reason=AgentFinishReason.STOP))]
+    with pytest.raises(AssertionError, match='finishReason'):
+        assert_chunks(actual_chunks=chunks, expected_chunks=[{'turnEnd': {'finishReason': None}}])
+    assert_chunks(actual_chunks=chunks, expected_chunks=[{'turnEnd': {}}])
+
+    omitted = [AgentStreamChunk(turn_end=TurnEnd())]
+    with pytest.raises(AssertionError, match='finishReason null'):
+        assert_chunks(actual_chunks=omitted, expected_chunks=[{'turnEnd': {'finishReason': None}}])
+
+    explicit_null = [AgentStreamChunk(turn_end=TurnEnd.model_validate({'finishReason': None}))]
+    assert_chunks(actual_chunks=explicit_null, expected_chunks=[{'turnEnd': {'finishReason': None}}])


### PR DESCRIPTION
Adds the Python harness for the shared agent conformance spec. 

Includes some updates to docs/agents-conformance-testing.md to reflect reality.