### PR TITLE
feat(go/plugins/compat_oai/openrouter): add an OpenRouter plugin

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1278,7 +1278,7 @@ Genkit provides a unified interface across all major AI providers. Use whichever
 | **Anthropic** | `anthropic.Anthropic` | Claude Opus 5, Claude Sonnet 5, Claude Fable 5, Claude Haiku 4.5 |
 | **Vertex AI Model Garden** | `modelgarden.Anthropic`, `.Llama`, `.Mistral` | Claude, Llama, and Mistral via Google Cloud |
 | **Ollama** | `ollama.Ollama` | Llama 4, Qwen 3, DeepSeek, and other local models |
-| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Grok, DeepSeek, Qwen, Kimi, GLM, and any OpenAI-compatible API |
+| **OpenAI Compatible** | `compat_oai` | GPT-5.6, Grok, DeepSeek, Qwen, Kimi, GLM, the OpenRouter gateway, and any OpenAI-compatible API |
 
 ```go
 // Google AI

--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -189,8 +189,17 @@ providers and `max_completion_tokens` on others. Use the same camelCase name
 other plugins use for the same setting; `conformance_test.go` enforces that
 across the package.
 
-See the `openai`, `anthropic`, `dashscope`, `deepseek`, `kimi`, `xai`, and
-`zai` directories for complete implementations.
+Not every provider is a model vendor. `openrouter` fronts a gateway serving
+hundreds of models from dozens of vendors, so it curates no `supportedModels`
+map at all: it registers nothing at `Init`, returns no descriptors from
+`ListActions` (a descriptor carries full request and response schemas, so
+listing that catalog would put megabytes on every reflection poll), and
+describes every model it resolves with one permissive capability set. `Models`
+is how a caller narrows one. Follow that shape for a gateway, and the curated
+shape above for a vendor.
+
+See the `openai`, `anthropic`, `dashscope`, `deepseek`, `kimi`, `openrouter`,
+`xai`, and `zai` directories for complete implementations.
 
 ## Running Tests
 
@@ -203,6 +212,7 @@ export ZAI_API_KEY=<your-zai-key>
 export KIMI_API_KEY=<your-kimi-key>
 export XAI_API_KEY=<your-xai-key>
 export DEEPSEEK_API_KEY=<your-deepseek-key>
+export OPENROUTER_API_KEY=<your-openrouter-key>
 ```
 
 Run all tests:
@@ -232,6 +242,9 @@ go test -v ./xai
 
 # DeepSeek tests
 go test -v ./deepseek
+
+# OpenRouter tests
+go test -v ./openrouter
 ```
 
 Note: Tests will be skipped if the required API keys are not set.

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -602,12 +602,15 @@ func sdkModelOptions(provider, id string) ai.ModelOptions {
 }
 
 // DefaultModelOptions is the capability set advertised for models that are
-// discovered or resolved dynamically rather than curated by a plugin.
+// discovered or resolved dynamically rather than curated by a plugin. Each
+// call returns its own copy of the capabilities, so a caller that adjusts
+// them adjusts one model's description rather than the package's default.
 func DefaultModelOptions() ai.ModelOptions {
+	supports := Multimodal
 	return ai.ModelOptions{
 		Stage:    ai.ModelStageStable,
 		Versions: []string{},
-		Supports: &Multimodal,
+		Supports: &supports,
 	}
 }
 

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/compat_oai/dashscope"
 	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
 	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
+	"github.com/firebase/genkit/go/plugins/compat_oai/openrouter"
 	"github.com/firebase/genkit/go/plugins/compat_oai/xai"
 	"github.com/firebase/genkit/go/plugins/compat_oai/zai"
 )
@@ -59,34 +60,44 @@ func TestConfigSchemaConformance(t *testing.T) {
 	t.Setenv("DASHSCOPE_API_KEY", "test-key")
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("KIMI_API_KEY", "test-key")
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("XAI_API_KEY", "test-key")
 	t.Setenv("ZAI_API_KEY", "test-key")
 
-	g := genkit.Init(context.Background(), genkit.WithPlugins(
-		&anthropic.Anthropic{},
-		&dashscope.DashScope{},
-		&deepseek.DeepSeek{},
-		&kimi.Kimi{},
-		&xai.XAI{},
-		&zai.ZAI{},
-	))
-
-	models := []string{
-		"anthropic/claude-sonnet-4-5-20250929",
-		"dashscope/qwen-plus",
-		"deepseek/deepseek-v4-pro",
-		"kimi/kimi-k3",
-		"xai/grok-4.5",
-		"zai/glm-5.1",
+	// Every plugin here resolves a model on demand, so each one is fetched the
+	// same way rather than looked up in the registry. Most also register a
+	// catalog at Init and would be there to look up, but OpenRouter fronts a
+	// gateway whose catalog is too large to enumerate and registers nothing.
+	// Resolving covers all of them, and the config a model advertises is the
+	// same either way; TestModelsOverrideConformance is where registration is
+	// pinned.
+	plugins := []struct {
+		plugin api.DynamicPlugin
+		id     string
+	}{
+		{&anthropic.Anthropic{}, "claude-sonnet-4-5-20250929"},
+		{&dashscope.DashScope{}, "qwen-plus"},
+		{&deepseek.DeepSeek{}, "deepseek-v4-pro"},
+		{&kimi.Kimi{}, "kimi-k3"},
+		{&openrouter.OpenRouter{}, "openai/gpt-5"},
+		{&xai.XAI{}, "grok-4.5"},
+		{&zai.ZAI{}, "glm-5.1"},
 	}
 
-	for _, name := range models {
+	all := make([]api.Plugin, len(plugins))
+	for i, p := range plugins {
+		all[i] = p.plugin
+	}
+	genkit.Init(context.Background(), genkit.WithPlugins(all...))
+
+	for _, tc := range plugins {
+		name := api.NewName(tc.plugin.Name(), tc.id)
 		t.Run(name, func(t *testing.T) {
-			m := genkit.LookupModel(g, name)
-			if m == nil {
-				t.Fatalf("%s not registered by Init", name)
+			action := tc.plugin.ResolveAction(api.ActionTypeModel, tc.id)
+			if action == nil {
+				t.Fatalf("%s did not resolve", name)
 			}
-			model, ok := m.(api.Action).Desc().Metadata["model"].(map[string]any)
+			model, ok := action.Desc().Metadata["model"].(map[string]any)
 			if !ok {
 				t.Fatalf("model metadata missing for %s", name)
 			}
@@ -219,12 +230,13 @@ func TestModelsOverrideConformance(t *testing.T) {
 // Each new plugin adds its config here.
 func TestClosedEnumsUseNamedTypes(t *testing.T) {
 	configs := map[string]any{
-		"anthropic": anthropic.ChatConfig{},
-		"dashscope": dashscope.ChatConfig{},
-		"deepseek":  deepseek.ChatConfig{},
-		"kimi":      kimi.ChatConfig{},
-		"xai":       xai.ChatConfig{},
-		"zai":       zai.ChatConfig{},
+		"anthropic":  anthropic.ChatConfig{},
+		"dashscope":  dashscope.ChatConfig{},
+		"deepseek":   deepseek.ChatConfig{},
+		"kimi":       kimi.ChatConfig{},
+		"openrouter": openrouter.ChatConfig{},
+		"xai":        xai.ChatConfig{},
+		"zai":        zai.ChatConfig{},
 	}
 	for name, config := range configs {
 		t.Run(name, func(t *testing.T) {

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -506,8 +506,12 @@ func (g *ModelGenerator) generateStream(ctx context.Context, req *ai.ModelReques
 	// The accumulator knows nothing of the citations xAI answers a live search
 	// with either, so they are carried out of the chunk that has them.
 	var citations any
-	// The error object a gateway attaches to a failing choice is raw JSON the
-	// accumulator drops with the rest, so it too is carried out by hand.
+	// An error object a provider attaches to a failing choice is raw JSON the
+	// accumulator drops with the rest, so it too is carried out by hand. That
+	// is the shape of a failure a gateway reports on the response as a whole; a
+	// failure part-way through a stream is reported at the top level of a chunk
+	// instead, which ends the stream rather than reaching this loop. See
+	// [wrapStreamError].
 	var failure map[string]any
 
 	for stream.Next() {
@@ -570,10 +574,14 @@ func (g *ModelGenerator) generateStream(ctx context.Context, req *ai.ModelReques
 		}
 	}
 
-	// NewStreaming defers its HTTP error to the stream, so a 4xx on the
-	// request that opened it surfaces here rather than at the call.
+	// NewStreaming defers its HTTP error to the stream, so a 4xx on the request
+	// that opened it surfaces here rather than at the call, as does a gateway's
+	// mid-stream failure. Whatever was generated before the failure has already
+	// reached the callback, and the aggregate response is dropped: a caller and
+	// the middleware around it are told the generation failed, rather than
+	// handed a short answer that reads as a complete one.
 	if err := stream.Err(); err != nil {
-		return nil, fmt.Errorf("stream error: %w", WrapAPIError(err))
+		return nil, wrapStreamError(err)
 	}
 
 	if usageSeen {
@@ -614,6 +622,37 @@ func (g *ModelGenerator) generateStream(ctx context.Context, req *ai.ModelReques
 	}
 	resp.Request = req
 	return resp, nil
+}
+
+// wrapStreamError classifies the error a stream ended with, so that
+// status-aware middleware can tell a rate limit from a request the provider
+// will refuse again.
+//
+// A gateway whose upstream fails part-way through a generation reports it as an
+// error object at the top level of a chunk. The SDK looks for that field before
+// it unmarshals and ends the stream when it finds one, so the chunk never
+// reaches the caller and the object survives only as raw JSON inside the error
+// message. Reading the code back out of it is the one way to recover the status
+// the failure carries.
+//
+// An error that classifies to nothing is left unclassified rather than marked
+// Unknown, since the retry middleware reissues an unclassified error and gives
+// up on an Unknown one, and a failure this cannot read is not a reason to stop
+// trying.
+func wrapStreamError(err error) error {
+	err = WrapAPIError(err)
+	if _, classified := status.Classified(err); classified {
+		return fmt.Errorf("stream error: %w", err)
+	}
+	message := err.Error()
+	if brace := strings.IndexByte(message, '{'); brace >= 0 {
+		if code, ok := extractErrorObject(message[brace:])["code"].(float64); ok {
+			if name := status.FromHTTPCode(int(code)); name != status.Unknown {
+				return status.Errorf(status.Base(name), "stream error: %w", err)
+			}
+		}
+	}
+	return fmt.Errorf("stream error: %w", err)
 }
 
 // extractTokenCount reads a token count a provider reports as a usage field the
@@ -818,9 +857,9 @@ func convertChatCompletionToModelResponse(completion *openai.ChatCompletion) (*a
 	if citations := extractJSONValue(completion.JSON.ExtraFields["citations"].Raw()); citations != nil {
 		custom["citations"] = citations
 	}
-	// The error object rides whole beside the finish message it fed: retrying
-	// around a failed upstream takes its name and the failure's code, which
-	// have no [ai.ModelResponse] field but belong to the response's metadata.
+	// The error object rides whole beside the finish message it fed: the code
+	// and the typed error_type saying which class of failure it was have no
+	// [ai.ModelResponse] field but belong to the response's metadata.
 	if failure != nil {
 		custom["error"] = failure
 	}

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -506,6 +506,9 @@ func (g *ModelGenerator) generateStream(ctx context.Context, req *ai.ModelReques
 	// The accumulator knows nothing of the citations xAI answers a live search
 	// with either, so they are carried out of the chunk that has them.
 	var citations any
+	// The error object a gateway attaches to a failing choice is raw JSON the
+	// accumulator drops with the rest, so it too is carried out by hand.
+	var failure map[string]any
 
 	for stream.Next() {
 		chunk := stream.Current()
@@ -524,13 +527,19 @@ func (g *ModelGenerator) generateStream(ctx context.Context, req *ai.ModelReques
 			continue
 		}
 
+		if value := extractErrorObject(chunk.Choices[0].JSON.ExtraFields["error"].Raw()); value != nil {
+			failure = value
+		}
+
 		// Create chunk for callback
 		modelChunk := &ai.ModelResponseChunk{}
 
-		// Some OpenAI-compatible reasoning models, including Kimi, return
-		// reasoning in the non-standard reasoning_content field.
-		if reasoningDelta := extractReasoningContent(
+		// Some OpenAI-compatible reasoning models return reasoning in a
+		// non-standard field: reasoning_content for Kimi and DeepSeek,
+		// reasoning for OpenRouter.
+		if reasoningDelta := firstReasoning(
 			chunk.Choices[0].Delta.JSON.ExtraFields["reasoning_content"].Raw(),
+			chunk.Choices[0].Delta.JSON.ExtraFields["reasoning"].Raw(),
 		); reasoningDelta != "" {
 			reasoning.WriteString(reasoningDelta)
 			modelChunk.Content = append(modelChunk.Content, ai.NewReasoningPart(reasoningDelta, nil))
@@ -582,12 +591,24 @@ func (g *ModelGenerator) generateStream(ctx context.Context, req *ai.ModelReques
 			resp.Message.Content...,
 		)
 	}
-	if citations != nil {
+	// The message the failing upstream sent rode on a chunk's raw choice, so
+	// it is restored here; a refusal, which the accumulator does keep, wins as
+	// the more specific reason.
+	if message, _ := failure["message"].(string); message != "" &&
+		resp.FinishMessage == "" && resp.FinishReason != ai.FinishReasonStop {
+		resp.FinishMessage = message
+	}
+	if citations != nil || failure != nil {
 		custom, ok := resp.Custom.(map[string]any)
 		if !ok {
 			custom = map[string]any{}
 		}
-		custom["citations"] = citations
+		if citations != nil {
+			custom["citations"] = citations
+		}
+		if failure != nil {
+			custom["error"] = failure
+		}
 		resp.Custom = custom
 		resp.Raw = custom
 	}
@@ -634,6 +655,30 @@ func extractReasoningContent(raw string) string {
 	return reasoning
 }
 
+// firstReasoning returns the first non-empty reasoning string among raws, the
+// raw JSON of the response fields a provider may carry reasoning in. None of
+// them is in the OpenAI schema and providers disagree on the name, so the
+// caller passes every field it knows in preference order; a provider sending
+// two of them is read once rather than appended twice.
+func firstReasoning(raws ...string) string {
+	for _, raw := range raws {
+		if reasoning := extractReasoningContent(raw); reasoning != "" {
+			return reasoning
+		}
+	}
+	return ""
+}
+
+// extractErrorObject decodes the error object a provider returns beside a
+// choice when an upstream fails mid-generation, or nil when the field is
+// absent or is not an object. The object is kept whole: its message becomes
+// the finish message, and the code and metadata beside it, which name the
+// upstream provider and the failure class, ride on the response's Raw.
+func extractErrorObject(raw string) map[string]any {
+	failure, _ := extractJSONValue(raw).(map[string]any)
+	return failure
+}
+
 // convertChatCompletionToModelResponse converts openai.ChatCompletion to ai.ModelResponse
 func convertChatCompletionToModelResponse(completion *openai.ChatCompletion) (*ai.ModelResponse, error) {
 	if len(completion.Choices) == 0 {
@@ -675,6 +720,17 @@ func convertChatCompletionToModelResponse(completion *openai.ChatCompletion) (*a
 		completion.Usage.JSON.ExtraFields["num_sources_used"].Raw()))
 	addCustomTokens(usage, "imageTokens", extractTokenCount(
 		completion.Usage.PromptTokensDetails.JSON.ExtraFields["image_tokens"].Raw()))
+	// A gateway prices the request it routed and reports what it charged, which
+	// is a main reason to route through one. Unlike the counts above, presence
+	// decides rather than the value: a free-tier request is priced at an
+	// explicit zero, which is an answer, while a provider that does not price
+	// requests has no cost field at all.
+	if cost, ok := extractJSONValue(completion.Usage.JSON.ExtraFields["cost"].Raw()).(float64); ok {
+		if usage.Custom == nil {
+			usage.Custom = make(map[string]float64)
+		}
+		usage.Custom["cost"] = cost
+	}
 
 	resp := &ai.ModelResponse{
 		Usage: usage,
@@ -694,10 +750,22 @@ func convertChatCompletionToModelResponse(completion *openai.ChatCompletion) (*a
 		resp.FinishReason = ai.FinishReasonLength
 	case "content_filter", "sensitive":
 		resp.FinishReason = ai.FinishReasonBlocked
-	case "function_call", "network_error", "insufficient_system_resource":
+	case "error", "function_call", "network_error", "insufficient_system_resource":
 		resp.FinishReason = ai.FinishReasonOther
 	default:
 		resp.FinishReason = ai.FinishReasonUnknown
+	}
+
+	// A provider that fails part-way through a generation is answered by a
+	// gateway with a 200: the status and headers are already committed, so the
+	// failure rides on the choice as finish_reason "error" and an error object,
+	// next to whatever text was produced first. Reading that object is what
+	// tells a failed request apart from a complete answer, since the response
+	// is otherwise well-formed. A choice that finished cleanly keeps an empty
+	// FinishMessage even when an error-shaped extra rides beside it.
+	failure := extractErrorObject(choice.JSON.ExtraFields["error"].Raw())
+	if message, _ := failure["message"].(string); message != "" && resp.FinishReason != ai.FinishReasonStop {
+		resp.FinishMessage = message
 	}
 
 	// Set finish message if there's a refusal
@@ -707,9 +775,12 @@ func convertChatCompletionToModelResponse(completion *openai.ChatCompletion) (*a
 	}
 
 	// Keep parity with the JS compat-oai plugin by surfacing the non-standard
-	// reasoning_content field as a Genkit reasoning part.
-	if reasoning := extractReasoningContent(
+	// reasoning field as a Genkit reasoning part. DeepSeek and Kimi name it
+	// reasoning_content; OpenRouter normalizes every vendor it fronts onto
+	// reasoning.
+	if reasoning := firstReasoning(
 		choice.Message.JSON.ExtraFields["reasoning_content"].Raw(),
+		choice.Message.JSON.ExtraFields["reasoning"].Raw(),
 	); reasoning != "" {
 		resp.Message.Content = append(resp.Message.Content, ai.NewReasoningPart(reasoning, nil))
 	}
@@ -746,6 +817,12 @@ func convertChatCompletionToModelResponse(completion *openai.ChatCompletion) (*a
 	// request carries.
 	if citations := extractJSONValue(completion.JSON.ExtraFields["citations"].Raw()); citations != nil {
 		custom["citations"] = citations
+	}
+	// The error object rides whole beside the finish message it fed: retrying
+	// around a failed upstream takes its name and the failure's code, which
+	// have no [ai.ModelResponse] field but belong to the response's metadata.
+	if failure != nil {
+		custom["error"] = failure
 	}
 	// Raw carries the same metadata as Custom, which is deprecated in favor of
 	// it: new fields are documented against Raw, and the readers of the older

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -17,6 +17,7 @@ package compat_oai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/shared"
@@ -364,7 +366,7 @@ func TestConvertChatCompletionToModelResponseProviderFailure(t *testing.T) {
 		"id":"1","object":"chat.completion","created":1,"model":"openai/gpt-5",
 		"choices":[{"index":0,"message":{"role":"assistant","content":"partial out"},
 			"finish_reason":"error","native_finish_reason":"provider_error",
-			"error":{"code":502,"message":"Provider returned error","metadata":{"provider_name":"Together"}}}],
+			"error":{"code":502,"message":"Provider returned error","metadata":{"error_type":"provider_unavailable"}}}],
 		"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}
 	}`), &completion); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
@@ -385,8 +387,8 @@ func TestConvertChatCompletionToModelResponseProviderFailure(t *testing.T) {
 	if want := "partial out"; resp.Text() != want {
 		t.Errorf("Text() = %q, want %q", resp.Text(), want)
 	}
-	// The code and the upstream provider's name ride whole on the response
-	// metadata: routing around a failed upstream needs them, and the finish
+	// The code and the typed error_type ride whole on the response metadata:
+	// telling a rate limit from a dead upstream needs them, and the finish
 	// message carries only the prose.
 	custom, _ := resp.Custom.(map[string]any)
 	failure, _ := custom["error"].(map[string]any)
@@ -394,8 +396,8 @@ func TestConvertChatCompletionToModelResponseProviderFailure(t *testing.T) {
 		t.Errorf("custom[error][code] = %v, want 502", failure["code"])
 	}
 	metadata, _ := failure["metadata"].(map[string]any)
-	if got, _ := metadata["provider_name"].(string); got != "Together" {
-		t.Errorf("custom[error][metadata][provider_name] = %v, want %q", metadata["provider_name"], "Together")
+	if want := "provider_unavailable"; metadata["error_type"] != want {
+		t.Errorf("custom[error][metadata][error_type] = %v, want %q", metadata["error_type"], want)
 	}
 }
 
@@ -556,19 +558,20 @@ func TestGenerateStreamReportsCitations(t *testing.T) {
 	}
 }
 
-// TestGenerateStreamReportsProviderFailure pins that a streamed provider
-// failure is told apart from a complete answer the same way a non-streamed one
-// is. The error object rides on a chunk's raw choice, which
-// [openai.ChatCompletionAccumulator] rebuilds from the fields it models, so
-// the failure is lost unless it is carried out of the stream directly. A
-// stream that instead fails with a top-level error object never gets here: the
-// SDK turns that shape into a stream error.
+// TestGenerateStreamReportsProviderFailure covers a stream whose failing choice
+// carries the error object, the shape a gateway reports a failure on the
+// response as a whole with. It is told apart from a complete answer the same
+// way a non-streamed one is: the object rides on a chunk's raw choice, which
+// [openai.ChatCompletionAccumulator] rebuilds from the fields it models, so the
+// failure is lost unless it is carried out of the stream directly. A failure
+// reported at the top level of a chunk takes the other path, covered by
+// [TestGenerateStreamTopLevelFailureEndsStream].
 func TestGenerateStreamReportsProviderFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		for _, event := range []string{
 			`{"id":"1","object":"chat.completion.chunk","created":1,"model":"openai/gpt-5","choices":[{"index":0,"delta":{"role":"assistant","content":"partial out"},"finish_reason":null}]}`,
-			`{"id":"1","object":"chat.completion.chunk","created":1,"model":"openai/gpt-5","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"provider_error","error":{"code":502,"message":"Provider returned error","metadata":{"provider_name":"Together"}}}]}`,
+			`{"id":"1","object":"chat.completion.chunk","created":1,"model":"openai/gpt-5","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"provider_error","error":{"code":502,"message":"Provider returned error","metadata":{"error_type":"provider_unavailable"}}}]}`,
 		} {
 			_, _ = io.WriteString(w, "data: "+event+"\n\n")
 		}
@@ -600,6 +603,82 @@ func TestGenerateStreamReportsProviderFailure(t *testing.T) {
 	failure, _ := custom["error"].(map[string]any)
 	if got, _ := failure["code"].(float64); got != 502 {
 		t.Errorf("custom[error][code] = %v, want 502", failure["code"])
+	}
+}
+
+// TestGenerateStreamTopLevelFailureEndsStream covers the other shape: a gateway
+// whose upstream dies part-way through a stream reports it at the top level of
+// a chunk rather than on the choice. The SDK looks for that field before it
+// unmarshals and ends the stream when it finds one, so the chunk never reaches
+// the loop and no response is assembled.
+//
+// What the model generated first has already reached the callback, so the test
+// pins that too: the failure costs the aggregate response, not the output. That
+// is what keeps the failure retryable, since retry and fallback middleware read
+// the error rather than the finish reason, and a truncated answer returned as a
+// success would reach neither.
+func TestGenerateStreamTopLevelFailureEndsStream(t *testing.T) {
+	// The code the gateway reports decides the status the failure carries. A
+	// code that maps to nothing stays unclassified rather than becoming
+	// Unknown, which the retry middleware would give up on.
+	for name, tc := range map[string]struct {
+		code int
+		want status.Name
+	}{
+		"rate limited upstream": {code: 429, want: status.ResourceExhausted},
+		"dead upstream":         {code: 502, want: status.Internal},
+		"unmapped code":         {code: 402, want: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				for _, event := range []string{
+					`{"id":"1","object":"chat.completion.chunk","created":1,"model":"openai/gpt-5","choices":[{"index":0,"delta":{"role":"assistant","content":"partial out"},"finish_reason":null}]}`,
+					fmt.Sprintf(`{"id":"1","object":"chat.completion.chunk","created":1,"model":"openai/gpt-5","provider":"Together","error":{"code":%d,"message":"Provider disconnected","metadata":{"error_type":"provider_unavailable"}},"choices":[{"index":0,"delta":{"content":""},"finish_reason":"error","native_finish_reason":"provider_error"}]}`, tc.code),
+				} {
+					_, _ = io.WriteString(w, "data: "+event+"\n\n")
+				}
+				_, _ = io.WriteString(w, "data: [DONE]\n\n")
+			}))
+			t.Cleanup(srv.Close)
+
+			client := openai.NewClient(option.WithBaseURL(srv.URL), option.WithAPIKey("stub"))
+			messages := []*ai.Message{ai.NewUserTextMessage("hi")}
+			var streamed strings.Builder
+			resp, err := NewModelGenerator(&client, "openai/gpt-5").
+				WithMessages(messages).
+				Generate(context.Background(), &ai.ModelRequest{Messages: messages},
+					func(_ context.Context, chunk *ai.ModelResponseChunk) error {
+						streamed.WriteString(chunk.Text())
+						return nil
+					})
+			if err == nil {
+				t.Fatal("Generate() error = nil, want the stream failure reported")
+			}
+			if resp != nil {
+				t.Errorf("Generate() response = %v, want nil", resp)
+			}
+			// The generated text is not lost with the response: a streaming
+			// caller was handed it as it arrived.
+			if want := "partial out"; streamed.String() != want {
+				t.Errorf("streamed text = %q, want %q", streamed.String(), want)
+			}
+			// The gateway's own wording is what says which upstream failed and
+			// why, so it has to survive the wrapping.
+			if want := "Provider disconnected"; !strings.Contains(err.Error(), want) {
+				t.Errorf("error = %q, want it to carry %q", err, want)
+			}
+			got, classified := status.Classified(err)
+			if tc.want == "" {
+				if classified {
+					t.Errorf("status = %q, want the error left unclassified", got)
+				}
+				return
+			}
+			if !classified || got != tc.want {
+				t.Errorf("status = %q (classified %v), want %q", got, classified, tc.want)
+			}
+		})
 	}
 }
 

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -30,40 +30,52 @@ import (
 	"github.com/openai/openai-go/shared"
 )
 
-func TestConvertChatCompletionToModelResponseReasoningContent(t *testing.T) {
-	var completion openai.ChatCompletion
-	if err := json.Unmarshal([]byte(`{
-		"id": "chatcmpl-1",
-		"object": "chat.completion",
-		"created": 1,
-		"model": "reasoning-model",
-		"choices": [{
-			"index": 0,
-			"message": {
-				"role": "assistant",
-				"reasoning_content": "Let me think...",
-				"content": "Final answer"
-			},
-			"finish_reason": "stop"
-		}]
-	}`), &completion); err != nil {
-		t.Fatalf("json.Unmarshal() error = %v", err)
-	}
+// TestConvertChatCompletionToModelResponseReasoning covers the non-standard
+// fields a provider may carry reasoning in: DeepSeek and Kimi send
+// reasoning_content, OpenRouter sends reasoning. A provider sending both must
+// still yield one reasoning part rather than two.
+func TestConvertChatCompletionToModelResponseReasoning(t *testing.T) {
+	for name, field := range map[string]string{
+		"reasoning_content": `"reasoning_content": "Let me think...",`,
+		"reasoning":         `"reasoning": "Let me think...",`,
+		"both":              `"reasoning_content": "Let me think...", "reasoning": "Let me think...",`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var completion openai.ChatCompletion
+			if err := json.Unmarshal([]byte(`{
+				"id": "chatcmpl-1",
+				"object": "chat.completion",
+				"created": 1,
+				"model": "reasoning-model",
+				"choices": [{
+					"index": 0,
+					"message": {
+						"role": "assistant",
+						`+field+`
+						"content": "Final answer"
+					},
+					"finish_reason": "stop"
+				}]
+			}`), &completion); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
 
-	resp, err := convertChatCompletionToModelResponse(&completion)
-	if err != nil {
-		t.Fatalf("convertChatCompletionToModelResponse() error = %v", err)
-	}
-	if got := resp.Reasoning(); got != "Let me think..." {
-		t.Errorf("Reasoning() = %q, want %q", got, "Let me think...")
-	}
-	if got := resp.Text(); got != "Final answer" {
-		t.Errorf("Text() = %q, want %q", got, "Final answer")
-	}
-	if len(resp.Message.Content) != 2 ||
-		!resp.Message.Content[0].IsReasoning() ||
-		!resp.Message.Content[1].IsText() {
-		t.Fatalf("content = %#v, want reasoning followed by text", resp.Message.Content)
+			resp, err := convertChatCompletionToModelResponse(&completion)
+			if err != nil {
+				t.Fatalf("convertChatCompletionToModelResponse() error = %v", err)
+			}
+			if got := resp.Reasoning(); got != "Let me think..." {
+				t.Errorf("Reasoning() = %q, want %q", got, "Let me think...")
+			}
+			if got := resp.Text(); got != "Final answer" {
+				t.Errorf("Text() = %q, want %q", got, "Final answer")
+			}
+			if len(resp.Message.Content) != 2 ||
+				!resp.Message.Content[0].IsReasoning() ||
+				!resp.Message.Content[1].IsText() {
+				t.Fatalf("content = %#v, want reasoning followed by text", resp.Message.Content)
+			}
+		})
 	}
 }
 
@@ -138,6 +150,8 @@ func TestConvertChatCompletionToModelResponseProviderFinishReasons(t *testing.T)
 		"model_context_window_exceeded": ai.FinishReasonLength,
 		"network_error":                 ai.FinishReasonOther,
 		"insufficient_system_resource":  ai.FinishReasonOther,
+		// A gateway reports an upstream provider failure this way, on a 200.
+		"error": ai.FinishReasonOther,
 		// xAI documents three finish reasons and this is one of them, so an
 		// unmapped end_turn would report ordinary answers as unknown.
 		"end_turn": ai.FinishReasonStop,
@@ -296,6 +310,150 @@ func TestConvertChatCompletionToModelResponseSearchUsage(t *testing.T) {
 	}
 }
 
+// TestConvertChatCompletionToModelResponseCost pins that the price a gateway
+// charged for a request survives, as the fraction it arrived as. Knowing what
+// a request cost is a main reason to route through a gateway, and the value is
+// a usage field the OpenAI SDK does not model.
+// TestConvertChatCompletionToModelResponseCost pins that the price a gateway
+// reports reaches the usage on presence rather than value: a free-tier request
+// is priced at an explicit zero, which is an answer, while a provider that
+// does not price requests has no cost field and must not gain one.
+func TestConvertChatCompletionToModelResponseCost(t *testing.T) {
+	for name, tc := range map[string]struct {
+		usage string
+		want  float64
+		keyed bool
+	}{
+		"fraction kept":       {`{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12,"cost":0.00042}`, 0.00042, true},
+		"explicit zero kept":  {`{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12,"cost":0}`, 0, true},
+		"absent stays absent": {`{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}`, 0, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var completion openai.ChatCompletion
+			if err := json.Unmarshal([]byte(`{
+				"id":"1","object":"chat.completion","created":1,"model":"openai/gpt-5",
+				"choices":[{"index":0,"message":{"role":"assistant","content":"answer"},"finish_reason":"stop"}],
+				"usage":`+tc.usage+`
+			}`), &completion); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			resp, err := convertChatCompletionToModelResponse(&completion)
+			if err != nil {
+				t.Fatalf("convertChatCompletionToModelResponse() error = %v", err)
+			}
+			got, keyed := resp.Usage.Custom["cost"]
+			if keyed != tc.keyed {
+				t.Errorf("Usage.Custom has \"cost\" = %t, want %t", keyed, tc.keyed)
+			}
+			if got != tc.want {
+				t.Errorf("Usage.Custom[\"cost\"] = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConvertChatCompletionToModelResponseProviderFailure pins that a provider
+// failing part-way through a generation is not read as a complete answer. The
+// gateway has already committed a 200 by then, so the response is well-formed
+// and carries the text produced before the failure; the reason it stopped is
+// only in the error object beside the choice.
+func TestConvertChatCompletionToModelResponseProviderFailure(t *testing.T) {
+	var completion openai.ChatCompletion
+	if err := json.Unmarshal([]byte(`{
+		"id":"1","object":"chat.completion","created":1,"model":"openai/gpt-5",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"partial out"},
+			"finish_reason":"error","native_finish_reason":"provider_error",
+			"error":{"code":502,"message":"Provider returned error","metadata":{"provider_name":"Together"}}}],
+		"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}
+	}`), &completion); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	resp, err := convertChatCompletionToModelResponse(&completion)
+	if err != nil {
+		t.Fatalf("convertChatCompletionToModelResponse() error = %v", err)
+	}
+	if resp.FinishReason != ai.FinishReasonOther {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, ai.FinishReasonOther)
+	}
+	if want := "Provider returned error"; resp.FinishMessage != want {
+		t.Errorf("FinishMessage = %q, want %q so the caller can tell a failure from an answer",
+			resp.FinishMessage, want)
+	}
+	// The partial output is what the gateway returns the 200 for, so it stays.
+	if want := "partial out"; resp.Text() != want {
+		t.Errorf("Text() = %q, want %q", resp.Text(), want)
+	}
+	// The code and the upstream provider's name ride whole on the response
+	// metadata: routing around a failed upstream needs them, and the finish
+	// message carries only the prose.
+	custom, _ := resp.Custom.(map[string]any)
+	failure, _ := custom["error"].(map[string]any)
+	if got, _ := failure["code"].(float64); got != 502 {
+		t.Errorf("custom[error][code] = %v, want 502", failure["code"])
+	}
+	metadata, _ := failure["metadata"].(map[string]any)
+	if got, _ := metadata["provider_name"].(string); got != "Together" {
+		t.Errorf("custom[error][metadata][provider_name] = %v, want %q", metadata["provider_name"], "Together")
+	}
+}
+
+// TestConvertChatCompletionToModelResponseErrorBesideStop pins that a choice
+// that finished cleanly keeps an empty FinishMessage even when an error-shaped
+// extra rides beside it: a finish message on a stop reads as the reason
+// generation ended, which a warning is not. The object itself still reaches
+// the response metadata.
+func TestConvertChatCompletionToModelResponseErrorBesideStop(t *testing.T) {
+	var completion openai.ChatCompletion
+	if err := json.Unmarshal([]byte(`{
+		"id":"1","object":"chat.completion","created":1,"model":"openai/gpt-5",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"answer"},
+			"finish_reason":"stop",
+			"error":{"code":299,"message":"deprecation warning"}}],
+		"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}
+	}`), &completion); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	resp, err := convertChatCompletionToModelResponse(&completion)
+	if err != nil {
+		t.Fatalf("convertChatCompletionToModelResponse() error = %v", err)
+	}
+	if resp.FinishReason != ai.FinishReasonStop {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, ai.FinishReasonStop)
+	}
+	if resp.FinishMessage != "" {
+		t.Errorf("FinishMessage = %q, want empty on a choice that finished cleanly", resp.FinishMessage)
+	}
+	custom, _ := resp.Custom.(map[string]any)
+	if _, ok := custom["error"].(map[string]any); !ok {
+		t.Errorf("custom[error] = %#v, want the object kept on the metadata", custom["error"])
+	}
+}
+
+// TestConvertChatCompletionToModelResponseNoErrorObject pins that an ordinary
+// answer reports no finish message, so the failure path above cannot report
+// one where there was no failure.
+func TestConvertChatCompletionToModelResponseNoErrorObject(t *testing.T) {
+	var completion openai.ChatCompletion
+	if err := json.Unmarshal([]byte(`{
+		"id":"1","object":"chat.completion","created":1,"model":"openai/gpt-5",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"answer"},"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}
+	}`), &completion); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	resp, err := convertChatCompletionToModelResponse(&completion)
+	if err != nil {
+		t.Fatalf("convertChatCompletionToModelResponse() error = %v", err)
+	}
+	if resp.FinishMessage != "" {
+		t.Errorf("FinishMessage = %q, want empty on a response carrying no error", resp.FinishMessage)
+	}
+}
+
 // TestGenerateStreamReportsUsage pins that a stream asks for its token usage
 // and reports every part of it. The usage rides on a final chunk the request
 // has to opt into, and [openai.ChatCompletionAccumulator] sums only the three
@@ -318,7 +476,7 @@ func TestGenerateStreamReportsUsage(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		for _, event := range []string{
 			`{"id":"1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"answer"},"finish_reason":null},{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null}`,
-			`{"id":"1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":7,"total_tokens":17,"prompt_cache_hit_tokens":6,"prompt_cache_miss_tokens":4,"completion_tokens_details":{"reasoning_tokens":5}}}`,
+			`{"id":"1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":7,"total_tokens":17,"prompt_cache_hit_tokens":6,"prompt_cache_miss_tokens":4,"completion_tokens_details":{"reasoning_tokens":5},"cost":0.00042}}`,
 		} {
 			_, _ = io.WriteString(w, "data: "+event+"\n\n")
 		}
@@ -353,6 +511,11 @@ func TestGenerateStreamReportsUsage(t *testing.T) {
 		if tc.got != tc.want {
 			t.Errorf("%s = %d, want %d", tc.field, tc.got, tc.want)
 		}
+	}
+	// The price rides on the same final chunk and is a fraction, so it is
+	// checked apart from the counts.
+	if got := resp.Usage.Custom["cost"]; got != 0.00042 {
+		t.Errorf("Usage.Custom[\"cost\"] = %v, want 0.00042 carried out of the stream", got)
 	}
 }
 
@@ -390,6 +553,53 @@ func TestGenerateStreamReportsCitations(t *testing.T) {
 	}
 	if resp.FinishReason != ai.FinishReasonStop {
 		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, ai.FinishReasonStop)
+	}
+}
+
+// TestGenerateStreamReportsProviderFailure pins that a streamed provider
+// failure is told apart from a complete answer the same way a non-streamed one
+// is. The error object rides on a chunk's raw choice, which
+// [openai.ChatCompletionAccumulator] rebuilds from the fields it models, so
+// the failure is lost unless it is carried out of the stream directly. A
+// stream that instead fails with a top-level error object never gets here: the
+// SDK turns that shape into a stream error.
+func TestGenerateStreamReportsProviderFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, event := range []string{
+			`{"id":"1","object":"chat.completion.chunk","created":1,"model":"openai/gpt-5","choices":[{"index":0,"delta":{"role":"assistant","content":"partial out"},"finish_reason":null}]}`,
+			`{"id":"1","object":"chat.completion.chunk","created":1,"model":"openai/gpt-5","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"provider_error","error":{"code":502,"message":"Provider returned error","metadata":{"provider_name":"Together"}}}]}`,
+		} {
+			_, _ = io.WriteString(w, "data: "+event+"\n\n")
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(srv.Close)
+
+	client := openai.NewClient(option.WithBaseURL(srv.URL), option.WithAPIKey("stub"))
+	messages := []*ai.Message{ai.NewUserTextMessage("hi")}
+	resp, err := NewModelGenerator(&client, "openai/gpt-5").
+		WithMessages(messages).
+		Generate(context.Background(), &ai.ModelRequest{Messages: messages},
+			func(context.Context, *ai.ModelResponseChunk) error { return nil })
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	if resp.FinishReason != ai.FinishReasonOther {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, ai.FinishReasonOther)
+	}
+	if want := "Provider returned error"; resp.FinishMessage != want {
+		t.Errorf("FinishMessage = %q, want %q carried out of the stream", resp.FinishMessage, want)
+	}
+	// The partial output is what the gateway returns the 200 for, so it stays.
+	if want := "partial out"; resp.Text() != want {
+		t.Errorf("Text() = %q, want %q", resp.Text(), want)
+	}
+	custom, _ := resp.Custom.(map[string]any)
+	failure, _ := custom["error"].(map[string]any)
+	if got, _ := failure["code"].(float64); got != 502 {
+		t.Errorf("custom[error][code] = %v, want 502", failure["code"])
 	}
 }
 

--- a/go/plugins/compat_oai/openrouter/README.md
+++ b/go/plugins/compat_oai/openrouter/README.md
@@ -1,0 +1,205 @@
+# OpenRouter Plugin
+
+This plugin provides Genkit support for [OpenRouter](https://openrouter.ai), a
+gateway that serves models from many vendors behind one OpenAI-compatible
+endpoint.
+
+## Setup
+
+Set an OpenRouter API key:
+
+```bash
+export OPENROUTER_API_KEY=<your-api-key>
+```
+
+The plugin uses `https://openrouter.ai/api/v1` by default. Set
+`OPENROUTER_BASE_URL`, or pass `option.WithBaseURL` through the plugin's
+`Opts`, to use another compatible endpoint.
+
+```go
+import (
+    "context"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/openrouter"
+)
+
+ctx := context.Background()
+g := genkit.Init(ctx,
+    genkit.WithPlugins(&openrouter.OpenRouter{}),
+    genkit.WithDefaultModel("openrouter/anthropic/claude-sonnet-4.5"),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain reinforcement learning."))
+```
+
+`SiteURL` and `AppName` are optional. They name the application on
+OpenRouter's public rankings, sent as the `HTTP-Referer` and `X-Title`
+headers, and change nothing else about a request.
+
+Reasoning output is returned as Genkit reasoning parts and is available
+through `response.Reasoning()`.
+
+## Models
+
+The plugin registers no models and carries no catalog. OpenRouter serves
+hundreds of models and adds more weekly, so every model resolves on demand
+instead:
+
+```go
+ai.WithModelName("openrouter/openai/gpt-5")
+ai.WithModelName("openrouter/anthropic/claude-sonnet-4.5")
+ai.WithModelName("openrouter/meta-llama/llama-4-70b-instruct:free")
+```
+
+A model ID keeps its upstream vendor's prefix, so a Genkit action name carries
+two slashes: the first is this plugin's provider prefix and the rest is the
+ID OpenRouter serves. Variant suffixes work the same way, including `:free`,
+`:nitro` for the fastest provider, and `:floor` for the cheapest.
+
+For the same reason, the plugin advertises nothing to the Dev UI's model list.
+Models stay usable by name; only the browsable catalog is absent.
+
+Every resolved model is described permissively: multi-turn, tools, tool
+choice, system role, and media are all claimed. This is deliberate. A
+capability declared too narrow is refused by Genkit before the request is
+sent, which blocks a model that would have worked, while one declared too wide
+reaches OpenRouter and comes back with the real reason. Native constrained
+output is the exception, left unclaimed so that structured output falls back
+to schema instructions in the prompt, which every model handles and which
+returns the same typed result.
+
+Correct a model whose real capabilities are narrower through `Models`:
+
+```go
+plugin := &openrouter.OpenRouter{Models: map[string]ai.ModelOptions{
+    // A text-only model, so Genkit refuses media locally rather than paying
+    // for the upstream rejection.
+    "mistralai/mistral-7b-instruct": {Supports: &ai.ModelSupports{
+        Multiturn: true, Tools: true, SystemRole: true,
+    }},
+}}
+```
+
+Fields left at their zero value keep what the plugin resolves, so an entry can
+pin one capability without restating the rest.
+
+The current model list is at https://openrouter.ai/models, and the API
+reference is at https://openrouter.ai/docs.
+
+## Config
+
+Models take a typed `openrouter.ChatConfig`: the generation fields OpenRouter
+normalizes across vendors, plus the gateway controls that are the reason to
+route through it. `openrouter.ModelRef` carries the config with the model ID:
+
+```go
+response, err := genkit.Generate(ctx, g,
+    ai.WithModel(openrouter.ModelRef("openai/gpt-5", &openrouter.ChatConfig{
+        Provider: &openrouter.ProviderRouting{
+            Sort:           openrouter.ProviderSortPrice,
+            DataCollection: openrouter.DataCollectionDeny,
+        },
+        Models:    []string{"anthropic/claude-sonnet-4.5"},
+        Reasoning: &openrouter.ReasoningConfig{Effort: openrouter.ReasoningEffortHigh},
+    })),
+    ai.WithPrompt("Work through this step by step."),
+)
+```
+
+- `provider` chooses which upstream providers may serve the request: `order`,
+  `only`, `ignore`, `sort` by price, throughput, or latency, `maxPrice`,
+  `dataCollection`, `zdr`, `requireParameters`, and `quantizations`.
+- `models` is a fallback chain, tried in order when the requested model is
+  unavailable, rate-limited, or refuses.
+- `reasoning` sets `effort` or an exact `maxTokens` budget, with `exclude` to
+  reason without returning the reasoning.
+- `plugins` enables OpenRouter's request plugins, such as web search. They are
+  sent verbatim rather than typed, since the roster and each plugin's options
+  change on OpenRouter's schedule:
+  `Plugins: []map[string]any{{"id": "web", "max_results": 3}}`.
+- `transforms`, `sessionId`, `serviceTier`, and `metadata` cover context
+  compression, sticky routing, scheduling, and request tagging.
+- `topK`, `minP`, `topA`, and `repetitionPenalty` are the sampling knobs the
+  OpenAI schema has no home for.
+
+`maxOutputTokens` reaches OpenRouter as `max_tokens`, which reasoning models
+spend on thinking before they emit anything visible. A budget that is
+comfortable for a plain model can be consumed entirely by reasoning, leaving
+an empty answer and a `length` finish reason. Leave it unset, or budget for
+the thinking as well, on any model that reasons.
+
+Every config also carries the settings Genkit owns: `version` pins the exact
+model version a request is served by, `apiKey` (settable only from Go code)
+serves one request with a different credential, and `extra` forwards request
+body fields the config does not declare, keyed by OpenRouter's wire names.
+
+`extra` is also the way to reach the request shapes this config does not
+declare, such as the object form of `provider.sort` or the per-percentile form
+of the throughput and latency preferences. An extra wins over the field it
+collides with, so it replaces the whole declared object:
+
+```go
+&openrouter.ChatConfig{RequestConfig: compat_oai.RequestConfig{
+    Extra: map[string]any{
+        "provider": map[string]any{"sort": map[string]any{"by": "price", "partition": "model"}},
+    },
+}}
+```
+
+## Usage and failures
+
+OpenRouter prices every request it routes and reports what it charged. The
+amount arrives as `cost` on the response's usage, in credits:
+
+```go
+response.Usage.Custom["cost"]
+```
+
+It needs no request field. OpenRouter used to gate this behind
+`usage: {include: true}`, which is now deprecated and does nothing; the full
+accounting is returned either way, on streaming and non-streaming responses
+alike. A `:free` model reports an explicit cost of `0`, which is kept: the
+key's presence says the request was priced.
+
+A provider that fails part-way through a generation is a case worth handling.
+OpenRouter has already sent a 200 by then, so it cannot answer with an error
+status. It returns the text produced before the failure, a finish reason of
+`other`, and the reason in `response.FinishMessage`. Check the finish reason
+before trusting a short answer:
+
+```go
+if response.FinishReason == ai.FinishReasonOther && response.FinishMessage != "" {
+    // Upstream failed mid-generation. response.Text() is partial.
+}
+```
+
+The error object also rides whole on the response metadata, as
+`response.Raw.(map[string]any)["error"]`. It carries what the message alone
+does not: the failure's code, and metadata naming the upstream provider that
+failed, which is what `provider.ignore` takes to route the retry around it.
+
+A request that fails before any output returns an ordinary error instead, as
+does a stream that breaks part-way through.
+
+## Not supported
+
+This plugin serves the chat completions endpoint only. OpenRouter's image and
+audio generation endpoints are not part of it.
+
+Three request fields are left out on purpose. `n` asks for several completion
+choices and bills for all of them while Genkit reads only the first, and
+`route` and `usage` are deprecated by OpenRouter and have no effect. Anything
+else undeclared still reaches the wire through `extra`.
+
+## Live tests
+
+Live tests are skipped unless `OPENROUTER_API_KEY` is set:
+
+```bash
+go test -race ./plugins/compat_oai/openrouter -run '^TestPluginLive$' -v -count=1
+```
+
+They spend on ordinary catalog models named at the top of
+`openrouter_live_test.go`. Swap in whatever the key has credit for.

--- a/go/plugins/compat_oai/openrouter/openrouter.go
+++ b/go/plugins/compat_oai/openrouter/openrouter.go
@@ -1,0 +1,607 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package openrouter provides a Genkit plugin for OpenRouter, a gateway that
+// serves models from many providers behind one OpenAI-compatible endpoint.
+//
+// OpenRouter is not a model vendor, so this plugin carries no model catalog.
+// Every model resolves by name on demand, under an ID that keeps the
+// upstream vendor's prefix:
+//
+//	ai.WithModelName("openrouter/anthropic/claude-sonnet-4.5")
+//
+// A resolved model is described with permissive capabilities, which is what
+// makes an arbitrary model usable without an entry per model. Correct a model
+// whose real capabilities are narrower through [OpenRouter.Models].
+//
+// See https://openrouter.ai/docs.
+package openrouter
+
+import (
+	"context"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+const (
+	provider       = "openrouter"
+	defaultBaseURL = "https://openrouter.ai/api/v1"
+)
+
+// ReasoningEffort is how much reasoning a reasoning-capable model spends
+// before it answers. OpenRouter normalizes the level across vendors, so the
+// same value reaches an OpenAI, an Anthropic, and a Gemini model.
+//
+// Which levels a model takes is the model's to decide: a level the upstream
+// vendor does not offer is an error from OpenRouter rather than one from here.
+type ReasoningEffort string
+
+const (
+	// ReasoningEffortNone disables reasoning. Models that always reason
+	// reject it.
+	ReasoningEffortNone ReasoningEffort = "none"
+	// ReasoningEffortMinimal is the shallowest level that still reasons.
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	// ReasoningEffortLow is fast reasoning, for latency-sensitive work.
+	ReasoningEffortLow ReasoningEffort = "low"
+	// ReasoningEffortMedium is the level [ReasoningConfig.Enabled] selects on
+	// its own.
+	ReasoningEffortMedium ReasoningEffort = "medium"
+	// ReasoningEffortHigh is deeper thinking, for hard multi-step problems.
+	ReasoningEffortHigh ReasoningEffort = "high"
+	// ReasoningEffortXHigh is deeper still, offered by a few vendors.
+	ReasoningEffortXHigh ReasoningEffort = "xhigh"
+	// ReasoningEffortMax is the deepest level any vendor offers.
+	ReasoningEffortMax ReasoningEffort = "max"
+)
+
+// ServiceTier selects how a request is scheduled and billed upstream.
+//
+// It is declared here rather than reused from
+// [openai.ChatCompletionNewParamsServiceTier] because the sets differ: a
+// config advertising the SDK's type would omit "fast" and "scale".
+type ServiceTier string
+
+const (
+	// ServiceTierAuto lets OpenRouter pick the tier.
+	ServiceTierAuto ServiceTier = "auto"
+	// ServiceTierDefault is standard scheduling and billing.
+	ServiceTierDefault ServiceTier = "default"
+	// ServiceTierFast buys faster scheduling.
+	ServiceTierFast ServiceTier = "fast"
+	// ServiceTierFlex trades latency for a lower rate.
+	ServiceTierFlex ServiceTier = "flex"
+	// ServiceTierPriority buys the fastest scheduling at the highest rate.
+	ServiceTierPriority ServiceTier = "priority"
+	// ServiceTierScale is the tier for sustained high volume.
+	ServiceTierScale ServiceTier = "scale"
+)
+
+// ProviderSort is the metric upstream providers are ranked by, replacing
+// OpenRouter's default load balancing.
+type ProviderSort string
+
+const (
+	// ProviderSortPrice ranks the cheapest provider first.
+	ProviderSortPrice ProviderSort = "price"
+	// ProviderSortThroughput ranks the fastest provider first.
+	ProviderSortThroughput ProviderSort = "throughput"
+	// ProviderSortLatency ranks the provider with the lowest time to first
+	// token first.
+	ProviderSortLatency ProviderSort = "latency"
+)
+
+// DataCollection is whether a request may reach a provider that may store it.
+type DataCollection string
+
+const (
+	// DataCollectionAllow permits any provider, which is the default.
+	DataCollectionAllow DataCollection = "allow"
+	// DataCollectionDeny restricts routing to providers that do not store
+	// request data.
+	DataCollectionDeny DataCollection = "deny"
+)
+
+// ReasoningConfig controls the reasoning a model does before it answers,
+// sent as the API's reasoning object. See
+// https://openrouter.ai/docs/use-cases/reasoning-tokens.
+type ReasoningConfig struct {
+	// Effort is how much reasoning to spend, from none to max. Vendors that
+	// budget in tokens rather than levels take MaxTokens instead.
+	Effort ReasoningEffort `json:"effort,omitempty" jsonschema:"enum=none,enum=minimal,enum=low,enum=medium,enum=high,enum=xhigh,enum=max" jsonschema_description:"How much reasoning to spend, from none to max. It overrides the model's own default."`
+	// MaxTokens is the exact token budget to reason with, sent as the API's
+	// max_tokens inside the reasoning object. It overrides Effort. Vendors
+	// that take a budget usually reject one under 1,024 tokens, which is a
+	// per-vendor limit rather than a documented API-wide one.
+	MaxTokens int `json:"maxTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Exact token budget to reason with, which overrides effort. Vendors that take a budget usually reject one under 1,024 tokens."`
+	// Exclude keeps the reasoning out of the response without stopping the
+	// model from reasoning.
+	Exclude *bool `json:"exclude,omitempty" jsonschema_description:"Keeps the reasoning out of the response without stopping the model from reasoning."`
+	// Enabled turns reasoning on with the vendor's own defaults, which
+	// OpenRouter treats as medium effort. Effort and MaxTokens imply it.
+	Enabled *bool `json:"enabled,omitempty" jsonschema_description:"Turns reasoning on with the vendor's defaults, which OpenRouter treats as medium effort. Effort and maxTokens imply it."`
+}
+
+// wire returns the reasoning object to send, or nil when the config carries
+// nothing. An empty object is not sent: it would enable reasoning on a model
+// the caller only meant to configure conditionally.
+func (c *ReasoningConfig) wire() map[string]any {
+	if c == nil {
+		return nil
+	}
+	reasoning := map[string]any{}
+	if c.Effort != "" {
+		reasoning["effort"] = string(c.Effort)
+	}
+	if c.MaxTokens > 0 {
+		reasoning["max_tokens"] = c.MaxTokens
+	}
+	if c.Exclude != nil {
+		reasoning["exclude"] = *c.Exclude
+	}
+	if c.Enabled != nil {
+		reasoning["enabled"] = *c.Enabled
+	}
+	if len(reasoning) == 0 {
+		return nil
+	}
+	return reasoning
+}
+
+// MaxPrice caps what a request may cost, in USD per million tokens for the
+// token fields. A request that no provider can serve within the cap fails
+// rather than falling back to a dearer one.
+type MaxPrice struct {
+	// Prompt is the cap on the input price, per million tokens.
+	Prompt *float64 `json:"prompt,omitempty" jsonschema:"minimum=0" jsonschema_description:"Cap on the input price, in USD per million tokens."`
+	// Completion is the cap on the output price, per million tokens.
+	Completion *float64 `json:"completion,omitempty" jsonschema:"minimum=0" jsonschema_description:"Cap on the output price, in USD per million tokens."`
+	// Request is the cap on the per-request price.
+	Request *float64 `json:"request,omitempty" jsonschema:"minimum=0" jsonschema_description:"Cap on the per-request price, in USD."`
+	// Image is the cap on the per-image price.
+	Image *float64 `json:"image,omitempty" jsonschema:"minimum=0" jsonschema_description:"Cap on the per-image price, in USD."`
+}
+
+// wire returns the max_price object to send, or nil when nothing is capped.
+func (p *MaxPrice) wire() map[string]any {
+	if p == nil {
+		return nil
+	}
+	price := map[string]any{}
+	if p.Prompt != nil {
+		price["prompt"] = *p.Prompt
+	}
+	if p.Completion != nil {
+		price["completion"] = *p.Completion
+	}
+	if p.Request != nil {
+		price["request"] = *p.Request
+	}
+	if p.Image != nil {
+		price["image"] = *p.Image
+	}
+	if len(price) == 0 {
+		return nil
+	}
+	return price
+}
+
+// ProviderRouting chooses which upstream providers may serve a request and in
+// what order, sent as the API's provider object. This is the control the
+// gateway exists for: the same model is served by several providers at
+// different prices, speeds, and data policies.
+//
+// Sort, PreferredMinThroughput, and PreferredMaxLatency also have an object
+// form (a partition, or per-percentile thresholds) that this struct does not
+// declare. Send the whole provider object through [compat_oai.RequestConfig.Extra]
+// to reach it: an extra wins over the field it collides with, so the raw
+// object replaces this one wholesale.
+//
+// See https://openrouter.ai/docs/features/provider-routing.
+type ProviderRouting struct {
+	// Order lists provider slugs to try in order before any fallback.
+	Order []string `json:"order,omitempty" jsonschema_description:"Provider slugs to try in order before any fallback, e.g. anthropic or together."`
+	// Only restricts routing to these provider slugs.
+	Only []string `json:"only,omitempty" jsonschema_description:"Restricts routing to these provider slugs."`
+	// Ignore skips these provider slugs.
+	Ignore []string `json:"ignore,omitempty" jsonschema_description:"Skips these provider slugs."`
+	// AllowFallbacks lets another provider serve the request when the chosen
+	// ones fail. It defaults to true; false fails the request instead.
+	AllowFallbacks *bool `json:"allowFallbacks,omitempty" jsonschema_description:"Lets another provider serve the request when the chosen ones fail. Defaults to true; false fails the request instead."`
+	// RequireParameters routes only to providers that honor every parameter
+	// the request carries, rather than to one that would ignore some.
+	RequireParameters *bool `json:"requireParameters,omitempty" jsonschema_description:"Routes only to providers that honor every parameter the request carries, rather than to one that would ignore some."`
+	// DataCollection restricts routing to providers that do not store request
+	// data when set to deny.
+	DataCollection DataCollection `json:"dataCollection,omitempty" jsonschema:"enum=allow,enum=deny" jsonschema_description:"Restricts routing to providers that do not store request data when set to deny. Defaults to allow."`
+	// ZDR restricts routing to zero data retention endpoints.
+	ZDR *bool `json:"zdr,omitempty" jsonschema_description:"Restricts routing to zero data retention endpoints."`
+	// Sort ranks providers by one metric instead of OpenRouter's default load
+	// balancing.
+	Sort ProviderSort `json:"sort,omitempty" jsonschema:"enum=price,enum=throughput,enum=latency" jsonschema_description:"Ranks providers by price, throughput, or latency instead of the default load balancing."`
+	// Quantizations restricts routing to providers serving the model at these
+	// quantization levels, e.g. int4, int8, fp8, fp16, bf16, or fp32. The
+	// set is not enumerated in the schema: OpenRouter adds levels as hardware
+	// gains them, and a closed list here would reject a level it accepts.
+	Quantizations []string `json:"quantizations,omitempty" jsonschema_description:"Restricts routing to providers serving the model at these quantization levels, e.g. int4, int8, fp8, fp16, bf16, or fp32."`
+	// MaxPrice caps what the request may cost.
+	MaxPrice *MaxPrice `json:"maxPrice,omitempty" jsonschema_description:"Caps what the request may cost. A request no provider can serve within the cap fails rather than falling back to a dearer one."`
+	// PreferredMinThroughput deprioritizes providers below this many output
+	// tokens per second. They stay eligible as a fallback.
+	PreferredMinThroughput *float64 `json:"preferredMinThroughput,omitempty" jsonschema:"minimum=0" jsonschema_description:"Deprioritizes providers below this many output tokens per second. They stay eligible as a fallback."`
+	// PreferredMaxLatency deprioritizes providers slower than this many
+	// seconds to first token. They stay eligible as a fallback.
+	PreferredMaxLatency *float64 `json:"preferredMaxLatency,omitempty" jsonschema:"minimum=0" jsonschema_description:"Deprioritizes providers slower than this many seconds to first token. They stay eligible as a fallback."`
+}
+
+// wire returns the provider object to send, or nil when no preference is set.
+func (p *ProviderRouting) wire() map[string]any {
+	if p == nil {
+		return nil
+	}
+	routing := map[string]any{}
+	if len(p.Order) > 0 {
+		routing["order"] = p.Order
+	}
+	if len(p.Only) > 0 {
+		routing["only"] = p.Only
+	}
+	if len(p.Ignore) > 0 {
+		routing["ignore"] = p.Ignore
+	}
+	if p.AllowFallbacks != nil {
+		routing["allow_fallbacks"] = *p.AllowFallbacks
+	}
+	if p.RequireParameters != nil {
+		routing["require_parameters"] = *p.RequireParameters
+	}
+	if p.DataCollection != "" {
+		routing["data_collection"] = string(p.DataCollection)
+	}
+	if p.ZDR != nil {
+		routing["zdr"] = *p.ZDR
+	}
+	if p.Sort != "" {
+		routing["sort"] = string(p.Sort)
+	}
+	if len(p.Quantizations) > 0 {
+		routing["quantizations"] = p.Quantizations
+	}
+	if price := p.MaxPrice.wire(); price != nil {
+		routing["max_price"] = price
+	}
+	if p.PreferredMinThroughput != nil {
+		routing["preferred_min_throughput"] = *p.PreferredMinThroughput
+	}
+	if p.PreferredMaxLatency != nil {
+		routing["preferred_max_latency"] = *p.PreferredMaxLatency
+	}
+	if len(routing) == 0 {
+		return nil
+	}
+	return routing
+}
+
+// ChatConfig is the per-request config for models served through OpenRouter:
+// the sampling fields the gateway normalizes across vendors, plus the routing
+// controls that are the reason to route through it at all. See
+// https://openrouter.ai/docs/api-reference/chat-completion.
+//
+// Several documented request fields are deliberately absent. n asks for
+// several completion choices and bills for all of them, while Genkit reads
+// only the first. route and usage are deprecated by OpenRouter and have no
+// effect. cache_control is a message annotation rather than a request field,
+// so it has no home in a config. Anything undeclared still reaches the wire
+// through [compat_oai.RequestConfig.Extra].
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// Temperature controls the degree of randomness in token selection, from
+	// 0 to 2.
+	Temperature *float64 `json:"temperature,omitempty" jsonschema:"minimum=0,maximum=2" jsonschema_description:"Controls the degree of randomness in token selection, from 0 to 2."`
+	// TopP is the nucleus sampling threshold, from 0 to 1.
+	TopP *float64 `json:"topP,omitempty" jsonschema:"minimum=0,maximum=1" jsonschema_description:"Nucleus sampling threshold, from 0 to 1: only the tokens comprising the top P probability mass are considered."`
+	// TopK limits sampling to the K most likely tokens, sent as the API's
+	// top_k. 0, the default, applies no limit. Some vendors ignore it.
+	TopK *int `json:"topK,omitempty" jsonschema:"minimum=0" jsonschema_description:"Limits sampling to the K most likely tokens, sent as the API's top_k. 0, the default, applies no limit."`
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as
+	// the API's max_tokens.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_tokens."`
+	// StopSequences stop generation when produced by the model, up to four.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema:"maxItems=4" jsonschema_description:"Stop generation when produced by the model, up to four sequences."`
+	// FrequencyPenalty penalizes tokens by their frequency so far, from -2.0
+	// to 2.0.
+	FrequencyPenalty *float64 `json:"frequencyPenalty,omitempty" jsonschema:"minimum=-2,maximum=2" jsonschema_description:"Penalizes tokens by their frequency so far, from -2.0 to 2.0."`
+	// PresencePenalty penalizes tokens that have appeared at all, from -2.0
+	// to 2.0.
+	PresencePenalty *float64 `json:"presencePenalty,omitempty" jsonschema:"minimum=-2,maximum=2" jsonschema_description:"Penalizes tokens that have appeared at all, from -2.0 to 2.0."`
+	// RepetitionPenalty penalizes tokens by whether they appeared in the
+	// input, from 0 to 2, sent as the API's repetition_penalty. 1 is neutral.
+	RepetitionPenalty *float64 `json:"repetitionPenalty,omitempty" jsonschema:"minimum=0,maximum=2" jsonschema_description:"Penalizes tokens by whether they appeared in the input, from 0 to 2, sent as the API's repetition_penalty. 1 is neutral."`
+	// MinP is the minimum probability a token needs relative to the most
+	// likely one, from 0 to 1, sent as the API's min_p.
+	MinP *float64 `json:"minP,omitempty" jsonschema:"minimum=0,maximum=1" jsonschema_description:"Minimum probability a token needs relative to the most likely one, from 0 to 1, sent as the API's min_p."`
+	// TopA filters tokens by a threshold scaled from the most likely token's
+	// probability, from 0 to 1, sent as the API's top_a.
+	TopA *float64 `json:"topA,omitempty" jsonschema:"minimum=0,maximum=1" jsonschema_description:"Filters tokens by a threshold scaled from the most likely token's probability, from 0 to 1, sent as the API's top_a."`
+	// Seed makes generation reproducible across calls when set, on a
+	// best-effort basis.
+	Seed *int `json:"seed,omitempty" jsonschema_description:"Makes generation reproducible across calls when set, on a best-effort basis."`
+	// LogProbs requests log probabilities for the output tokens.
+	LogProbs *bool `json:"logProbs,omitempty" jsonschema_description:"Requests log probabilities for the output tokens."`
+	// TopLogProbs is how many of the most likely tokens to return log
+	// probabilities for at each position, from 0 to 20; it requires LogProbs.
+	TopLogProbs *int `json:"topLogProbs,omitempty" jsonschema:"minimum=0,maximum=20" jsonschema_description:"How many of the most likely tokens to return log probabilities for at each position, from 0 to 20; requires logProbs."`
+	// ParallelToolCalls lets the model request several tool calls in one
+	// response, which it may do by default. It applies to a request that
+	// carries tools.
+	ParallelToolCalls *bool `json:"parallelToolCalls,omitempty" jsonschema_description:"Lets the model request several tool calls in one response, which it may do by default; false caps it at one call per response."`
+	// User identifies the end user a request is made for, which OpenRouter
+	// uses to isolate abuse to one user rather than the whole key.
+	User string `json:"user,omitempty" jsonschema_description:"Identifies the end user a request is made for, which OpenRouter uses to isolate abuse to one user rather than the whole key."`
+
+	// Models lists further models to fall back to, in order, when the
+	// requested one is unavailable, rate-limited, or refuses. The model the
+	// request names is tried first.
+	Models []string `json:"models,omitempty" jsonschema_description:"Further models to fall back to, in order, when the requested one is unavailable, rate-limited, or refuses. The requested model is tried first."`
+	// Provider chooses which upstream providers may serve the request.
+	Provider *ProviderRouting `json:"provider,omitempty" jsonschema_description:"Chooses which upstream providers may serve the request, and in what order."`
+	// Reasoning controls the reasoning the model does before answering.
+	Reasoning *ReasoningConfig `json:"reasoning,omitempty" jsonschema_description:"Controls the reasoning the model does before answering."`
+	// Plugins enables OpenRouter's request plugins, such as web search and
+	// file parsing, each an object with an id and that plugin's own options:
+	//
+	//	Plugins: []map[string]any{{"id": "web", "max_results": 3}}
+	//
+	// They are sent verbatim rather than typed: the roster and each plugin's
+	// options change on OpenRouter's schedule, and a struct here would reject
+	// an option the gateway accepts. See
+	// https://openrouter.ai/docs/features/web-search.
+	Plugins []map[string]any `json:"plugins,omitempty" jsonschema_description:"OpenRouter request plugins such as web search and file parsing, each an object with an id and that plugin's own options, e.g. {\"id\": \"web\", \"max_results\": 3}."`
+	// Transforms are the prompt transforms to apply, currently "middle-out",
+	// which compresses a prompt that would overflow the model's context by
+	// dropping from the middle.
+	Transforms []string `json:"transforms,omitempty" jsonschema_description:"Prompt transforms to apply, currently middle-out, which compresses a prompt that would overflow the model's context by dropping from the middle."`
+	// SessionID groups related requests so they keep reaching the same
+	// upstream provider, sent as the API's session_id. It is what keeps a
+	// multi-turn conversation on one provider's prompt cache.
+	SessionID string `json:"sessionId,omitempty" jsonschema_description:"Groups related requests so they keep reaching the same upstream provider, sent as the API's session_id. It keeps a multi-turn conversation on one provider's prompt cache."`
+	// ServiceTier selects how the request is scheduled and billed upstream.
+	ServiceTier ServiceTier `json:"serviceTier,omitempty" jsonschema:"enum=auto,enum=default,enum=fast,enum=flex,enum=priority,enum=scale" jsonschema_description:"How the request is scheduled and billed upstream: auto, default, fast, flex, priority, or scale."`
+	// Metadata attaches key-value pairs to the request, readable later on
+	// OpenRouter's activity pages. It takes up to 16 pairs, with keys up to
+	// 64 characters and values up to 512.
+	Metadata map[string]string `json:"metadata,omitempty" jsonschema_description:"Key-value pairs attached to the request, readable later on OpenRouter's activity pages. Up to 16 pairs, keys up to 64 characters and values up to 512."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the fields the
+// OpenAI schema already has land on their chat completion counterparts, and
+// the sampling knobs and routing controls OpenRouter adds ride as extra
+// request fields.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.Temperature != nil {
+		params.Temperature = openai.Float(*c.Temperature)
+	}
+	if c.TopP != nil {
+		params.TopP = openai.Float(*c.TopP)
+	}
+	if c.MaxOutputTokens > 0 {
+		params.MaxTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+	if c.FrequencyPenalty != nil {
+		params.FrequencyPenalty = openai.Float(*c.FrequencyPenalty)
+	}
+	if c.PresencePenalty != nil {
+		params.PresencePenalty = openai.Float(*c.PresencePenalty)
+	}
+	if c.Seed != nil {
+		params.Seed = openai.Int(int64(*c.Seed))
+	}
+	if c.LogProbs != nil {
+		params.Logprobs = openai.Bool(*c.LogProbs)
+	}
+	if c.TopLogProbs != nil {
+		params.TopLogprobs = openai.Int(int64(*c.TopLogProbs))
+	}
+	if c.ParallelToolCalls != nil {
+		params.ParallelToolCalls = openai.Bool(*c.ParallelToolCalls)
+	}
+	if c.User != "" {
+		params.User = openai.String(c.User)
+	}
+	if c.ServiceTier != "" {
+		params.ServiceTier = openai.ChatCompletionNewParamsServiceTier(c.ServiceTier)
+	}
+	if len(c.Metadata) > 0 {
+		params.Metadata = c.Metadata
+	}
+
+	extra := map[string]any{}
+	if c.TopK != nil {
+		extra["top_k"] = *c.TopK
+	}
+	if c.RepetitionPenalty != nil {
+		extra["repetition_penalty"] = *c.RepetitionPenalty
+	}
+	if c.MinP != nil {
+		extra["min_p"] = *c.MinP
+	}
+	if c.TopA != nil {
+		extra["top_a"] = *c.TopA
+	}
+	if len(c.Models) > 0 {
+		extra["models"] = c.Models
+	}
+	if len(c.Transforms) > 0 {
+		extra["transforms"] = c.Transforms
+	}
+	if len(c.Plugins) > 0 {
+		extra["plugins"] = c.Plugins
+	}
+	if c.SessionID != "" {
+		extra["session_id"] = c.SessionID
+	}
+	if routing := c.Provider.wire(); routing != nil {
+		extra["provider"] = routing
+	}
+	if reasoning := c.Reasoning.wire(); reasoning != nil {
+		extra["reasoning"] = reasoning
+	}
+	compat_oai.AddExtraFields(params, extra)
+}
+
+// OpenRouter configures the OpenRouter plugin.
+type OpenRouter struct {
+	// APIKey is the OpenRouter API key. If empty, OPENROUTER_API_KEY is
+	// consulted.
+	APIKey string
+	// SiteURL identifies the calling application on OpenRouter's rankings,
+	// sent as the HTTP-Referer header. It is optional and affects
+	// attribution only.
+	SiteURL string
+	// AppName is the title the calling application appears under on
+	// OpenRouter's rankings, sent as the X-Title header. It is optional and
+	// affects attribution only.
+	AppName string
+	// Opts contains additional OpenAI client request options, such as
+	// [option.WithBaseURL] for a different endpoint (OPENROUTER_BASE_URL
+	// works too). Options supplied here are applied after the plugin
+	// defaults, so they win on overlap.
+	Opts []option.RequestOption
+
+	// Models overrides what the plugin knows about a model, keyed by model
+	// ID, bare or provider-prefixed. Every model already works without an
+	// entry: OpenRouter serves hundreds of models from dozens of vendors and
+	// adds more weekly, so the plugin curates no catalog and describes every
+	// model it resolves with the same deliberately permissive capabilities.
+	// The two ways to be wrong are not symmetric: a capability declared too
+	// narrow is refused by Genkit before the request is sent, which blocks a
+	// model that would have worked, while one declared too wide reaches
+	// OpenRouter, which answers with the real reason the model cannot serve
+	// it. Constrained output is the exception, left unclaimed on purpose:
+	// a large share of the catalog lacks it natively, and unset, Genkit
+	// falls back to putting the schema in the prompt, which every model
+	// handles and which returns the same typed result.
+	//
+	// Supply an entry to correct what a model can actually do:
+	//
+	//	&openrouter.OpenRouter{Models: map[string]ai.ModelOptions{
+	//		// A text-only model, so Genkit refuses media locally rather
+	//		// than paying for the upstream rejection.
+	//		"mistralai/mistral-7b-instruct": {Supports: &ai.ModelSupports{
+	//			Multiturn: true, Tools: true, SystemRole: true,
+	//		}},
+	//	}}
+	//
+	// Fields left at their zero value keep what the plugin resolves, so an
+	// entry can pin one capability without restating the rest. The model ID
+	// keeps the upstream vendor's prefix, so it contains a slash; the
+	// optional provider prefix is this plugin's own, as in
+	// "openrouter/mistralai/mistral-7b-instruct".
+	Models map[string]ai.ModelOptions
+
+	openAICompatible compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (o *OpenRouter) Name() string {
+	return provider
+}
+
+// Init implements genkit.Plugin. It registers no models: OpenRouter's catalog
+// is too large and too fast-moving to enumerate, so every model is resolved on
+// demand by [OpenRouter.ResolveAction].
+func (o *OpenRouter) Init(ctx context.Context) []api.Action {
+	baseURL := os.Getenv("OPENROUTER_BASE_URL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiKey := o.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENROUTER_API_KEY")
+	}
+	if apiKey == "" {
+		panic("openrouter plugin initialization failed: apiKey is required")
+	}
+
+	opts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL),
+	}
+	// Attribution only: OpenRouter lists the calling application under these
+	// on its public rankings, and omitting them changes nothing else.
+	if o.SiteURL != "" {
+		opts = append(opts, option.WithHeader("HTTP-Referer", o.SiteURL))
+	}
+	if o.AppName != "" {
+		opts = append(opts, option.WithHeader("X-Title", o.AppName))
+	}
+	opts = append(opts, o.Opts...)
+
+	o.openAICompatible.Provider = provider
+	o.openAICompatible.Opts = opts
+	return o.openAICompatible.Init(ctx)
+}
+
+// modelOptions returns the ModelOptions for a model ID: the permissive
+// defaults, with an entry from [OpenRouter.Models] overlaid on them.
+//
+// Every path that describes a model goes through this one, which is what
+// makes a caller's entry authoritative.
+func (o *OpenRouter) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, nil, compat_oai.DefaultModelOptions(), o.Models)
+}
+
+// ModelRef names a model and carries the config to generate with, so the
+// config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(openrouter.ModelRef("anthropic/claude-sonnet-4.5", &openrouter.ChatConfig{
+//		Provider: &openrouter.ProviderRouting{Sort: openrouter.ProviderSortThroughput},
+//	}))
+//
+// id is the model ID, with or without this plugin's provider prefix. It keeps
+// the upstream vendor's prefix either way.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// ListActions returns no descriptors. OpenRouter serves hundreds of models,
+// and a descriptor carries a full copy of the request and response schemas,
+// so listing the catalog would put megabytes on every reflection poll for a
+// list nobody reads in full. Models stay reachable by name through
+// [OpenRouter.ResolveAction].
+func (o *OpenRouter) ListActions(ctx context.Context) []api.ActionDesc {
+	return nil
+}
+
+// ResolveAction dynamically builds a model served by OpenRouter, described by
+// the plugin's config schema and capabilities. Any model ID the gateway
+// serves resolves, whether or not this plugin has heard of it.
+func (o *OpenRouter) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&o.openAICompatible, atype, id, o.modelOptions)
+}

--- a/go/plugins/compat_oai/openrouter/openrouter_live_test.go
+++ b/go/plugins/compat_oai/openrouter/openrouter_live_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
+	"github.com/firebase/genkit/go/plugins/compat_oai/openrouter"
+	"github.com/openai/openai-go"
+)
+
+// The models the live checks spend on. They are ordinary catalog entries
+// rather than anything the plugin knows about, so swap in whatever the key
+// has credit for; the plugin resolves any ID the gateway serves.
+const (
+	chatModel      = "openai/gpt-5-mini"
+	visionModel    = "anthropic/claude-haiku-4.5"
+	reasoningModel = "deepseek/deepseek-r1"
+)
+
+func TestPluginLive(t *testing.T) {
+	if os.Getenv("OPENROUTER_API_KEY") == "" {
+		t.Skip("OPENROUTER_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&openrouter.OpenRouter{}),
+		genkit.WithDefaultModel("openrouter/"+chatModel),
+	)
+
+	livetest.Run(t, g, livetest.Suite{
+		Model: openrouter.ModelRef(chatModel, nil),
+		// OpenRouter normalizes each vendor's thinking onto the response's
+		// reasoning field, so the content reaches the caller.
+		ReasoningModel: openrouter.ModelRef(reasoningModel, &openrouter.ChatConfig{
+			MaxOutputTokens: 1024,
+			Reasoning:       &openrouter.ReasoningConfig{Effort: openrouter.ReasoningEffortLow},
+		}),
+		ReasoningContent: true,
+		VisionModel:      openrouter.ModelRef(visionModel, nil),
+		ToolChoice:       true,
+		ExtraConfig: map[string]any{
+			"extra": map[string]any{"user": "genkit-livetest"},
+		},
+	})
+}
+
+// TestCostReportedLive pins that OpenRouter prices a request and reports what
+// it charged, with no request field asking for it. The field that used to turn
+// this on is deprecated and does nothing, so the only check that the
+// accounting still arrives is against the real API.
+func TestCostReportedLive(t *testing.T) {
+	if os.Getenv("OPENROUTER_API_KEY") == "" {
+		t.Skip("OPENROUTER_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&openrouter.OpenRouter{}))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModel(openrouter.ModelRef(chatModel, nil)),
+		ai.WithPrompt("Name one primary color. Answer with the word alone."),
+	)
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if cost := resp.Usage.Custom["cost"]; cost <= 0 {
+		t.Errorf("Usage.Custom[\"cost\"] = %v, want the price OpenRouter charged (usage %+v)",
+			cost, resp.Usage)
+	}
+}
+
+// TestGatewayControlsAcceptedLive pins the fields the gateway exists for
+// against the real API. OpenRouter answers a malformed provider object or
+// models list with a 400 rather than ignoring it, so a request that comes back
+// at all is the assertion.
+//
+// The assertion is deliberately not about the answer's content. Price sorting
+// routes to whichever endpoint is cheapest at the time, which may be a heavily
+// quantized one, so tying this to a correct arithmetic result would make it
+// fail on the routing working exactly as asked.
+func TestGatewayControlsAcceptedLive(t *testing.T) {
+	if os.Getenv("OPENROUTER_API_KEY") == "" {
+		t.Skip("OPENROUTER_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&openrouter.OpenRouter{}))
+
+	for name, config := range map[string]*openrouter.ChatConfig{
+		"provider routing": {
+			MaxOutputTokens: 512,
+			Provider: &openrouter.ProviderRouting{
+				Sort:              openrouter.ProviderSortPrice,
+				DataCollection:    openrouter.DataCollectionDeny,
+				RequireParameters: openai.Ptr(true),
+			},
+		},
+		// The fallback list is for a model that fails at request time, not for
+		// one that does not exist: OpenRouter validates the primary model ID up
+		// front and answers an unknown one with a 400 rather than falling
+		// through. So this pins that a well-formed list is accepted; which
+		// entry serves the request is not deterministic enough to assert.
+		"fallback chain": {
+			MaxOutputTokens: 512,
+			Models:          []string{visionModel},
+		},
+		"transforms and session": {
+			MaxOutputTokens: 512,
+			Transforms:      []string{"middle-out"},
+			SessionID:       "genkit-livetest",
+			Metadata:        map[string]string{"suite": "genkit-livetest"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, err := genkit.Generate(ctx, g,
+				ai.WithModel(openrouter.ModelRef(chatModel, config)),
+				ai.WithPrompt("Name one primary color. Answer with the word alone."),
+			)
+			if err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			if strings.TrimSpace(resp.Text()) == "" {
+				// The budget is the usual suspect: it reaches OpenRouter as
+				// max_tokens, which a reasoning model spends on thinking
+				// before any visible text, so too small a cap returns an
+				// empty answer with a length finish reason.
+				t.Errorf("Text() is empty, want the request served (finish reason %q, usage %+v)",
+					resp.FinishReason, resp.Usage)
+			}
+		})
+	}
+}

--- a/go/plugins/compat_oai/openrouter/openrouter_live_test.go
+++ b/go/plugins/compat_oai/openrouter/openrouter_live_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
 	"github.com/firebase/genkit/go/plugins/compat_oai/openrouter"
@@ -86,6 +87,77 @@ func TestCostReportedLive(t *testing.T) {
 	if cost := resp.Usage.Custom["cost"]; cost <= 0 {
 		t.Errorf("Usage.Custom[\"cost\"] = %v, want the price OpenRouter charged (usage %+v)",
 			cost, resp.Usage)
+	}
+}
+
+// TestErrorStatusClassifiedLive pins that a request the gateway refuses reaches
+// the caller as a classified status rather than an opaque error, on both
+// transports. Two refusals are checked rather than one, so the assertion is
+// that they are told apart rather than merely classified: middleware routes
+// around a failure by status, and one that collapses every refusal into the
+// same value is no better than none.
+//
+// Streaming is the half worth spending a live check on. NewStreaming returns
+// before the response arrives, so a refusal surfaces at the stream rather than
+// at the call, and only the real gateway says whether that assumption holds.
+//
+// A provider dying part-way through a generation is the other source of a
+// stream error and is deliberately not here: it needs an upstream to fail
+// mid-response, which no request can provoke. That path is pinned against the
+// documented shape in TestGenerateStreamTopLevelFailureEndsStream.
+func TestErrorStatusClassifiedLive(t *testing.T) {
+	if os.Getenv("OPENROUTER_API_KEY") == "" {
+		t.Skip("OPENROUTER_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	keyed := genkit.Init(ctx, genkit.WithPlugins(&openrouter.OpenRouter{}))
+	// Deliberately not shaped like a key. OpenRouter rejects any bearer token
+	// it does not recognize, and a realistic-looking placeholder only trips
+	// secret scanning on the way to the same 401.
+	rejected := genkit.Init(ctx, genkit.WithPlugins(&openrouter.OpenRouter{APIKey: "invalid"}))
+
+	for name, tc := range map[string]struct {
+		g     *genkit.Genkit
+		model ai.ModelRef
+		want  status.Name
+	}{
+		"rejected key": {
+			g:     rejected,
+			model: openrouter.ModelRef(chatModel, nil),
+			want:  status.Unauthenticated,
+		},
+		"no provider serves the model": {
+			g: keyed,
+			model: openrouter.ModelRef(chatModel, &openrouter.ChatConfig{
+				Provider: &openrouter.ProviderRouting{Only: []string{"not-a-provider"}},
+			}),
+			want: status.NotFound,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, streaming := range []string{"call", "stream"} {
+				t.Run(streaming, func(t *testing.T) {
+					opts := []ai.GenerateOption{
+						ai.WithModel(tc.model),
+						ai.WithPrompt("Name one primary color. Answer with the word alone."),
+					}
+					if streaming == "stream" {
+						opts = append(opts, ai.WithStreaming(
+							func(context.Context, *ai.ModelResponseChunk) error { return nil }))
+					}
+
+					resp, err := genkit.Generate(ctx, tc.g, opts...)
+					if err == nil {
+						t.Fatalf("Generate() error = nil, want the request refused (response %+v)", resp)
+					}
+					got, classified := status.Classified(err)
+					if !classified || got != tc.want {
+						t.Errorf("status = %q (classified %v), want %q: %v", got, classified, tc.want, err)
+					}
+				})
+			}
+		})
 	}
 }
 

--- a/go/plugins/compat_oai/openrouter/openrouter_test.go
+++ b/go/plugins/compat_oai/openrouter/openrouter_test.go
@@ -1,0 +1,580 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openrouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/openrouter"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+// completion answers any chat request with a fixed completion, so a test can
+// assert on what was sent rather than on what came back.
+const completion = `{
+	"id":"c1","object":"chat.completion","created":1,"model":"anthropic/claude-sonnet-4.5",
+	"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+	"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+}`
+
+func completionServer(t *testing.T, capture func(r *http.Request, body map[string]any)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode request: %v", err)
+			}
+			capture(r, body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, completion)
+	}))
+}
+
+func TestPluginRequiresAPIKey(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "")
+	// An OPENAI_API_KEY must never be picked up as a fallback: sending it to
+	// OpenRouter would silently authenticate with the wrong provider's key.
+	t.Setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+
+	defer func() {
+		got := recover()
+		if got != "openrouter plugin initialization failed: apiKey is required" {
+			t.Fatalf("panic = %v, want missing API key error", got)
+		}
+	}()
+
+	(&openrouter.OpenRouter{}).Init(context.Background())
+}
+
+func TestPluginConfigPrecedenceAndAttribution(t *testing.T) {
+	var mu sync.Mutex
+	var rightHit, wrongHit bool
+	var gotAuth, gotReferer, gotTitle string
+
+	right := completionServer(t, func(r *http.Request, _ map[string]any) {
+		mu.Lock()
+		defer mu.Unlock()
+		rightHit = true
+		gotAuth = r.Header.Get("Authorization")
+		gotReferer = r.Header.Get("HTTP-Referer")
+		gotTitle = r.Header.Get("X-Title")
+	})
+	defer right.Close()
+
+	wrong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		wrongHit = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer wrong.Close()
+
+	// Explicit configuration must win over env vars: the struct field for the
+	// key, and an Opts [option.WithBaseURL] for the endpoint, which the plugin
+	// applies after its own defaults.
+	t.Setenv("OPENROUTER_API_KEY", "env-key")
+	t.Setenv("OPENROUTER_BASE_URL", wrong.URL+"/api/v1")
+
+	ctx := context.Background()
+	plugin := &openrouter.OpenRouter{
+		APIKey:  "struct-key",
+		SiteURL: "https://example.test",
+		AppName: "Genkit Test",
+		Opts:    []option.RequestOption{option.WithBaseURL(right.URL)},
+	}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin),
+		genkit.WithDefaultModel("openrouter/anthropic/claude-sonnet-4.5"))
+
+	if _, err := genkit.Generate(ctx, g, ai.WithPrompt("hi")); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !rightHit || wrongHit {
+		t.Fatalf("rightHit = %v, wrongHit = %v, want struct fields to take precedence over env vars", rightHit, wrongHit)
+	}
+	if gotAuth != "Bearer struct-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer struct-key")
+	}
+	if gotReferer != "https://example.test" {
+		t.Errorf("HTTP-Referer = %q, want the plugin's SiteURL", gotReferer)
+	}
+	if gotTitle != "Genkit Test" {
+		t.Errorf("X-Title = %q, want the plugin's AppName", gotTitle)
+	}
+}
+
+// TestVendorPrefixedModelIDs pins the naming that makes a gateway work: an
+// OpenRouter model ID carries its upstream vendor's prefix, so the Genkit
+// action name has two slashes. The plugin's own prefix must be the only one
+// stripped, and the vendor prefix must survive onto the wire, or the request
+// names a model OpenRouter does not serve.
+func TestVendorPrefixedModelIDs(t *testing.T) {
+	var mu sync.Mutex
+	var gotModel string
+	server := completionServer(t, func(_ *http.Request, body map[string]any) {
+		mu.Lock()
+		defer mu.Unlock()
+		gotModel, _ = body["model"].(string)
+	})
+	defer server.Close()
+
+	const id = "anthropic/claude-sonnet-4.5"
+	for _, name := range []string{id, "openrouter/" + id} {
+		ref := openrouter.ModelRef(name, nil)
+		if want := "openrouter/" + id; ref.Name() != want {
+			t.Errorf("ModelRef(%q).Name() = %q, want %q", name, ref.Name(), want)
+		}
+	}
+
+	ctx := context.Background()
+	plugin := &openrouter.OpenRouter{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(openrouter.ModelRef(id, nil)), ai.WithPrompt("hi"))
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Text(); got != "ok" {
+		t.Errorf("Text() = %q, want %q", got, "ok")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gotModel != id {
+		t.Errorf("model = %q, want the vendor-prefixed ID %q", gotModel, id)
+	}
+}
+
+func TestConfigSchema(t *testing.T) {
+	plugin := &openrouter.OpenRouter{APIKey: "test-key"}
+	genkit.Init(context.Background(), genkit.WithPlugins(plugin))
+
+	resolved := plugin.ResolveAction(api.ActionTypeModel, "anthropic/claude-sonnet-4.5")
+	if resolved == nil {
+		t.Fatal("ResolveAction returned nil")
+	}
+	model := resolved.Desc().Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions missing, got %v", model["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions has no properties: %v", schema)
+	}
+
+	for _, key := range []string{
+		"temperature", "topP", "topK", "maxOutputTokens", "stopSequences",
+		"repetitionPenalty", "minP", "topA", "models", "provider", "reasoning",
+		"plugins", "transforms", "sessionId", "serviceTier", "metadata",
+		"version", "extra",
+	} {
+		if props[key] == nil {
+			t.Errorf("config schema is missing the %q property", key)
+		}
+	}
+
+	// The constraints OpenRouter documents ride on the schema, where the
+	// framework enforces them before a request is sent and billed.
+	for field, want := range map[string]map[string]any{
+		"temperature":       {"minimum": 0.0, "maximum": 2.0},
+		"topP":              {"minimum": 0.0, "maximum": 1.0},
+		"topK":              {"minimum": 0.0},
+		"repetitionPenalty": {"minimum": 0.0, "maximum": 2.0},
+		"minP":              {"minimum": 0.0, "maximum": 1.0},
+		"topA":              {"minimum": 0.0, "maximum": 1.0},
+		"frequencyPenalty":  {"minimum": -2.0, "maximum": 2.0},
+		"presencePenalty":   {"minimum": -2.0, "maximum": 2.0},
+		"topLogProbs":       {"minimum": 0.0, "maximum": 20.0},
+		"maxOutputTokens":   {"minimum": 1.0},
+		"stopSequences":     {"maxItems": 4.0},
+		"serviceTier":       {"enum": []any{"auto", "default", "fast", "flex", "priority", "scale"}},
+	} {
+		prop, _ := props[field].(map[string]any)
+		for key, value := range want {
+			if got := prop[key]; !reflect.DeepEqual(got, value) {
+				t.Errorf("%s %s = %#v, want %#v", field, key, got, value)
+			}
+		}
+	}
+
+	// Nested routing and reasoning objects carry their own documented sets.
+	routing, _ := props["provider"].(map[string]any)
+	routingProps, _ := routing["properties"].(map[string]any)
+	for _, key := range []string{
+		"order", "only", "ignore", "allowFallbacks", "requireParameters",
+		"dataCollection", "zdr", "sort", "quantizations", "maxPrice",
+		"preferredMinThroughput", "preferredMaxLatency",
+	} {
+		if routingProps[key] == nil {
+			t.Errorf("provider schema is missing the %q property", key)
+		}
+	}
+	if got := routingProps["sort"].(map[string]any)["enum"]; !reflect.DeepEqual(got, []any{"price", "throughput", "latency"}) {
+		t.Errorf("provider.sort enum = %#v", got)
+	}
+	// Quantizations deliberately carries no enum: OpenRouter adds levels as
+	// hardware gains them, and a closed list would reject one it accepts.
+	if _, has := routingProps["quantizations"].(map[string]any)["enum"]; has {
+		t.Error("provider.quantizations declares an enum, which would reject a level OpenRouter accepts")
+	}
+
+	reasoning, _ := props["reasoning"].(map[string]any)
+	reasoningProps, _ := reasoning["properties"].(map[string]any)
+	want := []any{"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+	if got := reasoningProps["effort"].(map[string]any)["enum"]; !reflect.DeepEqual(got, want) {
+		t.Errorf("reasoning.effort enum = %#v, want %#v", got, want)
+	}
+
+	// n and route are deliberately absent: Genkit reads the first choice only,
+	// and OpenRouter deprecated route in favor of provider sorting.
+	for _, key := range []string{"n", "route", "usage"} {
+		if props[key] != nil {
+			t.Errorf("config schema declares %q, which must not be offered", key)
+		}
+	}
+}
+
+// TestConfigConstraintsRejected pins that a documented constraint is enforced,
+// not just advertised. The server answers success so that, were validation to
+// let one through, the test fails on the nil error rather than on a network
+// call.
+func TestConfigConstraintsRejected(t *testing.T) {
+	server := completionServer(t, nil)
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &openrouter.OpenRouter{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	for name, tc := range map[string]struct {
+		config map[string]any
+		field  string
+	}{
+		"temperature above 2":     {map[string]any{"temperature": 3}, "temperature"},
+		"repetition penalty high": {map[string]any{"repetitionPenalty": 2.5}, "repetitionPenalty"},
+		"fifth stop sequence":     {map[string]any{"stopSequences": []any{"a", "b", "c", "d", "e"}}, "stopSequences"},
+		"unknown reasoning level": {map[string]any{"reasoning": map[string]any{"effort": "ultra"}}, "effort"},
+		"unknown service tier":    {map[string]any{"serviceTier": "turbo"}, "serviceTier"},
+		"unknown data collection": {map[string]any{"provider": map[string]any{"dataCollection": "maybe"}}, "dataCollection"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := genkit.Generate(ctx, g,
+				ai.WithModelName("openrouter/anthropic/claude-sonnet-4.5"),
+				ai.WithConfig(tc.config),
+				ai.WithPrompt("hi"),
+			)
+			if err == nil {
+				t.Fatal("Generate() error = nil, want the config rejected by schema validation")
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("error = %v, want it to name %q", err, tc.field)
+			}
+		})
+	}
+}
+
+// TestGatewayControlsReachTheWire pins the fields that are the reason to route
+// through OpenRouter at all: routing preferences, the fallback chain, the
+// reasoning object, and the sampling knobs the OpenAI schema has no home for.
+func TestGatewayControlsReachTheWire(t *testing.T) {
+	var mu sync.Mutex
+	var got map[string]any
+	server := completionServer(t, func(_ *http.Request, body map[string]any) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = body
+	})
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &openrouter.OpenRouter{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	deny := false
+	topK := 40
+	minP := 0.05
+	if _, err := genkit.Generate(ctx, g,
+		ai.WithModel(openrouter.ModelRef("anthropic/claude-sonnet-4.5", &openrouter.ChatConfig{
+			TopK:       &topK,
+			MinP:       &minP,
+			Models:     []string{"openai/gpt-5", "google/gemini-3-pro"},
+			Transforms: []string{"middle-out"},
+			Plugins:    []map[string]any{{"id": "web", "max_results": 3}},
+			SessionID:  "session-42",
+			Metadata:   map[string]string{"tenant": "acme"},
+			Provider: &openrouter.ProviderRouting{
+				Order:          []string{"anthropic", "google-vertex"},
+				AllowFallbacks: &deny,
+				Sort:           openrouter.ProviderSortThroughput,
+				DataCollection: openrouter.DataCollectionDeny,
+				MaxPrice:       &openrouter.MaxPrice{Prompt: openai.Ptr(3.0)},
+			},
+			Reasoning: &openrouter.ReasoningConfig{
+				Effort:    openrouter.ReasoningEffortHigh,
+				MaxTokens: 2048,
+			},
+		})),
+		ai.WithPrompt("hi"),
+	); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for field, want := range map[string]any{
+		"top_k":      40.0,
+		"min_p":      0.05,
+		"models":     []any{"openai/gpt-5", "google/gemini-3-pro"},
+		"transforms": []any{"middle-out"},
+		"plugins":    []any{map[string]any{"id": "web", "max_results": 3.0}},
+		"session_id": "session-42",
+		"metadata":   map[string]any{"tenant": "acme"},
+		"provider": map[string]any{
+			"order":           []any{"anthropic", "google-vertex"},
+			"allow_fallbacks": false,
+			"sort":            "throughput",
+			"data_collection": "deny",
+			"max_price":       map[string]any{"prompt": 3.0},
+		},
+		"reasoning": map[string]any{"effort": "high", "max_tokens": 2048.0},
+	} {
+		if !reflect.DeepEqual(got[field], want) {
+			t.Errorf("%s = %#v, want %#v", field, got[field], want)
+		}
+	}
+	// A config that sets none of them must not send an empty object that
+	// would enable a feature the caller never asked for.
+	if _, has := got["top_a"]; has {
+		t.Errorf("top_a = %#v, want it absent when unset", got["top_a"])
+	}
+}
+
+// TestExtraWinsOverDeclaredRouting pins the escape hatch for the request
+// shapes this config does not declare, such as the object form of the
+// provider sort. An extra collides with the declared provider object and must
+// replace it wholesale, so a caller is never blocked by a mapping the plugin
+// has not caught up with.
+func TestExtraWinsOverDeclaredRouting(t *testing.T) {
+	var mu sync.Mutex
+	var got map[string]any
+	server := completionServer(t, func(_ *http.Request, body map[string]any) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = body
+	})
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &openrouter.OpenRouter{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	if _, err := genkit.Generate(ctx, g,
+		ai.WithModelName("openrouter/anthropic/claude-sonnet-4.5"),
+		ai.WithConfig(map[string]any{
+			"provider": map[string]any{"sort": "price"},
+			"extra": map[string]any{
+				"provider": map[string]any{"sort": map[string]any{"by": "price", "partition": "model"}},
+				"debug":    true,
+			},
+		}),
+		ai.WithPrompt("hi"),
+	); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := map[string]any{"sort": map[string]any{"by": "price", "partition": "model"}}
+	if !reflect.DeepEqual(got["provider"], want) {
+		t.Errorf("provider = %#v, want the extra to replace the declared object: %#v", got["provider"], want)
+	}
+	if got["debug"] != true {
+		t.Errorf("debug = %#v, want an undeclared field to ride the extra map", got["debug"])
+	}
+}
+
+// TestReasoningReachesTheCaller pins the response half of the reasoning knob.
+// OpenRouter normalizes every vendor's thinking onto the reasoning field,
+// which is not the reasoning_content the OpenAI-compatible providers that came
+// before it use, so a config asking for reasoning would otherwise be billed
+// for output the caller never sees.
+func TestReasoningReachesTheCaller(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Stream    bool           `json:"stream"`
+			Reasoning map[string]any `json:"reasoning"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if got := body.Reasoning["effort"]; got != "high" {
+			t.Errorf("reasoning.effort = %v, want %q", got, "high")
+		}
+
+		if body.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			for _, event := range []string{
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"Think "},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"reasoning":"carefully."},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"content":"42"},"finish_reason":null}]}`,
+				`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			} {
+				_, _ = io.WriteString(w, "data: "+event+"\n\n")
+			}
+			_, _ = io.WriteString(w, "data: [DONE]\n\n")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"m",
+			"choices":[{"index":0,"message":{"role":"assistant","reasoning":"Think carefully.","content":"42"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &openrouter.OpenRouter{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+	model := openrouter.ModelRef("openai/gpt-5", &openrouter.ChatConfig{
+		Reasoning: &openrouter.ReasoningConfig{Effort: openrouter.ReasoningEffortHigh},
+	})
+
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(model), ai.WithPrompt("hi"))
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Reasoning(); got != "Think carefully." {
+		t.Errorf("Reasoning() = %q, want %q", got, "Think carefully.")
+	}
+	if got := resp.Text(); got != "42" {
+		t.Errorf("Text() = %q, want %q", got, "42")
+	}
+
+	var streamed strings.Builder
+	resp, err = genkit.Generate(ctx, g, ai.WithModel(model), ai.WithPrompt("hi"),
+		ai.WithStreaming(func(_ context.Context, chunk *ai.ModelResponseChunk) error {
+			for _, part := range chunk.Content {
+				if part.IsReasoning() {
+					streamed.WriteString(part.Text)
+				}
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("streaming Generate() error = %v", err)
+	}
+	if got := streamed.String(); got != "Think carefully." {
+		t.Errorf("streamed reasoning = %q, want %q", got, "Think carefully.")
+	}
+	if got := resp.Reasoning(); got != "Think carefully." {
+		t.Errorf("accumulated Reasoning() = %q, want %q", got, "Think carefully.")
+	}
+}
+
+// TestListActionsIsEmpty pins a deliberate choice rather than an oversight.
+// OpenRouter serves hundreds of models and a descriptor carries full request
+// and response schemas, so listing the catalog would put megabytes on every
+// reflection poll. Models stay reachable by name.
+func TestListActionsIsEmpty(t *testing.T) {
+	ctx := context.Background()
+	plugin := &openrouter.OpenRouter{APIKey: "test-key"}
+	genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	if got := plugin.ListActions(ctx); len(got) != 0 {
+		t.Errorf("ListActions() returned %d descriptors, want none", len(got))
+	}
+	if plugin.ResolveAction(api.ActionTypeModel, "openai/gpt-5") == nil {
+		t.Error("ResolveAction returned nil, so an unlisted model is unreachable")
+	}
+	// Only models resolve; asking for another action type must not invent one.
+	if got := plugin.ResolveAction(api.ActionTypeEmbedder, "openai/text-embedding-3-small"); got != nil {
+		t.Errorf("ResolveAction(embedder) = %v, want nil", got)
+	}
+}
+
+// TestDynamicCapabilitiesAndOverride pins the capability policy. Every model
+// resolves permissive, because a capability declared too narrow is refused by
+// Genkit locally and blocks a model that works, while one declared too wide
+// fails at OpenRouter with the real reason. Constrained output is the
+// exception, left unset so structured output falls back to prompt
+// instructions that every model handles. Models is the correction.
+func TestDynamicCapabilitiesAndOverride(t *testing.T) {
+	ctx := context.Background()
+	plugin := &openrouter.OpenRouter{
+		APIKey: "test-key",
+		Models: map[string]ai.ModelOptions{
+			"mistralai/mistral-7b-instruct": {Supports: &ai.ModelSupports{
+				Multiturn: true, Tools: true, SystemRole: true,
+			}},
+		},
+	}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	supports := func(id string) map[string]any {
+		t.Helper()
+		resolved := plugin.ResolveAction(api.ActionTypeModel, id)
+		if resolved == nil {
+			t.Fatalf("ResolveAction(%q) = nil", id)
+		}
+		return resolved.Desc().Metadata["model"].(map[string]any)["supports"].(map[string]any)
+	}
+
+	got := supports("openai/gpt-5")
+	for _, key := range []string{"multiturn", "tools", "systemRole", "media", "toolChoice"} {
+		if got[key] != true {
+			t.Errorf("dynamic supports[%q] = %v, want true", key, got[key])
+		}
+	}
+	if c, _ := got["constrained"].(ai.ConstrainedSupport); c != "" {
+		t.Errorf("dynamic constrained = %q, want it unset so structured output falls back to prompt instructions", c)
+	}
+
+	if got := supports("mistralai/mistral-7b-instruct"); got["media"] != false {
+		t.Errorf("overridden supports[media] = %v, want the Models entry to narrow it", got["media"])
+	}
+
+	// The narrowed entry is enforced, not just advertised: Genkit refuses the
+	// media locally rather than paying for the upstream rejection.
+	_, err := genkit.Generate(ctx, g,
+		ai.WithModelName("openrouter/mistralai/mistral-7b-instruct"),
+		ai.WithMessages(ai.NewUserMessage(ai.NewMediaPart("image/png", "data:image/png;base64,iVBORw0KGgo="))),
+	)
+	if err == nil {
+		t.Fatal("Generate() error = nil, want the media refused by the overridden capabilities")
+	}
+	if !strings.Contains(err.Error(), "does not support media") {
+		t.Errorf("error = %v, want it to name the missing media support", err)
+	}
+}

--- a/go/samples/compat_oai/openrouter/main.go
+++ b/go/samples/compat_oai/openrouter/main.go
@@ -12,16 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This sample demonstrates the base compat_oai plugin pointed at a custom
-// OpenAI-compatible provider, here OpenRouter: a streaming flow that generates
-// a joke with a model that resolves dynamically by name and takes the OpenAI
-// SDK's own request type as its config.
-//
-// This is the shape for a provider with no plugin of its own. OpenRouter has
-// one, in plugins/compat_oai/openrouter, and it is the better way to reach
-// OpenRouter: the SDK request type has no home for the routing, fallback, and
-// reasoning fields that are the reason to use the gateway, and the config
-// schema rejects them. See samples/compat_oai/openrouter.
+// This sample demonstrates the OpenRouter plugin: a streaming flow that
+// generates a joke through a model named with its upstream vendor's prefix,
+// routed to the cheapest provider serving it, with a second model to fall
+// back to.
 //
 // Run it:
 //
@@ -46,13 +40,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
-	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/firebase/genkit/go/plugins/compat_oai/openrouter"
 	"github.com/firebase/genkit/go/plugins/server"
-	"github.com/openai/openai-go"
 )
 
 // JokeRequest is what the flow takes. A struct rather than a bare string lets
@@ -64,32 +56,28 @@ type JokeRequest struct {
 }
 
 // model pins the model and its config in one place, so switching either is a
-// one-line change. The base plugin ships no typed ModelRef helper, since it
-// knows nothing about the provider it is pointed at, so ai.NewModelRef pins any
-// model the provider serves by name under the plugin's provider prefix.
-//
-// The name after the prefix is OpenRouter's, not Genkit's, and OpenRouter
-// retires models on its own schedule; a 404 saying "no endpoints found" means
-// this one is gone. The current catalog is at https://openrouter.ai/models.
-var model = ai.NewModelRef("openrouter/deepseek/deepseek-chat", &openai.ChatCompletionNewParams{
-	Temperature: openai.Float(0.7),
-	MaxTokens:   openai.Int(1024),
+// one-line change. The ID keeps its upstream vendor's prefix, and no model is
+// registered up front: any model OpenRouter serves resolves by name.
+var model = openrouter.ModelRef("openai/gpt-5-mini", &openrouter.ChatConfig{
+	// Route to the cheapest provider serving the model, and skip any that
+	// would keep the request.
+	Provider: &openrouter.ProviderRouting{
+		Sort:           openrouter.ProviderSortPrice,
+		DataCollection: openrouter.DataCollectionDeny,
+	},
+	// If that model is unavailable or rate-limited, serve the request with
+	// this one instead.
+	Models: []string{"anthropic/claude-haiku-4.5"},
 })
 
 func main() {
 	ctx := context.Background()
 
-	// A custom provider has no environment variable of its own, so the plugin
-	// takes the key, the provider prefix, and the endpoint as fields.
-	apiKey := os.Getenv("OPENROUTER_API_KEY")
-	if apiKey == "" {
-		log.Fatal("OPENROUTER_API_KEY environment variable not set")
-	}
-
-	g := genkit.Init(ctx, genkit.WithPlugins(&compat_oai.OpenAICompatible{
-		Provider: "openrouter",
-		APIKey:   apiKey,
-		BaseURL:  "https://openrouter.ai/api/v1",
+	// The plugin reads the API key from the OPENROUTER_API_KEY environment
+	// variable. SiteURL and AppName are optional: they name the application on
+	// OpenRouter's public rankings and change nothing else.
+	g := genkit.Init(ctx, genkit.WithPlugins(&openrouter.OpenRouter{
+		AppName: "Genkit OpenRouter sample",
 	}))
 
 	// Passing sendChunk straight to WithStreaming forwards the model's chunks


### PR DESCRIPTION
Stacked on #6071, which lands first.

Adds an OpenRouter plugin to the `compat_oai` family, and the three response fields a gateway answers with that the shared converter dropped.

```go
g := genkit.Init(ctx,
    genkit.WithPlugins(&openrouter.OpenRouter{}),
    genkit.WithDefaultModel("openrouter/anthropic/claude-sonnet-4.5"),
)
```

A model ID keeps its upstream vendor's prefix, so an action name carries two slashes: the first is this plugin's provider prefix and the rest is the ID OpenRouter serves. Variant suffixes work the same way, including `:free`, `:nitro`, and `:floor`.

## The catalog is resolved, not curated

OpenRouter is not a model vendor. It fronts hundreds of models from dozens of vendors and adds more weekly, so the plugin curates no `supportedModels` map, registers nothing at `Init`, and returns no descriptors from `ListActions`. That last one is a size decision rather than a stylistic one: a descriptor carries full request and response schemas, so returning that catalog would put megabytes on every reflection poll. Models stay usable by name and only the browsable Dev UI list is absent.

Every resolved model is described permissively, because the two ways to be wrong are not symmetric. A capability declared too narrow is refused by Genkit before the request leaves, which blocks a model that would have worked; one declared too wide reaches OpenRouter and comes back with the real reason. Native constrained output is the exception, left unclaimed so structured output falls back to schema instructions in the prompt, which every model handles and which returns the same typed result.

`Models` narrows a model whose real capabilities are known, and a zero-value field keeps what the plugin resolves:

```go
&openrouter.OpenRouter{Models: map[string]ai.ModelOptions{
    "mistralai/mistral-7b-instruct": {Supports: &ai.ModelSupports{
        Multiturn: true, Tools: true, SystemRole: true,
    }},
}}
```

## The gateway controls are the config

A typed `ChatConfig` carries the fields that are the reason to route through a gateway at all, rather than leaving them to `extra`:

```go
genkit.Generate(ctx, g,
    ai.WithModel(openrouter.ModelRef("openai/gpt-5", &openrouter.ChatConfig{
        Provider: &openrouter.ProviderRouting{
            Sort:           openrouter.ProviderSortPrice,
            DataCollection: openrouter.DataCollectionDeny,
        },
        Models:    []string{"anthropic/claude-sonnet-4.5"},
        Reasoning: &openrouter.ReasoningConfig{Effort: openrouter.ReasoningEffortHigh},
    })),
    ai.WithPrompt("Work through this step by step."),
)
```

`provider` picks which upstreams may serve the request, `models` is a fallback chain tried in order, and `reasoning` sets effort or an exact token budget. `plugins` stays `[]map[string]any` on purpose: the roster and each plugin's options change on OpenRouter's schedule, so typing them would date the config faster than the gateway ships.

`maxOutputTokens` reaches OpenRouter as `max_tokens`, which reasoning models spend on thinking before emitting anything visible, so a budget comfortable for a plain model can return an empty answer with a `length` finish reason.

## Three response fields the shared converter dropped

These land in `generate.go`, so all eight subplugins get them.

**`usage.cost`** reaches `Usage.Custom["cost"]`. Presence decides rather than value: a `:free` model is priced at an explicit `0`, which is an answer and is kept, while a provider that does not price requests has no field and gains no key. OpenRouter used to gate this behind `usage: {include: true}`, which is now deprecated and does nothing.

**A provider failing mid-generation** arrives as a 200. The status and headers are committed by the time the upstream dies, so the failure cannot arrive as an error status. Where the error object lands depends on the transport, and so does what is left to recover.

On a non-streaming response it rides on the choice, as `finish_reason: "error"` plus an error object beside the text produced first. The response is otherwise well-formed, so before this it read as a complete answer with an `unknown` finish reason and no message. It now maps to `other`, the error's message becomes `FinishMessage`, and the object rides whole on `Raw["error"]`, carrying the code and the typed `error_type` naming the class of failure. The partial text stays: that 200 is the only delivery, and erroring would discard it.

On a stream the object arrives at the top level of a chunk instead. The SDK checks for that field before it unmarshals and ends the stream when it finds one, so the chunk never reaches the loop and no response is assembled. That stays an error rather than becoming a partial response. What the model generated first has already reached the stream callback, so the failure costs the aggregate rather than the output, and retry and fallback middleware key on the error rather than the finish reason: a truncated answer returned as a success would reach neither. The error's own code now classifies it, so a rate limit and a request the provider will refuse again are no longer alike reissued until the attempts run out.

A choice that finished cleanly keeps an empty `FinishMessage` even when an error-shaped extra rides beside it, since a finish message on a `stop` reads as the reason generation ended.

**`reasoning`**, the field OpenRouter normalizes every vendor's thinking onto, is read beside DeepSeek and Kimi's `reasoning_content` with the same precedence on both the streaming and non-streaming paths.

## `DefaultModelOptions` returns a fresh `Supports`

It returned `Supports: &Multimodal`, a pointer to the package-level var. Go hands out that pointer to every caller, so `opts.Supports.Media = false` wrote through to the global and silently narrowed every dynamically resolved model in the process, racing with concurrent resolution. `ai.NewModelAction` clones `Supports` at construction, which reads the global at resolution time, so the poison spread to everything resolved afterward rather than staying with the one caller. Each call now returns its own copy.

## API reference

```go
// Plugin
type OpenRouter struct{ APIKey, SiteURL, AppName string; Opts []option.RequestOption; Models map[string]ai.ModelOptions }
func (o *OpenRouter) Name() string
func (o *OpenRouter) Init(ctx) []api.Action
func (o *OpenRouter) ListActions(ctx) []api.ActionDesc
func (o *OpenRouter) ResolveAction(atype api.ActionType, id string) api.Action

// Config
func ModelRef(id string, config *ChatConfig) ai.ModelRef
type ChatConfig struct{ ...; Provider *ProviderRouting; Models []string; Reasoning *ReasoningConfig;
                        Plugins []map[string]any; Transforms []string; SessionID string;
                        ServiceTier ServiceTier; Metadata map[string]string;
                        TopK, MinP, TopA, RepetitionPenalty float64 }
func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams)
type ProviderRouting struct{ Order, Only, Ignore, Quantizations []string; Sort ProviderSort;
                             MaxPrice *MaxPrice; DataCollection DataCollection;
                             ZDR, RequireParameters, AllowFallbacks *bool }
type MaxPrice struct{ Prompt, Completion, Request, Image *float64 }
type ReasoningConfig struct{ Effort ReasoningEffort; MaxTokens int; Exclude *bool }

// Closed sets, per the family rule that an enum-tagged field is a named type
type ReasoningEffort string  // None, Minimal, Low, Medium, High, XHigh, Max
type ProviderSort string     // Price, Throughput, Latency
type DataCollection string   // Allow, Deny
type ServiceTier string      // Auto, Default, Fast, Flex, Priority, Scale
```

## What this deliberately leaves out

- **No model catalog and no Dev UI list.** Both scale with OpenRouter's catalog rather than with what the application uses. `Models` covers correcting a specific model.
- **Three request fields.** `n` bills for choices Genkit never reads, and `route` and `usage` are deprecated by OpenRouter and do nothing. Everything else undeclared still reaches the wire through `extra`.
- **Chat completions only.** OpenRouter's image and audio generation endpoints are separate surfaces.
- **`url_citation` annotations.** OpenRouter's web plugin and OpenAI's `web_search_options` both return them and both drop them today. Surfacing them needs a shape decision (source part, part metadata, or `Raw`) that applies to the whole family, so it belongs in its own change.
- **`native_finish_reason`.** It carries the upstream vendor's own reason beside the normalized one, with no `ai.ModelResponse` field to land in. `Raw["error"]` covers the failure case that motivated reading it.
