### PR TITLE
fix(py): resolve agent behavioral divergences from conformance spec

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -176,11 +176,12 @@ class Agent(
         snapshot_id: str | None = None,
         session_id: str | None = None,
     ) -> SessionSnapshot | None:
-        """Read a snapshot by id, or the stored session leaf (client-visible form).
+        """Read a stored snapshot without starting a session.
 
-        A session lookup returns the newest row even when it isn't resumable.
-        Use ``load_chat(session_id=…)`` / ``chat(session_id=…)`` to land on the
-        last completed turn.
+        Pass exactly one of ``snapshot_id`` or ``session_id``. A session
+        lookup returns the newest row even when that turn failed or was
+        aborted. ``chat(session_id=)`` is how you continue from the last
+        good turn.
         """
         if self.store is None:
             return None

--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -176,7 +176,12 @@ class Agent(
         snapshot_id: str | None = None,
         session_id: str | None = None,
     ) -> SessionSnapshot | None:
-        """Read a snapshot by id or latest session leaf (client-visible form)."""
+        """Read a snapshot by id, or the stored session leaf (client-visible form).
+
+        A session lookup returns the newest row even when it isn't resumable.
+        Use ``load_chat(session_id=…)`` / ``chat(session_id=…)`` to land on the
+        last completed turn.
+        """
         if self.store is None:
             return None
         return await resolve_snapshot(

--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -188,7 +188,15 @@ class Agent(
         )
 
     async def abort_snapshot_data(self, snapshot_id: str) -> SnapshotStatus | None:
-        """Abort a running snapshot."""
+        """Abort a running snapshot.
+
+        The return is the snapshot's status from *before* this call, not after.
+        ``pending`` means the turn was still running and this call cancelled it
+        (the row is now ``aborted``). A terminal status means the turn had
+        already finished — this call did not rewrite it. ``None`` means
+        nothing was observed (no store, no row, or the store never ran the
+        abort write). This Python server always returns the previous status.
+        """
         if self.store is None:
             return None
         return await abort_snapshot_in_store(

--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -633,10 +633,37 @@ class AgentClient(Generic[StateT]):
         snapshot_id: str | None = None,
         session_id: str | None = None,
     ) -> AgentChat[StateT]:
-        """Loads a server snapshot and returns a chat with history restored."""
+        """Loads a server snapshot and returns a chat with history restored.
+
+        ``snapshot_id`` is an exact row. ``session_id`` is "pick this
+        conversation back up", so a failed / aborted / pending leaf walks its
+        parent chain to the last completed turn — same as ``chat(session_id=)``.
+        """
         snapshot = await self._transport.get_snapshot(snapshot_id=snapshot_id, session_id=session_id)
         if snapshot is None:
             raise ValueError(f'Snapshot {lookup_label(snapshot_id=snapshot_id, session_id=session_id)!r} not found.')
+        # Session resume has to skip a dead leaf, so walk parents after reading
+        # the stored one. snapshot_id stays an exact row.
+        if session_id is not None and snapshot_id is None:
+            visited: set[str] = set()
+            while snapshot is not None and snapshot.status != SnapshotStatus.COMPLETED:
+                if snapshot.snapshot_id in visited:
+                    raise GenkitError(
+                        status='FAILED_PRECONDITION',
+                        message=(
+                            f'Snapshot parent chain for {snapshot.snapshot_id!r} is cyclic '
+                            '(a snapshot was visited twice). Resume by snapshot_id instead.'
+                        ),
+                    )
+                visited.add(snapshot.snapshot_id)
+                if not snapshot.parent_id:
+                    snapshot = None
+                    break
+                snapshot = await self._transport.get_snapshot(snapshot_id=snapshot.parent_id)
+            if snapshot is None:
+                raise ValueError(
+                    f'Snapshot {lookup_label(snapshot_id=snapshot_id, session_id=session_id)!r} not found.'
+                )
         session_transport = copy.copy(self._transport)
         session_transport.state_management = 'server'
         chat = AgentChat(session_transport, state_schema=self._state_schema)
@@ -649,7 +676,11 @@ class AgentClient(Generic[StateT]):
         snapshot_id: str | None = None,
         session_id: str | None = None,
     ) -> SessionSnapshotSchema | None:
-        """Reads a snapshot without starting a session."""
+        """Reads the stored snapshot without starting a session.
+
+        A session lookup returns the newest leaf even if it isn't resumable.
+        Use ``load_chat(session_id=…)`` to land on the last completed turn.
+        """
         return await self._transport.get_snapshot(snapshot_id=snapshot_id, session_id=session_id)
 
     async def abort(self, snapshot_id: str) -> SnapshotStatus | None:

--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -705,9 +705,8 @@ def validate_init(init: AgentInit) -> None:
     custom state alongside either id — resume from the store, or seed a new
     conversation, not both.
     """
-    has_state = init.state is not None
     has_resume = bool(init.snapshot_id) or bool(init.session_id)
-    if has_state and has_resume:
+    if init.state is not None and has_resume:
         fields = seeded_init_fields(init.state)
         raise AgentInitError(
             status='FAILED_PRECONDITION',

--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -529,9 +529,13 @@ class AgentAPI(Protocol, Generic[StateT]):
     ) -> AgentChat[StateT]:
         """Starts a new session, or attaches to one via a snapshot/session id or saved conversation state.
 
-        ``messages`` / ``artifacts`` / ``state`` are only for client-managed agents
-        (no store). Store-backed agents take ``snapshot_id`` or ``session_id``;
-        passing a state blob raises :class:`AgentInitError`.
+        ``messages`` / ``artifacts`` / ``state`` are only for client-managed
+        agents (no store). Store-backed agents take ``snapshot_id`` and/or
+        ``session_id``. Passing both is fine: the snapshot id picks the row,
+        and the session id checks that the row belongs to that session.
+        Passing a state blob, or mixing ``messages`` / ``artifacts`` /
+        ``state`` with a resume id, raises :class:`AgentInitError` naming the
+        kwargs.
         """
         ...
 
@@ -554,7 +558,19 @@ class AgentAPI(Protocol, Generic[StateT]):
         ...
 
     async def abort(self, snapshot_id: str) -> SnapshotStatus | None:
-        """Aborts a running snapshot."""
+        """Aborts a running snapshot.
+
+        The return is the snapshot's status from *before* this call, not after.
+        ``pending`` means the turn was still running and this call cancelled it
+        (the row is now ``aborted``). A terminal status (``completed``,
+        ``failed``, ``aborted``) means the turn had already finished — this
+        call did not rewrite it. ``None`` means nothing was observed (no row,
+        or the store never ran the abort write).
+
+        Some servers report the status *after* a successful cancel
+        (``aborted``) instead of the previous one (``pending``). If you only
+        need "did this call stop a running turn?", treat either as yes.
+        """
         ...
 
 
@@ -590,9 +606,13 @@ class AgentClient(Generic[StateT]):
     ) -> AgentChat[StateT]:
         """Starts a new session, or attaches to one via a snapshot/session id or saved conversation state.
 
-        ``messages`` / ``artifacts`` / ``state`` are only for client-managed agents
-        (no store). Store-backed agents take ``snapshot_id`` or ``session_id``;
-        passing a state blob raises :class:`AgentInitError`.
+        ``messages`` / ``artifacts`` / ``state`` are only for client-managed
+        agents (no store). Store-backed agents take ``snapshot_id`` and/or
+        ``session_id``. Passing both is fine: the snapshot id picks the row,
+        and the session id checks that the row belongs to that session.
+        Passing a state blob, or mixing ``messages`` / ``artifacts`` /
+        ``state`` with a resume id, raises :class:`AgentInitError` naming the
+        kwargs.
         """
         session_transport = copy.copy(self._transport)
         return AgentChat(
@@ -633,7 +653,19 @@ class AgentClient(Generic[StateT]):
         return await self._transport.get_snapshot(snapshot_id=snapshot_id, session_id=session_id)
 
     async def abort(self, snapshot_id: str) -> SnapshotStatus | None:
-        """Aborts a running snapshot on the server."""
+        """Aborts a running snapshot on the server.
+
+        The return is the snapshot's status from *before* this call, not after.
+        ``pending`` means the turn was still running and this call cancelled it
+        (the row is now ``aborted``). A terminal status (``completed``,
+        ``failed``, ``aborted``) means the turn had already finished — this
+        call did not rewrite it. ``None`` means nothing was observed (no row,
+        or the store never ran the abort write).
+
+        Some servers report the status *after* a successful cancel
+        (``aborted``) instead of the previous one (``pending``). If you only
+        need "did this call stop a running turn?", treat either as yes.
+        """
         return await self._transport.abort_snapshot(snapshot_id)
 
 
@@ -665,19 +697,24 @@ def init_from(
 
 
 def validate_init(init: AgentInit) -> None:
-    """Ensures init specifies at most one resume handle."""
-    provided = [
-        name
-        for name, present in (
-            ('state', init.state is not None),
-            ('snapshot_id', bool(init.snapshot_id)),
-            ('session_id', bool(init.session_id)),
-        )
-        if present
-    ]
-    if len(provided) > 1:
-        raise ValueError(
-            f'AgentInit may specify at most one of state, snapshot_id, or session_id; got {", ".join(provided)}.'
+    """Rejects mixing a state blob with a resume id.
+
+    Passing both ``snapshot_id`` and ``session_id`` is fine: the snapshot id
+    picks the row, and the session id checks that the row belongs to that
+    session. What is not allowed is sending ``messages`` / ``artifacts`` /
+    custom state alongside either id — resume from the store, or seed a new
+    conversation, not both.
+    """
+    has_state = init.state is not None
+    has_resume = bool(init.snapshot_id) or bool(init.session_id)
+    if has_state and has_resume:
+        fields = seeded_init_fields(init.state)
+        raise AgentInitError(
+            status='FAILED_PRECONDITION',
+            message=(
+                f'Cannot send {fields} together with snapshot_id/session_id. '
+                'Resume with snapshot_id and/or session_id, or send a state blob, not both.'
+            ),
         )
 
 
@@ -973,10 +1010,10 @@ class AgentChat(Generic[StateT]):
                 )
             if init.state is not None:
                 self._set_state(init.state)
-            elif init.snapshot_id:
+            if init.snapshot_id:
                 self._snapshot_id = init.snapshot_id
                 self._resume_snapshot_id = init.snapshot_id
-            elif init.session_id:
+            if init.session_id:
                 self._session_id = init.session_id
 
     @property
@@ -1168,6 +1205,16 @@ class AgentChat(Generic[StateT]):
     async def abort(self) -> SnapshotStatus | None:
         """Stops the session's server-side work by aborting its current snapshot.
 
+        The return is the snapshot's status from *before* this call, not after.
+        ``pending`` means the turn was still running and this call cancelled it
+        (the row is now ``aborted``). A terminal status means the turn had
+        already finished. ``None`` means nothing was observed.
+
+        Against this SDK the return is always the previous status. After abort
+        the chat still points at the aborted leaf — ``load_chat(session_id=…)``
+        before the next ``send()``. This does not roll back the local
+        transcript; ``DetachedTask.abort`` does.
+
         Raises:
             ValueError: if there's no snapshot to abort — the agent is
                 client-managed (no store) or no turn has produced a snapshot yet.
@@ -1222,8 +1269,10 @@ class AgentChat(Generic[StateT]):
 
         # Server store owns the state; point it at what to load. Prefer the
         # current resume snapshot, fall back to the session id, else start fresh.
+        # When both are set, the snapshot id picks the row and the session id
+        # stays as an ownership check.
         if self._resume_snapshot_id:
-            return AgentInit(snapshot_id=self._resume_snapshot_id)
+            return AgentInit(snapshot_id=self._resume_snapshot_id, session_id=self._session_id)
         if self._session_id:
             return AgentInit(session_id=self._session_id)
         return AgentInit()
@@ -1418,13 +1467,23 @@ class DetachedTask(Generic[StateT]):
     async def abort(self) -> SnapshotStatus | None:
         """Aborts the detached task on the server.
 
-        If the turn was actually aborted (and not already finished by the time the
-        abort lands), the originating chat drops the prompt it optimistically held
-        for this turn, so its view doesn't strand an unanswered message.
+        The return is the snapshot's status from *before* this call, not after.
+        ``pending`` means this call cancelled a still-running turn (the row is
+        now ``aborted``). A terminal status means the turn had already
+        finished. ``None`` means nothing was observed.
+
+        If this call cancelled a running turn, the originating chat drops the
+        optimistic prompt it added when detach started. That rollback runs at
+        most once. Some servers report ``aborted`` (status after the cancel)
+        instead of ``pending`` (status before); either one is treated as "this
+        call stopped in-flight work" so the prompt is still dropped. A later
+        abort is a no-op.
         """
         status = await self._transport.abort_snapshot(self.snapshot_id)
-        if status == SnapshotStatus.ABORTED and self._on_abort_rollback is not None:
-            self._on_abort_rollback()
+        if status in (SnapshotStatus.PENDING, SnapshotStatus.ABORTED) and self._on_abort_rollback is not None:
+            rollback = self._on_abort_rollback
+            self._on_abort_rollback = None
+            rollback()
         return status
 
 

--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -527,15 +527,18 @@ class AgentAPI(Protocol, Generic[StateT]):
         artifacts: list[Artifact] | None = None,
         state: StateT | None = None,
     ) -> AgentChat[StateT]:
-        """Starts a new session, or attaches to one via a snapshot/session id or saved conversation state.
+        """Starts a new session, or resumes one.
+
+        Store-backed agents take ``snapshot_id`` and/or ``session_id``.
+        ``snapshot_id`` resumes that exact row (it must be completed).
+        ``session_id`` continues the conversation: skip a failed / aborted /
+        pending leaf, or start fresh if there isn't a completed turn yet.
+        Passing both is fine: the snapshot picks the row, the session id
+        checks it belongs to that session.
 
         ``messages`` / ``artifacts`` / ``state`` are only for client-managed
-        agents (no store). Store-backed agents take ``snapshot_id`` and/or
-        ``session_id``. Passing both is fine: the snapshot id picks the row,
-        and the session id checks that the row belongs to that session.
-        Passing a state blob, or mixing ``messages`` / ``artifacts`` /
-        ``state`` with a resume id, raises :class:`AgentInitError` naming the
-        kwargs.
+        agents (no store). Mixing those with a resume id, or sending a state
+        blob to a store-backed agent, raises :class:`AgentInitError`.
         """
         ...
 
@@ -545,7 +548,13 @@ class AgentAPI(Protocol, Generic[StateT]):
         snapshot_id: str | None = None,
         session_id: str | None = None,
     ) -> AgentChat[StateT]:
-        """Loads a server snapshot and returns a session with history restored."""
+        """Loads a stored snapshot onto a new chat.
+
+        Pass exactly one of ``snapshot_id`` or ``session_id``. The chat is
+        pointed at that row as stored — including a failed, aborted, or
+        still-pending turn. ``send()`` resumes that row, so a non-completed
+        leaf is rejected. To continue the conversation, use ``chat(session_id=)``.
+        """
         ...
 
     async def get_snapshot(
@@ -554,7 +563,13 @@ class AgentAPI(Protocol, Generic[StateT]):
         snapshot_id: str | None = None,
         session_id: str | None = None,
     ) -> SessionSnapshotSchema | None:
-        """Reads a snapshot without starting a session."""
+        """Reads a stored snapshot without starting a session.
+
+        Pass exactly one of ``snapshot_id`` or ``session_id``. A session
+        lookup returns the newest row even when that turn failed or was
+        aborted. ``chat(session_id=)`` is how you continue from the last
+        good turn.
+        """
         ...
 
     async def abort(self, snapshot_id: str) -> SnapshotStatus | None:
@@ -579,8 +594,8 @@ class AgentClient(Generic[StateT]):
 
     This is the one ergonomic surface (``chat``/``load_chat``/``get_snapshot``/
     ``abort``) for talking to an agent, whether it's remote (HTTP transport) or
-    in-process (the local agent action). Point it at a transport and you get the
-    same client either way.
+    in-process (the local agent action). ``get_snapshot`` and ``load_chat``
+    read the store; ``chat()`` is how you start or continue a conversation.
 
     ``state_schema`` types the custom session state so the resulting chat hands
     back a validated model instead of a bare dict; leave it None for untyped state.
@@ -604,15 +619,18 @@ class AgentClient(Generic[StateT]):
         artifacts: list[Artifact] | None = None,
         state: StateT | None = None,
     ) -> AgentChat[StateT]:
-        """Starts a new session, or attaches to one via a snapshot/session id or saved conversation state.
+        """Starts a new session, or resumes one.
+
+        Store-backed agents take ``snapshot_id`` and/or ``session_id``.
+        ``snapshot_id`` resumes that exact row (it must be completed).
+        ``session_id`` continues the conversation: skip a failed / aborted /
+        pending leaf, or start fresh if there isn't a completed turn yet.
+        Passing both is fine: the snapshot picks the row, the session id
+        checks it belongs to that session.
 
         ``messages`` / ``artifacts`` / ``state`` are only for client-managed
-        agents (no store). Store-backed agents take ``snapshot_id`` and/or
-        ``session_id``. Passing both is fine: the snapshot id picks the row,
-        and the session id checks that the row belongs to that session.
-        Passing a state blob, or mixing ``messages`` / ``artifacts`` /
-        ``state`` with a resume id, raises :class:`AgentInitError` naming the
-        kwargs.
+        agents (no store). Mixing those with a resume id, or sending a state
+        blob to a store-backed agent, raises :class:`AgentInitError`.
         """
         session_transport = copy.copy(self._transport)
         return AgentChat(
@@ -633,37 +651,16 @@ class AgentClient(Generic[StateT]):
         snapshot_id: str | None = None,
         session_id: str | None = None,
     ) -> AgentChat[StateT]:
-        """Loads a server snapshot and returns a chat with history restored.
+        """Loads a stored snapshot onto a new chat.
 
-        ``snapshot_id`` is an exact row. ``session_id`` is "pick this
-        conversation back up", so a failed / aborted / pending leaf walks its
-        parent chain to the last completed turn — same as ``chat(session_id=)``.
+        Pass exactly one of ``snapshot_id`` or ``session_id``. The chat is
+        pointed at that row as stored — including a failed, aborted, or
+        still-pending turn. ``send()`` resumes that row, so a non-completed
+        leaf is rejected. To continue the conversation, use ``chat(session_id=)``.
         """
         snapshot = await self._transport.get_snapshot(snapshot_id=snapshot_id, session_id=session_id)
         if snapshot is None:
             raise ValueError(f'Snapshot {lookup_label(snapshot_id=snapshot_id, session_id=session_id)!r} not found.')
-        # Session resume has to skip a dead leaf, so walk parents after reading
-        # the stored one. snapshot_id stays an exact row.
-        if session_id is not None and snapshot_id is None:
-            visited: set[str] = set()
-            while snapshot is not None and snapshot.status != SnapshotStatus.COMPLETED:
-                if snapshot.snapshot_id in visited:
-                    raise GenkitError(
-                        status='FAILED_PRECONDITION',
-                        message=(
-                            f'Snapshot parent chain for {snapshot.snapshot_id!r} is cyclic '
-                            '(a snapshot was visited twice). Resume by snapshot_id instead.'
-                        ),
-                    )
-                visited.add(snapshot.snapshot_id)
-                if not snapshot.parent_id:
-                    snapshot = None
-                    break
-                snapshot = await self._transport.get_snapshot(snapshot_id=snapshot.parent_id)
-            if snapshot is None:
-                raise ValueError(
-                    f'Snapshot {lookup_label(snapshot_id=snapshot_id, session_id=session_id)!r} not found.'
-                )
         session_transport = copy.copy(self._transport)
         session_transport.state_management = 'server'
         chat = AgentChat(session_transport, state_schema=self._state_schema)
@@ -676,10 +673,12 @@ class AgentClient(Generic[StateT]):
         snapshot_id: str | None = None,
         session_id: str | None = None,
     ) -> SessionSnapshotSchema | None:
-        """Reads the stored snapshot without starting a session.
+        """Reads a stored snapshot without starting a session.
 
-        A session lookup returns the newest leaf even if it isn't resumable.
-        Use ``load_chat(session_id=…)`` to land on the last completed turn.
+        Pass exactly one of ``snapshot_id`` or ``session_id``. A session
+        lookup returns the newest row even when that turn failed or was
+        aborted. ``chat(session_id=)`` is how you continue from the last
+        good turn.
         """
         return await self._transport.get_snapshot(snapshot_id=snapshot_id, session_id=session_id)
 
@@ -1083,7 +1082,7 @@ class AgentChat(Generic[StateT]):
         metadata a resume needs). The chunks are identical whether state is server-
         or client-managed, so there's one path here. For server-managed sessions
         the durable snapshot in the store stays the source of truth — use
-        ``get_snapshot()`` / ``load_chat`` when you need it (e.g. after a detached
+        ``get_snapshot()`` / ``load_chat`` to read it (e.g. after a detached
         turn, whose chunks this session never saw).
         """
         return self._messages
@@ -1217,10 +1216,10 @@ class AgentChat(Generic[StateT]):
         # reads the stream. For detach we only care about the resulting handle.
         _stream, output_awaitable = await self._transport.run_turn(agent_input=inp, init=init)
         raw_output = await output_awaitable
-        # Point the chat at the pending detached snapshot (same as JS applyOutput).
-        # A send() while it is still pending is rejected; after it completes, send
-        # continues from that snapshot. Abort rolls back the optimistic prompt —
-        # reload via load_chat(session_id=...) to resume from the last completed turn.
+        # Point the chat at the pending detached snapshot. A send() while it is
+        # still pending is rejected; after it completes, send continues from
+        # that snapshot. Abort rolls back the optimistic prompt — use
+        # chat(session_id=...) to resume from the last completed turn.
         self._update_from_output(raw=raw_output, message_count_before=message_count_before)
 
         if not raw_output.snapshot_id:
@@ -1241,7 +1240,7 @@ class AgentChat(Generic[StateT]):
         already finished. ``None`` means nothing was observed.
 
         Against this SDK the return is always the previous status. After abort
-        the chat still points at the aborted leaf — ``load_chat(session_id=…)``
+        the chat still points at the aborted leaf — ``chat(session_id=…)``
         before the next ``send()``. This does not roll back the local
         transcript; ``DetachedTask.abort`` does.
 
@@ -1297,12 +1296,12 @@ class AgentChat(Generic[StateT]):
             # full live state every turn.
             return AgentInit(state=self._session_state())
 
-        # Server store owns the state; point it at what to load. Prefer the
-        # current resume snapshot, fall back to the session id, else start fresh.
-        # When both are set, the snapshot id picks the row and the session id
-        # stays as an ownership check.
+        # A snapshot id already names the row. Sending session_id too would
+        # re-check ownership every turn, and a mismatched id on the snapshot
+        # vs its state would reject a row the caller already chose. Session
+        # id is only the resume handle when there isn't a snapshot yet.
         if self._resume_snapshot_id:
-            return AgentInit(snapshot_id=self._resume_snapshot_id, session_id=self._session_id)
+            return AgentInit(snapshot_id=self._resume_snapshot_id)
         if self._session_id:
             return AgentInit(session_id=self._session_id)
         return AgentInit()

--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -1218,8 +1218,9 @@ class AgentChat(Generic[StateT]):
         raw_output = await output_awaitable
         # Point the chat at the pending detached snapshot. A send() while it is
         # still pending is rejected; after it completes, send continues from
-        # that snapshot. Abort rolls back the optimistic prompt — use
-        # chat(session_id=...) to resume from the last completed turn.
+        # that snapshot. Abort stops the server turn but keeps the prompt —
+        # it was still asked. Use chat(session_id=...) to resume from the last
+        # completed turn.
         self._update_from_output(raw=raw_output, message_count_before=message_count_before)
 
         if not raw_output.snapshot_id:
@@ -1228,7 +1229,6 @@ class AgentChat(Generic[StateT]):
             snapshot_id=raw_output.snapshot_id,
             transport=self._transport,
             state_schema=self._state_schema,
-            on_abort_rollback=lambda: self._rollback_optimistic(message_count_before),
         )
 
     async def abort(self) -> SnapshotStatus | None:
@@ -1241,8 +1241,8 @@ class AgentChat(Generic[StateT]):
 
         Against this SDK the return is always the previous status. After abort
         the chat still points at the aborted leaf — ``chat(session_id=…)``
-        before the next ``send()``. This does not roll back the local
-        transcript; ``DetachedTask.abort`` does.
+        before the next ``send()``. The local transcript keeps the prompt;
+        it was still asked.
 
         Raises:
             ValueError: if there's no snapshot to abort — the agent is
@@ -1448,12 +1448,10 @@ class DetachedTask(Generic[StateT]):
         snapshot_id: str,
         transport: AgentTransport[StateT],
         state_schema: type[StateT] | None = None,
-        on_abort_rollback: Callable[[], None] | None = None,
     ) -> None:
         self.snapshot_id = snapshot_id
         self._transport = transport
         self._state_schema = state_schema
-        self._on_abort_rollback = on_abort_rollback
 
     def _parse_snapshot(self, raw: SessionSnapshotSchema | None) -> SessionSnapshot[StateT] | None:
         if raw is None:
@@ -1501,19 +1499,11 @@ class DetachedTask(Generic[StateT]):
         now ``aborted``). A terminal status means the turn had already
         finished. ``None`` means nothing was observed.
 
-        If this call cancelled a running turn, the originating chat drops the
-        optimistic prompt it added when detach started. That rollback runs at
-        most once. Some servers report ``aborted`` (status after the cancel)
-        instead of ``pending`` (status before); either one is treated as "this
-        call stopped in-flight work" so the prompt is still dropped. A later
-        abort is a no-op.
+        This does not edit the originating chat's transcript. The prompt was
+        still asked; reload via ``chat(session_id=...)`` before the next send
+        so you are not still pointed at the aborted leaf.
         """
-        status = await self._transport.abort_snapshot(self.snapshot_id)
-        if status in (SnapshotStatus.PENDING, SnapshotStatus.ABORTED) and self._on_abort_rollback is not None:
-            rollback = self._on_abort_rollback
-            self._on_abort_rollback = None
-            rollback()
-        return status
+        return await self._transport.abort_snapshot(self.snapshot_id)
 
 
 # ===========================================================================

--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -581,10 +581,6 @@ class AgentAPI(Protocol, Generic[StateT]):
         ``failed``, ``aborted``) means the turn had already finished — this
         call did not rewrite it. ``None`` means nothing was observed (no row,
         or the store never ran the abort write).
-
-        Some servers report the status *after* a successful cancel
-        (``aborted``) instead of the previous one (``pending``). If you only
-        need "did this call stop a running turn?", treat either as yes.
         """
         ...
 
@@ -691,10 +687,6 @@ class AgentClient(Generic[StateT]):
         ``failed``, ``aborted``) means the turn had already finished — this
         call did not rewrite it. ``None`` means nothing was observed (no row,
         or the store never ran the abort write).
-
-        Some servers report the status *after* a successful cancel
-        (``aborted``) instead of the previous one (``pending``). If you only
-        need "did this call stop a running turn?", treat either as yes.
         """
         return await self._transport.abort_snapshot(snapshot_id)
 

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -347,6 +347,8 @@ async def load_session(
     """Construct a Session from AgentInit payload.
 
     Server-managed (store set): resume via snapshot_id or session_id.
+    snapshot_id is that exact row (must be completed). session_id continues
+    the conversation: skip a dead leaf, or start fresh if none is completed.
     Client-managed (no store): use init.state or start fresh.
 
     When ``state_schema`` is set the custom state loaded from a snapshot or the

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -37,6 +37,7 @@ from genkit._ai._agents._session import (
     reserve_snapshot_id,
     run_with_session,
 )
+from genkit._ai._agents._session_stores._util import session_id_of
 from genkit._ai._agents._snapshot import walk_back_to_resumable
 from genkit._ai._agents._types import ChunkTransform, StateTransform, TurnContext, TurnResult
 from genkit._ai._generate import generate_action
@@ -316,7 +317,9 @@ def assert_init_matches_state_management(
 ) -> None:
     """Raise ``AgentInitError`` when init does not match the agent's store mode."""
     if (init.snapshot_id or init.session_id) and store is None:
-        field = 'snapshot_id' if init.snapshot_id else 'session_id'
+        # Wire-facing errors use the wire (camelCase) field names so a
+        # client talking over HTTP sees the same identifiers it sent.
+        field = 'snapshotId' if init.snapshot_id else 'sessionId'
         raise AgentInitError(
             status='FAILED_PRECONDITION',
             message=(
@@ -325,12 +328,11 @@ def assert_init_matches_state_management(
             ),
         )
     if init.state is not None and store is not None:
-        fields = seeded_init_fields(init.state)
         raise AgentInitError(
             status='FAILED_PRECONDITION',
             message=(
-                f"Cannot send {fields} to agent '{agent_name}': this agent uses a "
-                "server-managed store. Send 'snapshot_id' or 'session_id' instead."
+                f"Cannot send 'state' to agent '{agent_name}': this agent uses a "
+                "server-managed store. Send 'snapshotId' or 'sessionId' instead."
             ),
         )
 
@@ -356,11 +358,6 @@ async def load_session(
     """
     name = agent_name or 'agent'
 
-    if init.snapshot_id and init.session_id:
-        raise AgentInitError(
-            status='INVALID_ARGUMENT',
-            message=(f"Cannot send both 'snapshot_id' and 'session_id' to agent '{name}'. Provide exactly one."),
-        )
     assert_init_matches_state_management(init=init, store=store, agent_name=name)
 
     ctx = get_current_context()
@@ -372,6 +369,20 @@ async def load_session(
                 status='NOT_FOUND',
                 message=f'Snapshot {init.snapshot_id!r} not found',
             )
+        # When init carries both ids, the snapshot id picks the row and the
+        # session id is an ownership check: the snapshot must belong to that
+        # session. Wrong pairing is a client error, not a silent load.
+        if init.session_id:
+            snap_session_id = session_id_of(snap)
+            if snap_session_id != init.session_id:
+                owner = snap_session_id if snap_session_id is not None else 'an unknown session'
+                raise AgentInitError(
+                    status='INVALID_ARGUMENT',
+                    message=(
+                        f'Snapshot {init.snapshot_id!r} does not belong to session '
+                        f'{init.session_id!r} (it belongs to {owner!r}).'
+                    ),
+                )
         # A failed/aborted/pending snapshot is kept for inspection but isn't a
         # valid place to continue a conversation from.
         if snap.status != SnapshotStatus.COMPLETED:
@@ -738,7 +749,17 @@ class AgentRuntime:
         state = await self.session.state()
         now = datetime.now(timezone.utc).isoformat()
         fn_err = err_holder[0] if err_holder else None
-        if fn_err:
+        # SessionRunner.run swallows turn exceptions into last_turn_error and
+        # still returns. The attached path consults that field; detached
+        # finalize used to look only at err_holder, so a graceful turn failure
+        # wrote status=completed / error=None. Same rule as emit_turn_end.
+        turn_err = self.session_runner.last_turn_error
+        is_failed = (
+            fn_err is not None
+            or turn_err is not None
+            or self.session_runner.last_turn_finish_reason == AgentFinishReason.FAILED
+        )
+        if is_failed:
             finish_reason = AgentFinishReason.FAILED
         else:
             result = result_holder[0] if result_holder else None
@@ -753,9 +774,9 @@ class AgentRuntime:
             return SessionSnapshot(
                 snapshot_id=existing.snapshot_id if existing else '',
                 parent_id=pending_snap.parent_id or '',
-                status=SnapshotStatus.FAILED if fn_err else SnapshotStatus.COMPLETED,
+                status=SnapshotStatus.FAILED if is_failed else SnapshotStatus.COMPLETED,
                 state=state,
-                error=(to_error_details(fn_err) if fn_err else None),
+                error=(to_error_details(fn_err) if fn_err else turn_err),
                 finish_reason=finish_reason,
                 created_at=existing.created_at if existing else now,
             )
@@ -796,6 +817,12 @@ class AgentRuntime:
                 async for item in client_inputs:
                     if item.detach:
                         is_detached = True
+                        # Stop chunk emission immediately: a detached run must
+                        # not stream chunks back on this connection. Setting the
+                        # flag here — before the payload is queued — closes the
+                        # race where the background turn starts streaming before
+                        # the detach branch of run() marks the runtime detached.
+                        self.detached = True
                         # Forward the detach input's payload (if any) into the turn
                         # loop and close it *before* signaling detach. Doing it in
                         # this order means the turn is deterministically queued for

--- a/py/packages/genkit/src/genkit/_ai/_agents/_session.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_session.py
@@ -125,8 +125,10 @@ class SessionStore(Protocol, Generic[StateT_co]):
         """Atomically read-modify-write a snapshot under ``snapshot_id``.
 
         fn receives the existing snapshot (or None for new) and returns the
-        snapshot to persist, or None to skip. fn must be side-effect free —
-        stores may call it more than once under contention.
+        snapshot to persist, or None to skip. Stores may call fn more than
+        once under contention, so it must not mutate external state; recording
+        what it observed is fine as long as a retried call may overwrite the
+        record (last call wins).
 
         Callers reserve the id up front (``reserve_snapshot_id``) so it can be
         known before the write — e.g. handed to a turn handler via

--- a/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
@@ -163,6 +163,25 @@ def abort_if_pending(existing: SessionSnapshot | None) -> SessionSnapshot | None
     return existing.model_copy(update={'status': SnapshotStatus.ABORTED})
 
 
+class _AbortRecorder:
+    """save_snapshot mutator for abort that also records the row it saw.
+
+    Abort reports the turn's prior status (was it still running, or already
+    finished?), and the only trustworthy source for that is the row the winning
+    write actually observed — a separate read could see a newer state. Stores
+    may invoke the mutator more than once under contention; the last
+    observation wins, matching what got committed.
+    """
+
+    def __init__(self) -> None:
+        self.previous: SnapshotStatus | None = None
+
+    def __call__(self, existing: SessionSnapshot | None) -> SessionSnapshot | None:
+        if existing is not None:
+            self.previous = existing.status
+        return abort_if_pending(existing)
+
+
 async def abort_snapshot_in_store(
     *,
     store: SessionStore,
@@ -180,20 +199,10 @@ async def abort_snapshot_in_store(
     Returns the last status the mutator saw on the existing row — typically
     ``pending`` when this call cancelled in-flight work, or the unchanged
     terminal status if the turn had already finished. ``None`` if the mutator
-    never ran (missing row, or the store skipped the write).
-
-    Stores may invoke the mutator more than once under contention. We keep the
-    last observation, not the first, so the return matches what the winning
-    write saw. We do not re-read the row afterward to invent a previous
-    status: if the mutator never ran, there is nothing to report.
+    never ran (missing row, or the store skipped the write). We do not re-read
+    the row afterward to invent a previous status: if the mutator never ran,
+    there is nothing to report.
     """
-    previous: SnapshotStatus | None = None
-
-    def capture_and_abort(existing: SessionSnapshot | None) -> SessionSnapshot | None:
-        nonlocal previous
-        if existing is not None:
-            previous = existing.status
-        return abort_if_pending(existing)
-
-    await store.save_snapshot(snapshot_id, capture_and_abort, context=context)
-    return previous
+    recorder = _AbortRecorder()
+    await store.save_snapshot(snapshot_id, recorder, context=context)
+    return recorder.previous

--- a/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
@@ -35,16 +35,11 @@ async def walk_back_to_resumable(
     store: SessionStore,
     snapshot: SessionSnapshot | None,
 ) -> SessionSnapshot | None:
-    """Falls back from a session leaf to the last resumable (completed) snapshot.
+    """Skip a failed / aborted / pending leaf back to the last completed snapshot.
 
-    A session's newest snapshot can be a failed, aborted, or still-pending turn,
-    and none of those are a place you can pick the conversation back up from. So
-    a non-completed leaf walks its parent chain back to the last good turn —
-    landing a reload on the same spot a live chat would resume from, instead of a
-    dead handle. A visited set guards a corrupt or cyclic chain.
-
-    Parent hops use the ambient request context so tenant-scoped stores keep
-    reading under the same auth as the caller.
+    That's the only kind of row you can continue a conversation from. If the
+    parent chain loops, we fail instead of reading forever. Parent hops use
+    the ambient request context so tenant-scoped stores keep the caller's auth.
     """
     visited: set[str] = set()
     while snapshot is not None and snapshot.status != SnapshotStatus.COMPLETED:
@@ -149,9 +144,9 @@ async def resolve_snapshot(
         snapshot = await store.get_snapshot(snapshot_id=snapshot_id, context=context)
     else:
         assert session_id is not None
-        # Inspect returns the stored leaf as-is — including a failed, aborted,
-        # or still-pending turn — so you can see why the last turn died.
-        # Resume (chat / load_chat / load_session) walks back separately.
+        # Return the stored leaf as-is — including a failed, aborted, or
+        # still-pending turn — so you can see why the last turn died.
+        # chat(session_id=) / load_session skip a dead leaf separately.
         snapshot = await store.get_snapshot(session_id=session_id, context=context)
     if snapshot is None:
         return None

--- a/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
@@ -149,10 +149,10 @@ async def resolve_snapshot(
         snapshot = await store.get_snapshot(snapshot_id=snapshot_id, context=context)
     else:
         assert session_id is not None
-        # Resolving a session means "where do I continue from", so skip a
-        # failed/aborted/pending leaf back to the last resumable turn.
+        # Inspect returns the stored leaf as-is — including a failed, aborted,
+        # or still-pending turn — so you can see why the last turn died.
+        # Resume (chat / load_chat / load_session) walks back separately.
         snapshot = await store.get_snapshot(session_id=session_id, context=context)
-        snapshot = await walk_back_to_resumable(store=store, snapshot=snapshot)
     if snapshot is None:
         return None
     effective = (

--- a/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_snapshot.py
@@ -176,18 +176,29 @@ async def abort_snapshot_in_store(
 ) -> SnapshotStatus | None:
     """Abort a running snapshot by flipping it to aborted.
 
-    There's no dedicated store abort call: aborting is an ordinary atomic
-    snapshot write whose mutator flips a still-pending turn to aborted and leaves
-    an already-finished one untouched, so a late abort never rewrites a
-    completed/failed result. The write also notifies any status subscribers,
-    which is how a detached turn learns it was aborted. Returns the snapshot's
-    resulting status (aborted when this call did the flip), or None if it doesn't
-    exist.
+    There's no separate abort API on the store. Aborting is an ordinary atomic
+    snapshot write: the mutator flips a still-pending turn to aborted and leaves
+    an already-finished one untouched, so a late abort never overwrites a
+    completed or failed result. The write also notifies status subscribers,
+    which is how a detached turn learns it was aborted.
+
+    Returns the last status the mutator saw on the existing row — typically
+    ``pending`` when this call cancelled in-flight work, or the unchanged
+    terminal status if the turn had already finished. ``None`` if the mutator
+    never ran (missing row, or the store skipped the write).
+
+    Stores may invoke the mutator more than once under contention. We keep the
+    last observation, not the first, so the return matches what the winning
+    write saw. We do not re-read the row afterward to invent a previous
+    status: if the mutator never ran, there is nothing to report.
     """
-    saved = await store.save_snapshot(snapshot_id, abort_if_pending, context=context)
-    if saved is not None:
-        return saved.status
-    # The mutator skipped the write: either the snapshot is gone or already
-    # terminal. Report its current status without touching it.
-    current = await store.get_snapshot(snapshot_id=snapshot_id, context=context)
-    return current.status if current is not None else None
+    previous: SnapshotStatus | None = None
+
+    def capture_and_abort(existing: SessionSnapshot | None) -> SessionSnapshot | None:
+        nonlocal previous
+        if existing is not None:
+            previous = existing.status
+        return abort_if_pending(existing)
+
+    await store.save_snapshot(snapshot_id, capture_and_abort, context=context)
+    return previous

--- a/py/packages/genkit/tests/genkit/ai/agent_chat_client_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_chat_client_test.py
@@ -175,46 +175,11 @@ def test_connect_init_rejects_multiple_resume_fields() -> None:
 
 
 @pytest.mark.asyncio
-async def test_detached_task_abort_rolls_back_once() -> None:
-    rolls = 0
-
-    def rollback() -> None:
-        nonlocal rolls
-        rolls += 1
-
-    task = DetachedTask(
-        snapshot_id='snap-1',
-        transport=MockAgentTransport(),
-        on_abort_rollback=rollback,
-    )
-    assert await task.abort() == SnapshotStatus.PENDING
-    assert await task.abort() == SnapshotStatus.PENDING
-    assert rolls == 1
-
-
-@pytest.mark.asyncio
-async def test_detached_task_abort_rolls_back_on_after_status_aborted() -> None:
-    """Some servers return the status after cancel; still treat that as a stop."""
-    rolls = 0
-
-    def rollback() -> None:
-        nonlocal rolls
-        rolls += 1
-
+async def test_detached_task_abort_returns_previous_status() -> None:
     transport = MockAgentTransport()
-
-    async def abort_as_aborted(snapshot_id: str) -> SnapshotStatus | None:
-        transport.abort_snapshot_id = snapshot_id
-        return SnapshotStatus.ABORTED
-
-    transport.abort_snapshot = abort_as_aborted  # type: ignore[method-assign]
-    task = DetachedTask(
-        snapshot_id='snap-1',
-        transport=transport,
-        on_abort_rollback=rollback,
-    )
-    assert await task.abort() == SnapshotStatus.ABORTED
-    assert rolls == 1
+    task = DetachedTask(snapshot_id='snap-1', transport=transport)
+    assert await task.abort() == SnapshotStatus.PENDING
+    assert transport.abort_snapshot_id == 'snap-1'
 
 
 def test_connect_init_allows_snapshot_id_and_session_id() -> None:

--- a/py/packages/genkit/tests/genkit/ai/agent_chat_client_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_chat_client_test.py
@@ -26,6 +26,7 @@ from genkit._ai._agents._client import (
     AgentError,
     AgentInterrupt,
     AgentTransport,
+    DetachedTask,
     TurnDriver,
 )
 from genkit._ai._agents._runtime import AgentInitError
@@ -139,7 +140,7 @@ class MockAgentTransport(AgentTransport[Any]):
 
     async def abort_snapshot(self, snapshot_id: str) -> SnapshotStatus | None:
         self.abort_snapshot_id = snapshot_id
-        return SnapshotStatus.ABORTED
+        return SnapshotStatus.PENDING
 
     def push_chunk(self, chunk: AgentStreamChunk | None) -> None:
         self._receive_queue.put_nowait(chunk)
@@ -166,11 +167,64 @@ def test_restart_applies_replace_input() -> None:
 
 
 def test_connect_init_rejects_multiple_resume_fields() -> None:
-    with pytest.raises(ValueError, match='at most one'):
+    with pytest.raises(AgentInitError, match="Cannot send 'state' together with"):
         AgentChat(
             MockAgentTransport(),
             AgentInit(state=SessionState(), snapshot_id='snap-1'),
         )
+
+
+@pytest.mark.asyncio
+async def test_detached_task_abort_rolls_back_once() -> None:
+    rolls = 0
+
+    def rollback() -> None:
+        nonlocal rolls
+        rolls += 1
+
+    task = DetachedTask(
+        snapshot_id='snap-1',
+        transport=MockAgentTransport(),
+        on_abort_rollback=rollback,
+    )
+    assert await task.abort() == SnapshotStatus.PENDING
+    assert await task.abort() == SnapshotStatus.PENDING
+    assert rolls == 1
+
+
+@pytest.mark.asyncio
+async def test_detached_task_abort_rolls_back_on_after_status_aborted() -> None:
+    """Some servers return the status after cancel; still treat that as a stop."""
+    rolls = 0
+
+    def rollback() -> None:
+        nonlocal rolls
+        rolls += 1
+
+    transport = MockAgentTransport()
+
+    async def abort_as_aborted(snapshot_id: str) -> SnapshotStatus | None:
+        transport.abort_snapshot_id = snapshot_id
+        return SnapshotStatus.ABORTED
+
+    transport.abort_snapshot = abort_as_aborted  # type: ignore[method-assign]
+    task = DetachedTask(
+        snapshot_id='snap-1',
+        transport=transport,
+        on_abort_rollback=rollback,
+    )
+    assert await task.abort() == SnapshotStatus.ABORTED
+    assert rolls == 1
+
+
+def test_connect_init_allows_snapshot_id_and_session_id() -> None:
+    # JS resolveSession: snapshotId selects, sessionId is an ownership guard.
+    chat = AgentChat(
+        MockAgentTransport(state_management='server'),
+        AgentInit(snapshot_id='snap-1', session_id='sess-1'),
+    )
+    assert chat.snapshot_id == 'snap-1'
+    assert chat.session_id == 'sess-1'
 
 
 def test_connect_init_applies_state_only() -> None:
@@ -219,9 +273,9 @@ async def test_wire_init_derives_from_live_session_state() -> None:
 
     # First turn (no snapshot yet) resumes by the bootstrap session id.
     assert transport.connect_init == AgentInit(session_id='sess-bootstrap')
-    # Output advanced the live snapshot id, so the next turn would resume by snapshot.
+    # Output advanced the live snapshot id; sessionId stays as the ownership guard.
     assert chat.snapshot_id == 'snap-1'
-    assert chat._wire_init() == AgentInit(snapshot_id='snap-1')
+    assert chat._wire_init() == AgentInit(snapshot_id='snap-1', session_id='sess-bootstrap')
 
 
 # ---------------------------------------------------------------------------
@@ -1139,7 +1193,9 @@ async def test_session_abort() -> None:
 
     # Abort the running snapshot on the server (requires a store)
     status = await chat.abort()
-    assert status == SnapshotStatus.ABORTED
+    # abort() returns the snapshot's *previous* status — pending, since the
+    # detached turn was still running (spec: tests/specs/agent.yaml).
+    assert status == SnapshotStatus.PENDING
 
     # Give the background task a moment to process cancellation
     await asyncio.sleep(0.5)

--- a/py/packages/genkit/tests/genkit/ai/agent_chat_client_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_chat_client_test.py
@@ -218,7 +218,7 @@ async def test_detached_task_abort_rolls_back_on_after_status_aborted() -> None:
 
 
 def test_connect_init_allows_snapshot_id_and_session_id() -> None:
-    # JS resolveSession: snapshotId selects, sessionId is an ownership guard.
+    # snapshot_id picks the row; session_id is an ownership check.
     chat = AgentChat(
         MockAgentTransport(state_management='server'),
         AgentInit(snapshot_id='snap-1', session_id='sess-1'),
@@ -273,9 +273,9 @@ async def test_wire_init_derives_from_live_session_state() -> None:
 
     # First turn (no snapshot yet) resumes by the bootstrap session id.
     assert transport.connect_init == AgentInit(session_id='sess-bootstrap')
-    # Output advanced the live snapshot id; sessionId stays as the ownership guard.
+    # Output advanced the live snapshot id; later turns resume that row only.
     assert chat.snapshot_id == 'snap-1'
-    assert chat._wire_init() == AgentInit(snapshot_id='snap-1', session_id='sess-bootstrap')
+    assert chat._wire_init() == AgentInit(snapshot_id='snap-1')
 
 
 # ---------------------------------------------------------------------------

--- a/py/packages/genkit/tests/genkit/ai/agent_detach_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_detach_test.py
@@ -307,7 +307,8 @@ async def test_abort_snapshot_stops_detached_work() -> None:
     assert out.snapshot_id is not None
 
     prev = await abort_snapshot_in_store(store=store, snapshot_id=out.snapshot_id)
-    assert prev == SnapshotStatus.ABORTED
+    # Previous-status semantics: the snapshot was pending when we aborted it.
+    assert prev == SnapshotStatus.PENDING
 
     await _wait_for_snapshot_status(store, out.snapshot_id, SnapshotStatus.ABORTED, timeout_s=2.0)
     await asyncio.wait_for(aborted.wait(), timeout=2.0)
@@ -366,3 +367,46 @@ async def test_generate_tool_respects_abort_signal() -> None:
     abort_signal.set()
     await asyncio.wait_for(task, timeout=2.0)
     assert tool_saw_abort.is_set()
+
+
+@pytest.mark.asyncio
+async def test_detach_swallowed_turn_error_finalizes_failed() -> None:
+    """A turn that raises inside SessionRunner.run must finalize as failed.
+
+    run() swallows the exception into last_turn_error and returns. The AgentFn
+    here does not re-raise — that is the documented / user-shaped path. Detached
+    finalize must consult last_turn_error, not only an exception escaping fn.
+    """
+    store = InMemorySessionStore()
+    session = Session(SessionState(session_id='test-session', messages=[]))
+    rt, _out_queue = _runtime(session, store)
+    await rt.session_runner.seed_last_good_state()
+
+    async def agent_fn(session_runner: SessionRunner, _ctx: ActionRunContext) -> AgentResult:
+        async def handle_turn(_inp: AgentInput, _: TurnContext) -> None:
+            raise RuntimeError('intentional failure')
+
+        await session_runner.run(handle_turn)
+        return await session_runner.result()
+
+    in_queue = CloseableQueue()
+    await in_queue.put(
+        AgentInput(
+            message=MessageData(role=Role.USER, content=[Part(TextPart(text='fail'))]),
+            detach=True,
+        )
+    )
+    in_queue.close()
+
+    out = await rt.run(fn=agent_fn, client_inputs=in_queue)
+    assert out.finish_reason == AgentFinishReason.DETACHED
+    assert out.snapshot_id is not None
+
+    await _wait_for_snapshot_status(store, out.snapshot_id, SnapshotStatus.FAILED)
+
+    snap = await store.get_snapshot(snapshot_id=out.snapshot_id)
+    assert snap is not None
+    assert snap.status == SnapshotStatus.FAILED
+    assert snap.finish_reason == AgentFinishReason.FAILED
+    assert snap.error is not None
+    assert 'intentional failure' in (snap.error.message or '')

--- a/py/packages/genkit/tests/genkit/ai/agent_init_funnel_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_init_funnel_test.py
@@ -137,6 +137,23 @@ def test_chat_rejects_messages_on_server_managed_agent() -> None:
     assert "Cannot send 'state'" not in str(exc.value)
 
 
+def test_chat_rejects_messages_mixed_with_snapshot_id() -> None:
+    """messages= + snapshot_id= is AgentInitError naming 'messages', not 'state'."""
+    registry = Registry()
+    store = InMemorySessionStore()
+    agent = define_custom_agent(registry, 'serverChatMix', echo_fn, store=store)
+
+    with pytest.raises(AgentInitError) as exc:
+        agent.chat(
+            messages=[MessageData(role='user', content=[Part(root=TextPart(text='hi'))])],
+            snapshot_id='snap-1',
+        )
+
+    assert exc.value.status == 'FAILED_PRECONDITION'
+    assert "Cannot send 'messages'" in str(exc.value)
+    assert "Cannot send 'state'" not in str(exc.value)
+
+
 @pytest.mark.asyncio
 async def test_snapshot_id_on_client_managed_agent_raises_agent_init_error() -> None:
     registry = Registry()

--- a/py/packages/genkit/tests/genkit/ai/agent_load_session_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_load_session_test.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import pytest
 
-from genkit._ai._agents._runtime import load_session
+from genkit._ai._agents._runtime import AgentInitError, load_session
 from genkit._ai._agents._session import SessionStore
 from genkit._core._error import GenkitError
 from genkit._core._typing import (
@@ -127,3 +127,33 @@ async def test_resume_by_session_id_no_completed_seeds_fresh() -> None:
     assert snap is None
     state = await session.state()
     assert state.session_id == SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_snapshot_id_and_matching_session_id_resumes() -> None:
+    completed = _snap('snap-c', SnapshotStatus.COMPLETED)
+    store = _ScriptedStore({'snap-c': completed}, leaf=completed)
+
+    _session, snap = await load_session(
+        init=AgentInit(snapshot_id='snap-c', session_id=SESSION_ID),
+        store=store,
+        agent_name='a',
+    )
+    assert snap is not None
+    assert snap.snapshot_id == 'snap-c'
+
+
+@pytest.mark.asyncio
+async def test_snapshot_id_with_mismatched_session_id_rejected() -> None:
+    completed = _snap('snap-c', SnapshotStatus.COMPLETED)
+    store = _ScriptedStore({'snap-c': completed}, leaf=completed)
+
+    with pytest.raises(AgentInitError) as exc:
+        await load_session(
+            init=AgentInit(snapshot_id='snap-c', session_id='other-sess'),
+            store=store,
+            agent_name='a',
+        )
+    assert exc.value.status == INVALID_ARGUMENT
+    assert 'does not belong to session' in str(exc.value)
+    assert 'it belongs to' in str(exc.value)

--- a/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
@@ -228,7 +228,7 @@ async def test_abort_returns_last_mutator_observation_under_retry() -> None:
 
 @pytest.mark.asyncio
 async def test_abort_returns_none_when_mutator_never_runs() -> None:
-    """JS returns undefined if saveSnapshot never invokes the callback — do not invent pending via get_snapshot."""
+    """If save_snapshot never runs the mutator, abort reports nothing — don't invent pending via get_snapshot."""
     pending = make_snapshot('sess-skip', 'work', SnapshotStatus.PENDING)
 
     class _SkipMutatorStore(SessionStore):

--- a/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_session_stores_test.py
@@ -151,7 +151,9 @@ async def test_abort_flips_pending_only() -> None:
     pending = await store.save_snapshot(pending_snap.snapshot_id, lambda _: pending_snap)
     assert pending is not None
 
-    assert await abort_snapshot_in_store(store=store, snapshot_id=pending.snapshot_id) == SnapshotStatus.ABORTED
+    # Abort returns the *previous* status (spec: tests/specs/agent.yaml) —
+    # 'pending' when this call performed the flip.
+    assert await abort_snapshot_in_store(store=store, snapshot_id=pending.snapshot_id) == SnapshotStatus.PENDING
     snap = await store.get_snapshot(snapshot_id=pending.snapshot_id)
     assert snap is not None and snap.status == SnapshotStatus.ABORTED
 
@@ -201,6 +203,42 @@ def test_apply_save_rejects_async_mutator() -> None:
     with pytest.raises(GenkitError) as exc_info:
         apply_save(existing=existing, snapshot_id=existing.snapshot_id, fn=bad)  # type: ignore[arg-type]
     assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_abort_returns_last_mutator_observation_under_retry() -> None:
+    """save_snapshot may call fn more than once; return the last pre-image, not the first."""
+    pending = make_snapshot('sess-retry', 'work', SnapshotStatus.PENDING)
+    completed = pending.model_copy(update={'status': SnapshotStatus.COMPLETED})
+
+    class _RetryStore(SessionStore):
+        async def get_snapshot(self, *, snapshot_id=None, session_id=None, context=None):  # noqa: ANN001
+            return completed
+
+        async def save_snapshot(self, snapshot_id, fn, *, context=None):  # noqa: ANN001
+            fn(pending)
+            fn(completed)
+            return completed
+
+    # First observation is pending; last observation is completed (finalize won).
+    assert (
+        await abort_snapshot_in_store(store=_RetryStore(), snapshot_id=pending.snapshot_id) == SnapshotStatus.COMPLETED
+    )
+
+
+@pytest.mark.asyncio
+async def test_abort_returns_none_when_mutator_never_runs() -> None:
+    """JS returns undefined if saveSnapshot never invokes the callback — do not invent pending via get_snapshot."""
+    pending = make_snapshot('sess-skip', 'work', SnapshotStatus.PENDING)
+
+    class _SkipMutatorStore(SessionStore):
+        async def get_snapshot(self, *, snapshot_id=None, session_id=None, context=None):  # noqa: ANN001
+            return pending
+
+        async def save_snapshot(self, snapshot_id, fn, *, context=None):  # noqa: ANN001
+            return pending
+
+    assert await abort_snapshot_in_store(store=_SkipMutatorStore(), snapshot_id=pending.snapshot_id) is None
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/agent_snapshot_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_snapshot_test.py
@@ -231,9 +231,9 @@ async def test_custom_agent_turn_that_raises_resolves_as_failed() -> None:
 
 @pytest.mark.asyncio
 async def test_chat_points_at_detached_snapshot_so_send_needs_completed_or_reload() -> None:
-    """After detach the chat resumes the pending snapshot (JS applyOutput shape).
+    """After detach the chat resumes the pending snapshot.
 
-    A send while it is still pending (or after abort) is rejected; reload by
+    A send while it is still pending (or after abort) is rejected; resume by
     session_id walks back to the last completed turn.
     """
     registry = Registry()
@@ -259,7 +259,7 @@ async def test_chat_points_at_detached_snapshot_so_send_needs_completed_or_reloa
 
     task = await chat.detach('slow background work')
     assert chat.messages != history_before_detach  # optimistic prompt pushed
-    # Resume handle tracks the pending detached snapshot — same as JS.
+    # Resume handle tracks the pending detached snapshot.
     assert chat.snapshot_id == task.snapshot_id
     assert chat._resume_snapshot_id == task.snapshot_id  # noqa: SLF001
 
@@ -275,16 +275,16 @@ async def test_chat_points_at_detached_snapshot_so_send_needs_completed_or_reloa
     with pytest.raises(AgentError, match='not resumable'):
         await chat.send('still stranded')
 
-    chat = await agent.load_chat(session_id=session_id)
+    chat = agent.chat(session_id=session_id)
     out = await chat.send('are you there?')
     assert out.finish_reason == AgentFinishReason.STOP
     assert chat.snapshot_id not in (None, task.snapshot_id)
 
 
 @pytest.mark.asyncio
-async def test_load_chat_by_session_skips_aborted_leaf_to_last_resumable() -> None:
-    """Reloading a session whose newest snapshot is an aborted detached turn lands
-    on the last completed turn, not the dead leaf — so the reloaded chat resumes."""
+async def test_load_chat_by_session_hydrates_aborted_leaf() -> None:
+    """load_chat is inspect: a session whose newest snapshot is aborted lands
+    on that leaf. send() is rejected; chat(session_id=) walks back to resume."""
     registry = Registry()
     store = InMemorySessionStore()
 
@@ -303,7 +303,6 @@ async def test_load_chat_by_session_skips_aborted_leaf_to_last_resumable() -> No
     chat = agent.chat()
     await chat.send('hello')
     session_id = chat.session_id
-    last_good_parent = chat.snapshot_id
 
     task = await chat.detach('slow background work')
     assert await task.abort() == SnapshotStatus.PENDING  # previous status
@@ -315,7 +314,11 @@ async def test_load_chat_by_session_skips_aborted_leaf_to_last_resumable() -> No
     assert inspected.status == SnapshotStatus.ABORTED
 
     reloaded = await agent.load_chat(session_id=session_id)
-    # Landed on the last completed turn, not the aborted leaf.
-    assert reloaded.snapshot_id == last_good_parent
-    out = await reloaded.send('still there?')
+    assert reloaded.snapshot_id == task.snapshot_id
+    with pytest.raises(AgentError, match='not resumable'):
+        await reloaded.send('still there?')
+
+    resumed = agent.chat(session_id=session_id)
+    out = await resumed.send('still there?')
     assert out.finish_reason == AgentFinishReason.STOP
+    assert resumed.snapshot_id not in (None, task.snapshot_id)

--- a/py/packages/genkit/tests/genkit/ai/agent_snapshot_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_snapshot_test.py
@@ -148,6 +148,19 @@ async def test_snapshot_action_raises_not_found_for_missing_snapshot() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_snapshot_data_returns_none_for_missing_snapshot() -> None:
+    """The method returns None on a miss; the action wraps that as NOT_FOUND."""
+    registry = Registry()
+    store = InMemorySessionStore()
+
+    async def fn(session_runner: SessionRunner, _: ActionRunContext) -> AgentResult:
+        return await session_runner.result()
+
+    agent = define_custom_agent(registry, 'missingMethodSnapTest', fn, store=store)
+    assert await agent.get_snapshot_data(snapshot_id='non-existent-id') is None
+
+
+@pytest.mark.asyncio
 async def test_custom_agent_turn_that_raises_resolves_as_failed() -> None:
     """A turn that raises settles FAILED, keeps the resume handle on the last good
     parent, and rolls the optimistic prompt back instead of crashing the chat."""
@@ -222,7 +235,8 @@ async def test_chat_points_at_detached_snapshot_so_send_needs_completed_or_reloa
         await chat.send('too soon')
 
     status = await task.abort()
-    assert status == SnapshotStatus.ABORTED
+    # abort() returns the previous status: pending while the turn was running.
+    assert status == SnapshotStatus.PENDING
     # Aborting drops the optimistic prompt; the resume id still names the aborted
     # snapshot, so a bare send keeps failing until we reload.
     assert chat.messages == history_before_detach
@@ -260,7 +274,7 @@ async def test_load_chat_by_session_skips_aborted_leaf_to_last_resumable() -> No
     last_good_parent = chat.snapshot_id
 
     task = await chat.detach('slow background work')
-    assert await task.abort() == SnapshotStatus.ABORTED
+    assert await task.abort() == SnapshotStatus.PENDING  # previous status
     await asyncio.sleep(1.1)  # let the aborted background turn unwind
 
     reloaded = await agent.load_chat(session_id=session_id)

--- a/py/packages/genkit/tests/genkit/ai/agent_snapshot_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_snapshot_test.py
@@ -81,6 +81,38 @@ async def test_resolve_snapshot_applies_client_transform() -> None:
     assert 'secret' not in (result.state.custom or {})
 
 
+@pytest.mark.asyncio
+async def test_resolve_snapshot_by_session_returns_failed_leaf() -> None:
+    """Inspect by sessionId returns the stored leaf, even when it isn't resumable.
+
+    A failed leaf has to stay visible so you can see why the last turn died.
+    Resume walks back separately.
+    """
+    store = InMemorySessionStore()
+    completed = SessionSnapshot(
+        snapshot_id='snap-ok',
+        session_id='sess',
+        created_at='2026-01-01T00:00:00Z',
+        status=SnapshotStatus.COMPLETED,
+        state=SessionState(session_id='sess'),
+    )
+    failed = SessionSnapshot(
+        snapshot_id='snap-fail',
+        session_id='sess',
+        parent_id='snap-ok',
+        created_at='2026-01-01T00:01:00Z',
+        status=SnapshotStatus.FAILED,
+        state=SessionState(session_id='sess'),
+    )
+    await store.save_snapshot(completed.snapshot_id, lambda _: completed)
+    await store.save_snapshot(failed.snapshot_id, lambda _: failed)
+
+    inspected = await resolve_snapshot(store=store, session_id='sess')
+    assert inspected is not None
+    assert inspected.snapshot_id == 'snap-fail'
+    assert inspected.status == SnapshotStatus.FAILED
+
+
 def test_is_heartbeat_expired_pending_with_stale_heartbeat() -> None:
     old = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
     snap = SessionSnapshot(
@@ -276,6 +308,11 @@ async def test_load_chat_by_session_skips_aborted_leaf_to_last_resumable() -> No
     task = await chat.detach('slow background work')
     assert await task.abort() == SnapshotStatus.PENDING  # previous status
     await asyncio.sleep(1.1)  # let the aborted background turn unwind
+
+    inspected = await agent.get_snapshot(session_id=session_id)
+    assert inspected is not None
+    assert inspected.snapshot_id == task.snapshot_id
+    assert inspected.status == SnapshotStatus.ABORTED
 
     reloaded = await agent.load_chat(session_id=session_id)
     # Landed on the last completed turn, not the aborted leaf.

--- a/py/packages/genkit/tests/genkit/ai/agent_snapshot_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_snapshot_test.py
@@ -269,9 +269,9 @@ async def test_chat_points_at_detached_snapshot_so_send_needs_completed_or_reloa
     status = await task.abort()
     # abort() returns the previous status: pending while the turn was running.
     assert status == SnapshotStatus.PENDING
-    # Aborting drops the optimistic prompt; the resume id still names the aborted
-    # snapshot, so a bare send keeps failing until we reload.
-    assert chat.messages == history_before_detach
+    # The prompt stays — it was still asked. The resume id still names the
+    # aborted snapshot, so a bare send keeps failing until we reload.
+    assert chat.messages != history_before_detach
     with pytest.raises(AgentError, match='not resumable'):
         await chat.send('still stranded')
 

--- a/py/samples/agents/basic/12_abort_client_and_server.py
+++ b/py/samples/agents/basic/12_abort_client_and_server.py
@@ -90,9 +90,9 @@ async def main() -> None:
     await asyncio.sleep(2.0)  # let the tool start churning
 
     # chat.abort() fires abort_signal inside slowWork. The call returns the
-    # previous status (PENDING) — not ABORTED. It does not roll back local
-    # history (DetachedTask.abort does). Reload before the next send() so
-    # you are not still pointed at the aborted leaf.
+    # previous status (PENDING) — not ABORTED. The prompt stays in history;
+    # it was still asked. Reload before the next send() so you are not still
+    # pointed at the aborted leaf.
     status = await worker_chat.abort()
     assert status == SnapshotStatus.PENDING
     await asyncio.sleep(0.5)  # let the background task unwind

--- a/py/samples/agents/basic/12_abort_client_and_server.py
+++ b/py/samples/agents/basic/12_abort_client_and_server.py
@@ -89,8 +89,12 @@ async def main() -> None:
     assert task.snapshot_id
     await asyncio.sleep(2.0)  # let the tool start churning
 
-    status = await worker_chat.abort()  # abort_signal fires inside slowWork; the snapshot settles ABORTED
-    assert status == SnapshotStatus.ABORTED
+    # chat.abort() fires abort_signal inside slowWork. The call returns the
+    # previous status (PENDING) — not ABORTED. It does not roll back local
+    # history (DetachedTask.abort does). Reload before the next send() so
+    # you are not still pointed at the aborted leaf.
+    status = await worker_chat.abort()
+    assert status == SnapshotStatus.PENDING
     await asyncio.sleep(0.5)  # let the background task unwind
 
     # The stop is durable: read the snapshot back and it stays ABORTED.

--- a/py/samples/agents/basic/14_abort_failure_store_drift.py
+++ b/py/samples/agents/basic/14_abort_failure_store_drift.py
@@ -29,10 +29,10 @@ store, which is the source of truth:
   2. task.abort() — a *server-side* cancel of a detached turn. The snapshot
      settles ABORTED and never becomes the session's resume point. abort()
      returns the snapshot's status from *before* this call (``pending`` when
-     it cancelled in-flight work) and rolls back the optimistic prompt on
-     the in-memory chat. The live chat still points at that aborted leaf, so
-     send() is rejected. chat(session_id=) continues from the last completed
-     turn. load_chat(session_id=) would show the aborted row.
+     it cancelled in-flight work). The in-memory chat keeps the prompt (it
+     was still asked) and still points at that aborted leaf, so send() is
+     rejected. chat(session_id=) continues from the last completed turn.
+     load_chat(session_id=) would show the aborted row.
 
   3. a real server error (e.g. the model is exhausted) — the chat client raises
      AgentError, the optimistic prompt is rolled back, and the resume handle stays
@@ -131,9 +131,9 @@ async def server_side_task_abort() -> None:
     status = await task.abort()
     # abort() returns the *previous* status: pending, because the turn was still running.
     assert status == SnapshotStatus.PENDING
-    # Aborting drops the optimistic 'slow a2' prompt the chat was holding for the
-    # killed turn, so the local view rolls back to the last completed turn.
-    assert turns(chat) == ['a1/user', 'reply/model']
+    # The prompt stays — it was still asked. The chat still points at the
+    # aborted leaf, so send() is rejected until you reload.
+    assert turns(chat) == ['a1/user', 'reply/model', 'slow a2/user']
 
     # The live chat still points at the aborted leaf, so send() is rejected.
     # The store's session leaf is that aborted row; chat(session_id=) is how

--- a/py/samples/agents/basic/14_abort_failure_store_drift.py
+++ b/py/samples/agents/basic/14_abort_failure_store_drift.py
@@ -30,8 +30,9 @@ store, which is the source of truth:
      settles ABORTED and never becomes the session's resume point. abort()
      returns the snapshot's status from *before* this call (``pending`` when
      it cancelled in-flight work) and rolls back the optimistic prompt on
-     the in-memory chat. Reload from the store to resync — which skips the
-     dead aborted leaf back to the last completed turn.
+     the in-memory chat. The live chat still points at that aborted leaf, so
+     send() is rejected. chat(session_id=) continues from the last completed
+     turn. load_chat(session_id=) would show the aborted row.
 
   3. a real server error (e.g. the model is exhausted) — the chat client raises
      AgentError, the optimistic prompt is rolled back, and the resume handle stays
@@ -134,15 +135,19 @@ async def server_side_task_abort() -> None:
     # killed turn, so the local view rolls back to the last completed turn.
     assert turns(chat) == ['a1/user', 'reply/model']
 
-    # After abort, `_resume_snapshot_id` still names the aborted leaf, so a
-    # bare send() is rejected as not resumable. Reload by session_id to walk
-    # back to the last completed turn.
-    chat = await agent.load_chat(session_id=session_id)
-    assert turns(chat) == ['a1/user', 'reply/model']
+    # The live chat still points at the aborted leaf, so send() is rejected.
+    # The store's session leaf is that aborted row; chat(session_id=) is how
+    # you continue from the last completed turn.
+    leaf = await agent.get_snapshot(session_id=session_id)
+    assert leaf is not None
+    assert leaf.status == SnapshotStatus.ABORTED
 
+    chat = agent.chat(session_id=session_id)
     out = await chat.send('a3')
     assert out.finish_reason == AgentFinishReason.STOP
-    assert turns(chat) == ['a1/user', 'reply/model', 'a3/user', 'reply/model']
+    # This chat only saw the new turn. Read the store for the full history.
+    synced = await agent.load_chat(session_id=session_id)
+    assert turns(synced) == ['a1/user', 'reply/model', 'a3/user', 'reply/model']
 
 
 async def server_side_failure() -> None:
@@ -182,9 +187,9 @@ async def detached_turn_reload_to_resync() -> None:
     # optimistic prompt — it never saw the model's answer.
     assert turns(chat) == ['c1/user', 'reply/model', 'c2/user']
 
-    # Reload from the store to pick up the authoritative history (reply included)
-    # before continuing; sending on the stale chat would build on a view missing
-    # the detached turn's reply.
+    # The detached turn completed, so load_chat(session_id=) hydrates that
+    # leaf — reply included — and send() can continue from it. Sending on
+    # the stale in-memory chat would build on a view missing the reply.
     chat = await agent.load_chat(session_id=session_id)
     assert turns(chat) == ['c1/user', 'reply/model', 'c2/user', 'reply/model']
 

--- a/py/samples/agents/basic/14_abort_failure_store_drift.py
+++ b/py/samples/agents/basic/14_abort_failure_store_drift.py
@@ -27,10 +27,11 @@ store, which is the source of truth:
      prompt. The client view drifts ahead of (really, behind) the store.
 
   2. task.abort() — a *server-side* cancel of a detached turn. The snapshot
-     settles ABORTED and never becomes the session's resume point. Your chat is
-     left holding the optimistic prompt (drift again), so you reload from the
-     store to resync — which skips the dead aborted leaf back to the last
-     completed turn.
+     settles ABORTED and never becomes the session's resume point. abort()
+     returns the snapshot's status from *before* this call (``pending`` when
+     it cancelled in-flight work) and rolls back the optimistic prompt on
+     the in-memory chat. Reload from the store to resync — which skips the
+     dead aborted leaf back to the last completed turn.
 
   3. a real server error (e.g. the model is exhausted) — the chat client raises
      AgentError, the optimistic prompt is rolled back, and the resume handle stays
@@ -127,14 +128,15 @@ async def server_side_task_abort() -> None:
     assert turns(chat) == ['a1/user', 'reply/model', 'slow a2/user']
 
     status = await task.abort()
-    assert status == SnapshotStatus.ABORTED
+    # abort() returns the *previous* status: pending, because the turn was still running.
+    assert status == SnapshotStatus.PENDING
     # Aborting drops the optimistic 'slow a2' prompt the chat was holding for the
     # killed turn, so the local view rolls back to the last completed turn.
     assert turns(chat) == ['a1/user', 'reply/model']
 
-    # Still reload from the store before continuing — it's the authoritative
-    # state, and a detached turn's work never streams back to this chat object,
-    # so load_chat is the way to pick up whatever actually landed server-side.
+    # After abort, `_resume_snapshot_id` still names the aborted leaf, so a
+    # bare send() is rejected as not resumable. Reload by session_id to walk
+    # back to the last completed turn.
     chat = await agent.load_chat(session_id=session_id)
     assert turns(chat) == ['a1/user', 'reply/model']
 


### PR DESCRIPTION
## Summary
The agent conformance harness (#6075 / `tests/specs/agent.yaml`) failed a handful of Python cases that JS already satisfied. This is those client-contract fixes.

### Changes
**Abort return.** Before: `abort()` reported the status *after* the write (`aborted` when it cancelled in-flight work). After: it returns the status the write saw — `pending` if this call cancelled the turn, the unchanged terminal status if it was already done, `None` if nothing was observed.

**Abort and chat history.** Before: `DetachedTask.abort` popped the prompt off the live chat. After: abort only stops the server turn. The prompt stays. The chat still points at the aborted leaf, so the next `send()` needs `chat(session_id=)`.

**Inspect vs continue.** Before: `get_snapshot` / `load_chat` by `session_id` walked back to the last completed turn, so you could not see a failed/aborted/pending leaf. After: inspect returns that leaf as stored. `chat(session_id=)` still skips a dead leaf (or starts fresh if there is no completed ancestor).

**Both ids.** Before: `snapshot_id` + `session_id` together was an error. After: the snapshot id picks the row; the session id is an ownership check. Mismatch is `INVALID_ARGUMENT`.

**Detach stream.** Before: a detached run could still emit chunks on the original connection. After: `detached` is set before the payload is queued.

**Detached failure.** Before: a swallowed turn error finalized the detached snapshot as `completed`. After: it is `failed`.

**Bad init.** Before: mixing a state blob with a resume id was a bare `ValueError`. After: `AgentInitError` (`FAILED_PRECONDITION`), and wire errors use `snapshotId` / `sessionId`.

Samples 12 and 14 follow the abort return. After these fixes are in, agent conformance tests pass (see #6076.)