### PR TITLE
feat(go): Add support for Agentskills.io compliant skills

### DIFF
--- a/go/plugins/middleware/skills.go
+++ b/go/plugins/middleware/skills.go
@@ -119,14 +119,11 @@ func (s Skills) New(ctx context.Context) (*ai.Hooks, error) {
 			targetPath := si.Path
 			if in.FilePath != "" {
 				candidate := filepath.Join(si.Dir, filepath.FromSlash(in.FilePath))
-				resolved, err := filepath.Abs(candidate)
-				if err != nil {
-					return "", fmt.Errorf("invalid file path %q in skill %q: %w", in.FilePath, in.SkillName, err)
-				}
-				if !strings.HasPrefix(resolved, si.Dir+string(filepath.Separator)) {
+				rel, err := filepath.Rel(si.Dir, candidate)
+				if err != nil || strings.HasPrefix(rel, "..") {
 					return "", fmt.Errorf("file path %q escapes skill directory %q", in.FilePath, in.SkillName)
 				}
-				targetPath = resolved
+				targetPath = candidate
 			}
 
 			data, err := os.ReadFile(targetPath)

--- a/go/plugins/middleware/skills.go
+++ b/go/plugins/middleware/skills.go
@@ -72,7 +72,8 @@ type Skills struct {
 
 // skillInfo records where a skill's SKILL.md lives and its description.
 type skillInfo struct {
-	Path        string
+	Path        string // absolute path to SKILL.md
+	Dir         string // absolute path to the skill directory
 	Description string
 }
 
@@ -102,17 +103,35 @@ func (s Skills) New(ctx context.Context) (*ai.Hooks, error) {
 
 	useSkill := ai.NewTool(
 		useSkillToolName,
-		"Use a skill by its name.",
+		"Load a skill's instructions or supporting files by name. "+
+			"When filePath is omitted, returns the full SKILL.md. "+
+			"When filePath is provided (e.g. 'references/PROCEDURE.md'), returns that file from the skill directory.",
 		func(_ *ai.ToolContext, in struct {
-			SkillName string `json:"skillName" jsonschema_description:"The name of the skill to use."`
-		}) (string, error) {
+			SkillName string `json:"skillName" jsonschema:"description=The name of the skill to use."`
+			FilePath  string `json:"filePath,omitempty" jsonschema:"description=Optional relative path to a file within the skill directory (e.g. references/PROCEDURE.md). When omitted the full SKILL.md is returned."`
+		},
+		) (string, error) {
 			si, ok := info[in.SkillName]
 			if !ok {
 				return "", fmt.Errorf("skill %q not found", in.SkillName)
 			}
-			data, err := os.ReadFile(si.Path)
+
+			targetPath := si.Path
+			if in.FilePath != "" {
+				candidate := filepath.Join(si.Dir, filepath.FromSlash(in.FilePath))
+				resolved, err := filepath.Abs(candidate)
+				if err != nil {
+					return "", fmt.Errorf("invalid file path %q in skill %q: %w", in.FilePath, in.SkillName, err)
+				}
+				if !strings.HasPrefix(resolved, si.Dir+string(filepath.Separator)) {
+					return "", fmt.Errorf("file path %q escapes skill directory %q", in.FilePath, in.SkillName)
+				}
+				targetPath = resolved
+			}
+
+			data, err := os.ReadFile(targetPath)
 			if err != nil {
-				return "", fmt.Errorf("failed to read skill %q: %w", in.SkillName, err)
+				return "", fmt.Errorf("failed to read %q in skill %q: %w", targetPath, in.SkillName, err)
 			}
 			return string(data), nil
 		},
@@ -181,6 +200,7 @@ func scanSkills(ctx context.Context, paths []string, explicit bool) (map[string]
 			}
 			result[entry.Name()] = skillInfo{
 				Path:        skillMd,
+				Dir:         filepath.Join(abs, entry.Name()),
 				Description: desc,
 			}
 		}
@@ -225,6 +245,7 @@ func buildSkillsPrompt(info map[string]skillInfo) string {
 	b.WriteString("You have access to a library of skills that serve as specialized instructions/personas.\n")
 	b.WriteString("Strongly prefer to use them when working on anything related to them.\n")
 	b.WriteString("Only use them once to load the context.\n")
+	b.WriteString("Skills may reference sub-files by relative path. Use the use_skill tool with the filePath parameter to load them.\n")
 	b.WriteString("Here are the available skills:\n")
 	for _, name := range names {
 		desc := info[name].Description

--- a/go/plugins/middleware/skills_test.go
+++ b/go/plugins/middleware/skills_test.go
@@ -47,6 +47,14 @@ func setupSkillsDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 
+	refsDir := filepath.Join(py, "references")
+	if err := os.Mkdir(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "PROCEDURE.md"), []byte("Step 1: do the thing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	js := filepath.Join(skillsDir, "javascript")
 	if err := os.Mkdir(js, 0o755); err != nil {
 		t.Fatal(err)
@@ -246,6 +254,118 @@ func TestSkillsNoopWhenNoSkillsFound(t *testing.T) {
 
 	if findSystem(*captured) != nil {
 		t.Error("did not expect a system message when no skills were found")
+	}
+}
+
+func TestSkillsReadSubFile(t *testing.T) {
+	r := newTestRegistry(t)
+	skillsDir := setupSkillsDir(t)
+
+	m := toolCallingModel(t, r, "test/subfile", useSkillToolName, map[string]any{
+		"skillName": "python",
+		"filePath":  "references/PROCEDURE.md",
+	})
+
+	s := &Skills{SkillPaths: []string{skillsDir}}
+	registerTestMiddleware(r, "skills-subfile", s)
+
+	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("load procedure"), ai.WithUse(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got string
+	for _, msg := range resp.History() {
+		for _, part := range msg.Content {
+			if part.IsToolResponse() && part.ToolResponse.Name == useSkillToolName {
+				if out, ok := part.ToolResponse.Output.(string); ok {
+					got = out
+				}
+			}
+		}
+	}
+	if got == "" {
+		t.Fatalf("expected a tool response with sub-file content; history=%v", resp.History())
+	}
+	if !strings.Contains(got, "Step 1: do the thing") {
+		t.Errorf("tool response missing sub-file body: %q", got)
+	}
+}
+
+func TestSkillsReadSubFileTraversalBlocked(t *testing.T) {
+	r := newTestRegistry(t)
+	skillsDir := setupSkillsDir(t)
+
+	m := toolCallingModel(t, r, "test/traversal", useSkillToolName, map[string]any{
+		"skillName": "python",
+		"filePath":  "../../etc/passwd",
+	})
+
+	s := &Skills{SkillPaths: []string{skillsDir}}
+	registerTestMiddleware(r, "skills-traversal", s)
+
+	_, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("escape"), ai.WithUse(s))
+	if err == nil {
+		t.Fatal("expected an error for directory traversal attempt")
+	}
+	if !strings.Contains(err.Error(), "escapes skill directory") {
+		t.Errorf("expected 'escapes skill directory' in error, got %v", err)
+	}
+}
+
+func TestSkillsReadSubFileNotFound(t *testing.T) {
+	r := newTestRegistry(t)
+	skillsDir := setupSkillsDir(t)
+
+	m := toolCallingModel(t, r, "test/notfound", useSkillToolName, map[string]any{
+		"skillName": "python",
+		"filePath":  "references/NONEXISTENT.md",
+	})
+
+	s := &Skills{SkillPaths: []string{skillsDir}}
+	registerTestMiddleware(r, "skills-notfound", s)
+
+	_, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("missing"), ai.WithUse(s))
+	if err == nil {
+		t.Fatal("expected an error for missing sub-file")
+	}
+	if !strings.Contains(err.Error(), "failed to read") {
+		t.Errorf("expected 'failed to read' in error, got %v", err)
+	}
+}
+
+func TestSkillsReadSubFileEmptyPath(t *testing.T) {
+	r := newTestRegistry(t)
+	skillsDir := setupSkillsDir(t)
+
+	m := toolCallingModel(t, r, "test/emptypath", useSkillToolName, map[string]any{
+		"skillName": "python",
+		"filePath":  "",
+	})
+
+	s := &Skills{SkillPaths: []string{skillsDir}}
+	registerTestMiddleware(r, "skills-emptypath", s)
+
+	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("use python"), ai.WithUse(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got string
+	for _, msg := range resp.History() {
+		for _, part := range msg.Content {
+			if part.IsToolResponse() && part.ToolResponse.Name == useSkillToolName {
+				if out, ok := part.ToolResponse.Output.(string); ok {
+					got = out
+				}
+			}
+		}
+	}
+	if got == "" {
+		t.Fatalf("expected a tool response with SKILL.md content; history=%v", resp.History())
+	}
+	if !strings.Contains(got, "Python prompt content") {
+		t.Errorf("empty filePath should return SKILL.md body: %q", got)
 	}
 }
 


### PR DESCRIPTION
agentskills.io specification (https://agentskills.io/specification)

The Go skills middleware (plugins/middleware/skills.go) currently defines the use_skill tool to statically load a complete SKILL.md file.

However, skills implemented following the agentskill spec can reference additional files via relative Markdown links inside SKILL.md. The middleware cannot properly load those files (and leveraging any filesystem tool is fragile and error prone)

This patch adds parameters to the use_skill tool in order to let genkit load referenced files properly.

If no specific relative is provided, then the tool behaves as before.

Description here... Help the reviewer by:
 - linking to an issue that includes more details
 - if it's a new feature include samples of how to use the new feature
 - (optional if issue link is provided) if you fixed a bug include basic bug details

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
