### PR TITLE
fix(go/ai): stop masking abnormal finish reasons with schema errors

### DIFF
--- a/go/ai/errors.go
+++ b/go/ai/errors.go
@@ -63,4 +63,14 @@ var (
 	// ErrUnresolvedToolRequest means a resumed generation left an interrupted
 	// tool request without a Respond or Restart directive.
 	ErrUnresolvedToolRequest = status.ErrInvalidArgument.Subtype("unresolved tool request")
+
+	// ErrGenerationBlocked means the provider refused to generate, which is
+	// usually a safety filter firing. Only the typed helpers report it
+	// ([GenerateData], [GenerateDataStream], [DataPrompt.Execute],
+	// [DataPrompt.ExecuteStream]): a refusal cannot produce the value they
+	// promise, so returning a zero value with no error would read as success.
+	// [Generate] still hands the response back unwrapped, so read
+	// FinishReason there. The status is FAILED_PRECONDITION, matching the
+	// GenerationBlockedError that JS and Python raise on the same event.
+	ErrGenerationBlocked = status.ErrFailedPrecondition.Subtype("generation blocked")
 )

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -328,6 +328,10 @@ func LookupModel(r api.Registry, name string) Model {
 // FinishReasonUnknown is not in the set on purpose: plugins map unrecognized
 // provider reasons to it, so treating it as abnormal would silently drop
 // output validation for responses the model may well have completed.
+//
+// FinishReasonBlocked is in the set, because a refusal must skip parsing like
+// any other abnormal finish, but the typed helpers test for it first and
+// report [ErrGenerationBlocked] instead of reaching here.
 func (fr FinishReason) isAbnormal() bool {
 	switch fr {
 	case FinishReasonBlocked, FinishReasonAborted, FinishReasonInterrupted, FinishReasonOther:
@@ -335,6 +339,17 @@ func (fr FinishReason) isAbnormal() bool {
 	default:
 		return false
 	}
+}
+
+// blockedError reports a refusal as [ErrGenerationBlocked], carrying the
+// provider's explanation when there is one. Only the typed helpers call it:
+// they promise a value that a refusal cannot produce, whereas [Generate]
+// hands the response back and lets the caller read FinishReason.
+func blockedError(resp *ModelResponse) error {
+	if resp.FinishMessage == "" {
+		return status.Errorf(ErrGenerationBlocked, "generation blocked")
+	}
+	return status.Errorf(ErrGenerationBlocked, "generation blocked: %s", resp.FinishMessage)
 }
 
 // GenerateWithRequest is the central generation implementation for ai.Generate(), prompt.Execute(), and the GenerateAction direct call.
@@ -1038,12 +1053,14 @@ func GenerateText(ctx context.Context, r api.Registry, opts ...GenerateOption) (
 	return res.Text(), nil
 }
 
-// GenerateData runs a generate request and returns strongly-typed output.
-// If the response doesn't contain text output (e.g., contains tool requests
-// or interrupts instead), or generation ended abnormally (blocked, aborted,
-// interrupted, other), the output will be nil and no error is returned. Check
-// resp.FinishReason, resp.Interrupts() or resp.ToolRequests() to handle these
-// cases.
+// A refusal is an error: when the response finished blocked, the output is nil
+// and the error is [ErrGenerationBlocked], carrying the provider's explanation.
+// The response is still returned alongside it.
+//
+// Every other finish that yields nothing to extract is not an error. If the
+// response carries no text (tool requests or interrupts instead), or ended
+// aborted, interrupted, or other, the output is nil and the error is nil.
+// Check resp.FinishReason, resp.Interrupts(), and resp.ToolRequests().
 //
 // The output format is JSON with a schema inferred from Out; an explicit
 // [WithOutputSchema] or [WithOutputSchemaName] overrides the schema while
@@ -1063,11 +1080,17 @@ func GenerateData[Out any](ctx context.Context, r api.Registry, opts ...Generate
 		return nil, nil, err
 	}
 
-	// Two responses have no conforming output to extract: one that ended
-	// abnormally, whose FinishReason is the news the caller needs, and one with
-	// no text at all, which is what a turn holding tool requests, interrupts, or
-	// media looks like. Both hand the response back unparsed rather than report a
-	// schema error naming the wrong cause. See [FinishReason.isAbnormal].
+	// A refusal cannot produce the value this helper promises, so it is
+	// reported rather than handed back as a zero value that reads as success.
+	// [Generate] still returns the response unwrapped.
+	if resp.FinishReason == FinishReasonBlocked {
+		return nil, resp, blockedError(resp)
+	}
+
+	// The remaining abnormal finishes, and a response with no text at all
+	// (what a turn holding tool requests, interrupts, or media looks like), have
+	// nothing to extract but are not failures. The response goes back unparsed
+	// rather than as a schema error naming the wrong cause.
 	if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 		return nil, resp, nil
 	}
@@ -1154,9 +1177,15 @@ func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption)
 // Like [GenerateData], the output format is JSON with a schema inferred from
 // Out; overriding the format with a non-JSON [WithOutputFormat] or
 // [WithOutputEnums] breaks typed extraction. Also like [GenerateData], a
-// response with no text output or one that ended abnormally (blocked, aborted,
-// interrupted, other) yields zero-value Output and no error; check
-// Response.FinishReason, Interrupts() or ToolRequests() to handle those.
+// blocked response fails with [ErrGenerationBlocked], while a response with no
+// text output or one that ended aborted, interrupted, or other yields
+// zero-value Output and no error; check Response.FinishReason, Interrupts(),
+// and ToolRequests() to handle those.
+//
+// Chunks are provisional. They are parsed as they arrive, before the finish
+// reason exists, so a generation that streams partial output and then ends
+// abnormally will have yielded chunks that the final value does not stand
+// behind. The Done value is the authoritative one.
 func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...GenerateOption) iter.Seq2[*StreamValue[Out, Out], error] {
 	return func(yield func(*StreamValue[Out, Out], error) bool) {
 		done := false
@@ -1200,11 +1229,18 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 			return
 		}
 
-		// Two responses have no conforming output to extract: one that ended
-		// abnormally, whose FinishReason is the news the caller needs, and one with
-		// no text at all, which is what a turn holding tool requests, interrupts, or
-		// media looks like. Both hand the response back unparsed rather than report a
-		// schema error naming the wrong cause. See [FinishReason.isAbnormal].
+		// A refusal cannot produce the value this helper promises, so it is
+		// reported rather than handed back as a zero value that reads as success.
+		// [Generate] still returns the response unwrapped.
+		if resp.FinishReason == FinishReasonBlocked {
+			yield(nil, blockedError(resp))
+			return
+		}
+
+		// The remaining abnormal finishes, and a response with no text at all
+		// (what a turn holding tool requests, interrupts, or media looks like), have
+		// nothing to extract but are not failures. The response goes back unparsed
+		// rather than as a schema error naming the wrong cause.
 		if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 			yield(&StreamValue[Out, Out]{Done: true, Response: resp}, nil)
 			return

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -319,6 +319,24 @@ func LookupModel(r api.Registry, name string) Model {
 	return &ModelAction{*action}
 }
 
+// isAbnormal reports whether generation ended in a way known to carry no
+// conforming output. Every code path that would otherwise parse a response
+// against its output schema consults this predicate first: a schema error
+// raised on such a response would mask the FinishReason and FinishMessage the
+// caller needs to handle the outcome.
+//
+// FinishReasonUnknown is not in the set on purpose: plugins map unrecognized
+// provider reasons to it, so treating it as abnormal would silently drop
+// output validation for responses the model may well have completed.
+func (fr FinishReason) isAbnormal() bool {
+	switch fr {
+	case FinishReasonBlocked, FinishReasonAborted, FinishReasonInterrupted, FinishReasonOther:
+		return true
+	default:
+		return false
+	}
+}
+
 // GenerateWithRequest is the central generation implementation for ai.Generate(), prompt.Execute(), and the GenerateAction direct call.
 func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActionOptions, mmws []ModelMiddleware, cb ModelStreamCallback) (*ModelResponse, error) {
 	return generateWithRequest(ctx, r, opts, mmws, cb, true /* spanTurnZero */)
@@ -579,23 +597,15 @@ func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 
 		if formatHandler != nil {
 			resp.formatHandler = streamingHandler
-			switch resp.FinishReason {
-			case FinishReasonBlocked, FinishReasonAborted, FinishReasonInterrupted, FinishReasonOther:
-				// A termination known to be abnormal carries no conforming
-				// output, and a schema error here would mask the
-				// FinishReason and FinishMessage the caller needs to
-				// handle it, so the response passes through as-is.
-				// FinishReasonUnknown is not in this set on purpose:
-				// plugins map unrecognized provider reasons to it, and
-				// ParseMessage is the only place the output schema is
-				// enforced, so skipping it on an unclassified reason would
-				// silently drop validation for output the model may well
-				// have completed.
+			if resp.FinishReason.isAbnormal() {
+				// The response passes through as-is so the caller reads the
+				// finish reason rather than a schema error. See
+				// [FinishReason.isAbnormal].
 				logger.Warn(ctx, "model finished abnormally, skipping output parsing",
 					"model", opts.Model,
 					"finishReason", resp.FinishReason,
 					"finishMessage", resp.FinishMessage)
-			default:
+			} else {
 				// This is legacy behavior. New format handlers should implement ParseMessage as a passthrough.
 				resp.Message, err = formatHandler.ParseMessage(resp.Message)
 				if err != nil {
@@ -1030,8 +1040,10 @@ func GenerateText(ctx context.Context, r api.Registry, opts ...GenerateOption) (
 
 // GenerateData runs a generate request and returns strongly-typed output.
 // If the response doesn't contain text output (e.g., contains tool requests
-// or interrupts instead), the output will be nil and no error is returned.
-// Check resp.Interrupts() or resp.ToolRequests() to handle these cases.
+// or interrupts instead), or generation ended abnormally (blocked, aborted,
+// interrupted, other), the output will be nil and no error is returned. Check
+// resp.FinishReason, resp.Interrupts() or resp.ToolRequests() to handle these
+// cases.
 //
 // The output format is JSON with a schema inferred from Out; an explicit
 // [WithOutputSchema] or [WithOutputSchemaName] overrides the schema while
@@ -1049,6 +1061,14 @@ func GenerateData[Out any](ctx context.Context, r api.Registry, opts ...Generate
 	resp, err := Generate(ctx, r, opts...)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// A response that ended abnormally carries no conforming output, so return
+	// it unparsed rather than reporting a schema error that names the wrong
+	// cause. The caller should check resp.FinishReason and resp.FinishMessage.
+	// See [FinishReason.isAbnormal].
+	if resp.FinishReason.isAbnormal() {
+		return nil, resp, nil
 	}
 
 	// If there's no text content to parse (e.g., the response contains tool
@@ -1139,7 +1159,10 @@ func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption)
 //
 // Like [GenerateData], the output format is JSON with a schema inferred from
 // Out; overriding the format with a non-JSON [WithOutputFormat] or
-// [WithOutputEnums] breaks typed extraction.
+// [WithOutputEnums] breaks typed extraction. Also like [GenerateData], a
+// response with no text output or one that ended abnormally (blocked, aborted,
+// interrupted, other) yields zero-value Output and no error; check
+// Response.FinishReason, Interrupts() or ToolRequests() to handle those.
 func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...GenerateOption) iter.Seq2[*StreamValue[Out, Out], error] {
 	return func(yield func(*StreamValue[Out, Out], error) bool) {
 		done := false
@@ -1183,10 +1206,15 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 			return
 		}
 
+		// A response that ended abnormally carries no conforming output, so
+		// return it unparsed rather than reporting a schema error that names
+		// the wrong cause. The caller should check resp.FinishReason and
+		// resp.FinishMessage. See [FinishReason.isAbnormal].
+		//
 		// If there's no text content to parse (e.g., the response contains tool
 		// requests or interrupts), return zero-value output. The caller should check
 		// resp.Interrupts() or resp.ToolRequests() to handle these cases.
-		if resp.Text() == "" {
+		if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 			yield(&StreamValue[Out, Out]{Done: true, Response: resp}, nil)
 			return
 		}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1063,18 +1063,12 @@ func GenerateData[Out any](ctx context.Context, r api.Registry, opts ...Generate
 		return nil, nil, err
 	}
 
-	// A response that ended abnormally carries no conforming output, so return
-	// it unparsed rather than reporting a schema error that names the wrong
-	// cause. The caller should check resp.FinishReason and resp.FinishMessage.
-	// See [FinishReason.isAbnormal].
-	if resp.FinishReason.isAbnormal() {
-		return nil, resp, nil
-	}
-
-	// If there's no text content to parse (e.g., the response contains tool
-	// requests or interrupts), return nil output. The caller should check
-	// resp.Interrupts() or resp.ToolRequests() to handle these cases.
-	if resp.Text() == "" {
+	// Two responses have no conforming output to extract: one that ended
+	// abnormally, whose FinishReason is the news the caller needs, and one with
+	// no text at all, which is what a turn holding tool requests, interrupts, or
+	// media looks like. Both hand the response back unparsed rather than report a
+	// schema error naming the wrong cause. See [FinishReason.isAbnormal].
+	if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 		return nil, resp, nil
 	}
 
@@ -1206,14 +1200,11 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 			return
 		}
 
-		// A response that ended abnormally carries no conforming output, so
-		// return it unparsed rather than reporting a schema error that names
-		// the wrong cause. The caller should check resp.FinishReason and
-		// resp.FinishMessage. See [FinishReason.isAbnormal].
-		//
-		// If there's no text content to parse (e.g., the response contains tool
-		// requests or interrupts), return zero-value output. The caller should check
-		// resp.Interrupts() or resp.ToolRequests() to handle these cases.
+		// Two responses have no conforming output to extract: one that ended
+		// abnormally, whose FinishReason is the news the caller needs, and one with
+		// no text at all, which is what a turn holding tool requests, interrupts, or
+		// media looks like. Both hand the response back unparsed rather than report a
+		// schema error naming the wrong cause. See [FinishReason.isAbnormal].
 		if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 			yield(&StreamValue[Out, Out]{Done: true, Response: resp}, nil)
 			return

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2889,13 +2889,16 @@ func TestGenerateDataAbnormalFinish(t *testing.T) {
 	}{
 		{
 			// The common path: a provider reports a safety block and returns
-			// prose explaining it, with no middleware involved.
+			// prose explaining it, with no middleware involved. A refusal
+			// cannot produce a Report, so it is an error rather than a nil
+			// value the caller would read as success.
 			name: "blocked with explanatory text",
 			response: &ModelResponse{
 				FinishReason:  FinishReasonBlocked,
 				FinishMessage: "blocked by safety settings",
 				Message:       NewModelTextMessage("Response was blocked for safety reasons."),
 			},
+			wantErr: ErrGenerationBlocked,
 		},
 		{
 			name: "blocked with no content",
@@ -2904,6 +2907,7 @@ func TestGenerateDataAbnormalFinish(t *testing.T) {
 				FinishMessage: "blocked by safety settings",
 				Message:       &Message{Role: RoleModel},
 			},
+			wantErr: ErrGenerationBlocked,
 		},
 		{
 			// What a soft-failing middleware produces when the provider is
@@ -2958,6 +2962,14 @@ func TestGenerateDataAbnormalFinish(t *testing.T) {
 				if tt.wantErr != nil {
 					if !errors.Is(err, tt.wantErr) {
 						t.Fatalf("GenerateData() err = %v, want %v", err, tt.wantErr)
+					}
+					if errors.Is(err, ErrGenerationBlocked) {
+						if !strings.Contains(err.Error(), tt.response.FinishMessage) {
+							t.Errorf("GenerateData() err = %v, want it to carry %q", err, tt.response.FinishMessage)
+						}
+						// The response rides along so the caller can still
+						// inspect the turn that was refused.
+						checkResponse(t, resp, tt.response)
 					}
 					return
 				}
@@ -3014,6 +3026,95 @@ func TestGenerateDataAbnormalFinish(t *testing.T) {
 					t.Errorf("GenerateDataStream() output = %+v, want %+v", final.Output, want)
 				}
 			})
+		})
+	}
+}
+
+// TestGenerateDataStreamBlockedAfterChunks covers the path the one-shot tests
+// miss: a model that streams output and only then reports a block. Chunks are
+// parsed as they arrive, before any finish reason exists, so the caller can see
+// a populated chunk for a generation that is ultimately refused. The contract
+// is that the terminal value settles it, and here that means the refusal
+// surfaces as an error rather than as a zeroed Output the caller reads as an
+// empty answer.
+func TestGenerateDataStreamBlockedAfterChunks(t *testing.T) {
+	r := childRegistry(t)
+
+	type Report struct {
+		Title string `json:"title"`
+	}
+
+	tests := []struct {
+		name      string
+		streamed  string
+		wantChunk *Report
+	}{
+		{
+			// Partial structured output arrives, then the block lands.
+			name:      "partial json then blocked",
+			streamed:  `{"title":"partial`,
+			wantChunk: &Report{Title: "partial"},
+		},
+		{
+			// A refusal streamed as prose parses to nothing useful, which must
+			// not be mistaken for a stream failure: the finish reason still has
+			// to reach the caller.
+			name:     "prose then blocked",
+			streamed: "I cannot help with that request.",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := defineModel(r, fmt.Sprintf("test/streamBlocked-%d", i), &ModelOptions{Supports: defaultModelSupports()},
+				func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+					if cb != nil {
+						if err := cb(ctx, &ModelResponseChunk{Content: []*Part{NewTextPart(tt.streamed)}}); err != nil {
+							return nil, err
+						}
+					}
+					return &ModelResponse{
+						Request:       req,
+						FinishReason:  FinishReasonBlocked,
+						FinishMessage: "blocked by safety settings",
+						Message:       NewModelTextMessage(tt.streamed),
+					}, nil
+				})
+
+			var (
+				chunks []Report
+				gotErr error
+				done   bool
+			)
+			for v, err := range GenerateDataStream[Report](context.Background(), r,
+				WithModel(model), WithPrompt("please respond")) {
+				if err != nil {
+					gotErr = err
+					break
+				}
+				if v.Done {
+					done = true
+					continue
+				}
+				chunks = append(chunks, v.Chunk)
+			}
+
+			if !errors.Is(gotErr, ErrGenerationBlocked) {
+				t.Fatalf("stream err = %v, want %v", gotErr, ErrGenerationBlocked)
+			}
+			if !strings.Contains(gotErr.Error(), "blocked by safety settings") {
+				t.Errorf("stream err = %v, want it to carry the finish message", gotErr)
+			}
+			if done {
+				t.Error("stream yielded a done value for a refused generation")
+			}
+			if tt.wantChunk != nil {
+				// Documenting the provisional chunk rather than asserting it
+				// away: it is why the terminal value has to be authoritative.
+				if len(chunks) == 0 || chunks[len(chunks)-1] != *tt.wantChunk {
+					t.Errorf("chunks = %+v, want the last to be %+v", chunks, *tt.wantChunk)
+				}
+			}
 		})
 	}
 }

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2868,6 +2868,174 @@ func TestGenerateAbnormalFinishSkipsOutputParsing(t *testing.T) {
 	}
 }
 
+// TestGenerateDataAbnormalFinish verifies that GenerateData and
+// GenerateDataStream apply the same abnormal-finish rule as Generate: a
+// response that ended blocked, aborted, interrupted, or other is handed back
+// unparsed so the caller reads the finish reason, instead of being reported as
+// a schema mismatch that names the wrong cause.
+func TestGenerateDataAbnormalFinish(t *testing.T) {
+	r := childRegistry(t)
+
+	type Report struct {
+		Title string `json:"title"`
+		Score int    `json:"score"`
+	}
+
+	tests := []struct {
+		name     string
+		response *ModelResponse
+		wantData *Report
+		wantErr  error
+	}{
+		{
+			// The common path: a provider reports a safety block and returns
+			// prose explaining it, with no middleware involved.
+			name: "blocked with explanatory text",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonBlocked,
+				FinishMessage: "blocked by safety settings",
+				Message:       NewModelTextMessage("Response was blocked for safety reasons."),
+			},
+		},
+		{
+			name: "blocked with no content",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonBlocked,
+				FinishMessage: "blocked by safety settings",
+				Message:       &Message{Role: RoleModel},
+			},
+		},
+		{
+			// What a soft-failing middleware produces when the provider is
+			// unreachable: an aborted response carrying the failure text.
+			name: "aborted with failure text",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonAborted,
+				FinishMessage: "provider down",
+				Message:       NewModelTextMessage("Error: provider down"),
+			},
+		},
+		{
+			name: "other with filter details",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonOther,
+				FinishMessage: "malformed function call",
+				Message:       NewModelTextMessage("filter details, not JSON"),
+			},
+		},
+		{
+			// A normal completion still validates: the fix must not turn every
+			// schema mismatch into a silent nil.
+			name: "stop with non-conforming text still fails parsing",
+			response: &ModelResponse{
+				FinishReason: FinishReasonStop,
+				Message:      NewModelTextMessage("not json at all"),
+			},
+			wantErr: status.ErrInvalidOutput,
+		},
+		{
+			name: "stop with conforming text parses",
+			response: &ModelResponse{
+				FinishReason: FinishReasonStop,
+				Message:      NewModelTextMessage(`{"title":"ok","score":7}`),
+			},
+			wantData: &Report{Title: "ok", Score: 7},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := defineModel(r, fmt.Sprintf("test/data-abnormal-finish-%d", i), &ModelOptions{Supports: defaultModelSupports()},
+				func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+					resp := *tt.response
+					resp.Request = req
+					return &resp, nil
+				})
+			opts := []GenerateOption{WithModel(model), WithPrompt("please respond")}
+
+			t.Run("GenerateData", func(t *testing.T) {
+				data, resp, err := GenerateData[Report](context.Background(), r, opts...)
+				if tt.wantErr != nil {
+					if !errors.Is(err, tt.wantErr) {
+						t.Fatalf("GenerateData() err = %v, want %v", err, tt.wantErr)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("GenerateData() returned error for %q response: %v", tt.response.FinishReason, err)
+				}
+				checkResponse(t, resp, tt.response)
+				if tt.wantData == nil {
+					if data != nil {
+						t.Errorf("GenerateData() data = %+v, want nil", *data)
+					}
+					return
+				}
+				if data == nil {
+					t.Fatalf("GenerateData() data = nil, want %+v", *tt.wantData)
+				}
+				if *data != *tt.wantData {
+					t.Errorf("GenerateData() data = %+v, want %+v", *data, *tt.wantData)
+				}
+			})
+
+			t.Run("GenerateDataStream", func(t *testing.T) {
+				var (
+					final *StreamValue[Report, Report]
+					err   error
+				)
+				for v, streamErr := range GenerateDataStream[Report](context.Background(), r, opts...) {
+					if streamErr != nil {
+						err = streamErr
+						break
+					}
+					if v.Done {
+						final = v
+					}
+				}
+				if tt.wantErr != nil {
+					if !errors.Is(err, tt.wantErr) {
+						t.Fatalf("GenerateDataStream() err = %v, want %v", err, tt.wantErr)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("GenerateDataStream() returned error for %q response: %v", tt.response.FinishReason, err)
+				}
+				if final == nil {
+					t.Fatal("GenerateDataStream() never yielded a done value")
+				}
+				checkResponse(t, final.Response, tt.response)
+				want := Report{}
+				if tt.wantData != nil {
+					want = *tt.wantData
+				}
+				if final.Output != want {
+					t.Errorf("GenerateDataStream() output = %+v, want %+v", final.Output, want)
+				}
+			})
+		})
+	}
+}
+
+// checkResponse asserts that the caller was handed the model's own finish
+// reason, message, and text rather than a rewritten or parsed stand-in.
+func checkResponse(t *testing.T, got, want *ModelResponse) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("response = nil, want the model response")
+	}
+	if got.FinishReason != want.FinishReason {
+		t.Errorf("FinishReason = %q, want %q", got.FinishReason, want.FinishReason)
+	}
+	if got.FinishMessage != want.FinishMessage {
+		t.Errorf("FinishMessage = %q, want %q", got.FinishMessage, want.FinishMessage)
+	}
+	if got.Text() != want.Text() {
+		t.Errorf("Text() = %q, want %q", got.Text(), want.Text())
+	}
+}
+
 func TestGenerateNoGoroutineLeak(t *testing.T) {
 	r := registry.New()
 	ConfigureFormats(r)

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -1141,12 +1141,16 @@ func AsDataPrompt[In, Out any](p Prompt) *DataPrompt[In, Out] {
 // The typed input argument fills the input slot last, so it wins over any
 // [WithInput] passed in opts.
 //
-// When generation ends abnormally (blocked, aborted, interrupted, other), the
-// output is the zero value of Out and no error is returned; check
-// resp.FinishReason and resp.FinishMessage to handle the outcome. This holds
-// for a string Out as well, whose text is on the response rather than the
-// returned value: text produced alongside an abnormal finish is a block
-// notice or a partial answer, not the completion the prompt asked for.
+// The output is the zero value of Out and no error is returned in two cases:
+// generation ended abnormally (blocked, aborted, interrupted, other), or the
+// response carried no text to parse, which is what a turn holding tool
+// requests, interrupts, or media looks like. Check resp.FinishReason,
+// resp.Interrupts(), and resp.ToolRequests() to handle them.
+//
+// The abnormal-finish rule holds for a string Out as well, whose text is on
+// the response rather than the returned value: text produced alongside an
+// abnormal finish is a block notice or a partial answer, not the completion
+// the prompt asked for.
 func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...PromptExecuteOption) (Out, *ModelResponse, error) {
 	if dp == nil {
 		return base.Zero[Out](), nil, status.Errorf(status.ErrInvalidArgument, "DataPrompt.Execute: prompt is nil")
@@ -1158,11 +1162,12 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 		return base.Zero[Out](), nil, err
 	}
 
-	// A response that ended abnormally carries no conforming output, so return
-	// it unparsed rather than reporting a schema error that names the wrong
-	// cause. The caller should check resp.FinishReason and resp.FinishMessage.
-	// See [FinishReason.isAbnormal].
-	if resp.FinishReason.isAbnormal() {
+	// Two responses have no conforming output to extract: one that ended
+	// abnormally, whose FinishReason is the news the caller needs, and one with
+	// no text at all, which is what a turn holding tool requests, interrupts, or
+	// media looks like. Both hand the response back unparsed rather than report a
+	// schema error naming the wrong cause. See [FinishReason.isAbnormal].
+	if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 		return base.Zero[Out](), resp, nil
 	}
 
@@ -1191,8 +1196,9 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 // [WithInput] passed in opts.
 //
 // Like [DataPrompt.Execute], a generation that ends abnormally (blocked,
-// aborted, interrupted, other) yields zero-value Output and no error; check
-// Response.FinishReason and Response.FinishMessage to handle the outcome.
+// aborted, interrupted, other) or carries no text to parse yields zero-value
+// Output and no error; check Response.FinishReason, Response.Interrupts(), and
+// Response.ToolRequests() to handle those.
 func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts ...PromptExecuteOption) iter.Seq2[*StreamValue[Out, Out], error] {
 	return func(yield func(*StreamValue[Out, Out], error) bool) {
 		if dp == nil {
@@ -1238,11 +1244,12 @@ func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts
 			return
 		}
 
-		// A response that ended abnormally carries no conforming output, so
-		// return it unparsed rather than reporting a schema error that names
-		// the wrong cause. The caller should check resp.FinishReason and
-		// resp.FinishMessage. See [FinishReason.isAbnormal].
-		if resp.FinishReason.isAbnormal() {
+		// Two responses have no conforming output to extract: one that ended
+		// abnormally, whose FinishReason is the news the caller needs, and one with
+		// no text at all, which is what a turn holding tool requests, interrupts, or
+		// media looks like. Both hand the response back unparsed rather than report a
+		// schema error naming the wrong cause. See [FinishReason.isAbnormal].
+		if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 			yield(&StreamValue[Out, Out]{Done: true, Response: resp}, nil)
 			return
 		}

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -1140,6 +1140,13 @@ func AsDataPrompt[In, Out any](p Prompt) *DataPrompt[In, Out] {
 // output schema, either through [DefineDataPrompt] or by using [WithOutputType] when defining the prompt.
 // The typed input argument fills the input slot last, so it wins over any
 // [WithInput] passed in opts.
+//
+// When generation ends abnormally (blocked, aborted, interrupted, other), the
+// output is the zero value of Out and no error is returned; check
+// resp.FinishReason and resp.FinishMessage to handle the outcome. This holds
+// for a string Out as well, whose text is on the response rather than the
+// returned value: text produced alongside an abnormal finish is a block
+// notice or a partial answer, not the completion the prompt asked for.
 func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...PromptExecuteOption) (Out, *ModelResponse, error) {
 	if dp == nil {
 		return base.Zero[Out](), nil, status.Errorf(status.ErrInvalidArgument, "DataPrompt.Execute: prompt is nil")
@@ -1149,6 +1156,14 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 	resp, err := dp.prompt.Execute(ctx, allOpts...)
 	if err != nil {
 		return base.Zero[Out](), nil, err
+	}
+
+	// A response that ended abnormally carries no conforming output, so return
+	// it unparsed rather than reporting a schema error that names the wrong
+	// cause. The caller should check resp.FinishReason and resp.FinishMessage.
+	// See [FinishReason.isAbnormal].
+	if resp.FinishReason.isAbnormal() {
+		return base.Zero[Out](), resp, nil
 	}
 
 	output, err := extractTypedOutput[Out](resp)
@@ -1174,6 +1189,10 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 // output schema, either through [DefineDataPrompt] or by using [WithOutputType] when defining the prompt.
 // The typed input argument fills the input slot last, so it wins over any
 // [WithInput] passed in opts.
+//
+// Like [DataPrompt.Execute], a generation that ends abnormally (blocked,
+// aborted, interrupted, other) yields zero-value Output and no error; check
+// Response.FinishReason and Response.FinishMessage to handle the outcome.
 func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts ...PromptExecuteOption) iter.Seq2[*StreamValue[Out, Out], error] {
 	return func(yield func(*StreamValue[Out, Out], error) bool) {
 		if dp == nil {
@@ -1216,6 +1235,15 @@ func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts
 		}
 		if err != nil {
 			yield(nil, err)
+			return
+		}
+
+		// A response that ended abnormally carries no conforming output, so
+		// return it unparsed rather than reporting a schema error that names
+		// the wrong cause. The caller should check resp.FinishReason and
+		// resp.FinishMessage. See [FinishReason.isAbnormal].
+		if resp.FinishReason.isAbnormal() {
+			yield(&StreamValue[Out, Out]{Done: true, Response: resp}, nil)
 			return
 		}
 

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -1141,16 +1141,19 @@ func AsDataPrompt[In, Out any](p Prompt) *DataPrompt[In, Out] {
 // The typed input argument fills the input slot last, so it wins over any
 // [WithInput] passed in opts.
 //
-// The output is the zero value of Out and no error is returned in two cases:
-// generation ended abnormally (blocked, aborted, interrupted, other), or the
-// response carried no text to parse, which is what a turn holding tool
-// requests, interrupts, or media looks like. Check resp.FinishReason,
-// resp.Interrupts(), and resp.ToolRequests() to handle them.
+// A refusal is an error: when the response finished blocked, the output is the
+// zero value of Out and the error is [ErrGenerationBlocked], carrying the
+// provider's explanation. The response is still returned alongside it.
 //
-// The abnormal-finish rule holds for a string Out as well, whose text is on
-// the response rather than the returned value: text produced alongside an
-// abnormal finish is a block notice or a partial answer, not the completion
-// the prompt asked for.
+// The output is the zero value of Out with no error in two other cases:
+// generation ended aborted, interrupted, or other, or the response carried no
+// text to parse, which is what a turn holding tool requests, interrupts, or
+// media looks like. Check resp.FinishReason, resp.Interrupts(), and
+// resp.ToolRequests() to handle them.
+//
+// This holds for a string Out as well, whose text is on the response rather
+// than the returned value: text produced alongside an abnormal finish is a
+// block notice or a partial answer, not the completion the prompt asked for.
 func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...PromptExecuteOption) (Out, *ModelResponse, error) {
 	if dp == nil {
 		return base.Zero[Out](), nil, status.Errorf(status.ErrInvalidArgument, "DataPrompt.Execute: prompt is nil")
@@ -1162,11 +1165,17 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 		return base.Zero[Out](), nil, err
 	}
 
-	// Two responses have no conforming output to extract: one that ended
-	// abnormally, whose FinishReason is the news the caller needs, and one with
-	// no text at all, which is what a turn holding tool requests, interrupts, or
-	// media looks like. Both hand the response back unparsed rather than report a
-	// schema error naming the wrong cause. See [FinishReason.isAbnormal].
+	// A refusal cannot produce the value this helper promises, so it is
+	// reported rather than handed back as a zero value that reads as success.
+	// [Generate] still returns the response unwrapped.
+	if resp.FinishReason == FinishReasonBlocked {
+		return base.Zero[Out](), resp, blockedError(resp)
+	}
+
+	// The remaining abnormal finishes, and a response with no text at all
+	// (what a turn holding tool requests, interrupts, or media looks like), have
+	// nothing to extract but are not failures. The response goes back unparsed
+	// rather than as a schema error naming the wrong cause.
 	if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 		return base.Zero[Out](), resp, nil
 	}
@@ -1195,10 +1204,13 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 // The typed input argument fills the input slot last, so it wins over any
 // [WithInput] passed in opts.
 //
-// Like [DataPrompt.Execute], a generation that ends abnormally (blocked,
-// aborted, interrupted, other) or carries no text to parse yields zero-value
-// Output and no error; check Response.FinishReason, Response.Interrupts(), and
-// Response.ToolRequests() to handle those.
+// Like [DataPrompt.Execute], a blocked response fails with
+// [ErrGenerationBlocked], while one that ends aborted, interrupted, or other,
+// or carries no text to parse, yields zero-value Output and no error; check
+// Response.FinishReason, Response.Interrupts(), and Response.ToolRequests().
+//
+// Chunks are provisional, for the reason given on [GenerateDataStream]: the
+// Done value is the authoritative one.
 func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts ...PromptExecuteOption) iter.Seq2[*StreamValue[Out, Out], error] {
 	return func(yield func(*StreamValue[Out, Out], error) bool) {
 		if dp == nil {
@@ -1244,11 +1256,18 @@ func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts
 			return
 		}
 
-		// Two responses have no conforming output to extract: one that ended
-		// abnormally, whose FinishReason is the news the caller needs, and one with
-		// no text at all, which is what a turn holding tool requests, interrupts, or
-		// media looks like. Both hand the response back unparsed rather than report a
-		// schema error naming the wrong cause. See [FinishReason.isAbnormal].
+		// A refusal cannot produce the value this helper promises, so it is
+		// reported rather than handed back as a zero value that reads as success.
+		// [Generate] still returns the response unwrapped.
+		if resp.FinishReason == FinishReasonBlocked {
+			yield(nil, blockedError(resp))
+			return
+		}
+
+		// The remaining abnormal finishes, and a response with no text at all
+		// (what a turn holding tool requests, interrupts, or media looks like), have
+		// nothing to extract but are not failures. The response goes back unparsed
+		// rather than as a schema error naming the wrong cause.
 		if resp.FinishReason.isAbnormal() || resp.Text() == "" {
 			yield(&StreamValue[Out, Out]{Done: true, Response: resp}, nil)
 			return

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -1934,6 +1934,188 @@ func TestDataPromptExecute(t *testing.T) {
 	})
 }
 
+// TestDataPromptAbnormalFinish verifies that DataPrompt.Execute and
+// DataPrompt.ExecuteStream apply the same abnormal-finish rule as Generate and
+// GenerateData: a response that ended blocked, aborted, interrupted, or other
+// is handed back unparsed so the caller reads the finish reason, instead of
+// being reported as a parse failure that names the wrong cause.
+func TestDataPromptAbnormalFinish(t *testing.T) {
+	r := registry.New()
+	ConfigureFormats(r)
+	DefineGenerateAction(context.Background(), r)
+
+	type Query struct {
+		Topic string `json:"topic"`
+	}
+
+	type Report struct {
+		Title string `json:"title"`
+		Score int    `json:"score"`
+	}
+
+	tests := []struct {
+		name     string
+		response *ModelResponse
+		wantData *Report
+		wantErr  bool
+	}{
+		{
+			// The common path: a provider reports a safety block and returns
+			// prose explaining it, with no middleware involved.
+			name: "blocked with explanatory text",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonBlocked,
+				FinishMessage: "blocked by safety settings",
+				Message:       NewModelTextMessage("Response was blocked for safety reasons."),
+			},
+		},
+		{
+			name: "blocked with no content",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonBlocked,
+				FinishMessage: "blocked by safety settings",
+				Message:       &Message{Role: RoleModel},
+			},
+		},
+		{
+			// What a soft-failing middleware produces when the provider is
+			// unreachable: an aborted response carrying the failure text.
+			name: "aborted with failure text",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonAborted,
+				FinishMessage: "provider down",
+				Message:       NewModelTextMessage("Error: provider down"),
+			},
+		},
+		{
+			name: "other with filter details",
+			response: &ModelResponse{
+				FinishReason:  FinishReasonOther,
+				FinishMessage: "malformed function call",
+				Message:       NewModelTextMessage("filter details, not JSON"),
+			},
+		},
+		{
+			// A normal completion still parses: the fix must not turn every
+			// parse failure into a silent zero value.
+			name: "stop with non-conforming text still fails parsing",
+			response: &ModelResponse{
+				FinishReason: FinishReasonStop,
+				Message:      NewModelTextMessage("not json at all"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "stop with conforming text parses",
+			response: &ModelResponse{
+				FinishReason: FinishReasonStop,
+				Message:      NewModelTextMessage(`{"title":"ok","score":7}`),
+			},
+			wantData: &Report{Title: "ok", Score: 7},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := defineModel(r, fmt.Sprintf("test/promptAbnormalFinish%d", i), &ModelOptions{
+				Supports: &ModelSupports{Multiturn: true, Constrained: ConstrainedSupportAll},
+			}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+				resp := *tt.response
+				resp.Request = req
+				return &resp, nil
+			})
+			structPrompt := DefineDataPrompt[Query, Report](r, fmt.Sprintf("abnormalFinishStruct%d", i),
+				WithModel(model), WithPrompt("Report on {{topic}}"))
+			input := Query{Topic: "widgets"}
+
+			want := Report{}
+			if tt.wantData != nil {
+				want = *tt.wantData
+			}
+
+			t.Run("Execute", func(t *testing.T) {
+				output, resp, err := structPrompt.Execute(context.Background(), input)
+				if tt.wantErr {
+					if err == nil {
+						t.Fatalf("Execute() err = nil, want a parse failure")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("Execute() returned error for %q response: %v", tt.response.FinishReason, err)
+				}
+				checkResponse(t, resp, tt.response)
+				if output != want {
+					t.Errorf("Execute() output = %+v, want %+v", output, want)
+				}
+			})
+
+			t.Run("ExecuteStream", func(t *testing.T) {
+				var (
+					final *StreamValue[Report, Report]
+					err   error
+				)
+				for v, streamErr := range structPrompt.ExecuteStream(context.Background(), input) {
+					if streamErr != nil {
+						err = streamErr
+						break
+					}
+					if v.Done {
+						final = v
+					}
+				}
+				if tt.wantErr {
+					if err == nil {
+						t.Fatalf("ExecuteStream() err = nil, want a parse failure")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("ExecuteStream() returned error for %q response: %v", tt.response.FinishReason, err)
+				}
+				if final == nil {
+					t.Fatal("ExecuteStream() never yielded a done value")
+				}
+				checkResponse(t, final.Response, tt.response)
+				if final.Output != want {
+					t.Errorf("ExecuteStream() output = %+v, want %+v", final.Output, want)
+				}
+			})
+		})
+	}
+
+	// A string Out has no schema to violate, so it never produced a parse
+	// error. It follows the same rule anyway: text emitted alongside an
+	// abnormal finish is a block notice or a partial answer, not the
+	// completion the prompt asked for, so it stays on the response instead of
+	// being returned as the value.
+	t.Run("string output withholds text on abnormal finish", func(t *testing.T) {
+		blocked := &ModelResponse{
+			FinishReason:  FinishReasonBlocked,
+			FinishMessage: "blocked by safety settings",
+			Message:       NewModelTextMessage("Response was blocked for safety reasons."),
+		}
+		model := defineModel(r, "test/promptAbnormalFinishString", &ModelOptions{
+			Supports: &ModelSupports{Multiturn: true},
+		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			resp := *blocked
+			resp.Request = req
+			return &resp, nil
+		})
+		stringPrompt := DefineDataPrompt[Query, string](r, "abnormalFinishString",
+			WithModel(model), WithPrompt("Report on {{topic}}"))
+
+		output, resp, err := stringPrompt.Execute(context.Background(), Query{Topic: "widgets"})
+		if err != nil {
+			t.Fatalf("Execute() returned error: %v", err)
+		}
+		checkResponse(t, resp, blocked)
+		if output != "" {
+			t.Errorf("Execute() output = %q, want empty", output)
+		}
+	})
+}
+
 func TestDataPromptExecuteStream(t *testing.T) {
 	r := registry.New()
 	ConfigureFormats(r)

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -2116,6 +2116,98 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 	})
 }
 
+// TestDataPromptNoTextOutput verifies that a normally-finished response with
+// no text to parse (a turn holding only tool requests, which is what
+// WithReturnToolRequests asks for) yields the zero value and no error, the same
+// answer GenerateData gives. Parsing it would report a schema failure for a
+// turn that succeeded.
+func TestDataPromptNoTextOutput(t *testing.T) {
+	r := registry.New()
+	ConfigureFormats(r)
+	DefineGenerateAction(context.Background(), r)
+
+	type Query struct {
+		Topic string `json:"topic"`
+	}
+
+	type Report struct {
+		Title string `json:"title"`
+		Score int    `json:"score"`
+	}
+
+	tool := defineTool(r, "noTextTool", "returns a fact",
+		func(ctx *ToolContext, input struct{}) (string, error) { return "fact", nil })
+
+	model := defineModel(r, "test/promptNoText", &ModelOptions{
+		Supports: &ModelSupports{Multiturn: true, Tools: true, Constrained: ConstrainedSupportAll},
+	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+		return &ModelResponse{
+			Request:      req,
+			FinishReason: FinishReasonStop,
+			Message: &Message{Role: RoleModel, Content: []*Part{
+				NewToolRequestPart(&ToolRequest{Name: "noTextTool", Input: map[string]any{}}),
+			}},
+		}, nil
+	})
+
+	dp := DefineDataPrompt[Query, Report](r, "noTextPrompt",
+		WithModel(model),
+		WithPrompt("Report on {{topic}}"),
+		WithTools(tool),
+		WithReturnToolRequests(true))
+	input := Query{Topic: "widgets"}
+
+	checkToolRequestOnly := func(t *testing.T, resp *ModelResponse) {
+		t.Helper()
+		if resp == nil {
+			t.Fatal("response = nil, want the model response")
+		}
+		if resp.Text() != "" {
+			t.Errorf("Text() = %q, want empty", resp.Text())
+		}
+		if len(resp.ToolRequests()) != 1 {
+			t.Errorf("ToolRequests() = %d, want 1", len(resp.ToolRequests()))
+		}
+	}
+
+	t.Run("Execute", func(t *testing.T) {
+		output, resp, err := dp.Execute(context.Background(), input)
+		if err != nil {
+			t.Fatalf("Execute() returned error: %v", err)
+		}
+		checkToolRequestOnly(t, resp)
+		if output != (Report{}) {
+			t.Errorf("Execute() output = %+v, want zero value", output)
+		}
+	})
+
+	t.Run("ExecuteStream", func(t *testing.T) {
+		var (
+			final *StreamValue[Report, Report]
+			err   error
+		)
+		for v, streamErr := range dp.ExecuteStream(context.Background(), input) {
+			if streamErr != nil {
+				err = streamErr
+				break
+			}
+			if v.Done {
+				final = v
+			}
+		}
+		if err != nil {
+			t.Fatalf("ExecuteStream() returned error: %v", err)
+		}
+		if final == nil {
+			t.Fatal("ExecuteStream() never yielded a done value")
+		}
+		checkToolRequestOnly(t, final.Response)
+		if final.Output != (Report{}) {
+			t.Errorf("ExecuteStream() output = %+v, want zero value", final.Output)
+		}
+	})
+}
+
 func TestDataPromptExecuteStream(t *testing.T) {
 	r := registry.New()
 	ConfigureFormats(r)

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -1957,17 +1957,22 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 		name     string
 		response *ModelResponse
 		wantData *Report
-		wantErr  bool
+		wantErr  error
+		// wantParseErr marks a plain parse failure, which carries no sentinel.
+		wantParseErr bool
 	}{
 		{
 			// The common path: a provider reports a safety block and returns
-			// prose explaining it, with no middleware involved.
+			// prose explaining it, with no middleware involved. A refusal
+			// cannot produce a Report, so it is an error rather than a zero
+			// value the caller would read as success.
 			name: "blocked with explanatory text",
 			response: &ModelResponse{
 				FinishReason:  FinishReasonBlocked,
 				FinishMessage: "blocked by safety settings",
 				Message:       NewModelTextMessage("Response was blocked for safety reasons."),
 			},
+			wantErr: ErrGenerationBlocked,
 		},
 		{
 			name: "blocked with no content",
@@ -1976,6 +1981,7 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 				FinishMessage: "blocked by safety settings",
 				Message:       &Message{Role: RoleModel},
 			},
+			wantErr: ErrGenerationBlocked,
 		},
 		{
 			// What a soft-failing middleware produces when the provider is
@@ -2003,7 +2009,7 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 				FinishReason: FinishReasonStop,
 				Message:      NewModelTextMessage("not json at all"),
 			},
-			wantErr: true,
+			wantParseErr: true,
 		},
 		{
 			name: "stop with conforming text parses",
@@ -2035,10 +2041,20 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 
 			t.Run("Execute", func(t *testing.T) {
 				output, resp, err := structPrompt.Execute(context.Background(), input)
-				if tt.wantErr {
+				if tt.wantParseErr {
 					if err == nil {
 						t.Fatalf("Execute() err = nil, want a parse failure")
 					}
+					return
+				}
+				if tt.wantErr != nil {
+					if !errors.Is(err, tt.wantErr) {
+						t.Fatalf("Execute() err = %v, want %v", err, tt.wantErr)
+					}
+					if !strings.Contains(err.Error(), tt.response.FinishMessage) {
+						t.Errorf("Execute() err = %v, want it to carry %q", err, tt.response.FinishMessage)
+					}
+					checkResponse(t, resp, tt.response)
 					return
 				}
 				if err != nil {
@@ -2064,9 +2080,15 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 						final = v
 					}
 				}
-				if tt.wantErr {
+				if tt.wantParseErr {
 					if err == nil {
 						t.Fatalf("ExecuteStream() err = nil, want a parse failure")
+					}
+					return
+				}
+				if tt.wantErr != nil {
+					if !errors.Is(err, tt.wantErr) {
+						t.Fatalf("ExecuteStream() err = %v, want %v", err, tt.wantErr)
 					}
 					return
 				}
@@ -2084,12 +2106,11 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 		})
 	}
 
-	// A string Out has no schema to violate, so it never produced a parse
-	// error. It follows the same rule anyway: text emitted alongside an
-	// abnormal finish is a block notice or a partial answer, not the
-	// completion the prompt asked for, so it stays on the response instead of
-	// being returned as the value.
-	t.Run("string output withholds text on abnormal finish", func(t *testing.T) {
+	// A string Out has no schema to violate, so a refusal used to come back as
+	// the answer. It reports the same error as every other Out: a block notice
+	// is not the completion the prompt asked for, and the notice itself stays
+	// on the response.
+	t.Run("string output reports a refusal", func(t *testing.T) {
 		blocked := &ModelResponse{
 			FinishReason:  FinishReasonBlocked,
 			FinishMessage: "blocked by safety settings",
@@ -2106,8 +2127,8 @@ func TestDataPromptAbnormalFinish(t *testing.T) {
 			WithModel(model), WithPrompt("Report on {{topic}}"))
 
 		output, resp, err := stringPrompt.Execute(context.Background(), Query{Topic: "widgets"})
-		if err != nil {
-			t.Fatalf("Execute() returned error: %v", err)
+		if !errors.Is(err, ErrGenerationBlocked) {
+			t.Fatalf("Execute() err = %v, want %v", err, ErrGenerationBlocked)
 		}
 		checkResponse(t, resp, blocked)
 		if output != "" {

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1433,6 +1433,11 @@ func GenerateText(ctx context.Context, g *Genkit, opts ...ai.GenerateOption) (st
 // list of available options. Note that output options like [ai.WithOutputType] are
 // automatically applied based on the Out type parameter.
 //
+// When the response carries no text output (tool requests or interrupts
+// instead), or generation ended abnormally (blocked, aborted, interrupted,
+// other), the typed output is nil and no error is returned. Check the returned
+// response's FinishReason, Interrupts() or ToolRequests() to handle those.
+//
 // Example:
 //
 //	type BookInfo struct {
@@ -1468,6 +1473,10 @@ func GenerateData[Out any](ctx context.Context, g *Genkit, opts ...ai.GenerateOp
 // GenerateDataStream accepts the same options as [Generate]. See [Generate] for the full
 // list of available options. Note that output options are automatically applied based on
 // the Out type parameter.
+//
+// Like [GenerateData], a response with no text output or one that ended
+// abnormally yields zero-value Output and no error; check Response.FinishReason,
+// Interrupts() or ToolRequests() to handle those.
 //
 // Example:
 //

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1433,10 +1433,11 @@ func GenerateText(ctx context.Context, g *Genkit, opts ...ai.GenerateOption) (st
 // list of available options. Note that output options like [ai.WithOutputType] are
 // automatically applied based on the Out type parameter.
 //
-// When the response carries no text output (tool requests or interrupts
-// instead), or generation ended abnormally (blocked, aborted, interrupted,
-// other), the typed output is nil and no error is returned. Check the returned
-// response's FinishReason, Interrupts() or ToolRequests() to handle those.
+// A refusal fails with [ai.ErrGenerationBlocked]. When the response carries no
+// text output (tool requests or interrupts instead), or generation ended
+// aborted, interrupted, or other, the typed output is nil and no error is
+// returned; check the returned response's FinishReason, Interrupts(), and
+// ToolRequests() to handle those.
 //
 // Example:
 //
@@ -1474,9 +1475,10 @@ func GenerateData[Out any](ctx context.Context, g *Genkit, opts ...ai.GenerateOp
 // list of available options. Note that output options are automatically applied based on
 // the Out type parameter.
 //
-// Like [GenerateData], a response with no text output or one that ended
-// abnormally yields zero-value Output and no error; check Response.FinishReason,
-// Interrupts() or ToolRequests() to handle those.
+// Like [GenerateData], a refusal fails with [ai.ErrGenerationBlocked], while a
+// response with no text output or one that ended aborted, interrupted, or
+// other yields zero-value Output and no error. Chunks are parsed before the
+// finish reason exists, so the Done value is the authoritative one.
 //
 // Example:
 //


### PR DESCRIPTION
`Generate` skips output parsing when a response finished `blocked`, `aborted`, `interrupted`, or `other`, so the caller reads the finish reason rather than a parse failure. The typed helpers did not: `GenerateData`, `GenerateDataStream`, `DataPrompt.Execute`, and `DataPrompt.ExecuteStream` parsed unconditionally, so a safety-blocked response came back as `data did not match expected schema: (root): Invalid type. Expected: object, given: null` while `resp.FinishReason` said `blocked`. `DataPrompt` also never had the no-text escape the generate helpers have, so a turn holding only tool requests, which is what `WithReturnToolRequests` asks for, failed the same way.

All four now share one guard. Skipping the parse is only half of it: handing back a nil value with a nil error reads as success, and the `DefineDataPrompt` example in `genkit.go` does exactly that, printing an empty capital for a refusal it never sees. A refusal is now an error.

```go
// Added
ai.ErrGenerationBlocked = status.ErrFailedPrecondition.Subtype("generation blocked")
```

The typed helpers return it when `FinishReason` is `blocked`, carrying the provider's `FinishMessage`, with the response alongside it. FAILED_PRECONDITION is the status JS `GenerationResponseError` defaults to, so a refusal reports the same way in both; Python does the same in #6100.

Everything else that yields nothing to extract keeps a nil output and a nil error, since none of it is a failure: interrupts, tool requests, no text at all, and the `aborted` and `other` finishes. For those a string `Out` now leaves the text on `resp.Text()` rather than returning it as the answer. `Generate` is unchanged and still hands a blocked response back as a value. Matching JS `assertValid` there would touch every existing caller and belongs in its own PR.

**Streaming chunks are provisional.** They parse as they arrive, before any finish reason exists, so a generation that streams `{"title":"partial` and then blocks has already yielded a populated chunk. The terminal value settles it, and for a refusal that is now an error rather than a zeroed `Output`.
