### PR TITLE
fix(go/ai): give each JSON-dispatched middleware call its own config

### DIFF
--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -19,6 +19,7 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
@@ -95,8 +96,17 @@ type ToolNext = func(ctx context.Context, params *ToolParams) (*MultipartToolRes
 // per-call [Hooks] bundle (via [New]).
 //
 // Plugin-level state belongs on unexported fields of the config type. A
-// plugin's [MiddlewarePlugin.Middlewares] sets those fields on a prototype
-// that is preserved across JSON dispatch by value-copy inside the descriptor.
+// plugin's [MiddlewarePlugin.Middlewares] sets those fields on a prototype,
+// which every JSON-dispatched call copies before unmarshalling its own
+// config over the exported fields. Unexported state therefore carries into
+// each call, and state that must be shared across calls (a client, a cache)
+// belongs behind a pointer, which survives the copy pointing at the same
+// object.
+//
+// Exported fields are per-call user config, never plugin defaults: a call
+// that omits one gets the zero value, so defaults belong in New. Leave them
+// zero on the prototype, since a copy would otherwise share their slices and
+// maps with it.
 type Middleware interface {
 	// Name returns the registered middleware's unique identifier. Must be a
 	// stable constant, since it is read from a zero value of the config type
@@ -111,8 +121,8 @@ type Middleware interface {
 
 // middlewareFactoryFunc is the closure stored on [MiddlewareDesc] that
 // materializes a [Hooks] bundle from JSON config. It is produced by
-// [NewMiddleware] and captures the prototype so value-copy preserves any
-// unexported plugin-level state across JSON-dispatched calls.
+// [NewMiddleware] and copies the prototype per call so unexported
+// plugin-level state carries into each JSON-dispatched invocation.
 type middlewareFactoryFunc = func(ctx context.Context, configJSON []byte) (*Hooks, error)
 
 // middlewareRegistryPrefix is the registry-key prefix under which middleware
@@ -131,10 +141,9 @@ func (d *MiddlewareDesc) Register(r api.Registry) {
 
 // NewMiddleware constructs a descriptor without registering it. Useful for
 // [MiddlewarePlugin.Middlewares] implementations that defer registration
-// to [genkit.Init]. The prototype argument supplies both the registered name
-// (via its [Middleware.Name] method) and any plugin-level state that should
-// flow into JSON-dispatched invocations via unexported fields preserved by
-// value-copy.
+// to [genkit.Init]. The prototype argument supplies the registered name (via
+// its [Middleware.Name] method), the config schema, and any plugin-level
+// state on unexported fields; see [Middleware] for what belongs where.
 func NewMiddleware[M Middleware](description string, prototype M) *MiddlewareDesc {
 	name := prototype.Name()
 	return &MiddlewareDesc{
@@ -142,7 +151,7 @@ func NewMiddleware[M Middleware](description string, prototype M) *MiddlewareDes
 		Description:  description,
 		ConfigSchema: core.InferSchemaMap(prototype),
 		buildFromJSON: func(ctx context.Context, configJSON []byte) (*Hooks, error) {
-			cfg := prototype // value copy preserves unexported fields, shares pointers
+			cfg := isolate(prototype)
 			if len(configJSON) > 0 {
 				if err := json.Unmarshal(configJSON, &cfg); err != nil {
 					return nil, status.Errorf(status.ErrInvalidArgument, "middleware %q: %w", name, err)
@@ -151,6 +160,24 @@ func NewMiddleware[M Middleware](description string, prototype M) *MiddlewareDes
 			return cfg.New(ctx)
 		},
 	}
+}
+
+// isolate returns a copy of prototype that a call's config can be
+// unmarshalled into without writing through to the registered prototype.
+// Assignment already copies a value prototype; a pointer one would share its
+// pointee, so the struct behind it is copied into a fresh allocation.
+func isolate[M Middleware](prototype M) M {
+	v := reflect.ValueOf(prototype)
+	if v.Kind() != reflect.Pointer {
+		return prototype
+	}
+	fresh := reflect.New(v.Type().Elem())
+	if !v.IsNil() {
+		fresh.Elem().Set(v.Elem())
+	}
+	// A nil prototype has no state to copy, but New still needs a receiver:
+	// a call that sends no config unmarshals nothing and would get the nil.
+	return fresh.Interface().(M)
 }
 
 // MiddlewareFunc adapts a per-call factory closure to the [Middleware]

--- a/go/ai/middleware_test.go
+++ b/go/ai/middleware_test.go
@@ -127,6 +127,133 @@ func TestPluginStateCarriedThroughPrototype(t *testing.T) {
 	}
 }
 
+// --- per-call isolation: JSON dispatch never writes through to the prototype ---
+
+// isolationLog records the config each New() was built with. Dispatches in
+// these tests are sequential, so no locking.
+type isolationLog struct {
+	seen []isolationConfig
+}
+
+func (l *isolationLog) at(t *testing.T, i int) isolationConfig {
+	t.Helper()
+	if i >= len(l.seen) {
+		t.Fatalf("wanted config %d, only %d recorded", i, len(l.seen))
+	}
+	return l.seen[i]
+}
+
+// isolationConfig mirrors the built-in middleware shape: exported fields are
+// per-call user config, unexported fields are plugin state.
+type isolationConfig struct {
+	Label    string            `json:"label,omitempty"`
+	Statuses []string          `json:"statuses,omitempty"`
+	Tags     map[string]string `json:"tags,omitempty"`
+
+	log *isolationLog
+}
+
+func (isolationConfig) Name() string { return "test/isolation" }
+
+func (c isolationConfig) New(ctx context.Context) (*Hooks, error) {
+	if c.log != nil {
+		c.log.seen = append(c.log.seen, c)
+	}
+	return &Hooks{}, nil
+}
+
+// Registering by value is the documented shape, but [NewMiddleware] accepts
+// any [Middleware], so a pointer prototype has to isolate just the same.
+func forEachPrototypeShape(t *testing.T, run func(t *testing.T, desc *MiddlewareDesc, log *isolationLog, snapshot func() isolationConfig)) {
+	t.Helper()
+	for _, tc := range []struct {
+		name  string
+		build func(isolationConfig) (*MiddlewareDesc, func() isolationConfig)
+	}{
+		{"value prototype", func(p isolationConfig) (*MiddlewareDesc, func() isolationConfig) {
+			return NewMiddleware("desc", p), func() isolationConfig { return p }
+		}},
+		{"pointer prototype", func(p isolationConfig) (*MiddlewareDesc, func() isolationConfig) {
+			ptr := &p
+			return NewMiddleware("desc", ptr), func() isolationConfig { return *ptr }
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			log := &isolationLog{}
+			desc, snapshot := tc.build(isolationConfig{log: log})
+			run(t, desc, log, snapshot)
+		})
+	}
+}
+
+func TestBuildFromJSON_ConfigDoesNotLeakBetweenCalls(t *testing.T) {
+	forEachPrototypeShape(t, func(t *testing.T, desc *MiddlewareDesc, log *isolationLog, _ func() isolationConfig) {
+		buildOrFail(t, desc, `{"label":"first","statuses":["a","b"],"tags":{"k":"v"}}`)
+		buildOrFail(t, desc, `{}`)
+
+		second := log.at(t, 1)
+		if second.Label != "" {
+			t.Errorf("Label = %q, want empty (leaked from the previous call)", second.Label)
+		}
+		if second.Statuses != nil {
+			t.Errorf("Statuses = %v, want nil (leaked from the previous call)", second.Statuses)
+		}
+		if second.Tags != nil {
+			t.Errorf("Tags = %v, want nil (leaked from the previous call)", second.Tags)
+		}
+	})
+}
+
+func TestBuildFromJSON_PrototypeNotMutated(t *testing.T) {
+	forEachPrototypeShape(t, func(t *testing.T, desc *MiddlewareDesc, _ *isolationLog, snapshot func() isolationConfig) {
+		buildOrFail(t, desc, `{"label":"first","statuses":["a","b"],"tags":{"k":"v"}}`)
+
+		got := snapshot()
+		if got.Label != "" || got.Statuses != nil || got.Tags != nil {
+			t.Errorf("prototype mutated by dispatch: %+v", got)
+		}
+	})
+}
+
+// ptrRecvConfig takes pointer receivers, so Name() survives being read off a
+// nil prototype during registration.
+type ptrRecvConfig struct {
+	Label string `json:"label,omitempty"`
+}
+
+func (*ptrRecvConfig) Name() string { return "test/ptr-recv" }
+
+func (c *ptrRecvConfig) New(context.Context) (*Hooks, error) {
+	return &Hooks{
+		WrapModel: func(ctx context.Context, p *ModelParams, next ModelNext) (*ModelResponse, error) {
+			_ = c.Label // A nil receiver surfaces here, not in New.
+			return next(ctx, p)
+		},
+	}, nil
+}
+
+// A nil pointer prototype is a programming error, but it must not panic the
+// process. A call that sends no config has nothing to unmarshal, so nothing
+// allocates through the pointer and New would otherwise get a nil receiver.
+func TestBuildFromJSON_NilPrototype(t *testing.T) {
+	desc := NewMiddleware("desc", (*ptrRecvConfig)(nil))
+	h, err := desc.buildFromJSON(testCtx, nil)
+	if err != nil {
+		t.Fatalf("buildFromJSON failed: %v", err)
+	}
+	next := func(context.Context, *ModelParams) (*ModelResponse, error) { return &ModelResponse{}, nil }
+	if _, err := h.WrapModel(testCtx, &ModelParams{}, next); err != nil {
+		t.Fatalf("WrapModel failed: %v", err)
+	}
+}
+
+func buildOrFail(t *testing.T, desc *MiddlewareDesc, configJSON string) {
+	t.Helper()
+	if _, err := desc.buildFromJSON(testCtx, []byte(configJSON)); err != nil {
+		t.Fatalf("buildFromJSON(%s) failed: %v", configJSON, err)
+	}
+}
+
 // --- call-level state: each Generate gets fresh BuildMiddleware scope ---
 
 type perCallConfig struct {

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -901,10 +901,10 @@ func LookupTool(g *Genkit, name string) ai.Tool {
 //
 // The `description` is a human-readable explanation shown in the Dev UI. The
 // `prototype` is a value of a type that implements [ai.Middleware]. Its
-// [ai.Middleware.Name] method supplies the registered name, and its fields
-// (both exported JSON config and unexported plugin-level state) are captured
-// by a value-copy inside the descriptor so JSON-dispatched invocations
-// preserve prototype state across calls.
+// [ai.Middleware.Name] method supplies the registered name, and each
+// JSON-dispatched invocation copies it so unexported plugin-level state
+// carries into the call while the call's own config is unmarshalled over the
+// exported fields (see [ai.Middleware] for what belongs where).
 //
 // For pure Go use, registration is not strictly required: passing a middleware
 // config directly to [ai.WithUse] invokes its [ai.Middleware.New] method on

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -143,7 +143,7 @@ type Agents struct {
 	ArtifactStrategy ArtifactStrategy `json:"artifactStrategy,omitempty"`
 }
 
-func (a *Agents) Name() string { return provider + "/agents" }
+func (a Agents) Name() string { return provider + "/agents" }
 
 // agentsState is the per-generate mutable state shared by the delegation tools
 // and the generate hook. New allocates a fresh one per call, and a mutex guards
@@ -161,7 +161,7 @@ type agentsState struct {
 // New validates the configuration and returns the hooks: a delegation tool per
 // agent plus a generate hook that injects the <sub-agents> system prompt and
 // captures conversation history.
-func (a *Agents) New(ctx context.Context) (*ai.Hooks, error) {
+func (a Agents) New(ctx context.Context) (*ai.Hooks, error) {
 	if len(a.Agents) == 0 {
 		return nil, fmt.Errorf("agents middleware requires at least one agent in the \"agents\" option")
 	}

--- a/go/plugins/middleware/exp/artifacts.go
+++ b/go/plugins/middleware/exp/artifacts.go
@@ -71,11 +71,11 @@ type Artifacts struct {
 	Readonly bool `json:"readonly,omitempty"`
 }
 
-func (a *Artifacts) Name() string { return provider + "/artifacts" }
+func (a Artifacts) Name() string { return provider + "/artifacts" }
 
 // New returns the hooks that register the artifact tools and inject the
 // artifact listing into the system prompt on each turn.
-func (a *Artifacts) New(ctx context.Context) (*ai.Hooks, error) {
+func (a Artifacts) New(ctx context.Context) (*ai.Hooks, error) {
 	tools := []ai.Tool{newReadArtifactTool()}
 	if !a.Readonly {
 		tools = append(tools, newWriteArtifactTool())

--- a/go/plugins/middleware/exp/plugin.go
+++ b/go/plugins/middleware/exp/plugin.go
@@ -43,7 +43,7 @@ func (p *Middleware) Init(ctx context.Context) []api.Action { return nil }
 
 func (p *Middleware) Middlewares(ctx context.Context) ([]*ai.MiddlewareDesc, error) {
 	return []*ai.MiddlewareDesc{
-		ai.NewMiddleware("Delegate tasks to registered sub-agents via per-agent tools", &Agents{}),
-		ai.NewMiddleware("Provide read/write tools for session artifacts", &Artifacts{}),
+		ai.NewMiddleware("Delegate tasks to registered sub-agents via per-agent tools", Agents{}),
+		ai.NewMiddleware("Provide read/write tools for session artifacts", Artifacts{}),
 	}, nil
 }

--- a/go/plugins/middleware/fallback.go
+++ b/go/plugins/middleware/fallback.go
@@ -69,10 +69,10 @@ type Fallback struct {
 }
 
 // Name implements [ai.Middleware].
-func (f *Fallback) Name() string { return provider + "/fallback" }
+func (f Fallback) Name() string { return provider + "/fallback" }
 
 // New implements [ai.Middleware], hooking the model stage.
-func (f *Fallback) New(ctx context.Context) (*ai.Hooks, error) {
+func (f Fallback) New(ctx context.Context) (*ai.Hooks, error) {
 	return &ai.Hooks{
 		WrapModel: f.wrapModel,
 	}, nil

--- a/go/plugins/middleware/filesystem.go
+++ b/go/plugins/middleware/filesystem.go
@@ -164,12 +164,12 @@ type Filesystem struct {
 }
 
 // Name implements [ai.Middleware].
-func (f *Filesystem) Name() string { return provider + "/filesystem" }
+func (f Filesystem) Name() string { return provider + "/filesystem" }
 
 // New initializes a per-call instance: opens the [os.Root], builds the tool
 // set, and allocates the message queue used to bridge tool output back to the
 // model on the next turn.
-func (f *Filesystem) New(ctx context.Context) (*ai.Hooks, error) {
+func (f Filesystem) New(ctx context.Context) (*ai.Hooks, error) {
 	if strings.TrimSpace(f.RootDir) == "" {
 		return nil, status.Errorf(status.ErrInvalidArgument, "filesystem middleware: RootDir is required")
 	}

--- a/go/plugins/middleware/plugin.go
+++ b/go/plugins/middleware/plugin.go
@@ -35,10 +35,10 @@ func (p *Middleware) Init(ctx context.Context) []api.Action { return nil }
 
 func (p *Middleware) Middlewares(ctx context.Context) ([]*ai.MiddlewareDesc, error) {
 	return []*ai.MiddlewareDesc{
-		ai.NewMiddleware("Retry failed model calls with exponential backoff", &Retry{}),
-		ai.NewMiddleware("Try alternative models when the primary model fails", &Fallback{}),
-		ai.NewMiddleware("Require explicit approval before executing tools", &ToolApproval{}),
-		ai.NewMiddleware("Expose a local library of skills as loadable system instructions", &Skills{}),
-		ai.NewMiddleware("Grant the model file access scoped to a directory", &Filesystem{}),
+		ai.NewMiddleware("Retry failed model calls with exponential backoff", Retry{}),
+		ai.NewMiddleware("Try alternative models when the primary model fails", Fallback{}),
+		ai.NewMiddleware("Require explicit approval before executing tools", ToolApproval{}),
+		ai.NewMiddleware("Expose a local library of skills as loadable system instructions", Skills{}),
+		ai.NewMiddleware("Grant the model file access scoped to a directory", Filesystem{}),
 	}, nil
 }

--- a/go/plugins/middleware/plugin_test.go
+++ b/go/plugins/middleware/plugin_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+)
+
+// The Dev UI and cross-runtime callers dispatch middleware by name with a
+// JSON config, which every plugin middleware serves from one registered
+// prototype. Each dispatch must build its own config off that prototype:
+// a field one call sets must not stay set for calls after it, and the
+// registered prototype itself must stay untouched.
+func TestJSONDispatchDoesNotLeakConfigBetweenCalls(t *testing.T) {
+	r := newTestRegistry(t)
+	calls := 0
+	m := defineModel(t, r, "test/alwaysfail", func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		calls++
+		return nil, core.NewError(core.UNAVAILABLE, "always failing")
+	})
+	prototype := Retry{}
+	registerTestMiddleware(r, "retry", prototype)
+
+	dispatch := func(config map[string]any) {
+		t.Helper()
+		calls = 0
+		_, err := ai.GenerateWithRequest(ctx, r, &ai.GenerateActionOptions{
+			Model:    m.Name(),
+			Messages: []*ai.Message{ai.NewUserTextMessage("hello")},
+			Use:      []*ai.MiddlewareRef{{Name: provider + "/retry", Config: config}},
+		}, nil, nil)
+		if err == nil {
+			t.Fatal("expected the always-failing model to return an error")
+		}
+	}
+
+	dispatch(map[string]any{"maxRetries": 5, "noJitter": true})
+	if calls != 6 { // 1 initial + 5 retries
+		t.Fatalf("got %d model calls, want 6", calls)
+	}
+
+	dispatch(map[string]any{})
+	if calls != 4 { // 1 initial + the default 3 retries
+		t.Errorf("got %d model calls, want 4: maxRetries leaked from the previous dispatch", calls)
+	}
+
+	if !reflect.DeepEqual(prototype, Retry{}) {
+		t.Errorf("prototype mutated by dispatch: %+v", prototype)
+	}
+}

--- a/go/plugins/middleware/retry.go
+++ b/go/plugins/middleware/retry.go
@@ -89,10 +89,10 @@ type Retry struct {
 }
 
 // Name implements [ai.Middleware].
-func (r *Retry) Name() string { return provider + "/retry" }
+func (r Retry) Name() string { return provider + "/retry" }
 
 // New implements [ai.Middleware], hooking the model stage.
-func (r *Retry) New(ctx context.Context) (*ai.Hooks, error) {
+func (r Retry) New(ctx context.Context) (*ai.Hooks, error) {
 	return &ai.Hooks{
 		WrapModel: r.wrapModel,
 	}, nil

--- a/go/plugins/middleware/skills.go
+++ b/go/plugins/middleware/skills.go
@@ -82,13 +82,13 @@ type skillFrontmatter struct {
 	Description string `yaml:"description"`
 }
 
-func (s *Skills) Name() string { return provider + "/skills" }
+func (s Skills) Name() string { return provider + "/skills" }
 
 // New scans the configured skill paths and returns a [ai.Hooks] that injects
 // the skills system prompt and exposes the use_skill tool. Scanning happens
 // once per [ai.Generate] call; the result is captured in the returned hooks
 // so WrapGenerate and the use_skill tool agree on the same skill set.
-func (s *Skills) New(ctx context.Context) (*ai.Hooks, error) {
+func (s Skills) New(ctx context.Context) (*ai.Hooks, error) {
 	info, err := scanSkills(ctx, s.paths(), len(s.SkillPaths) > 0)
 	if err != nil {
 		return nil, err

--- a/go/plugins/middleware/tool_approval.go
+++ b/go/plugins/middleware/tool_approval.go
@@ -55,10 +55,10 @@ type ToolApproval struct {
 }
 
 // Name implements [ai.Middleware].
-func (t *ToolApproval) Name() string { return provider + "/toolApproval" }
+func (t ToolApproval) Name() string { return provider + "/toolApproval" }
 
 // New implements [ai.Middleware], hooking tool execution.
-func (t *ToolApproval) New(ctx context.Context) (*ai.Hooks, error) {
+func (t ToolApproval) New(ctx context.Context) (*ai.Hooks, error) {
 	return &ai.Hooks{
 		WrapTool: t.wrapTool,
 	}, nil


### PR DESCRIPTION
`NewMiddleware`'s build closure did `cfg := prototype`, which isolates the call only when the prototype is a value. Every middleware registered by the plugins passed a pointer (`&Retry{}`, `&Fallback{}`, `&Skills{}`, and the rest), so `cfg` copied the pointer and `json.Unmarshal(configJSON, &cfg)` decoded through a `**Retry` straight into the shared prototype struct.

Three consequences. A field one call sets stays set for every call after it, since keys absent from the next call's JSON leave the previous value in place. The registered prototype is permanently mutated, so the descriptor stops describing the plugin's intent. And concurrent dispatch is a data race: parallel `buildFromJSON` calls on one descriptor report races under `-race`.

This is not only a Dev UI path. `.prompt` files with `use:` frontmatter build a `middlewareRefArg`, and `configsToRefs` routes those through the registry so they resolve like any JSON call. Two prompts sharing one registered middleware leak into each other in a plain compiled binary, no dev tooling running:

```
prompt A   use: [{name: test/isolation, config: {label: from-yaml}}]   saw label=from-yaml
prompt B   use: [test/isolation]           (no config at all)          saw label=from-yaml
```

The fix is the copy the contract always assumed. Middleware prototypes now register by value: `Name` and `New` take value receivers and `Middlewares` hands `NewMiddleware` a value, so dispatch has no pointer to write through. `*Retry` still satisfies `ai.Middleware`, so `ai.WithUse(&Retry{...})` and existing callers are unaffected.

`NewMiddleware` is generic over any `Middleware`, and the shipped v1.11/v1.12 plugins taught the pointer shape, so `isolate` copies the pointee into a fresh allocation for prototypes that still arrive as pointers. That also gives `New` a receiver when a nil pointer is registered and the call sends no config.

The doc now states the contract it always intended: exported fields are per-call user config and belong zero on the prototype, unexported fields carry plugin state into each call, and state that must be shared across calls belongs behind a pointer, which survives the copy pointing at the same object.

The pure-Go `ai.WithUse` path was never affected: `configsToRefs` stores the Go value and `resolveRefs` takes the local fast path without touching JSON.
