### PR TITLE
feat(py/plugins/amazon-bedrock): register Claude 4.7, 4.8 and 5 models

### DIFF
--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -53,7 +53,7 @@ from genkit.embedder import (
     EmbedResponse,
 )
 from genkit.plugin_api import GenkitError
-from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
+from genkit_amazon_bedrock.model_info import model_label, strip_inference_profile_prefix
 from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
 
 # One call's result: a single vector per document, or a chunk of them for Cohere.
@@ -179,7 +179,7 @@ def get_embedder_options(model_id: str) -> EmbedderOptions:
         inputs = TEXT_ONLY
     return EmbedderOptions(
         # The label keeps the prefix: it names what the caller asked for.
-        label=model_id,
+        label=model_label(model_id),
         dimensions=info.dimensions if info is not None else None,
         supports=EmbedderSupports(input=list(inputs)),
     )

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
@@ -204,9 +204,9 @@ def _normalize_image_config(config: Any) -> dict[str, Any]:  # noqa: ANN401
         none was given.
 
     Raises:
-        GenkitError: INVALID_ARGUMENT for unsupported config types. Go silently
-            drops anything that is not a map; failing loudly beats sending a
-            body that quietly ignores the caller's settings.
+        GenkitError: INVALID_ARGUMENT for unsupported config types. Failing
+            loudly beats sending a body that quietly ignores the caller's
+            settings.
     """
     if config is None:
         return {}

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -139,6 +139,18 @@ def strip_inference_profile_prefix(model_id: str) -> str:
     return model_id
 
 
+def model_label(model_id: str) -> str:
+    """Formats the Dev UI label for a Bedrock model or embedder.
+
+    Args:
+        model_id: Bedrock model ID, inference-profile ID, or ARN, as given.
+
+    Returns:
+        The ID prefixed with the provider, as the Dev UI model picker expects.
+    """
+    return f'Amazon Bedrock - {model_id}'
+
+
 def get_model_info(
     model_name: str,
     model_type: Literal['chat', 'text', 'image'] = 'chat',
@@ -155,7 +167,7 @@ def get_model_info(
     """
     if model_type == 'image':
         return ModelInfo(
-            label=model_name,
+            label=model_label(model_name),
             stage=Stage.STABLE,
             supports=Supports(
                 multiturn=False,
@@ -175,7 +187,7 @@ def get_model_info(
         capability = ModelCapability(multimodal=True, tools=True)
 
     return ModelInfo(
-        label=model_name,
+        label=model_label(model_name),
         stage=stage,
         supports=Supports(
             multiturn=True,

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -55,15 +55,22 @@ MODEL_CAPABILITIES: dict[str, ModelCapability] = {
     'anthropic.claude-3-5-sonnet-20240620-v1:0': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-3-5-sonnet-20241022-v2:0': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-3-7-sonnet-20250219-v1:0': ModelCapability(multimodal=True, tools=True),
-    # Anthropic Claude 4/4.5/4.6 models
+    # Anthropic Claude 4.x models
     'anthropic.claude-haiku-4-5-20251001-v1:0': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-opus-4-1-20250805-v1:0': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-opus-4-20250514-v1:0': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-sonnet-4-20250514-v1:0': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-sonnet-4-5-20250929-v1:0': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-opus-4-5-20251101-v1:0': ModelCapability(multimodal=True, tools=True),
+    # From 4.6 on, IDs carry no date stamp and the -v1 suffix is per-model.
     'anthropic.claude-sonnet-4-6': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-opus-4-6-v1': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-opus-4-7': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-opus-4-8': ModelCapability(multimodal=True, tools=True),
+    # Anthropic Claude 5 models
+    'anthropic.claude-sonnet-5': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-opus-5': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-fable-5': ModelCapability(multimodal=True, tools=True),
     # Provisioned-throughput variants (28k/48k/200k context)
     'anthropic.claude-3-haiku-20240307-v1:0:48k': ModelCapability(multimodal=True, tools=True),
     'anthropic.claude-3-haiku-20240307-v1:0:200k': ModelCapability(multimodal=True, tools=True),

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -190,10 +190,9 @@ class Bedrock(Plugin):
             # Same story for rerank models; reranking is the Bedrock.rerank helper.
             return None
         declared = self._declared_model_type(model_id)
-        # Classifying undeclared IDs diverges from Go, which routes on the
-        # declared type alone: this plugin resolves lazily, so without it
-        # bedrock/amazon.nova-canvas-v1:0 would take the Converse path and fail
-        # at call time. Embedders already classify by ID the same way.
+        # Undeclared IDs are classified rather than assumed to be chat: resolve
+        # is lazy, so otherwise bedrock/amazon.nova-canvas-v1:0 would take the
+        # Converse path and fail at call time. Embedders classify the same way.
         model_type = declared if declared is not None else ('image' if is_image_model(model_id) else 'chat')
         return self._create_model_action(model_id, model_type)
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
@@ -223,8 +223,8 @@ def _tool_block_to_part(index: int, block: _StreamBlock, tools: list[ToolDefinit
 def _decode_tool_input(index: int, raw: str) -> Any:  # noqa: ANN401
     """Decodes accumulated tool-input fragments; None when none were sent.
 
-    ``json.loads`` rejects trailing data after the JSON value, which is the
-    check Go spells out by hand.
+    ``json.loads`` rejects trailing data after the JSON value, so a doubled or
+    truncated fragment raises instead of decoding halfway.
     """
     if not raw.strip():
         return None

--- a/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/embedders_test.py
@@ -679,7 +679,7 @@ def test_registry_dimensions_and_modalities(model_id: str, dimensions: int, inpu
     options = get_embedder_options(model_id)
     assert options.dimensions == dimensions
     assert options.supports is not None and options.supports.input == inputs
-    assert options.label == model_id
+    assert options.label == f'Amazon Bedrock - {model_id}'
 
 
 @pytest.mark.parametrize(
@@ -701,7 +701,7 @@ def test_unregistered_but_routable_model_falls_back_to_family_defaults(model_id:
 def test_profile_prefixed_lookup_strips_but_the_label_keeps_the_prefix() -> None:
     options = get_embedder_options(f'us.{TITAN_TEXT}')
     assert options.dimensions == 1024
-    assert options.label == f'us.{TITAN_TEXT}'
+    assert options.label == f'Amazon Bedrock - us.{TITAN_TEXT}'
 
 
 def test_all_registry_keys_are_base_ids() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -102,6 +102,44 @@ def test_inference_profile_id_resolves_registry_entry() -> None:
     assert info.label == 'eu.amazon.nova-micro-v1:0'
 
 
+@pytest.mark.parametrize(
+    'model_id',
+    [
+        'anthropic.claude-sonnet-4-6',
+        'anthropic.claude-opus-4-6-v1',
+        'anthropic.claude-opus-4-7',
+        'anthropic.claude-opus-4-8',
+        'anthropic.claude-sonnet-5',
+        'anthropic.claude-opus-5',
+        'anthropic.claude-fable-5',
+    ],
+)
+def test_current_claude_models_are_stable_and_multimodal(model_id: str) -> None:
+    info = get_model_info(model_id)
+    assert info.stage == Stage.STABLE
+    assert info.supports is not None
+    assert info.supports.media is True
+    assert info.supports.tools is True
+
+
+@pytest.mark.parametrize(
+    'model_id',
+    ['us.anthropic.claude-opus-5', 'global.anthropic.claude-fable-5', 'eu.anthropic.claude-opus-4-7'],
+)
+def test_current_claude_profile_ids_resolve_to_their_registry_entry(model_id: str) -> None:
+    info = get_model_info(model_id)
+    assert info.stage == Stage.STABLE
+    assert info.supports is not None
+    assert info.supports.media is True
+
+
+def test_messages_only_model_is_not_registered() -> None:
+    # Claude Mythos 5 is ACTIVE on Bedrock but has no Converse support, so it
+    # must not claim a stable capability entry on the Converse path.
+    info = get_model_info('anthropic.claude-mythos-5')
+    assert info.stage == Stage.UNSTABLE
+
+
 def test_unknown_model_defaults_to_unstable_converse_capabilities() -> None:
     info = get_model_info('vendor.brand-new-model-v1:0')
     assert info.stage == Stage.UNSTABLE
@@ -123,8 +161,8 @@ def test_image_model_supports_media_output_only() -> None:
     assert info.supports.system_role is False
 
 
-def test_registry_matches_go_plugin_size() -> None:
-    assert len(MODEL_CAPABILITIES) == 47
+def test_registry_size() -> None:
+    assert len(MODEL_CAPABILITIES) == 52
 
 
 def test_all_registry_keys_are_base_ids() -> None:

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -74,7 +74,7 @@ def test_strip_lowercases_for_lookup() -> None:
 def test_a_mixed_case_id_still_finds_its_capabilities() -> None:
     info = get_model_info('US.Amazon.Nova-Lite-V1:0')
     assert info.stage == Stage.STABLE
-    assert info.label == 'US.Amazon.Nova-Lite-V1:0'
+    assert info.label == 'Amazon Bedrock - US.Amazon.Nova-Lite-V1:0'
 
 
 def test_us_gov_wins_over_us() -> None:
@@ -99,7 +99,7 @@ def test_inference_profile_id_resolves_registry_entry() -> None:
     assert info.stage == Stage.STABLE
     assert info.supports is not None
     assert info.supports.media is False
-    assert info.label == 'eu.amazon.nova-micro-v1:0'
+    assert info.label == 'Amazon Bedrock - eu.amazon.nova-micro-v1:0'
 
 
 @pytest.mark.parametrize(
@@ -152,6 +152,7 @@ def test_unknown_model_defaults_to_unstable_converse_capabilities() -> None:
 def test_image_model_supports_media_output_only() -> None:
     info = get_model_info('amazon.titan-image-generator-v1', model_type='image')
     assert info.stage == Stage.STABLE
+    assert info.label == 'Amazon Bedrock - amazon.titan-image-generator-v1'
     assert info.supports is not None
     assert info.supports.output == ['media']
     # media is Genkit's input flag, and these models take text prompts only.


### PR DESCRIPTION
## Why

Follow-ups from the slice 2 registry review (genkit-ai/genkit#5699 (comment)), tracked on #5820. The registry stopped at Claude 4.6, so five models that are ACTIVE on Bedrock fell through to the unknown-model default and showed a `stage: unstable` badge. Labels were the bare model ID, next to peers' `Anthropic - ...` entries in the Dev UI picker.

## Changes

Registers `anthropic.claude-opus-4-7`, `-opus-4-8`, `-sonnet-5`, `-opus-5` and `-fable-5`, all multimodal with tools. IDs come from the control plane, not inference: no date stamp from 4.6 on, and the `-v1` suffix is per-model. Mythos 5 is Messages-only, so it stays unregistered.

Adds `model_label()`, so chat, image and embedder metadata all read `Amazon Bedrock - <id>`.