### PR TITLE
feat(py/plugins/amazon-bedrock): add debug logging and missing CHANGELOG

### DIFF
--- a/py/packages/genkit-amazon-bedrock/CHANGELOG.md
+++ b/py/packages/genkit-amazon-bedrock/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to the `genkit-amazon-bedrock` package are documented in
+this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+First release of the plugin.
+
+### Added
+
+- `Bedrock` plugin registering Bedrock-hosted models as Genkit model actions,
+  with AWS client knobs for `region`, `max_retries`, `read_timeout`,
+  `connect_timeout`, `max_pool_connections`, `total_timeout` and a
+  pre-configured `session`.
+- Text generation over the Converse and ConverseStream APIs, covering
+  multi-turn chat, system prompts, tool calling, reasoning content, and
+  streamed deltas.
+- `BedrockConfig` with Bedrock-specific knobs on top of the core `ModelConfig`
+  fields, plus `additional_model_request_fields` for anything Converse does not
+  model.
+- Prompt caching via `cache_point_part()`.
+- Embedders for the Titan text, Titan multimodal, Cohere v3 and Nova-2
+  families, over InvokeModel.
+- Image generation for the Nova Canvas, Titan Image and Stability families,
+  configured with `BedrockImageConfig`.
+- `Bedrock.rerank()` helper for the Cohere and Amazon rerank families; Genkit
+  Python has no reranker action kind to register against.
+- Inference-profile and ARN model IDs, sent to Bedrock verbatim while
+  capability lookup falls back to the base model.
+- AWS error codes mapped onto Genkit statuses, with `Retry-After` surfaced as
+  `retry_after_ms` on throttling errors.
+- Metadata-only debug logging through `structlog`.
+- Runnable sample under `py/samples/amazon-bedrock-sample/` covering chat,
+  streaming, tool calling, structured output, reasoning, prompt caching,
+  vision, PDF input, embeddings, image generation, and reranking.

--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -147,6 +147,12 @@ by the socket timeouts alone.
 never the bottleneck; concurrency is bounded first by the event loop's default
 thread pool, which the boto3 calls are dispatched to.
 
+`models` and `embedders` are what the Dev UI lists, so a bare `Bedrock()` lists
+nothing. The plugin does not discover the catalogue for you: that would mean a
+second client against the `bedrock` control plane and the IAM actions to go with
+it, on top of the runtime-only policy [above](#iam). Calls are unaffected, since
+any model ID resolves on demand either way.
+
 ### Config fields that are ignored
 
 `BedrockConfig` inherits the core `ModelConfig` fields, so the Dev UI offers
@@ -504,6 +510,13 @@ region. The plugin retries automatically with exponential backoff, up to
 `max_retries` retries after the initial attempt, and surfaces the error once
 those are exhausted. Raise `max_retries`, spread the load, or move to
 provisioned throughput.
+
+### Debug logging
+
+`GENKIT_LOG=debug` turns on the plugin's own log lines: the resolved region and
+client config, which model each call routed to, stop reasons, token counts, and
+what `resolve` declined. They carry metadata only, never prompts, embeddings or
+image bytes, so they are safe to leave on.
 
 ## Examples
 

--- a/py/packages/genkit-amazon-bedrock/pyproject.toml
+++ b/py/packages/genkit-amazon-bedrock/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # botocore is imported directly (config, exceptions) and pins the floor that
 # keeps the manual AWS_REGION lookup in transport.py necessary: it did not read
 # AWS_REGION itself until 1.41.
-dependencies = ["genkit", "boto3>=1.37.24", "botocore>=1.37.24"]
+dependencies = ["genkit", "boto3>=1.37.24", "botocore>=1.37.24", "structlog>=25.2.0"]
 description = "Genkit Amazon Bedrock Plugin"
 keywords = [
   "genkit",

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/converters.py
@@ -699,6 +699,22 @@ def usage_from_response(usage: dict[str, Any] | None) -> ModelUsage | None:  # n
     )
 
 
+def usage_log_fields(usage: dict[str, Any] | None) -> dict[str, Any]:  # noqa: ANN401
+    """Token counts as structlog keys; empty when the response reported none.
+
+    Cache writes are here but not on ``ModelUsage``, so the log is the only
+    place they surface.
+    """
+    if not usage:
+        return {}
+    return {
+        'input_tokens': usage.get('inputTokens'),
+        'output_tokens': usage.get('outputTokens'),
+        'cache_read_tokens': usage.get('cacheReadInputTokens'),
+        'cache_write_tokens': usage.get('cacheWriteInputTokens'),
+    }
+
+
 def to_model_response(response: dict[str, Any] | None, request: ModelRequest[Any]) -> ModelResponse:  # noqa: ANN401
     """Converts a raw Converse response to a Genkit ModelResponse."""
     if response is None:

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/embedders.py
@@ -39,6 +39,7 @@ import json
 from collections.abc import Coroutine
 from typing import Any, Literal, NamedTuple, Protocol, TypeVar, cast
 
+import structlog
 from botocore.exceptions import BotoCoreError, ClientError
 
 from genkit import MediaPart, TextPart
@@ -55,6 +56,8 @@ from genkit.embedder import (
 from genkit.plugin_api import GenkitError
 from genkit_amazon_bedrock.model_info import model_label, strip_inference_profile_prefix
 from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
+
+logger = structlog.get_logger(__name__)
 
 # One call's result: a single vector per document, or a chunk of them for Cohere.
 _T = TypeVar('_T')
@@ -384,6 +387,12 @@ class BedrockEmbedder:
                 status='UNIMPLEMENTED',
             )
 
+        logger.debug(
+            'Bedrock embed request',
+            model=self._model_id,
+            family=family,
+            documents=len(request.input),
+        )
         if family == 'titan_text':
             vectors = await self._embed_titan_text(request.input)
         elif family == 'titan_multimodal':
@@ -392,6 +401,12 @@ class BedrockEmbedder:
             vectors = await self._embed_cohere(request.input)
         else:
             vectors = await self._embed_nova(request.input)
+        logger.debug(
+            'Bedrock embed response',
+            model=self._model_id,
+            vectors=len(vectors),
+            dimensions=len(vectors[0]) if vectors else 0,
+        )
         return EmbedResponse(embeddings=[Embedding(embedding=vector) for vector in vectors])
 
     async def _embed_titan_text(self, documents: list[DocumentData]) -> list[list[float]]:

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/image.py
@@ -30,6 +30,7 @@ hardcoded ``image/png``, which would mislabel a jpeg or webp response.
 import json
 from typing import Any, Literal, cast
 
+import structlog
 from botocore.exceptions import BotoCoreError, ClientError
 
 from genkit import (
@@ -48,6 +49,8 @@ from genkit.plugin_api import ActionRunContext, GenkitError
 from genkit_amazon_bedrock.embedders import InvokeModelTransport
 from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
 from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
+
+logger = structlog.get_logger(__name__)
 
 ImageFamily = Literal['titan_image', 'nova_canvas', 'stability']
 
@@ -281,6 +284,7 @@ class BedrockImageModel:
                 status='INVALID_ARGUMENT',
             )
         config = _normalize_image_config(request.config)
+        logger.debug('Bedrock image request', model=self._model_id, family=family)
 
         if family == 'stability':
             body = build_stability_image_body(prompt, config)
@@ -298,6 +302,7 @@ class BedrockImageModel:
         parts = _media_parts(images, mime)
         if not parts:
             raise GenkitError(message=_NO_IMAGES_MESSAGE, status='INTERNAL')
+        logger.debug('Bedrock image response', model=self._model_id, images=len(parts), mime=mime)
         return ModelResponse(
             message=Message(role=Role.MODEL, content=parts),
             # Image generation always stops on its own and reports no tokens.

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/models.py
@@ -23,6 +23,7 @@ from contextlib import aclosing
 from email.utils import parsedate_to_datetime
 from typing import Any, Protocol
 
+import structlog
 from botocore.exceptions import (
     BotoCoreError,
     ClientError,
@@ -37,8 +38,10 @@ from botocore.exceptions import (
 
 from genkit import ErrorResponseMetadata, ModelRequest, ModelResponse
 from genkit.plugin_api import ActionRunContext, GenkitError, StatusName
-from genkit_amazon_bedrock.converters import build_converse_request, to_model_response
+from genkit_amazon_bedrock.converters import build_converse_request, to_model_response, usage_log_fields
 from genkit_amazon_bedrock.stream import consume_converse_stream
+
+logger = structlog.get_logger(__name__)
 
 
 class ConverseTransport(Protocol):
@@ -183,8 +186,16 @@ class BedrockModel:
         Returns:
             The converted model response.
         """
+        streaming = ctx is not None and ctx.is_streaming
         converse_kwargs = build_converse_request(self._model_id, request)
-        if ctx is not None and ctx.is_streaming:
+        logger.debug(
+            'Bedrock generate request',
+            model=self._model_id,
+            streaming=streaming,
+            messages=len(converse_kwargs.get('messages') or []),
+            tools=len((converse_kwargs.get('toolConfig') or {}).get('tools') or []),
+        )
+        if streaming and ctx is not None:
             return await self._generate_stream(converse_kwargs, request, ctx)
         try:
             response = await self._transport.converse(**converse_kwargs)
@@ -192,6 +203,15 @@ class BedrockModel:
             raise _from_client_error(e) from e
         except BotoCoreError as e:
             raise _from_botocore_error(e) from e
+        # Guarded so a transport returning None still reaches to_model_response,
+        # which reports it as INTERNAL rather than dying here on an attribute.
+        logged = response or {}
+        logger.debug(
+            'Bedrock generate response',
+            model=self._model_id,
+            stop_reason=logged.get('stopReason'),
+            **usage_log_fields(logged.get('usage')),
+        )
         return to_model_response(response, request)
 
     async def _generate_stream(
@@ -209,7 +229,7 @@ class BedrockModel:
         """
         try:
             async with aclosing(self._transport.converse_stream(**converse_kwargs)) as events:
-                return await consume_converse_stream(events, request, ctx)
+                return await consume_converse_stream(events, request, ctx, self._model_id)
         except ClientError as e:
             raise _from_client_error(e, 'converse stream') from e
         except BotoCoreError as e:

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -25,6 +25,8 @@ helper: Genkit Python has no reranker primitive to register an action against.
 
 from typing import TYPE_CHECKING, Any, Literal
 
+import structlog
+
 from genkit import Document, ModelRequest, ModelResponse
 
 # DocumentData has no public re-export yet; the rerank helper is built on it.
@@ -66,6 +68,8 @@ from genkit_amazon_bedrock.transport import BedrockTransport
 
 if TYPE_CHECKING:
     import boto3.session
+
+logger = structlog.get_logger(__name__)
 
 BEDROCK_PLUGIN_NAME = 'bedrock'
 
@@ -179,21 +183,28 @@ class Bedrock(Plugin):
         if action_type == ActionKind.EMBEDDER:
             # An unroutable embedding ID still resolves, so embed() can name it
             # as an unsupported embedder instead of the registry saying 404.
-            return self._create_embedder_action(model_id) if looks_like_embedding_model(model_id) else None
+            if not looks_like_embedding_model(model_id):
+                logger.debug('Bedrock resolve declined', model=model_id, kind='embedder', reason='not_an_embedder')
+                return None
+            return self._create_embedder_action(model_id)
         if action_type != ActionKind.MODEL:
+            logger.debug('Bedrock resolve declined', model=model_id, kind=str(action_type), reason='unsupported_kind')
             return None
         if looks_like_embedding_model(model_id):
             # Embedding models speak InvokeModel, not Converse; resolving one
             # as a chat model only defers the failure to call time.
+            logger.debug('Bedrock resolve declined', model=model_id, kind='model', reason='embedding_model')
             return None
         if is_rerank_model(model_id):
             # Same story for rerank models; reranking is the Bedrock.rerank helper.
+            logger.debug('Bedrock resolve declined', model=model_id, kind='model', reason='rerank_model')
             return None
         declared = self._declared_model_type(model_id)
         # Undeclared IDs are classified rather than assumed to be chat: resolve
         # is lazy, so otherwise bedrock/amazon.nova-canvas-v1:0 would take the
         # Converse path and fail at call time. Embedders classify the same way.
         model_type = declared if declared is not None else ('image' if is_image_model(model_id) else 'chat')
+        logger.debug('Bedrock model resolved', model=model_id, model_type=model_type, declared=declared is not None)
         return self._create_model_action(model_id, model_type)
 
     def _declared_model_type(self, model_id: str) -> Literal['chat', 'text', 'image'] | None:
@@ -267,10 +278,18 @@ class Bedrock(Plugin):
             and not is_rerank_model(definition.name)
             and (definition.type != 'image' or is_image_model(definition.name))
         ]
+        models = len(actions)
         actions.extend(
             embedder_action_metadata(bedrock_name(model_id), get_embedder_options(model_id))
             for model_id in self.embedders
             if is_embedding_model(model_id)
+        )
+        logger.debug(
+            'Bedrock actions listed',
+            models=models,
+            embedders=len(actions) - models,
+            models_configured=len(self.models),
+            embedders_configured=len(self.embedders),
         )
         return actions
 

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/plugin.py
@@ -165,8 +165,9 @@ class Bedrock(Plugin):
     async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
         """Resolve an action by namespaced name.
 
-        Any model ID resolves — the Bedrock catalogue includes arbitrary
-        inference profiles and ARNs and can never be fully enumerated.
+        Any model ID resolves. Nothing is discovered: listing the catalogue
+        needs a second, control-plane ``bedrock`` client and the IAM actions
+        that go with it, and this plugin opens only ``bedrock-runtime``.
 
         Args:
             action_type: The kind of action to resolve.
@@ -260,9 +261,9 @@ class Bedrock(Plugin):
         plugin can actually serve: an ID in the wrong list, or a chat model
         declared ``type='image'``, would otherwise be advertised and then fail
         on use. Such a declaration still resolves, so the caller reads the
-        image path's reason rather than a generic model-not-found. The
-        catalogue itself is open-ended, and any model ID still resolves on
-        demand.
+        image path's reason rather than a generic model-not-found. A bare
+        ``Bedrock()`` therefore lists nothing; see ``resolve`` for why the
+        catalogue is not read.
 
         Returns:
             ActionMetadata for each configured model and embedder.

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/rerank.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/rerank.py
@@ -39,6 +39,7 @@ import json
 from collections.abc import Mapping
 from typing import Any, Literal
 
+import structlog
 from botocore.exceptions import BotoCoreError, ClientError
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 from pydantic.alias_generators import to_camel
@@ -51,6 +52,8 @@ from genkit.plugin_api import GenkitError
 from genkit_amazon_bedrock.embedders import InvokeModelTransport, document_text
 from genkit_amazon_bedrock.model_info import strip_inference_profile_prefix
 from genkit_amazon_bedrock.models import _from_botocore_error, _from_client_error
+
+logger = structlog.get_logger(__name__)
 
 # The current Bedrock contract for the Cohere Rerank InvokeModel body.
 COHERE_RERANK_API_VERSION = 2
@@ -348,9 +351,19 @@ class BedrockReranker:
             top_n = options.top_n
 
         # Only the Amazon family drops api_version; an unknown ID takes Cohere's body.
-        include_api_version = _rerank_family(self._model_id) != 'amazon'
+        family = _rerank_family(self._model_id)
+        include_api_version = family != 'amazon'
+        logger.debug(
+            'Bedrock rerank request',
+            model=self._model_id,
+            family=family,
+            documents=len(texts),
+            top_n=top_n,
+        )
         payload = await self._invoke(build_rerank_body(query, texts, top_n, include_api_version=include_api_version))
-        return build_rerank_response(payload, request.documents)
+        response = build_rerank_response(payload, request.documents)
+        logger.debug('Bedrock rerank response', model=self._model_id, ranked=len(response.documents))
+        return response
 
     async def _invoke(self, body: dict[str, Any]) -> dict[str, Any]:
         try:

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/stream.py
@@ -27,6 +27,8 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 
+import structlog
+
 from genkit import (
     FinishReason,
     Message,
@@ -46,7 +48,10 @@ from genkit_amazon_bedrock.converters import (
     coerce_tool_input,
     map_finish_reason,
     usage_from_response,
+    usage_log_fields,
 )
+
+logger = structlog.get_logger(__name__)
 
 
 @dataclass
@@ -67,6 +72,7 @@ async def consume_converse_stream(
     events: AsyncIterator[dict[str, Any]],
     request: ModelRequest[Any],
     ctx: ActionRunContext | None = None,
+    model_id: str | None = None,
 ) -> ModelResponse:
     """Reassembles a ConverseStream into a ModelResponse, streaming chunks.
 
@@ -80,6 +86,7 @@ async def consume_converse_stream(
         request: The originating Genkit request; supplies tool schemas and is
             echoed on the response.
         ctx: Action run context; chunks are sent only when it is streaming.
+        model_id: Model the events came from, for the completion log line only.
 
     Returns:
         The assembled model response.
@@ -131,6 +138,14 @@ async def consume_converse_stream(
     # A stream that ends without messageStop stopped normally; the sync path's
     # mapping would call that OTHER.
     finish_reason = map_finish_reason(stop_reason) if stop_reason else FinishReason.STOP
+    logger.debug(
+        'Bedrock stream complete',
+        model=model_id,
+        stop_reason=stop_reason,
+        blocks=len(blocks),
+        tool_blocks=sum(1 for block in blocks.values() if block.is_tool),
+        **usage_log_fields(usage),
+    )
     return ModelResponse(
         message=Message(role=Role.MODEL, content=parts),
         finish_reason=finish_reason,

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/transport.py
@@ -30,6 +30,8 @@ import threading
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
+import structlog
+
 from genkit.plugin_api import GenkitError
 from genkit_amazon_bedrock.config import (
     DEFAULT_CONNECT_TIMEOUT,
@@ -41,6 +43,8 @@ from genkit_amazon_bedrock.config import (
 
 if TYPE_CHECKING:
     import boto3.session
+
+logger = structlog.get_logger(__name__)
 
 NO_REGION_MESSAGE = (
     'bedrock: no AWS region resolved; set Bedrock(region=...), AWS_REGION, '
@@ -347,4 +351,15 @@ class BedrockTransport:
 
         session = self._session or boto3.session.Session()
         region = self._resolve_region(session)
-        return session.client('bedrock-runtime', region_name=region, config=self._client_config(session))
+        config = self._client_config(session)
+        client = session.client('bedrock-runtime', region_name=region, config=config)
+        logger.debug(
+            'Bedrock client created',
+            region=region,
+            caller_session=self._session is not None,
+            read_timeout=config.read_timeout,
+            connect_timeout=config.connect_timeout,
+            max_pool_connections=config.max_pool_connections,
+            retries=config.retries,
+        )
+        return client

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1692,6 +1692,7 @@ dependencies = [
     { name = "boto3" },
     { name = "botocore" },
     { name = "genkit" },
+    { name = "structlog" },
 ]
 
 [package.metadata]
@@ -1699,6 +1700,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.37.24" },
     { name = "botocore", specifier = ">=1.37.24" },
     { name = "genkit", editable = "packages/genkit" },
+    { name = "structlog", specifier = ">=25.2.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #6084 and tracked on #5820

## Why

Three small gaps in the Bedrock plugin, from review of the #5820 port:

- `pyproject.toml` advertised a `Changelog` URL with no `CHANGELOG.md` behind it, so the first release would ship a dead link on PyPI.
- The package logged nothing, where the other plugins all carry metadata-only `structlog` lines. A misrouted model or a surprise region was invisible.
- The docstrings justified the empty default model list with "the catalogue can never be fully enumerated". It can; `list-foundation-models` does exactly that. Not opening a control-plane client is a fine reason, just a different one.

## Changes

Adds `CHANGELOG.md`, in the format `genkit-ollama` already uses.

Declares `structlog>=25.2.0` and adds a module logger to the plugin, transport, models, stream, embedders, image and rerank modules. The debug lines carry metadata only: model IDs, families, counts, stop reasons, token usage, and why `resolve` declined an ID. Never prompts, vectors or image bytes. `GENKIT_LOG=debug` turns them on, which the README now says under Troubleshooting.

Corrects the rationale in both docstrings and the README: enumerating the catalogue would need a second client against the `bedrock` control plane plus the IAM actions for it, and this plugin opens only `bedrock-runtime`.