### PR TITLE
feat(js/plugins/minimax): add MiniMax music generation plugin

### DIFF
--- a/js/index.typedoc.md
+++ b/js/index.typedoc.md
@@ -57,6 +57,7 @@ This reference documents the following packages:
 | **[@genkit-ai/compat-oai](modules/_genkit-ai_compat-oai.html)**                       | OpenAI-compatible model plugin.                                          |
 | **[@genkit-ai/fetch](modules/_genkit-ai_fetch.html)**                                 | HTTP fetch utilities for plugins.                                        |
 | **[@genkit-ai/middleware](modules/_genkit-ai_middleware.html)**                       | Model middleware plugin (retry, caching, etc.).                          |
+| **[@genkit-ai/minimax](modules/_genkit-ai_minimax.html)**                             | MiniMax music generation model plugin.                                   |
 
 The `genkit` package also provides subpath imports for specific functionality:
 

--- a/js/plugins/minimax/.gitignore
+++ b/js/plugins/minimax/.gitignore
@@ -1,0 +1,3 @@
+lib/
+node_modules/
+coverage/

--- a/js/plugins/minimax/.npmignore
+++ b/js/plugins/minimax/.npmignore
@@ -1,0 +1,17 @@
+# typescript source files
+src/
+tests/
+tsconfig.json
+tsup.common.ts
+tsup.config.ts
+
+# GitHub files
+.github/
+.gitignore
+.npmignore
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+
+# Developer related files
+.devcontainer/
+.vscode/

--- a/js/plugins/minimax/README.md
+++ b/js/plugins/minimax/README.md
@@ -1,0 +1,125 @@
+# MiniMax plugin for Genkit
+
+This plugin adds the MiniMax music generation models to Genkit.
+
+## Installation
+
+```bash
+npm i @genkit-ai/minimax
+```
+
+## Configuration
+
+The plugin reads the API key from the `MINIMAX_API_KEY` environment variable, or
+it can be passed explicitly:
+
+```ts
+import { minimax } from '@genkit-ai/minimax';
+import { genkit } from 'genkit';
+
+const ai = genkit({
+  plugins: [minimax({ apiKey: process.env.MINIMAX_API_KEY })],
+});
+```
+
+### Regions
+
+Requests go to the international endpoint by default. Set `region: 'cn'` to use
+the mainland China endpoint instead:
+
+```ts
+const ai = genkit({
+  plugins: [minimax({ region: 'cn' })],
+});
+```
+
+| Region     | Endpoint                                     |
+| ---------- | -------------------------------------------- |
+| `global`   | `https://api.minimax.io/v1/music_generation` |
+| `cn`       | `https://api.minimaxi.com/v1/music_generation` |
+
+`baseUrl` overrides the endpoint derived from the region, and the region can also
+be selected per request through the model config.
+
+## Music generation
+
+The music models turn a prompt, and optionally lyrics, into an audio track. The
+generated audio is returned as a media part.
+
+```ts
+const { message } = await ai.generate({
+  model: minimax.model('music-3.0'),
+  prompt: 'An upbeat acoustic folk song about the sunrise',
+  config: {
+    lyrics: '[Verse]\nMorning light\n[Chorus]\nHere comes the sun',
+  },
+});
+
+const audio = message?.content.find((part) => part.media)?.media;
+```
+
+Available models are `music-3.0`, `music-2.6`, `music-3.0-free` and
+`music-2.6-free`.
+
+### Instrumental tracks
+
+Set `is_instrumental` to generate a vocal-free track, which makes `lyrics`
+unnecessary. Alternatively, `lyrics_optimizer` lets the service derive the lyrics
+from the prompt.
+
+```ts
+const { message } = await ai.generate({
+  model: minimax.model('music-3.0'),
+  prompt: 'A calm lo-fi study beat',
+  config: { is_instrumental: true },
+});
+```
+
+### Audio output
+
+By default the audio bytes are returned as a hexadecimal string and inlined into
+the media part as a `data:` URL. Set `output_format: 'url'` to receive a download
+URL instead, which expires 24 hours after the request.
+
+```ts
+const { message } = await ai.generate({
+  model: minimax.model('music-3.0'),
+  prompt: 'A cinematic orchestral theme',
+  config: {
+    output_format: 'url',
+    audio_setting: { sample_rate: 44100, bitrate: 256000, format: 'mp3' },
+  },
+});
+```
+
+`audio_setting.format` accepts `mp3`, `wav` and `pcm`, and determines the content
+type reported on the media part.
+
+### Watermarking
+
+The `cn` endpoint accepts `aigc_watermark` to embed an AIGC watermark. Requests
+that set it against another region are rejected before they are sent.
+
+```ts
+const { message } = await ai.generate({
+  model: minimax.model('music-3.0'),
+  prompt: 'A gentle piano lullaby',
+  config: { region: 'cn', aigc_watermark: true },
+});
+```
+
+### Streaming
+
+The models always return a single response. The endpoint's streaming mode only
+emits hexadecimal audio and is not exposed through this plugin, so requests that
+set `stream` are rejected.
+
+## Documentation
+
+- International: https://platform.minimax.io/docs/api-reference/music-generation
+- Mainland China: https://platform.minimaxi.com/docs/api-reference/music-generation
+
+The sources for this package are in the main
+[Genkit](https://github.com/genkit-ai/genkit) repository.
+
+License: Apache 2.0

--- a/js/plugins/minimax/package.json
+++ b/js/plugins/minimax/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@genkit-ai/minimax",
+  "description": "Genkit AI framework plugin for MiniMax music generation APIs.",
+  "keywords": [
+    "genkit",
+    "genkit-plugin",
+    "genkit-model",
+    "minimax",
+    "music",
+    "music-generation",
+    "text-to-music",
+    "ai"
+  ],
+  "version": "0.1.0",
+  "type": "commonjs",
+  "scripts": {
+    "check": "tsc",
+    "compile": "tsup-node",
+    "build:clean": "rimraf ./lib",
+    "build": "npm-run-all build:clean check compile",
+    "build:watch": "tsup-node --watch",
+    "test": "tsx --test tests/*_test.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/genkit-ai/genkit.git",
+    "directory": "js/plugins/minimax"
+  },
+  "author": "genkit",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "genkit": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.16",
+    "@types/sinon": "^17.0.4",
+    "genkit": "workspace:*",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
+    "sinon": "^21.0.0",
+    "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs",
+      "default": "./lib/index.js"
+    }
+  }
+}

--- a/js/plugins/minimax/src/client.ts
+++ b/js/plugins/minimax/src/client.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GenkitError } from 'genkit';
+import {
+  MUSIC_GENERATION_PATH,
+  REGION_BASE_URLS,
+  SUCCESS_STATUS_CODE,
+  type ClientOptions,
+  type MusicGenerationRequest,
+  type MusicGenerationResponse,
+} from './types.js';
+
+/**
+ * Builds the absolute music generation URL for the resolved client options.
+ *
+ * An explicit `baseUrl` wins over the region default so that proxies and
+ * gateways can be used without changing the region semantics.
+ */
+export function getMusicGenerationUrl(clientOptions: ClientOptions): string {
+  const baseUrl =
+    clientOptions.baseUrl ?? REGION_BASE_URLS[clientOptions.region];
+  return `${baseUrl.replace(/\/+$/, '')}${MUSIC_GENERATION_PATH}`;
+}
+
+/**
+ * Builds the request headers, keeping caller-provided headers from
+ * overwriting authentication.
+ */
+export function getHeaders(
+  clientOptions: ClientOptions
+): Record<string, string> {
+  return {
+    ...(clientOptions.customHeaders ?? {}),
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${clientOptions.apiKey}`,
+  };
+}
+
+/**
+ * Calls the music generation endpoint and returns the decoded payload.
+ *
+ * The endpoint answers with HTTP 200 even for some failures, so the
+ * `base_resp.status_code` envelope is checked as well.
+ */
+export async function generateMusic(
+  request: MusicGenerationRequest,
+  clientOptions: ClientOptions
+): Promise<MusicGenerationResponse> {
+  const url = getMusicGenerationUrl(clientOptions);
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getHeaders(clientOptions),
+    body: JSON.stringify(request),
+    signal: clientOptions.signal,
+  });
+
+  if (!response.ok) {
+    const details = await response.text().catch(() => '');
+    throw new GenkitError({
+      status: 'UNKNOWN',
+      message: `Error fetching from ${url}: [${response.status} ${response.statusText}] ${details}`,
+    });
+  }
+
+  let payload: MusicGenerationResponse;
+  try {
+    payload = (await response.json()) as MusicGenerationResponse;
+  } catch (e) {
+    throw new GenkitError({
+      status: 'UNKNOWN',
+      message: `Error parsing the response from ${url}: ${e}`,
+    });
+  }
+
+  const statusCode = payload.base_resp?.status_code;
+  if (statusCode !== undefined && statusCode !== SUCCESS_STATUS_CODE) {
+    throw new GenkitError({
+      status: 'UNKNOWN',
+      message: `Error fetching from ${url}: [${statusCode}] ${
+        payload.base_resp?.status_msg ?? 'unknown error'
+      }`,
+    });
+  }
+
+  return payload;
+}

--- a/js/plugins/minimax/src/converters.ts
+++ b/js/plugins/minimax/src/converters.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GenkitError, type MessageData } from 'genkit';
+import {
+  getBasicUsageStats,
+  type GenerateRequest,
+  type GenerateResponseData,
+} from 'genkit/model';
+import type { MiniMaxMusicConfigSchemaType } from './music.js';
+import {
+  DEFAULT_AUDIO_FORMAT,
+  DEFAULT_OUTPUT_FORMAT,
+  MUSIC_STREAM_OUTPUT_FORMATS,
+  MUSIC_TASK_STATUS,
+  type MiniMaxRegion,
+  type MusicAudioFormat,
+  type MusicGenerationRequest,
+  type MusicGenerationResponse,
+  type MusicOutputFormat,
+} from './types.js';
+
+const AUDIO_CONTENT_TYPES: Record<MusicAudioFormat, string> = {
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  pcm: 'audio/pcm',
+};
+
+/**
+ * Maps an audio container format to the media content type reported on the
+ * returned media part.
+ */
+export function audioContentType(format: MusicAudioFormat): string {
+  return AUDIO_CONTENT_TYPES[format];
+}
+
+/**
+ * Joins the text parts of the request messages into a single prompt.
+ */
+function promptFromMessages(messages: MessageData[]): string {
+  return messages
+    .flatMap((message) => message.content)
+    .map((part) => part.text ?? '')
+    .join('')
+    .trim();
+}
+
+/**
+ * Builds the music generation request body.
+ *
+ * The prompt is taken from the request messages, falling back to
+ * `config.prompt` when the messages carry no text.
+ */
+export function toMusicGenerationRequest(
+  model: string,
+  request: GenerateRequest<MiniMaxMusicConfigSchemaType>,
+  region: MiniMaxRegion
+): MusicGenerationRequest {
+  const {
+    apiKey: _apiKey,
+    region: _region,
+    baseUrl: _baseUrl,
+    prompt,
+    stream,
+    aigc_watermark,
+    ...rest
+  } = request.config ?? {};
+
+  if (stream) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message:
+        'Streaming music generation is not supported by this model. Remove `stream` from the config, ' +
+        `or request one of the streaming output formats (${MUSIC_STREAM_OUTPUT_FORMATS.join(
+          ', '
+        )}) through a direct API call.`,
+    });
+  }
+
+  if (aigc_watermark !== undefined && region !== 'cn') {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `The \`aigc_watermark\` config is only accepted by the \`cn\` region, but the request targets \`${region}\`.`,
+    });
+  }
+
+  const resolvedPrompt = promptFromMessages(request.messages) || prompt;
+
+  return {
+    model,
+    ...(resolvedPrompt ? { prompt: resolvedPrompt } : {}),
+    ...(aigc_watermark !== undefined ? { aigc_watermark } : {}),
+    ...rest,
+  };
+}
+
+/**
+ * Decodes a hexadecimal audio payload into a base64 string.
+ */
+function hexToBase64(hex: string): string {
+  const normalized = hex.trim();
+  if (normalized.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(normalized)) {
+    throw new GenkitError({
+      status: 'UNKNOWN',
+      message:
+        'The response audio was not a valid hexadecimal string. Set `output_format` to `url` to receive a download URL instead.',
+    });
+  }
+  return Buffer.from(normalized, 'hex').toString('base64');
+}
+
+/**
+ * Converts a music generation response into a Genkit response holding a single
+ * audio media part.
+ *
+ * With `output_format: 'url'` the returned URL is passed through unchanged;
+ * with `hex` the audio bytes are inlined as a data URL.
+ */
+export function fromMusicGenerationResponse(
+  request: GenerateRequest<MiniMaxMusicConfigSchemaType>,
+  response: MusicGenerationResponse,
+  outputFormat: MusicOutputFormat = DEFAULT_OUTPUT_FORMAT,
+  audioFormat: MusicAudioFormat = DEFAULT_AUDIO_FORMAT
+): GenerateResponseData {
+  const status = response.data?.status;
+  if (status === MUSIC_TASK_STATUS.IN_PROGRESS) {
+    throw new GenkitError({
+      status: 'UNAVAILABLE',
+      message:
+        'The music generation is still in progress. The endpoint does not expose a way to poll for the result, so please retry the request.',
+    });
+  }
+
+  const audio = response.data?.audio;
+  if (!audio) {
+    throw new GenkitError({
+      status: 'UNKNOWN',
+      message: 'The response did not contain any generated audio.',
+    });
+  }
+
+  const contentType = audioContentType(audioFormat);
+  const url =
+    outputFormat === 'url'
+      ? audio
+      : `data:${contentType};base64,${hexToBase64(audio)}`;
+
+  const message: MessageData = {
+    role: 'model',
+    content: [{ media: { url, contentType } }],
+  };
+
+  return {
+    finishReason: 'stop',
+    message,
+    usage: getBasicUsageStats(request.messages, message),
+    custom: response,
+  };
+}

--- a/js/plugins/minimax/src/index.ts
+++ b/js/plugins/minimax/src/index.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ActionMetadata, ModelReference, z } from 'genkit';
+import type { ModelAction } from 'genkit/model';
+import { genkitPluginV2, type GenkitPluginV2 } from 'genkit/plugin';
+import type { ActionType } from 'genkit/registry';
+import * as music from './music.js';
+import type { MiniMaxPluginOptions } from './types.js';
+import { PLUGIN_NAME, checkApiKey, modelName } from './utils.js';
+
+export {
+  MiniMaxMusicConfigSchema,
+  type MiniMaxMusicConfig,
+  type MiniMaxMusicConfigSchemaType,
+  type MiniMaxMusicModelName,
+  type KnownMusicModels,
+} from './music.js';
+export {
+  AUDIO_URL_TTL_HOURS,
+  MINIMAX_REGIONS,
+  MUSIC_AUDIO_FORMATS,
+  MUSIC_OUTPUT_FORMATS,
+  REGION_BASE_URLS,
+  type MiniMaxPluginOptions,
+  type MiniMaxRegion,
+  type MusicAudioFormat,
+  type MusicOutputFormat,
+} from './types.js';
+
+/**
+ * This module provides an interface to the MiniMax music generation API through
+ * the Genkit plugin system.
+ *
+ * The main export is the `minimax` plugin, which can be configured with an API
+ * key either directly or through the `MINIMAX_API_KEY` environment variable.
+ * The `region` option selects the endpoint that requests are sent to.
+ *
+ * Example:
+ * ```ts
+ * import { minimax } from '@genkit-ai/minimax';
+ * import { genkit } from 'genkit';
+ *
+ * const ai = genkit({
+ *   plugins: [minimax({ apiKey: 'your-api-key' })],
+ * });
+ *
+ * const { message } = await ai.generate({
+ *   model: minimax.model('music-3.0'),
+ *   prompt: 'An upbeat acoustic folk song about the sunrise',
+ *   config: { lyrics: '[Verse]\nMorning light\n[Chorus]\nHere comes the sun' },
+ * });
+ *
+ * // The generated audio is returned as a media part.
+ * const audio = message?.content.find((part) => part.media)?.media;
+ * ```
+ */
+function minimaxPlugin(options?: MiniMaxPluginOptions): GenkitPluginV2 {
+  checkApiKey(options?.apiKey);
+
+  let listActionsCache: ActionMetadata[] | null = null;
+
+  return genkitPluginV2({
+    name: PLUGIN_NAME,
+    init: async () => music.listKnownModels(options),
+    resolve: (actionType: ActionType, name: string) => {
+      if (actionType !== 'model') {
+        return undefined;
+      }
+      const version = modelName(name);
+      if (!music.isMiniMaxMusicModelName(version)) {
+        return undefined;
+      }
+      return music.defineModel(version, options) as ModelAction;
+    },
+    list: async () => {
+      if (!listActionsCache) {
+        listActionsCache = music.listActions();
+      }
+      return listActionsCache;
+    },
+  });
+}
+
+/**
+ * The `minimax` plugin, which also exposes model references through
+ * {@link MiniMaxPlugin.model}.
+ */
+export type MiniMaxPlugin = {
+  (pluginOptions?: MiniMaxPluginOptions): GenkitPluginV2;
+  model(
+    name: music.KnownMusicModels | (music.MiniMaxMusicModelName & {}),
+    config?: music.MiniMaxMusicConfig
+  ): ModelReference<music.MiniMaxMusicConfigSchemaType>;
+  model(name: string, config?: any): ModelReference<z.ZodTypeAny>;
+};
+
+/**
+ * MiniMax plugin for Genkit, providing the music generation models.
+ */
+export const minimax = minimaxPlugin as MiniMaxPlugin;
+(minimax as any).model = (
+  name: string,
+  config?: any
+): ModelReference<z.ZodTypeAny> => {
+  return music.model(name, config);
+};
+
+export default minimax;

--- a/js/plugins/minimax/src/music.ts
+++ b/js/plugins/minimax/src/music.ts
@@ -1,0 +1,304 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { modelActionMetadata, z, type ActionMetadata } from 'genkit';
+import {
+  modelRef,
+  type ModelAction,
+  type ModelInfo,
+  type ModelReference,
+} from 'genkit/model';
+import { model as pluginModel } from 'genkit/plugin';
+import { generateMusic } from './client.js';
+import {
+  fromMusicGenerationResponse,
+  toMusicGenerationRequest,
+} from './converters.js';
+import {
+  AUDIO_URL_TTL_HOURS,
+  DEFAULT_OUTPUT_FORMAT,
+  DEFAULT_REGION,
+  MINIMAX_REGIONS,
+  MUSIC_AUDIO_FORMATS,
+  MUSIC_BITRATES,
+  MUSIC_OUTPUT_FORMATS,
+  MUSIC_SAMPLE_RATES,
+  type ClientOptions,
+  type MiniMaxPluginOptions,
+} from './types.js';
+import {
+  PLUGIN_NAME,
+  calculateApiKey,
+  checkApiKey,
+  checkModelName,
+} from './utils.js';
+
+/**
+ * Builds a zod schema accepting only the given numbers.
+ */
+function numberEnum(
+  values: readonly [number, number, ...number[]]
+): z.ZodUnion<[z.ZodLiteral<number>, z.ZodLiteral<number>]> {
+  return z.union(
+    values.map((value) => z.literal(value)) as unknown as [
+      z.ZodLiteral<number>,
+      z.ZodLiteral<number>,
+    ]
+  );
+}
+
+/**
+ * Config accepted by the MiniMax music generation models.
+ *
+ * The generation fields mirror the `POST /v1/music_generation` request body.
+ */
+export const MiniMaxMusicConfigSchema = z
+  .object({
+    apiKey: z
+      .string()
+      .describe('Override the API key provided at plugin initialization.')
+      .optional(),
+    region: z
+      .enum(MINIMAX_REGIONS)
+      .describe(
+        'Overrides the plugin-configured or default region, which selects the API endpoint.'
+      )
+      .optional(),
+    baseUrl: z
+      .string()
+      .describe('Overrides the base URL derived from the region.')
+      .optional(),
+    prompt: z
+      .string()
+      .max(2000)
+      .describe(
+        'Style, mood or scenario description. Only used when the request messages carry no text.'
+      )
+      .optional(),
+    lyrics: z
+      .string()
+      .min(1)
+      .max(3500)
+      .describe(
+        'Lyrics to sing, with lines separated by newlines and optional section tags such as [Verse] or [Chorus].'
+      )
+      .optional(),
+    stream: z
+      .boolean()
+      .describe(
+        'Not supported by this model, which always returns a single response.'
+      )
+      .optional(),
+    output_format: z
+      .enum(MUSIC_OUTPUT_FORMATS)
+      .describe(
+        `Encoding of the generated audio. \`url\` returns a URL that expires after ${AUDIO_URL_TTL_HOURS} hours, \`hex\` inlines the audio bytes. Defaults to \`${DEFAULT_OUTPUT_FORMAT}\`.`
+      )
+      .optional(),
+    audio_setting: z
+      .object({
+        sample_rate: numberEnum(MUSIC_SAMPLE_RATES)
+          .describe('Sample rate of the generated audio.')
+          .optional(),
+        bitrate: numberEnum(MUSIC_BITRATES)
+          .describe('Bitrate of the generated audio.')
+          .optional(),
+        format: z
+          .enum(MUSIC_AUDIO_FORMATS)
+          .describe('Container format of the generated audio.')
+          .optional(),
+      })
+      .describe('Audio output configuration.')
+      .optional(),
+    lyrics_optimizer: z
+      .boolean()
+      .describe('Let the service derive the lyrics from the prompt.')
+      .optional(),
+    is_instrumental: z
+      .boolean()
+      .describe('Generate vocal-free audio, which makes lyrics unnecessary.')
+      .optional(),
+    aigc_watermark: z
+      .boolean()
+      .describe(
+        'Embed an AIGC watermark. Only accepted by the `cn` region endpoint.'
+      )
+      .optional(),
+  })
+  .passthrough();
+
+/** Type of {@link MiniMaxMusicConfigSchema}. */
+export type MiniMaxMusicConfigSchemaType = typeof MiniMaxMusicConfigSchema;
+
+/** Config accepted by the MiniMax music generation models. */
+export type MiniMaxMusicConfig = z.infer<MiniMaxMusicConfigSchemaType>;
+
+type ConfigSchemaType = MiniMaxMusicConfigSchemaType;
+
+/**
+ * Model used when only the generic `music` name is requested.
+ */
+export const DEFAULT_MUSIC_MODEL = 'music-3.0';
+
+/**
+ * Prefix of the music cover models, which take reference audio instead of a
+ * prompt and are therefore not served by this model.
+ */
+const COVER_MODEL_PREFIX = 'music-cover';
+
+function commonRef(
+  name: string,
+  info?: ModelInfo,
+  configSchema: ConfigSchemaType = MiniMaxMusicConfigSchema
+): ModelReference<ConfigSchemaType> {
+  return modelRef({
+    name: `${PLUGIN_NAME}/${name}`,
+    configSchema,
+    info:
+      info ??
+      ({
+        label: `MiniMax - ${name}`,
+        supports: {
+          multiturn: false,
+          media: false,
+          tools: false,
+          toolChoice: false,
+          systemRole: false,
+          output: ['media'],
+        },
+      } as ModelInfo),
+  });
+}
+
+const GENERIC_MODEL = commonRef(DEFAULT_MUSIC_MODEL);
+
+const KNOWN_MODELS = {
+  'music-3.0': commonRef('music-3.0'),
+  'music-2.6': commonRef('music-2.6'),
+  'music-3.0-free': commonRef('music-3.0-free'),
+  'music-2.6-free': commonRef('music-2.6-free'),
+} as const;
+
+/** Music generation models known to this plugin. */
+export type KnownMusicModels = keyof typeof KNOWN_MODELS;
+
+/** Any music generation model name. */
+export type MiniMaxMusicModelName = `music-${string}`;
+
+/**
+ * Reports whether a name refers to a music generation model.
+ *
+ * Cover models share the `music-` prefix but take reference audio rather than a
+ * prompt, so they are not claimed here.
+ */
+export function isMiniMaxMusicModelName(
+  value?: string
+): value is MiniMaxMusicModelName {
+  return !!value?.startsWith('music-') && !value.startsWith(COVER_MODEL_PREFIX);
+}
+
+/**
+ * Returns a reference to a music generation model.
+ */
+export function model(
+  version: string,
+  config: MiniMaxMusicConfig = {}
+): ModelReference<ConfigSchemaType> {
+  const name = checkModelName(version);
+
+  if (Object.prototype.hasOwnProperty.call(KNOWN_MODELS, name)) {
+    return KNOWN_MODELS[name as KnownMusicModels].withConfig(config);
+  }
+
+  return modelRef({
+    name: `${PLUGIN_NAME}/${name}`,
+    config,
+    configSchema: MiniMaxMusicConfigSchema,
+    info: { ...GENERIC_MODEL.info },
+  });
+}
+
+/**
+ * Lists the music generation models known to this plugin.
+ *
+ * The API does not expose a model discovery endpoint, so the known models are
+ * reported instead.
+ */
+export function listActions(): ActionMetadata[] {
+  return Object.keys(KNOWN_MODELS).map((name) => {
+    const ref = model(name);
+    return modelActionMetadata({
+      name: ref.name,
+      info: ref.info,
+      configSchema: ref.configSchema,
+    });
+  });
+}
+
+/**
+ * Defines a model action for every known music generation model.
+ */
+export function listKnownModels(
+  pluginOptions?: MiniMaxPluginOptions
+): ModelAction<ConfigSchemaType>[] {
+  return Object.keys(KNOWN_MODELS).map((name) =>
+    defineModel(name, pluginOptions)
+  );
+}
+
+/**
+ * Defines the model action that calls the music generation endpoint.
+ */
+export function defineModel(
+  name: string,
+  pluginOptions?: MiniMaxPluginOptions
+): ModelAction<ConfigSchemaType> {
+  checkApiKey(pluginOptions?.apiKey);
+  const ref = model(name);
+  const version = checkModelName(ref.name);
+
+  return pluginModel(
+    {
+      name: ref.name,
+      ...ref.info,
+      configSchema: ref.configSchema,
+    },
+    async (request, { abortSignal }) => {
+      const config = request.config ?? {};
+      const region = config.region ?? pluginOptions?.region ?? DEFAULT_REGION;
+
+      const clientOptions: ClientOptions = {
+        apiKey: calculateApiKey(pluginOptions?.apiKey, config.apiKey),
+        region,
+        baseUrl: config.baseUrl ?? pluginOptions?.baseUrl,
+        customHeaders: pluginOptions?.customHeaders,
+        signal: abortSignal,
+      };
+
+      const musicRequest = toMusicGenerationRequest(version, request, region);
+      const response = await generateMusic(musicRequest, clientOptions);
+
+      return fromMusicGenerationResponse(
+        request,
+        response,
+        musicRequest.output_format,
+        musicRequest.audio_setting?.format
+      );
+    }
+  );
+}
+
+export const TEST_ONLY = { GENERIC_MODEL, KNOWN_MODELS };

--- a/js/plugins/minimax/src/types.ts
+++ b/js/plugins/minimax/src/types.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Service regions that expose the MiniMax API.
+ *
+ * - `global`: the international endpoint.
+ * - `cn`: the mainland China endpoint.
+ */
+export const MINIMAX_REGIONS = ['global', 'cn'] as const;
+
+/**
+ * Service region used to reach the MiniMax API.
+ */
+export type MiniMaxRegion = (typeof MINIMAX_REGIONS)[number];
+
+/**
+ * Base URL of each supported {@link MiniMaxRegion}.
+ */
+export const REGION_BASE_URLS: Record<MiniMaxRegion, string> = {
+  global: 'https://api.minimax.io',
+  cn: 'https://api.minimaxi.com',
+};
+
+/**
+ * Default region used when the plugin is configured without one.
+ */
+export const DEFAULT_REGION: MiniMaxRegion = 'global';
+
+/**
+ * Resource path of the music generation endpoint.
+ */
+export const MUSIC_GENERATION_PATH = '/v1/music_generation';
+
+/**
+ * Request fields that are only accepted by the `cn` region.
+ */
+export const CN_ONLY_REQUEST_FIELDS = ['aigc_watermark'] as const;
+
+/**
+ * Number of hours a generated audio URL stays reachable when
+ * `output_format: 'url'` is used.
+ */
+export const AUDIO_URL_TTL_HOURS = 24;
+
+/**
+ * Options accepted by the `minimax` plugin.
+ */
+export interface MiniMaxPluginOptions {
+  /**
+   * MiniMax API key. Defaults to the `MINIMAX_API_KEY` environment variable.
+   *
+   * Pass `false` to skip the check at plugin initialization and provide the key
+   * per request through the model config instead.
+   */
+  apiKey?: string | false;
+
+  /**
+   * Region whose endpoint should be called. Defaults to `global`.
+   */
+  region?: MiniMaxRegion;
+
+  /**
+   * Overrides the base URL derived from {@link MiniMaxPluginOptions.region}.
+   */
+  baseUrl?: string;
+
+  /**
+   * Extra headers added to every request.
+   */
+  customHeaders?: Record<string, string>;
+}
+
+/**
+ * Resolved per-request client configuration.
+ */
+export interface ClientOptions {
+  apiKey: string;
+  region: MiniMaxRegion;
+  baseUrl?: string;
+  customHeaders?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+/**
+ * Output formats supported by the music generation endpoint.
+ *
+ * - `url`: a temporary download URL, see {@link AUDIO_URL_TTL_HOURS}.
+ * - `hex`: the audio bytes as a hexadecimal string.
+ */
+export const MUSIC_OUTPUT_FORMATS = ['url', 'hex'] as const;
+
+/**
+ * Encoding of the generated audio returned by the API.
+ */
+export type MusicOutputFormat = (typeof MUSIC_OUTPUT_FORMATS)[number];
+
+/**
+ * Output formats the endpoint supports while streaming.
+ */
+export const MUSIC_STREAM_OUTPUT_FORMATS = ['hex'] as const;
+
+/**
+ * Output format used when the request does not specify one.
+ */
+export const DEFAULT_OUTPUT_FORMAT: MusicOutputFormat = 'hex';
+
+/**
+ * Audio container formats supported by the music generation endpoint.
+ */
+export const MUSIC_AUDIO_FORMATS = ['mp3', 'wav', 'pcm'] as const;
+
+/**
+ * Container format of the generated audio.
+ */
+export type MusicAudioFormat = (typeof MUSIC_AUDIO_FORMATS)[number];
+
+/**
+ * Container format used when the request does not specify one.
+ */
+export const DEFAULT_AUDIO_FORMAT: MusicAudioFormat = 'mp3';
+
+/**
+ * Sample rates accepted by `audio_setting.sample_rate`.
+ */
+export const MUSIC_SAMPLE_RATES = [16000, 24000, 32000, 44100] as const;
+
+/**
+ * Bitrates accepted by `audio_setting.bitrate`.
+ */
+export const MUSIC_BITRATES = [32000, 64000, 128000, 256000] as const;
+
+/**
+ * Audio output configuration sent as `audio_setting`.
+ *
+ * Allowed values are enforced by the model config schema, see
+ * {@link MUSIC_SAMPLE_RATES} and {@link MUSIC_BITRATES}.
+ */
+export interface MusicAudioSetting {
+  sample_rate?: number;
+  bitrate?: number;
+  format?: MusicAudioFormat;
+}
+
+/**
+ * Body of a `POST /v1/music_generation` request.
+ */
+export interface MusicGenerationRequest {
+  /** Music model to run. The only field the API always requires. */
+  model: string;
+  /** Style, mood or scenario description. */
+  prompt?: string;
+  /** Lyrics to sing, with lines separated by `\n`. */
+  lyrics?: string;
+  /** Whether the API should stream the audio back. */
+  stream?: boolean;
+  /** Encoding of the returned audio. */
+  output_format?: MusicOutputFormat;
+  /** Audio output configuration. */
+  audio_setting?: MusicAudioSetting;
+  /** Let the service derive lyrics from `prompt`. */
+  lyrics_optimizer?: boolean;
+  /** Generate vocal-free audio, which makes `lyrics` unnecessary. */
+  is_instrumental?: boolean;
+  /** Embed an AIGC watermark. Only accepted by the `cn` region. */
+  aigc_watermark?: boolean;
+}
+
+/**
+ * Generation status reported by `data.status`.
+ */
+export const MUSIC_TASK_STATUS = {
+  /** The service is still working on the audio. */
+  IN_PROGRESS: 1,
+  /** The audio is complete and present in `data.audio`. */
+  COMPLETED: 2,
+} as const;
+
+/**
+ * `status_code` returned by `base_resp` when a request succeeded.
+ */
+export const SUCCESS_STATUS_CODE = 0;
+
+/**
+ * Payload of a `POST /v1/music_generation` response.
+ */
+export interface MusicGenerationResponse {
+  data?: {
+    /** See {@link MUSIC_TASK_STATUS}. */
+    status?: number;
+    /**
+     * Generated audio. A hexadecimal string when `output_format` is `hex`,
+     * or a temporary download URL when it is `url`.
+     */
+    audio?: string;
+  };
+  base_resp?: {
+    /** See {@link SUCCESS_STATUS_CODE}. */
+    status_code?: number;
+    status_msg?: string;
+  };
+  trace_id?: string;
+  extra_info?: Record<string, unknown>;
+}

--- a/js/plugins/minimax/src/utils.ts
+++ b/js/plugins/minimax/src/utils.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GenkitError } from 'genkit';
+
+/**
+ * Namespace this plugin registers its actions under.
+ */
+export const PLUGIN_NAME = 'minimax';
+
+/**
+ * Environment variable read when no API key is configured.
+ */
+export const API_KEY_ENV_VAR = 'MINIMAX_API_KEY';
+
+/**
+ * Reads the API key from the environment.
+ */
+export function getApiKeyFromEnvVar(): string | undefined {
+  return process.env[API_KEY_ENV_VAR];
+}
+
+const MISSING_API_KEY_ERROR = new GenkitError({
+  status: 'FAILED_PRECONDITION',
+  message: `Please pass in the API key or set the ${API_KEY_ENV_VAR} environment variable.`,
+});
+
+const API_KEY_FALSE_ERROR = new GenkitError({
+  status: 'INVALID_ARGUMENT',
+  message:
+    'MiniMax plugin was initialized with {apiKey: false} but no apiKey configuration was passed at call time.',
+});
+
+/**
+ * Fails fast at plugin initialization when no API key can be resolved.
+ *
+ * Passing `false` defers the check to request time.
+ */
+export function checkApiKey(pluginApiKey: string | false | undefined): void {
+  if (pluginApiKey === false) {
+    return;
+  }
+  if (!pluginApiKey && !getApiKeyFromEnvVar()) {
+    throw MISSING_API_KEY_ERROR;
+  }
+}
+
+/**
+ * Resolves the API key to use for a single request.
+ *
+ * Precedence is request config, then plugin options, then the environment.
+ */
+export function calculateApiKey(
+  pluginApiKey: string | false | undefined,
+  requestApiKey: string | undefined
+): string {
+  if (requestApiKey) {
+    return requestApiKey;
+  }
+  if (pluginApiKey === false) {
+    throw API_KEY_FALSE_ERROR;
+  }
+  const apiKey = pluginApiKey || getApiKeyFromEnvVar();
+  if (!apiKey) {
+    throw MISSING_API_KEY_ERROR;
+  }
+  return apiKey;
+}
+
+/**
+ * Strips the `minimax/` namespace prefix from a model name.
+ */
+export function modelName(name?: string): string | undefined {
+  if (!name) {
+    return name;
+  }
+  return name.replace(new RegExp(`^${PLUGIN_NAME}/`), '');
+}
+
+/**
+ * Returns the bare model name, rejecting empty values.
+ */
+export function checkModelName(name?: string): string {
+  const version = modelName(name);
+  if (!version) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: 'Model name is required.',
+    });
+  }
+  return version;
+}

--- a/js/plugins/minimax/tests/music_test.ts
+++ b/js/plugins/minimax/tests/music_test.ts
@@ -1,0 +1,530 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import type { GenerateRequest } from 'genkit/model';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import * as sinon from 'sinon';
+import {
+  MiniMaxMusicConfigSchema,
+  defineModel,
+  isMiniMaxMusicModelName,
+  listActions,
+  model,
+} from '../src/music.js';
+import type {
+  MiniMaxPluginOptions,
+  MusicGenerationResponse,
+} from '../src/types.js';
+
+describe('MiniMax music generation', () => {
+  const ORIGINAL_ENV = { ...process.env };
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MINIMAX_API_KEY;
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  function mockFetchResponse(body: any, status = 200) {
+    fetchStub.callsFake(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status,
+          statusText: status === 200 ? 'OK' : 'Error',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+  }
+
+  const defaultPluginOptions: MiniMaxPluginOptions = {
+    apiKey: 'test-api-key-plugin',
+  };
+
+  const minimalRequest: GenerateRequest<typeof MiniMaxMusicConfigSchema> = {
+    messages: [
+      {
+        role: 'user',
+        content: [{ text: 'An upbeat acoustic folk song about the sunrise' }],
+      },
+    ],
+  };
+
+  // 0xff 0xd8 0xff encoded as base64 is '/9j/'.
+  const HEX_AUDIO = 'ffd8ff';
+  const HEX_AUDIO_BASE64 = '/9j/';
+
+  const completedResponse: MusicGenerationResponse = {
+    data: { status: 2, audio: HEX_AUDIO },
+    base_resp: { status_code: 0, status_msg: 'success' },
+    trace_id: 'trace-123',
+  };
+
+  function lastBody() {
+    return JSON.parse(fetchStub.lastCall.args[1].body);
+  }
+
+  function lastUrl() {
+    return fetchStub.lastCall.args[0];
+  }
+
+  function lastHeaders() {
+    return fetchStub.lastCall.args[1].headers;
+  }
+
+  describe('endpoints', () => {
+    it('calls the global endpoint by default', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await action(minimalRequest, {} as any);
+
+      sinon.assert.calledOnce(fetchStub);
+      assert.strictEqual(
+        lastUrl(),
+        'https://api.minimax.io/v1/music_generation'
+      );
+      assert.strictEqual(fetchStub.lastCall.args[1].method, 'POST');
+    });
+
+    it('calls the cn endpoint when the plugin selects that region', async () => {
+      const action = defineModel('music-3.0', {
+        ...defaultPluginOptions,
+        region: 'cn',
+      });
+      mockFetchResponse(completedResponse);
+
+      await action(minimalRequest, {} as any);
+
+      assert.strictEqual(
+        lastUrl(),
+        'https://api.minimaxi.com/v1/music_generation'
+      );
+    });
+
+    it('lets the request config override the plugin region', async () => {
+      const action = defineModel('music-3.0', {
+        ...defaultPluginOptions,
+        region: 'cn',
+      });
+      mockFetchResponse(completedResponse);
+
+      await action(
+        { ...minimalRequest, config: { region: 'global' } },
+        {} as any
+      );
+
+      assert.strictEqual(
+        lastUrl(),
+        'https://api.minimax.io/v1/music_generation'
+      );
+    });
+
+    it('lets baseUrl override the region endpoint', async () => {
+      const action = defineModel('music-3.0', {
+        ...defaultPluginOptions,
+        baseUrl: 'https://proxy.example.com/',
+      });
+      mockFetchResponse(completedResponse);
+
+      await action(minimalRequest, {} as any);
+
+      assert.strictEqual(
+        lastUrl(),
+        'https://proxy.example.com/v1/music_generation'
+      );
+    });
+  });
+
+  describe('authorization', () => {
+    it('sends the plugin API key as a bearer token with a JSON content type', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await action(minimalRequest, {} as any);
+
+      const headers = lastHeaders();
+      assert.strictEqual(headers.Authorization, 'Bearer test-api-key-plugin');
+      assert.strictEqual(headers['Content-Type'], 'application/json');
+    });
+
+    it('lets the request config override the API key', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await action(
+        { ...minimalRequest, config: { apiKey: 'test-api-key-request' } },
+        {} as any
+      );
+
+      assert.strictEqual(
+        lastHeaders().Authorization,
+        'Bearer test-api-key-request'
+      );
+    });
+
+    it('falls back to the environment variable', async () => {
+      process.env.MINIMAX_API_KEY = 'test-api-key-env';
+      const action = defineModel('music-3.0');
+      mockFetchResponse(completedResponse);
+
+      await action(minimalRequest, {} as any);
+
+      assert.strictEqual(
+        lastHeaders().Authorization,
+        'Bearer test-api-key-env'
+      );
+    });
+
+    it('throws when no API key is available', () => {
+      assert.throws(() => defineModel('music-3.0'), /MINIMAX_API_KEY/);
+    });
+
+    it('defers the API key check when apiKey is false', async () => {
+      const action = defineModel('music-3.0', { apiKey: false });
+      mockFetchResponse(completedResponse);
+
+      await assert.rejects(action(minimalRequest, {} as any), /apiKey: false/);
+    });
+
+    it('does not let custom headers overwrite the authorization header', async () => {
+      const action = defineModel('music-3.0', {
+        ...defaultPluginOptions,
+        customHeaders: { Authorization: 'Bearer spoofed', 'X-Trace': 'on' },
+      });
+      mockFetchResponse(completedResponse);
+
+      await action(minimalRequest, {} as any);
+
+      const headers = lastHeaders();
+      assert.strictEqual(headers.Authorization, 'Bearer test-api-key-plugin');
+      assert.strictEqual(headers['X-Trace'], 'on');
+    });
+  });
+
+  describe('request body', () => {
+    it('sends the model and the prompt taken from the messages', async () => {
+      const action = defineModel('music-2.6', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await action(minimalRequest, {} as any);
+
+      const body = lastBody();
+      assert.strictEqual(body.model, 'music-2.6');
+      assert.strictEqual(
+        body.prompt,
+        'An upbeat acoustic folk song about the sunrise'
+      );
+    });
+
+    it('falls back to the prompt from the config', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await action(
+        {
+          messages: [{ role: 'user', content: [] }],
+          config: { prompt: 'A slow piano ballad' },
+        },
+        {} as any
+      );
+
+      assert.strictEqual(lastBody().prompt, 'A slow piano ballad');
+    });
+
+    it('forwards the generation fields', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await action(
+        {
+          ...minimalRequest,
+          config: {
+            lyrics: '[Verse]\nMorning light\n[Chorus]\nHere comes the sun',
+            output_format: 'hex',
+            audio_setting: {
+              sample_rate: 44100,
+              bitrate: 256000,
+              format: 'mp3',
+            },
+            lyrics_optimizer: true,
+            is_instrumental: false,
+          },
+        },
+        {} as any
+      );
+
+      const body = lastBody();
+      assert.strictEqual(
+        body.lyrics,
+        '[Verse]\nMorning light\n[Chorus]\nHere comes the sun'
+      );
+      assert.strictEqual(body.output_format, 'hex');
+      assert.deepStrictEqual(body.audio_setting, {
+        sample_rate: 44100,
+        bitrate: 256000,
+        format: 'mp3',
+      });
+      assert.strictEqual(body.lyrics_optimizer, true);
+      assert.strictEqual(body.is_instrumental, false);
+    });
+
+    it('never sends the connection fields to the API', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await action(
+        {
+          ...minimalRequest,
+          config: {
+            apiKey: 'test-api-key-request',
+            region: 'global',
+            baseUrl: 'https://proxy.example.com',
+            stream: false,
+          },
+        },
+        {} as any
+      );
+
+      const body = lastBody();
+      assert.ok(!('apiKey' in body));
+      assert.ok(!('region' in body));
+      assert.ok(!('baseUrl' in body));
+      assert.ok(!('stream' in body));
+    });
+
+    it('rejects streaming output, which the model does not support', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await assert.rejects(
+        action({ ...minimalRequest, config: { stream: true } }, {} as any),
+        /Streaming music generation is not supported/
+      );
+      sinon.assert.notCalled(fetchStub);
+    });
+
+    it('sends aigc_watermark to the cn endpoint', async () => {
+      const action = defineModel('music-3.0', {
+        ...defaultPluginOptions,
+        region: 'cn',
+      });
+      mockFetchResponse(completedResponse);
+
+      await action(
+        { ...minimalRequest, config: { aigc_watermark: true } },
+        {} as any
+      );
+
+      assert.strictEqual(lastBody().aigc_watermark, true);
+    });
+
+    it('rejects aigc_watermark outside the cn endpoint', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      await assert.rejects(
+        action(
+          { ...minimalRequest, config: { aigc_watermark: true } },
+          {} as any
+        ),
+        /aigc_watermark.*only accepted by the `cn` region/
+      );
+      sinon.assert.notCalled(fetchStub);
+    });
+
+    it('forwards the abort signal', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+      const abortSignal = AbortSignal.timeout(60_000);
+
+      await action(minimalRequest, { abortSignal } as any);
+
+      assert.strictEqual(fetchStub.lastCall.args[1].signal, abortSignal);
+    });
+  });
+
+  describe('response parsing', () => {
+    it('inlines hex audio as a data URL, defaulting to mp3', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      const response = await action(minimalRequest, {} as any);
+
+      const media = response.message?.content[0].media;
+      assert.strictEqual(
+        media?.url,
+        `data:audio/mpeg;base64,${HEX_AUDIO_BASE64}`
+      );
+      assert.strictEqual(media?.contentType, 'audio/mpeg');
+      assert.strictEqual(response.finishReason, 'stop');
+      assert.deepStrictEqual(response.custom, completedResponse);
+    });
+
+    it('uses the configured audio format for the content type', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      // 0x00 0xff encoded as base64 is 'AP8='.
+      mockFetchResponse({
+        ...completedResponse,
+        data: { status: 2, audio: '00ff' },
+      });
+
+      const response = await action(
+        {
+          ...minimalRequest,
+          config: { audio_setting: { format: 'wav' } },
+        },
+        {} as any
+      );
+
+      const media = response.message?.content[0].media;
+      assert.strictEqual(media?.url, 'data:audio/wav;base64,AP8=');
+      assert.strictEqual(media?.contentType, 'audio/wav');
+    });
+
+    it('passes a url output through unchanged', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      const audioUrl = 'https://files.example.com/song.mp3?expires=86400';
+      mockFetchResponse({
+        ...completedResponse,
+        data: { status: 2, audio: audioUrl },
+      });
+
+      const response = await action(
+        { ...minimalRequest, config: { output_format: 'url' } },
+        {} as any
+      );
+
+      assert.strictEqual(response.message?.content[0].media?.url, audioUrl);
+    });
+
+    it('reports usage statistics', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse(completedResponse);
+
+      const response = await action(minimalRequest, {} as any);
+
+      assert.strictEqual(response.usage?.outputAudioFiles, 1);
+      assert.strictEqual(
+        response.usage?.inputCharacters,
+        'An upbeat acoustic folk song about the sunrise'.length
+      );
+    });
+
+    it('throws when the generation is still in progress', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse({
+        ...completedResponse,
+        data: { status: 1 },
+      });
+
+      await assert.rejects(
+        action(minimalRequest, {} as any),
+        /still in progress/
+      );
+    });
+
+    it('throws when the response carries no audio', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse({ ...completedResponse, data: { status: 2 } });
+
+      await assert.rejects(
+        action(minimalRequest, {} as any),
+        /did not contain any generated audio/
+      );
+    });
+
+    it('throws when the hex audio is malformed', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse({
+        ...completedResponse,
+        data: { status: 2, audio: 'not-hex' },
+      });
+
+      await assert.rejects(
+        action(minimalRequest, {} as any),
+        /not a valid hexadecimal string/
+      );
+    });
+
+    it('surfaces an API error reported in the response envelope', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse({
+        base_resp: { status_code: 1004, status_msg: 'auth failed' },
+      });
+
+      await assert.rejects(
+        action(minimalRequest, {} as any),
+        /\[1004\] auth failed/
+      );
+    });
+
+    it('surfaces an HTTP error', async () => {
+      const action = defineModel('music-3.0', defaultPluginOptions);
+      mockFetchResponse({ error: 'rate limited' }, 429);
+
+      await assert.rejects(
+        action(minimalRequest, {} as any),
+        /Error fetching from https:\/\/api\.minimax\.io\/v1\/music_generation/
+      );
+    });
+  });
+
+  describe('model references', () => {
+    it('namespaces known models', () => {
+      assert.strictEqual(model('music-3.0').name, 'minimax/music-3.0');
+      assert.strictEqual(model('minimax/music-2.6').name, 'minimax/music-2.6');
+    });
+
+    it('supports media output only', () => {
+      assert.deepStrictEqual(model('music-3.0').info?.supports?.output, [
+        'media',
+      ]);
+    });
+
+    it('accepts unknown music model versions', () => {
+      assert.strictEqual(model('music-9.9').name, 'minimax/music-9.9');
+    });
+
+    it('claims generation model names but not cover model names', () => {
+      assert.ok(isMiniMaxMusicModelName('music-3.0'));
+      assert.ok(isMiniMaxMusicModelName('music-2.6-free'));
+      assert.ok(!isMiniMaxMusicModelName('music-cover'));
+      assert.ok(!isMiniMaxMusicModelName('music-cover-free'));
+      assert.ok(!isMiniMaxMusicModelName('speech-2.6'));
+      assert.ok(!isMiniMaxMusicModelName(undefined));
+    });
+
+    it('lists the known generation models', () => {
+      assert.deepStrictEqual(
+        listActions().map((action) => action.name),
+        [
+          'minimax/music-3.0',
+          'minimax/music-2.6',
+          'minimax/music-3.0-free',
+          'minimax/music-2.6-free',
+        ]
+      );
+    });
+  });
+});

--- a/js/plugins/minimax/tsconfig.json
+++ b/js/plugins/minimax/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/js/plugins/minimax/tsup.config.ts
+++ b/js/plugins/minimax/tsup.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig, type Options } from 'tsup';
+import { defaultOptions } from '../../tsup.common';
+
+export default defineConfig({
+  ...(defaultOptions as Options),
+});

--- a/js/plugins/minimax/typedoc.json
+++ b/js/plugins/minimax/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/index.ts"]
+}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -931,6 +931,36 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  plugins/minimax:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.16
+        version: 20.19.37
+      '@types/sinon':
+        specifier: ^17.0.4
+        version: 17.0.4
+      genkit:
+        specifier: workspace:*
+        version: link:../../genkit
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      sinon:
+        specifier: ^21.0.0
+        version: 21.0.2
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   plugins/next:
     devDependencies:
       '@jest/globals':

--- a/js/typedoc.json
+++ b/js/typedoc.json
@@ -11,6 +11,7 @@
     "plugins/fetch",
     "plugins/google-cloud",
     "plugins/middleware",
+    "plugins/minimax",
     "plugins/next",
     "plugins/evaluators",
     "plugins/mcp",


### PR DESCRIPTION
Reason: Genkit had no MiniMax music provider, so the global and China `/v1/music_generation` endpoints, the current music models, the documented request fields and the URL/hex audio responses were all unreachable from Genkit.

## What this adds

A new `@genkit-ai/minimax` plugin (`js/plugins/minimax`) exposing the MiniMax music generation models as regular Genkit models that return the generated track as a media part.

- **Both regional endpoints.** `region: 'global'` targets `https://api.minimax.io/v1/music_generation` and `region: 'cn'` targets `https://api.minimaxi.com/v1/music_generation`. The region can be set on the plugin or per request, and `baseUrl` overrides the endpoint derived from it.
- **Models.** `music-3.0` (default), `music-2.6`, `music-3.0-free` and `music-2.6-free`. Unknown `music-*` versions still resolve, so newer releases work without a plugin change. Cover models take reference audio instead of a prompt and are deliberately not claimed by this model.
- **Request fields.** `model`, `prompt`, `lyrics`, `output_format`, `audio_setting` (`sample_rate`, `bitrate`, `format`), `lyrics_optimizer` and `is_instrumental`. The prompt is taken from the Genkit request messages and falls back to `config.prompt`.
- **Region-specific fields.** `aigc_watermark` is only accepted by the `cn` endpoint; setting it against another region fails before a request is sent.
- **Audio formats.** `mp3`, `wav` and `pcm`, which determine the `contentType` reported on the returned media part.
- **Response parsing.** `base_resp.status_code` is checked for success and its `status_msg` is surfaced on failure. `data.status` distinguishes in-progress from completed. With `output_format: 'hex'` (the API default) the audio bytes are decoded into a `data:` URL; with `url` the temporary download URL, which expires after 24 hours, is passed through unchanged.
- **Streaming.** The endpoint only emits hexadecimal audio while streaming and does not document the chunk framing, so `stream` is rejected with a clear error rather than parsed by guesswork.

Authentication uses a bearer token from `apiKey` or `MINIMAX_API_KEY`, validated at plugin initialization unless deferred with `apiKey: false`. Caller-supplied `customHeaders` cannot overwrite the authorization header.

`js/typedoc.json` and `js/index.typedoc.md` register the package for the API reference, and `js/pnpm-lock.yaml` gains the new workspace importer entry.

## Checks

Run in `js/plugins/minimax`:

- `pnpm check` — passes.
- `pnpm build` — passes (CJS, ESM and DTS).
- `pnpm test` — 32 tests, all passing. They stub `fetch` and cover endpoint and region selection, `baseUrl` override, bearer auth and API key precedence, the forwarded request fields, watermark region enforcement, streaming rejection, abort signal forwarding, hex decoding and content types, URL passthrough, usage stats, and the in-progress, missing-audio, malformed-hex, envelope-error and HTTP-error paths.

Also run:

- `pnpm install --frozen-lockfile` in `js` — reports the lockfile as up to date.
- Formatted the changed files with the repository Prettier settings.
- Smoke-checked the plugin against a real `genkit()` instance with `fetch` stubbed, confirming that both `minimax.model('music-3.0')` and the bare `minimax/music-2.6-free` name resolve through the plugin, that the request reaches the configured regional endpoint, that the audio comes back as a media part, and that the four models are listed to the registry.

I have not exercised the plugin against the live API, since that needs an API key.
