### PR TITLE
fix(go): stop tool descriptions truncating at the first comma

### DIFF
--- a/go/genkit/doc.go
+++ b/go/genkit/doc.go
@@ -222,8 +222,8 @@ Generate structured data that conforms to Go types using [GenerateData] or
 constraints that help the model understand the expected output:
 
 	type Joke struct {
-		Joke     string `json:"joke" jsonschema:"description=The joke text"`
-		Category string `json:"category" jsonschema:"description=The joke category"`
+		Joke     string `json:"joke" jsonschema_description:"The joke text"`
+		Category string `json:"category" jsonschema_description:"The joke category"`
 	}
 
 	joke, resp, err := genkit.GenerateData[*Joke](ctx, g,

--- a/go/genkit/example_test.go
+++ b/go/genkit/example_test.go
@@ -152,8 +152,8 @@ func ExampleDefineTool() {
 	_ = genkit.DefineTool(g, "add",
 		"Adds two numbers together",
 		func(ctx *ai.ToolContext, input struct {
-			A float64 `json:"a" jsonschema:"description=First number"`
-			B float64 `json:"b" jsonschema:"description=Second number"`
+			A float64 `json:"a" jsonschema_description:"First number"`
+			B float64 `json:"b" jsonschema_description:"Second number"`
 		}) (float64, error) {
 			return input.A + input.B, nil
 		},
@@ -195,8 +195,8 @@ func ExampleDefineSchemasFor() {
 
 	// Define a struct type
 	type Person struct {
-		Name string `json:"name" jsonschema:"description=The person's name"`
-		Age  int    `json:"age" jsonschema:"description=The person's age"`
+		Name string `json:"name" jsonschema_description:"The person's name"`
+		Age  int    `json:"age" jsonschema_description:"The person's age"`
 	}
 
 	// Register the schema - this makes it available for .prompt files

--- a/go/genkit/exp/tools.go
+++ b/go/genkit/exp/tools.go
@@ -41,7 +41,7 @@ import (
 // Example:
 //
 //	type WeatherInput struct {
-//		City string `json:"city" jsonschema:"description=city name"`
+//		City string `json:"city" jsonschema_description:"city name"`
 //	}
 //
 //	weatherTool := exp.DefineTool(g, "getWeather", "Fetches the weather for a given city",

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -205,7 +205,7 @@ func (a *Agents) New(ctx context.Context) (*ai.Hooks, error) {
 
 // delegateInput is the input schema for a delegation tool.
 type delegateInput struct {
-	Task string `json:"task" jsonschema:"description=A clear, self-contained description of the task to delegate."`
+	Task string `json:"task" jsonschema_description:"A clear, self-contained description of the task to delegate."`
 }
 
 // delegationResult is the output of a delegation tool.

--- a/go/plugins/middleware/exp/artifacts.go
+++ b/go/plugins/middleware/exp/artifacts.go
@@ -97,7 +97,7 @@ func (a *Artifacts) New(ctx context.Context) (*ai.Hooks, error) {
 }
 
 type readArtifactInput struct {
-	Name string `json:"name" jsonschema:"description=The name of the artifact to read."`
+	Name string `json:"name" jsonschema_description:"The name of the artifact to read."`
 }
 
 type readArtifactOutput struct {
@@ -125,8 +125,8 @@ func newReadArtifactTool() ai.Tool {
 }
 
 type writeArtifactInput struct {
-	Name    string `json:"name" jsonschema:"description=A unique name for the artifact (e.g. a filename like report.md)."`
-	Content string `json:"content" jsonschema:"description=The full text content of the artifact."`
+	Name    string `json:"name" jsonschema_description:"A unique name for the artifact (e.g. a filename like report.md)."`
+	Content string `json:"content" jsonschema_description:"The full text content of the artifact."`
 }
 
 type writeArtifactOutput struct {

--- a/go/plugins/middleware/filesystem.go
+++ b/go/plugins/middleware/filesystem.go
@@ -311,8 +311,8 @@ func requireFilePath(s string) error {
 }
 
 type listFilesInput struct {
-	DirPath   string `json:"dirPath,omitempty" jsonschema:"description=Directory path relative to root. Defaults to the root directory."`
-	Recursive bool   `json:"recursive,omitempty" jsonschema:"description=If true, descend into subdirectories."`
+	DirPath   string `json:"dirPath,omitempty" jsonschema_description:"Directory path relative to root. Defaults to the root directory."`
+	Recursive bool   `json:"recursive,omitempty" jsonschema_description:"If true, descend into subdirectories."`
 }
 
 type fileEntry struct {
@@ -380,9 +380,9 @@ func (f *Filesystem) newListFilesTool(root *os.Root) ai.Tool {
 }
 
 type readFileInput struct {
-	FilePath string `json:"filePath" jsonschema:"description=File path relative to root."`
-	Offset   int    `json:"offset,omitempty" jsonschema:"description=1-indexed line to start reading from. 0 or 1 means start at the beginning."`
-	Limit    int    `json:"limit,omitempty" jsonschema:"description=Maximum number of lines to read. 0 means read to end of file."`
+	FilePath string `json:"filePath" jsonschema_description:"File path relative to root."`
+	Offset   int    `json:"offset,omitempty" jsonschema_description:"1-indexed line to start reading from. 0 or 1 means start at the beginning."`
+	Limit    int    `json:"limit,omitempty" jsonschema_description:"Maximum number of lines to read. 0 means read to end of file."`
 }
 
 func (f *Filesystem) newReadFileTool(
@@ -554,8 +554,8 @@ func sliceLines(data []byte, offset, limit int) []byte {
 }
 
 type writeFileInput struct {
-	FilePath string `json:"filePath" jsonschema:"description=File path relative to root."`
-	Content  string `json:"content" jsonschema:"description=Content to write to the file."`
+	FilePath string `json:"filePath" jsonschema_description:"File path relative to root."`
+	Content  string `json:"content" jsonschema_description:"Content to write to the file."`
 }
 
 func (f *Filesystem) newWriteFileTool(
@@ -610,14 +610,14 @@ func (f *Filesystem) newWriteFileTool(
 }
 
 type editSpec struct {
-	OldString  string `json:"oldString" jsonschema:"description=The exact text to find. Match is byte-for-byte including whitespace and indentation."`
-	NewString  string `json:"newString" jsonschema:"description=The replacement text. Use an empty string to delete oldString."`
-	ReplaceAll bool   `json:"replaceAll,omitempty" jsonschema:"description=If true, replace every occurrence of oldString. If false (default), oldString must match exactly once in the file."`
+	OldString  string `json:"oldString" jsonschema_description:"The exact text to find. Match is byte-for-byte including whitespace and indentation."`
+	NewString  string `json:"newString" jsonschema_description:"The replacement text. Use an empty string to delete oldString."`
+	ReplaceAll bool   `json:"replaceAll,omitempty" jsonschema_description:"If true, replace every occurrence of oldString. If false (default), oldString must match exactly once in the file."`
 }
 
 type editFileInput struct {
-	FilePath string     `json:"filePath" jsonschema:"description=File path relative to root."`
-	Edits    []editSpec `json:"edits" jsonschema:"description=One or more edits to apply in order. Each edit is applied to the result of the previous edit."`
+	FilePath string     `json:"filePath" jsonschema_description:"File path relative to root."`
+	Edits    []editSpec `json:"edits" jsonschema_description:"One or more edits to apply in order. Each edit is applied to the result of the previous edit."`
 }
 
 func (f *Filesystem) newEditFileTool(

--- a/go/plugins/middleware/skills.go
+++ b/go/plugins/middleware/skills.go
@@ -104,7 +104,7 @@ func (s *Skills) New(ctx context.Context) (*ai.Hooks, error) {
 		useSkillToolName,
 		"Use a skill by its name.",
 		func(_ *ai.ToolContext, in struct {
-			SkillName string `json:"skillName" jsonschema:"description=The name of the skill to use."`
+			SkillName string `json:"skillName" jsonschema_description:"The name of the skill to use."`
 		}) (string, error) {
 			si, ok := info[in.SkillName]
 			if !ok {

--- a/go/samples/anthropic/main.go
+++ b/go/samples/anthropic/main.go
@@ -59,7 +59,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/basic-agents/banker.go
+++ b/go/samples/basic-agents/banker.go
@@ -45,8 +45,8 @@ import (
 // TransferInput and TransferOutput are the tool's contract: the JSON
 // schemas inferred from these field names are what the model sees.
 type TransferInput struct {
-	ToAccount string  `json:"toAccount" jsonschema:"description=destination account ID"`
-	Amount    float64 `json:"amount" jsonschema:"description=amount in dollars (e.g. 50.00 for $50)"`
+	ToAccount string  `json:"toAccount" jsonschema_description:"destination account ID"`
+	Amount    float64 `json:"amount" jsonschema_description:"amount in dollars (e.g. 50.00 for $50)"`
 }
 
 type TransferOutput struct {

--- a/go/samples/basic-agents/barista.go
+++ b/go/samples/basic-agents/barista.go
@@ -76,7 +76,7 @@ func defineBaristaAgent(g *genkit.Genkit) *aix.Agent[BaristaOrder] {
 	addToOrder := genkitx.DefineTool(g, "addToOrder",
 		"Records one drink the customer ordered. Call it every time they ask for a drink.",
 		func(ctx context.Context, in struct {
-			Drink string `json:"drink" jsonschema:"description=The drink to add e.g. flat white"`
+			Drink string `json:"drink" jsonschema_description:"The drink to add e.g. flat white"`
 		}) (string, error) {
 			sess := aix.SessionFromContext[BaristaOrder](ctx)
 			if sess == nil {

--- a/go/samples/basic-durable-streaming-exp/main.go
+++ b/go/samples/basic-durable-streaming-exp/main.go
@@ -74,7 +74,7 @@ type (
 	// pre-fills its form from. The default is not applied in transit, and a
 	// field without omitempty is required.
 	CountdownRequest struct {
-		Count int `json:"count" jsonschema:"description=How many seconds to count down from,default=5"`
+		Count int `json:"count" jsonschema:"default=5" jsonschema_description:"How many seconds to count down from"`
 	}
 
 	// CountdownChunk is one tick of the countdown. Chunks are what the manager

--- a/go/samples/basic-errors/main.go
+++ b/go/samples/basic-errors/main.go
@@ -86,12 +86,12 @@ type (
 	// empty string satisfies that, which is how the INVALID_ARGUMENT branch
 	// below is reached.
 	CookbookRequest struct {
-		Dish string `json:"dish" jsonschema:"description=A dish to look up in the cookbook,default=pancakes"`
+		Dish string `json:"dish" jsonschema:"default=pancakes" jsonschema_description:"A dish to look up in the cookbook"`
 	}
 
 	// ImproviseRequest is what improviseFlow takes.
 	ImproviseRequest struct {
-		Dish string `json:"dish" jsonschema:"description=The dish to cook,default=lasagna"`
+		Dish string `json:"dish" jsonschema:"default=lasagna" jsonschema_description:"The dish to cook"`
 	}
 )
 

--- a/go/samples/basic-formats/main.go
+++ b/go/samples/basic-formats/main.go
@@ -66,16 +66,16 @@ import (
 // StoryRequest is the input every flow here takes, so the format stays the
 // only difference between them.
 type StoryRequest struct {
-	Premise string `json:"premise" jsonschema:"description=The premise of the story,default=a lighthouse keeper who befriends a whale"`
+	Premise string `json:"premise" jsonschema:"default=a lighthouse keeper who befriends a whale" jsonschema_description:"The premise of the story"`
 }
 
 // Character is one invented character. The jsonschema tags describe the fields
 // to the model, which is what makes the generated values sensible.
 type Character struct {
-	Name       string `json:"name" jsonschema:"description=The character's name"`
-	Age        int    `json:"age" jsonschema:"description=The character's age in years"`
-	Hometown   string `json:"hometown" jsonschema:"description=Where the character grew up"`
-	Profession string `json:"profession" jsonschema:"description=What the character does for a living"`
+	Name       string `json:"name" jsonschema_description:"The character's name"`
+	Age        int    `json:"age" jsonschema_description:"The character's age in years"`
+	Hometown   string `json:"hometown" jsonschema_description:"Where the character grew up"`
+	Profession string `json:"profession" jsonschema_description:"What the character does for a living"`
 }
 
 // Rating is the set of labels the rating flow may answer with. Any string

--- a/go/samples/basic-media/main.go
+++ b/go/samples/basic-media/main.go
@@ -142,22 +142,22 @@ const pollInterval = 5 * time.Second
 type (
 	// DescribeRequest asks something about the picture.
 	DescribeRequest struct {
-		Question string `json:"question" jsonschema:"description=What to ask about the picture,default=What is in this picture?"`
+		Question string `json:"question" jsonschema:"default=What is in this picture?" jsonschema_description:"What to ask about the picture"`
 	}
 
 	// EditRequest says how to redraw the picture.
 	EditRequest struct {
-		Instruction string `json:"instruction" jsonschema:"description=How the picture should be changed,default=Redraw this as a watercolor painting."`
+		Instruction string `json:"instruction" jsonschema:"default=Redraw this as a watercolor painting." jsonschema_description:"How the picture should be changed"`
 	}
 
 	// DrawRequest describes a picture to make from nothing.
 	DrawRequest struct {
-		Description string `json:"description" jsonschema:"description=What to draw,default=a red panda reading a book in a library"`
+		Description string `json:"description" jsonschema:"default=a red panda reading a book in a library" jsonschema_description:"What to draw"`
 	}
 
 	// AnimateRequest says how the picture should move.
 	AnimateRequest struct {
-		Motion string `json:"motion" jsonschema:"description=How the picture should move,default=a slow drone push toward the ridge as clouds drift past"`
+		Motion string `json:"motion" jsonschema:"default=a slow drone push toward the ridge as clouds drift past" jsonschema_description:"How the picture should move"`
 	}
 )
 

--- a/go/samples/basic-middleware/filesystem/main.go
+++ b/go/samples/basic-middleware/filesystem/main.go
@@ -66,12 +66,12 @@ const workspaceDir = "./workspace"
 type (
 	// ExploreRequest asks a question about the workspace.
 	ExploreRequest struct {
-		Question string `json:"question" jsonschema:"description=A question about the project in workspace/,default=Summarise what this project does and what is still pending."`
+		Question string `json:"question" jsonschema:"default=Summarise what this project does and what is still pending." jsonschema_description:"A question about the project in workspace/"`
 	}
 
 	// EditRequest asks for a change to a file in the workspace.
 	EditRequest struct {
-		Instruction string `json:"instruction" jsonschema:"description=A change to make to a file in workspace/,default=Mark the in-memory response cache TODO as done."`
+		Instruction string `json:"instruction" jsonschema:"default=Mark the in-memory response cache TODO as done." jsonschema_description:"A change to make to a file in workspace/"`
 	}
 )
 

--- a/go/samples/basic-middleware/retry-fallback/main.go
+++ b/go/samples/basic-middleware/retry-fallback/main.go
@@ -63,7 +63,7 @@ import (
 // TopicRequest is what the flow takes. The field carries a description and a
 // default, which the Dev UI pre-fills its form from.
 type TopicRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What to explain,default=photosynthesis"`
+	Topic string `json:"topic" jsonschema:"default=photosynthesis" jsonschema_description:"What to explain"`
 }
 
 // model is the working model this sample falls back to. The primary model in

--- a/go/samples/basic-middleware/skills/main.go
+++ b/go/samples/basic-middleware/skills/main.go
@@ -66,7 +66,7 @@ const skillsDir = "./skills"
 // AskRequest is what the flow takes. A jsonschema tag is comma-delimited, so
 // the default holds no comma: one would silently truncate the value.
 type AskRequest struct {
-	Question string `json:"question" jsonschema:"description=What to ask,default=Explain how a rainbow forms in the voice of a pirate."`
+	Question string `json:"question" jsonschema:"default=Explain how a rainbow forms in the voice of a pirate." jsonschema_description:"What to ask"`
 }
 
 // model is shared by every flow below, so switching models or thinking levels

--- a/go/samples/basic-prompt-content/main.go
+++ b/go/samples/basic-prompt-content/main.go
@@ -68,18 +68,18 @@ const maxHistoryMessages = 6
 // SupportRequest is the prompt's input: the app's own shape, not a map. Every
 // content function below receives exactly this type, however it was called.
 type SupportRequest struct {
-	Area           string `json:"area" jsonschema:"description=The product area the question is about,enum=billing,enum=setup,enum=api,default=api"`
-	Tier           string `json:"tier" jsonschema:"description=The customer's support tier,enum=free,enum=pro,enum=enterprise,default=free"`
-	Question       string `json:"question" jsonschema:"description=The customer's question in their own words,default=Why was I charged twice this month?"`
-	Screenshot     string `json:"screenshot,omitempty" jsonschema:"description=Optional data: or https: URL of a screenshot the customer attached"`
-	ScreenshotType string `json:"screenshotType,omitempty" jsonschema:"description=Media type of the screenshot for example image/png"`
+	Area           string `json:"area" jsonschema:"enum=billing,enum=setup,enum=api,default=api" jsonschema_description:"The product area the question is about"`
+	Tier           string `json:"tier" jsonschema:"enum=free,enum=pro,enum=enterprise,default=free" jsonschema_description:"The customer's support tier"`
+	Question       string `json:"question" jsonschema:"default=Why was I charged twice this month?" jsonschema_description:"The customer's question in their own words"`
+	Screenshot     string `json:"screenshot,omitempty" jsonschema_description:"Optional data: or https: URL of a screenshot the customer attached"`
+	ScreenshotType string `json:"screenshotType,omitempty" jsonschema_description:"Media type of the screenshot for example image/png"`
 }
 
 // Turn is one exchange in the conversation the client keeps. A real app would
 // read these from a session or a database.
 type Turn struct {
-	Role string `json:"role" jsonschema:"description=Who said it,enum=user,enum=model"`
-	Text string `json:"text" jsonschema:"description=What was said"`
+	Role string `json:"role" jsonschema:"enum=user,enum=model" jsonschema_description:"Who said it"`
+	Text string `json:"text" jsonschema_description:"What was said"`
 }
 
 // SupportTicket is what the flows receive. The conversation is separate from
@@ -87,14 +87,14 @@ type Turn struct {
 // {{history}} in a template or through [ai.HistoryFromContext] in a function.
 type SupportTicket struct {
 	Request SupportRequest `json:"request"`
-	History []Turn         `json:"history,omitempty" jsonschema:"description=The conversation so far oldest first"`
+	History []Turn         `json:"history,omitempty" jsonschema_description:"The conversation so far oldest first"`
 }
 
 // Triage is the structured verdict the triage prompt returns.
 type Triage struct {
 	Category string `json:"category" jsonschema:"enum=bug,enum=how-to,enum=billing,enum=other"`
 	Urgency  string `json:"urgency" jsonschema:"enum=low,enum=medium,enum=high"`
-	Summary  string `json:"summary" jsonschema:"description=One sentence restating the customer's problem"`
+	Summary  string `json:"summary" jsonschema_description:"One sentence restating the customer's problem"`
 }
 
 // knowledgeBase stands in for a retriever.

--- a/go/samples/basic-prompts/main.go
+++ b/go/samples/basic-prompts/main.go
@@ -74,61 +74,61 @@ import (
 var promptsFS embed.FS
 
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 type Joke struct {
-	Joke     string `json:"joke" jsonschema:"description=The joke text"`
-	Category string `json:"category" jsonschema:"description=The joke category"`
+	Joke     string `json:"joke" jsonschema_description:"The joke text"`
+	Category string `json:"category" jsonschema_description:"The joke category"`
 }
 
 // A jsonschema "default" is form fill for the Dev UI, not a value applied on
 // the way through: every field here without omitempty is required.
 type RecipeRequest struct {
-	Dish                string   `json:"dish" jsonschema:"description=The dish to cook,default=pasta"`
-	Cuisine             string   `json:"cuisine" jsonschema:"description=The cuisine to cook it in,default=Italian"`
-	ServingSize         int      `json:"servingSize" jsonschema:"description=How many people it should feed,default=4"`
-	MaxPrepMinutes      int      `json:"maxPrepMinutes" jsonschema:"description=The longest the recipe may take to prepare,default=30"`
-	DietaryRestrictions []string `json:"dietaryRestrictions,omitempty" jsonschema:"description=Any dietary restrictions to respect"`
+	Dish                string   `json:"dish" jsonschema:"default=pasta" jsonschema_description:"The dish to cook"`
+	Cuisine             string   `json:"cuisine" jsonschema:"default=Italian" jsonschema_description:"The cuisine to cook it in"`
+	ServingSize         int      `json:"servingSize" jsonschema:"default=4" jsonschema_description:"How many people it should feed"`
+	MaxPrepMinutes      int      `json:"maxPrepMinutes" jsonschema:"default=30" jsonschema_description:"The longest the recipe may take to prepare"`
+	DietaryRestrictions []string `json:"dietaryRestrictions,omitempty" jsonschema_description:"Any dietary restrictions to respect"`
 }
 
 type Ingredient struct {
-	Name     string `json:"name" jsonschema:"description=The ingredient name"`
-	Amount   string `json:"amount" jsonschema:"description=The ingredient amount (e.g. 1 cup, 2 tablespoons, etc.)"`
-	Optional bool   `json:"optional,omitempty" jsonschema:"description=Whether the ingredient is optional in the recipe"`
+	Name     string `json:"name" jsonschema_description:"The ingredient name"`
+	Amount   string `json:"amount" jsonschema_description:"The ingredient amount (e.g. 1 cup, 2 tablespoons, etc.)"`
+	Optional bool   `json:"optional,omitempty" jsonschema_description:"Whether the ingredient is optional in the recipe"`
 }
 
 type Recipe struct {
-	Title        string       `json:"title" jsonschema:"description=The recipe title (e.g. 'Spicy Chicken Tacos')"`
-	Description  string       `json:"description,omitempty" jsonschema:"description=The recipe description (under 100 characters)"`
-	Ingredients  []Ingredient `json:"ingredients" jsonschema:"description=The recipe ingredients (group by type and order by importance)"`
-	Instructions []string     `json:"instructions" jsonschema:"description=The recipe instructions (step by step)"`
-	PrepTime     string       `json:"prepTime" jsonschema:"description=The recipe preparation time (e.g. 10 minutes, 30 minutes, etc.)"`
+	Title        string       `json:"title" jsonschema_description:"The recipe title (e.g. 'Spicy Chicken Tacos')"`
+	Description  string       `json:"description,omitempty" jsonschema_description:"The recipe description (under 100 characters)"`
+	Ingredients  []Ingredient `json:"ingredients" jsonschema_description:"The recipe ingredients (group by type and order by importance)"`
+	Instructions []string     `json:"instructions" jsonschema_description:"The recipe instructions (step by step)"`
+	PrepTime     string       `json:"prepTime" jsonschema_description:"The recipe preparation time (e.g. 10 minutes, 30 minutes, etc.)"`
 	Difficulty   string       `json:"difficulty" jsonschema:"enum=easy,enum=medium,enum=hard"`
 }
 
 type AssistantRequest struct {
-	Query string `json:"query" jsonschema:"description=The user's query or request,default=what files are in my current directory?"`
+	Query string `json:"query" jsonschema:"default=what files are in my current directory?" jsonschema_description:"The user's query or request"`
 }
 
 // ChatRequest is the chat prompt's input: just the new question. The
 // conversation is deliberately not in here, since it is passed to Execute and
 // placed by the prompt itself.
 type ChatRequest struct {
-	Question string `json:"question" jsonschema:"description=The new question to answer,default=What did I just ask you?"`
+	Question string `json:"question" jsonschema:"default=What did I just ask you?" jsonschema_description:"The new question to answer"`
 }
 
 // ChatTurn is one exchange in the conversation the client keeps.
 type ChatTurn struct {
-	Role string `json:"role" jsonschema:"description=Who said it,enum=user,enum=model"`
-	Text string `json:"text" jsonschema:"description=What was said"`
+	Role string `json:"role" jsonschema:"enum=user,enum=model" jsonschema_description:"Who said it"`
+	Text string `json:"text" jsonschema_description:"What was said"`
 }
 
 // ChatSession is what the chat flows receive: the new question plus the
 // conversation it continues.
 type ChatSession struct {
-	Question string     `json:"question" jsonschema:"description=The new question to answer,default=What did I just ask you?"`
-	History  []ChatTurn `json:"history,omitempty" jsonschema:"description=The conversation so far oldest first"`
+	Question string     `json:"question" jsonschema:"default=What did I just ask you?" jsonschema_description:"The new question to answer"`
+	History  []ChatTurn `json:"history,omitempty" jsonschema_description:"The conversation so far oldest first"`
 }
 
 // model is shared by every flow below, so switching models or thinking levels

--- a/go/samples/basic-structured/main.go
+++ b/go/samples/basic-structured/main.go
@@ -59,36 +59,36 @@ import (
 )
 
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 type Joke struct {
-	Joke     string `json:"joke" jsonschema:"description=The joke text"`
-	Category string `json:"category" jsonschema:"description=The joke category"`
+	Joke     string `json:"joke" jsonschema_description:"The joke text"`
+	Category string `json:"category" jsonschema_description:"The joke category"`
 }
 
 // A jsonschema "default" is form fill for the Dev UI, not a value applied on
 // the way through: every field here without omitempty is required.
 type RecipeRequest struct {
-	Dish                string   `json:"dish" jsonschema:"description=The dish to cook,default=pasta"`
-	Cuisine             string   `json:"cuisine" jsonschema:"description=The cuisine to cook it in,default=Italian"`
-	ServingSize         int      `json:"servingSize" jsonschema:"description=How many people it should feed,default=4"`
-	MaxPrepMinutes      int      `json:"maxPrepMinutes" jsonschema:"description=The longest the recipe may take to prepare,default=30"`
-	DietaryRestrictions []string `json:"dietaryRestrictions,omitempty" jsonschema:"description=Any dietary restrictions to respect"`
+	Dish                string   `json:"dish" jsonschema:"default=pasta" jsonschema_description:"The dish to cook"`
+	Cuisine             string   `json:"cuisine" jsonschema:"default=Italian" jsonschema_description:"The cuisine to cook it in"`
+	ServingSize         int      `json:"servingSize" jsonschema:"default=4" jsonschema_description:"How many people it should feed"`
+	MaxPrepMinutes      int      `json:"maxPrepMinutes" jsonschema:"default=30" jsonschema_description:"The longest the recipe may take to prepare"`
+	DietaryRestrictions []string `json:"dietaryRestrictions,omitempty" jsonschema_description:"Any dietary restrictions to respect"`
 }
 
 type Ingredient struct {
-	Name     string `json:"name" jsonschema:"description=The ingredient name"`
-	Amount   string `json:"amount" jsonschema:"description=The ingredient amount (e.g. 1 cup, 2 tablespoons, etc.)"`
-	Optional bool   `json:"optional,omitempty" jsonschema:"description=Whether the ingredient is optional in the recipe"`
+	Name     string `json:"name" jsonschema_description:"The ingredient name"`
+	Amount   string `json:"amount" jsonschema_description:"The ingredient amount (e.g. 1 cup, 2 tablespoons, etc.)"`
+	Optional bool   `json:"optional,omitempty" jsonschema_description:"Whether the ingredient is optional in the recipe"`
 }
 
 type Recipe struct {
-	Title        string       `json:"title" jsonschema:"description=The recipe title (e.g. 'Spicy Chicken Tacos')"`
-	Description  string       `json:"description,omitempty" jsonschema:"description=The recipe description (under 100 characters)"`
-	Ingredients  []Ingredient `json:"ingredients" jsonschema:"description=The recipe ingredients (order by type first and then importance)"`
-	Instructions []string     `json:"instructions" jsonschema:"description=The recipe instructions (step by step)"`
-	PrepTime     string       `json:"prepTime" jsonschema:"description=The recipe preparation time (e.g. 10 minutes, 30 minutes, etc.)"`
+	Title        string       `json:"title" jsonschema_description:"The recipe title (e.g. 'Spicy Chicken Tacos')"`
+	Description  string       `json:"description,omitempty" jsonschema_description:"The recipe description (under 100 characters)"`
+	Ingredients  []Ingredient `json:"ingredients" jsonschema_description:"The recipe ingredients (order by type first and then importance)"`
+	Instructions []string     `json:"instructions" jsonschema_description:"The recipe instructions (step by step)"`
+	PrepTime     string       `json:"prepTime" jsonschema_description:"The recipe preparation time (e.g. 10 minutes, 30 minutes, etc.)"`
 	Difficulty   string       `json:"difficulty" jsonschema:"enum=easy,enum=medium,enum=hard"`
 }
 

--- a/go/samples/basic-tool-interrupts-exp/main.go
+++ b/go/samples/basic-tool-interrupts-exp/main.go
@@ -97,14 +97,14 @@ var accountBalance = 150.00
 type (
 	// TransferInput is what the model fills in to call the tool.
 	TransferInput struct {
-		ToAccount string  `json:"toAccount" jsonschema:"description=The destination account"`
-		Amount    float64 `json:"amount" jsonschema:"description=The amount in dollars"`
+		ToAccount string  `json:"toAccount" jsonschema_description:"The destination account"`
+		Amount    float64 `json:"amount" jsonschema_description:"The amount in dollars"`
 	}
 
 	// TransferResult is what the tool answers with.
 	TransferResult struct {
 		Status  string  `json:"status" jsonschema:"enum=completed,enum=declined,enum=rejected"`
-		Balance float64 `json:"balance" jsonschema:"description=The balance after the transfer"`
+		Balance float64 `json:"balance" jsonschema_description:"The balance after the transfer"`
 	}
 
 	// Approval is the answer carried back into the tool when it is resumed. It
@@ -123,8 +123,8 @@ type (
 
 	// TransferRequest is what the flow takes.
 	TransferRequest struct {
-		Request string `json:"request" jsonschema:"description=What to do with the money,default=Send $120 to bob"`
-		Approve bool   `json:"approve,omitempty" jsonschema:"description=Whether to approve a transfer that needs it,default=true"`
+		Request string `json:"request" jsonschema:"default=Send $120 to bob" jsonschema_description:"What to do with the money"`
+		Approve bool   `json:"approve,omitempty" jsonschema:"default=true" jsonschema_description:"Whether to approve a transfer that needs it"`
 	}
 
 	// Transfer is what the flow returns.

--- a/go/samples/basic-tool-interrupts/main.go
+++ b/go/samples/basic-tool-interrupts/main.go
@@ -88,14 +88,14 @@ var accountBalance = 150.00
 type (
 	// TransferInput is what the model fills in to call the tool.
 	TransferInput struct {
-		ToAccount string  `json:"toAccount" jsonschema:"description=The destination account"`
-		Amount    float64 `json:"amount" jsonschema:"description=The amount in dollars"`
+		ToAccount string  `json:"toAccount" jsonschema_description:"The destination account"`
+		Amount    float64 `json:"amount" jsonschema_description:"The amount in dollars"`
 	}
 
 	// TransferResult is what the tool answers with.
 	TransferResult struct {
 		Status  string  `json:"status" jsonschema:"enum=completed,enum=declined,enum=rejected"`
-		Balance float64 `json:"balance" jsonschema:"description=The balance after the transfer"`
+		Balance float64 `json:"balance" jsonschema_description:"The balance after the transfer"`
 	}
 
 	// TransferInterrupt is the typed metadata the tool attaches when it pauses,
@@ -107,8 +107,8 @@ type (
 
 	// TransferRequest is what the flow takes.
 	TransferRequest struct {
-		Request string `json:"request" jsonschema:"description=What to do with the money,default=Send $120 to bob"`
-		Approve bool   `json:"approve,omitempty" jsonschema:"description=Whether to approve a transfer that needs it,default=true"`
+		Request string `json:"request" jsonschema:"default=Send $120 to bob" jsonschema_description:"What to do with the money"`
+		Approve bool   `json:"approve,omitempty" jsonschema:"default=true" jsonschema_description:"Whether to approve a transfer that needs it"`
 	}
 
 	// Transfer is what the flow returns.

--- a/go/samples/basic-tools-exp/main.go
+++ b/go/samples/basic-tools-exp/main.go
@@ -81,8 +81,8 @@ type (
 	// from this type, so a field's jsonschema tag is how the model learns
 	// what may go in it.
 	Deploy struct {
-		Service     string `json:"service" jsonschema:"description=The service to deploy"`
-		Environment string `json:"environment" jsonschema:"description=Where to deploy it,enum=staging,enum=production"`
+		Service     string `json:"service" jsonschema_description:"The service to deploy"`
+		Environment string `json:"environment" jsonschema:"enum=staging,enum=production" jsonschema_description:"Where to deploy it"`
 	}
 
 	// Rollout is the tool's answer, and the whole of its return type: the
@@ -91,7 +91,7 @@ type (
 		Service  string  `json:"service"`
 		Revision string  `json:"revision"`
 		Healthy  bool    `json:"healthy"`
-		P95Ms    float64 `json:"p95Ms" jsonschema:"description=The p95 latency after the rollout, in milliseconds"`
+		P95Ms    float64 `json:"p95Ms" jsonschema_description:"The p95 latency after the rollout, in milliseconds"`
 	}
 
 	// Progress is what tool.SendPartial sends. It is the tool's own shape, not
@@ -103,7 +103,7 @@ type (
 
 	// DeployRequest is what the flow takes.
 	DeployRequest struct {
-		Request string `json:"request" jsonschema:"description=What to deploy and where,default=Ship checkout-api to production."`
+		Request string `json:"request" jsonschema:"default=Ship checkout-api to production." jsonschema_description:"What to deploy and where"`
 	}
 )
 

--- a/go/samples/basic-tools/main.go
+++ b/go/samples/basic-tools/main.go
@@ -74,8 +74,8 @@ type (
 	// from this type, so a field's jsonschema tag is how the model learns
 	// what may go in it.
 	Deploy struct {
-		Service     string `json:"service" jsonschema:"description=The service to deploy"`
-		Environment string `json:"environment" jsonschema:"description=Where to deploy it,enum=staging,enum=production"`
+		Service     string `json:"service" jsonschema_description:"The service to deploy"`
+		Environment string `json:"environment" jsonschema:"enum=staging,enum=production" jsonschema_description:"Where to deploy it"`
 	}
 
 	// Rollout is the tool's answer, and the Output half of its multipart
@@ -84,12 +84,12 @@ type (
 		Service  string  `json:"service"`
 		Revision string  `json:"revision"`
 		Healthy  bool    `json:"healthy"`
-		P95Ms    float64 `json:"p95Ms" jsonschema:"description=The p95 latency after the rollout, in milliseconds"`
+		P95Ms    float64 `json:"p95Ms" jsonschema_description:"The p95 latency after the rollout, in milliseconds"`
 	}
 
 	// DeployRequest is what the flow takes.
 	DeployRequest struct {
-		Request string `json:"request" jsonschema:"description=What to deploy and where,default=Ship checkout-api to production."`
+		Request string `json:"request" jsonschema:"default=Ship checkout-api to production." jsonschema_description:"What to deploy and where"`
 	}
 )
 

--- a/go/samples/basic/main.go
+++ b/go/samples/basic/main.go
@@ -56,7 +56,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model is shared by every flow below, so switching models or thinking levels

--- a/go/samples/compat_oai/anthropic/main.go
+++ b/go/samples/compat_oai/anthropic/main.go
@@ -56,7 +56,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/compat_oai/custom/main.go
+++ b/go/samples/compat_oai/custom/main.go
@@ -60,7 +60,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/compat_oai/dashscope/main.go
+++ b/go/samples/compat_oai/dashscope/main.go
@@ -52,7 +52,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/compat_oai/deepseek/main.go
+++ b/go/samples/compat_oai/deepseek/main.go
@@ -51,7 +51,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/compat_oai/kimi/main.go
+++ b/go/samples/compat_oai/kimi/main.go
@@ -51,7 +51,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/compat_oai/openai/main.go
+++ b/go/samples/compat_oai/openai/main.go
@@ -52,7 +52,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/compat_oai/openrouter/main.go
+++ b/go/samples/compat_oai/openrouter/main.go
@@ -52,7 +52,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/compat_oai/xai/main.go
+++ b/go/samples/compat_oai/xai/main.go
@@ -51,7 +51,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a

--- a/go/samples/compat_oai/zai/main.go
+++ b/go/samples/compat_oai/zai/main.go
@@ -51,7 +51,7 @@ import (
 // form from. The default is not applied in transit, and a field without
 // omitempty is required.
 type JokeRequest struct {
-	Topic string `json:"topic" jsonschema:"description=What the joke should be about,default=airplane food"`
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
 }
 
 // model pins the model and its config in one place, so switching either is a


### PR DESCRIPTION
Fixes nine tool and sample schemas whose descriptions shipped truncated.

The `jsonschema` struct tag is a comma-separated keyword list, so a comma inside a value ends it and the remainder is dropped without an error. `description=If true, descend into subdirectories.` reached the model as `If true`. The filesystem middleware's `recursive` and `replaceAll` and the delegation tool's `task` are the ones a model reads; the rest are samples users copy from.

Moves every description to the `jsonschema_description` tag, a separate struct tag key with no list to terminate. Constraints stay in the `jsonschema` tag alongside it, so the truncation cannot recur.
