### PR TITLE
fix(go/plugins/middleware): describe config fields and offer status names as an enum

### DIFF
--- a/go/ai/exp/ref.go
+++ b/go/ai/exp/ref.go
@@ -30,11 +30,11 @@ package exp
 //	coderAgent.Ref()
 type AgentRef struct {
 	// Name identifies the agent, resolved as /agent/<Name>. Required.
-	Name string `json:"name"`
+	Name string `json:"name" jsonschema_description:"Name of the agent. Resolved as /agent/<Name>. Required."`
 	// Description is a human-readable description used by consumers that list
 	// agents (e.g. the agents middleware's system prompt). [Agent.Ref] fills it
 	// from the agent's descriptor. Optional.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" jsonschema_description:"Human-readable description used by consumers that list agents. Overrides the description discovered from the registry."`
 }
 
 // Ref returns an [AgentRef] for this agent, capturing its name and description

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1804,10 +1804,10 @@ func (ModelRef) JSONSchema() *jsonschema.Schema {
 	props := jsonschema.NewProperties()
 	props.Set("name", &jsonschema.Schema{
 		Type:        "string",
-		Description: "Model name (e.g. \"googleai/gemini-flash-latest\")",
+		Description: "Model name, e.g. \"googleai/gemini-flash-latest\".",
 	})
 	props.Set("config", &jsonschema.Schema{
-		Description: "Optional model configuration",
+		Description: "Optional model configuration, applied to this model only.",
 	})
 	return &jsonschema.Schema{
 		Type:       "object",

--- a/go/core/status/status.go
+++ b/go/core/status/status.go
@@ -16,7 +16,10 @@
 
 package status
 
-import "net/http"
+import (
+	"net/http"
+	"slices"
+)
 
 // Name is a canonical status name, drawn from the gRPC status codes. It is the
 // value Genkit puts on the wire, shared by the Go, JS, and Python runtimes.
@@ -95,6 +98,30 @@ var codeToName = func() map[int]Name {
 	}
 	return m
 }()
+
+// names lists the canonical status names in gRPC code order. It is derived
+// from [statuses] rather than restated, so a name added there cannot go
+// missing here.
+var names = func() []Name {
+	ns := make([]Name, 0, len(statuses))
+	for n := range statuses {
+		ns = append(ns, n)
+	}
+	slices.SortFunc(ns, func(a, b Name) int { return statuses[a].code - statuses[b].code })
+	return ns
+}()
+
+// Names returns the canonical status names, in gRPC code order.
+//
+// It is the Go counterpart of the JS StatusNameSchema, and is intended for
+// consumers that enumerate the statuses rather than test one: a config schema
+// offering them as an enum, say, or a plugin mapping a provider's error space
+// onto them. Use [Name.IsValid] to test a single name.
+//
+// The result is a fresh slice the caller may retain and modify.
+func Names() []Name {
+	return slices.Clone(names)
+}
 
 // IsValid reports whether n is one of the canonical status names.
 func (n Name) IsValid() bool {

--- a/go/internal/schematest/schematest.go
+++ b/go/internal/schematest/schematest.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package schematest provides assertions for the JSON schemas a plugin
+// publishes, so that the fields a user configures in the Dev UI stay
+// documented.
+package schematest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// AssertDescribed reports every property in schema, at any depth, that lacks a
+// description or whose description does not end in a period.
+//
+// Schema inference does not read Go doc comments: [github.com/invopop/jsonschema]
+// runs without a comment map, so a field is described only by a struct tag. The
+// Dev UI renders that description as the tooltip on the help icon beside the
+// field, so a field without one offers the user no explanation at all.
+//
+// name identifies the schema in failure messages, e.g. the middleware name.
+func AssertDescribed(t *testing.T, name string, schema map[string]any) {
+	t.Helper()
+	assertDescribed(t, name, schema)
+}
+
+func assertDescribed(t *testing.T, path string, schema map[string]any) {
+	t.Helper()
+	props, _ := schema["properties"].(map[string]any)
+	names := make([]string, 0, len(props))
+	for n := range props {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		prop, ok := props[n].(map[string]any)
+		if !ok {
+			continue
+		}
+		field := path + "." + n
+		desc, _ := prop["description"].(string)
+		switch {
+		case strings.TrimSpace(desc) == "":
+			t.Errorf("%s: no description; add a `jsonschema_description:\"...\"` tag (a Go doc comment alone does not reach the schema)", field)
+		case !strings.HasSuffix(desc, "."):
+			t.Errorf("%s: description does not end in a period: %q", field, desc)
+		}
+		assertDescribed(t, field, prop)
+	}
+	if items, ok := schema["items"].(map[string]any); ok {
+		assertDescribed(t, path+"[]", items)
+	}
+}
+
+// AssertNoInlineDescriptions reports every `jsonschema:"description=..."` tag
+// in the .go files directly under dir, which must instead be written as a
+// `jsonschema_description` tag.
+//
+// [github.com/invopop/jsonschema] splits the `jsonschema` tag on commas to
+// separate its keywords, so an inline description silently loses everything
+// from its first comma onward: `description=If true, descend into
+// subdirectories.` reaches the schema as "If true". The dedicated tag is read
+// whole, so punctuation needs no thought.
+//
+//	`json:"recursive,omitempty" jsonschema_description:"If true, descend into subdirectories."`
+//
+// Both forms produce the same schema, and a field may carry the dedicated tag
+// alongside a `jsonschema` tag holding other keywords such as an enum.
+//
+// Unlike [AssertDescribed], this reads the source rather than a published
+// schema, so it also covers schemas a plugin never exposes as a descriptor,
+// such as tool input types.
+func AssertNoInlineDescriptions(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		checked++
+		ast.Inspect(file, func(n ast.Node) bool {
+			t.Helper()
+			field, ok := n.(*ast.Field)
+			if !ok || field.Tag == nil {
+				return true
+			}
+			raw, err := strconv.Unquote(field.Tag.Value)
+			if err != nil {
+				return true
+			}
+			tag := reflect.StructTag(raw).Get("jsonschema")
+			for _, seg := range strings.Split(tag, ",") {
+				// Segments are trimmed before the check because the library
+				// does not trim them itself: " description=..." matches no
+				// keyword and is dropped without a word, so the field ends up
+				// with no description at all. Reporting it here is the only
+				// thing that catches that on a type no descriptor publishes.
+				if !strings.HasPrefix(strings.TrimSpace(seg), "description=") {
+					continue
+				}
+				t.Errorf("%s: a description inside a jsonschema tag does not survive the library's comma splitting; move it to a jsonschema_description tag\n\tfull tag: %s",
+					fmt.Sprintf("%s:%d", path, fset.Position(field.Tag.Pos()).Line), tag)
+			}
+			return true
+		})
+	}
+	if checked == 0 {
+		t.Fatalf("no .go files found in %s", dir)
+	}
+}

--- a/go/plugins/middleware/exp/agents.go
+++ b/go/plugins/middleware/exp/agents.go
@@ -125,22 +125,22 @@ type Agents struct {
 	// Agents lists the sub-agents available for delegation: by name
 	// (aix.AgentRef{Name: ...}) or as a captured instance (agentValue.Ref()).
 	// At least one is required.
-	Agents []aix.AgentRef `json:"agents,omitempty"`
+	Agents []aix.AgentRef `json:"agents,omitempty" jsonschema_description:"Sub-agents available for delegation. At least one is required."`
 	// ToolPrefix is the prefix for generated delegation tool names. A nil value
 	// defaults to "delegate_to" (tools become delegate_to_<agent>); a pointer to
 	// the empty string uses bare agent names.
-	ToolPrefix *string `json:"toolPrefix,omitempty"`
+	ToolPrefix *string `json:"toolPrefix,omitempty" jsonschema_description:"Prefix for generated delegation tool names. Defaults to \"delegate_to\", so tools become delegate_to_<agent>. Set it to the empty string to use bare agent names."`
 	// MaxDelegations caps the number of sub-agent delegations per generate call,
 	// preventing runaway delegation loops. 0 means unlimited.
-	MaxDelegations int `json:"maxDelegations,omitempty"`
+	MaxDelegations int `json:"maxDelegations,omitempty" jsonschema_description:"Caps the number of sub-agent delegations per generate call, preventing runaway delegation loops. Defaults to 0, which means unlimited."`
 	// HistoryLength is the number of recent user/model messages forwarded to a
 	// sub-agent as context. 0 means only the task description is sent. History is
 	// forwarded only to client-managed sub-agents (those without a session
 	// store); server-managed sub-agents receive only the task.
-	HistoryLength int `json:"historyLength,omitempty"`
+	HistoryLength int `json:"historyLength,omitempty" jsonschema_description:"Number of recent user/model messages forwarded to a sub-agent as context. Defaults to 0, which sends only the task description. History reaches client-managed sub-agents only."`
 	// ArtifactStrategy controls how sub-agent artifacts are surfaced. Defaults to
 	// ArtifactStrategyInline.
-	ArtifactStrategy ArtifactStrategy `json:"artifactStrategy,omitempty"`
+	ArtifactStrategy ArtifactStrategy `json:"artifactStrategy,omitempty" jsonschema_description:"How sub-agent artifacts are surfaced. \"inline\" adds artifact content to the delegation tool result and merges it into the parent session. \"session\" merges into the session only. Defaults to \"inline\"."`
 }
 
 func (a Agents) Name() string { return provider + "/agents" }

--- a/go/plugins/middleware/exp/artifacts.go
+++ b/go/plugins/middleware/exp/artifacts.go
@@ -68,7 +68,7 @@ const artifactsMarker = "artifacts-listing"
 type Artifacts struct {
 	// Readonly, when true, provides only the read_artifact tool; the model
 	// cannot create or update artifacts. Defaults to false.
-	Readonly bool `json:"readonly,omitempty"`
+	Readonly bool `json:"readonly,omitempty" jsonschema_description:"Provides only the read_artifact tool so the model cannot create or update artifacts. Defaults to false."`
 }
 
 func (a Artifacts) Name() string { return provider + "/artifacts" }

--- a/go/plugins/middleware/exp/plugin_test.go
+++ b/go/plugins/middleware/exp/plugin_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/firebase/genkit/go/internal/schematest"
+)
+
+// TestConfigSchemasDocumented asserts that every field the Dev UI renders for
+// a middleware config carries a description. Schema inference does not read Go
+// doc comments -- only a `jsonschema_description:"..."` struct tag reaches the
+// schema -- so a field documented in Go alone shows up as a bare input box.
+//
+// Walking the descriptors rather than a fixed list of types means a new
+// middleware, or a new field on an existing one, cannot ship undocumented.
+func TestConfigSchemasDocumented(t *testing.T) {
+	descs, err := (&Middleware{}).Middlewares(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(descs) == 0 {
+		t.Fatal("plugin returned no middleware descriptors")
+	}
+	for _, d := range descs {
+		if d.Description == "" {
+			t.Errorf("middleware %q has no description", d.Name)
+		}
+		schematest.AssertDescribed(t, d.Name, d.ConfigSchema)
+	}
+}
+
+// TestDescriptionsUseTheDedicatedTag guards the whole package against the
+// silent truncation described on [schematest.AssertNoInlineDescriptions]. It
+// covers the tool input schemas too, which no middleware descriptor exposes.
+func TestDescriptionsUseTheDedicatedTag(t *testing.T) {
+	schematest.AssertNoInlineDescriptions(t, ".")
+}

--- a/go/plugins/middleware/fallback.go
+++ b/go/plugins/middleware/fallback.go
@@ -61,11 +61,11 @@ type Fallback struct {
 	// These are tried in order after the primary model fails. Each ref's
 	// Config is used verbatim for that model -- the original request's
 	// Config is not inherited. Use [ai.NewModelRef] to attach config.
-	Models []ai.ModelRef `json:"models,omitempty"`
+	Models []ai.ModelRef `json:"models,omitempty" jsonschema_description:"Ordered list of fallback models to try after the primary model fails. Each ref's config is used verbatim for that model, and the original request's config is not inherited."`
 	// Statuses is the set of status codes that trigger a fallback for
 	// classified errors; unclassified errors propagate immediately and never
 	// trigger one. Defaults to [defaultFallbackStatuses].
-	Statuses []status.Name `json:"statuses,omitempty"`
+	Statuses []status.Name `json:"statuses,omitempty" jsonschema_description:"Status codes that trigger a fallback for classified errors. Unclassified errors propagate immediately and never trigger one. Defaults to UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, ABORTED, INTERNAL, NOT_FOUND and UNIMPLEMENTED." jsonschema:"enum=OK,enum=CANCELLED,enum=UNKNOWN,enum=INVALID_ARGUMENT,enum=DEADLINE_EXCEEDED,enum=NOT_FOUND,enum=ALREADY_EXISTS,enum=PERMISSION_DENIED,enum=UNAUTHENTICATED,enum=RESOURCE_EXHAUSTED,enum=FAILED_PRECONDITION,enum=ABORTED,enum=OUT_OF_RANGE,enum=UNIMPLEMENTED,enum=INTERNAL,enum=UNAVAILABLE,enum=DATA_LOSS"`
 }
 
 // Name implements [ai.Middleware].

--- a/go/plugins/middleware/filesystem.go
+++ b/go/plugins/middleware/filesystem.go
@@ -154,13 +154,13 @@ func (p *pathLocks) lock(path string) func() {
 //	)
 type Filesystem struct {
 	// RootDir is the directory that all operations are confined to.
-	RootDir string `json:"rootDirectory,omitempty"`
+	RootDir string `json:"rootDirectory,omitempty" jsonschema_description:"Directory that all file operations are confined to. Required."`
 	// AllowWriteAccess adds write_file and edit_file.
-	AllowWriteAccess bool `json:"allowWriteAccess,omitempty"`
+	AllowWriteAccess bool `json:"allowWriteAccess,omitempty" jsonschema_description:"Adds the write_file and edit_file tools. Defaults to false."`
 	// ToolNamePrefix is prepended to each tool name. Use distinct prefixes
 	// when attaching multiple Filesystem middlewares to one call so their
 	// tool names don't collide.
-	ToolNamePrefix string `json:"toolNamePrefix,omitempty"`
+	ToolNamePrefix string `json:"toolNamePrefix,omitempty" jsonschema_description:"Prepended to each tool name. Use distinct prefixes when attaching multiple filesystem middlewares to one call, so their tool names do not collide."`
 }
 
 // Name implements [ai.Middleware].

--- a/go/plugins/middleware/plugin_test.go
+++ b/go/plugins/middleware/plugin_test.go
@@ -19,10 +19,13 @@ package middleware
 import (
 	"context"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/internal/schematest"
 )
 
 // The Dev UI and cross-runtime callers dispatch middleware by name with a
@@ -65,5 +68,76 @@ func TestJSONDispatchDoesNotLeakConfigBetweenCalls(t *testing.T) {
 
 	if !reflect.DeepEqual(prototype, Retry{}) {
 		t.Errorf("prototype mutated by dispatch: %+v", prototype)
+	}
+}
+
+// TestConfigSchemasDocumented asserts that every field the Dev UI renders for
+// a middleware config carries a description. Schema inference does not read Go
+// doc comments -- only a `jsonschema_description:"..."` struct tag reaches the
+// schema -- so a field documented in Go alone shows up as a bare input box.
+//
+// Walking the descriptors rather than a fixed list of types means a new
+// middleware, or a new field on an existing one, cannot ship undocumented.
+func TestConfigSchemasDocumented(t *testing.T) {
+	descs, err := (&Middleware{}).Middlewares(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(descs) == 0 {
+		t.Fatal("plugin returned no middleware descriptors")
+	}
+	for _, d := range descs {
+		if d.Description == "" {
+			t.Errorf("middleware %q has no description", d.Name)
+		}
+		schematest.AssertDescribed(t, d.Name, d.ConfigSchema)
+	}
+}
+
+// TestDescriptionsUseTheDedicatedTag guards the whole package against the
+// silent truncation described on [schematest.AssertNoInlineDescriptions]. It
+// covers the tool input schemas too, which no middleware descriptor exposes.
+func TestDescriptionsUseTheDedicatedTag(t *testing.T) {
+	schematest.AssertNoInlineDescriptions(t, ".")
+}
+
+// TestStatusEnumsAreCanonical asserts that every "statuses" field offers the
+// full canonical status set, so the Dev UI renders a picker rather than a
+// free-text box and a name added to [status.Names] cannot be left out.
+//
+// The enum lives on the two struct tags rather than on a JSONSchema method on
+// [status.Name] itself, because that type is also the status field of a
+// serialized error. Action output is validated against its inferred schema, so
+// an enum there would reject an error that crossed the wire from another
+// runtime carrying a status this build does not know. Middleware config is
+// never validated -- the descriptor schema only drives the UI -- so the enum
+// is safe here.
+func TestStatusEnumsAreCanonical(t *testing.T) {
+	descs, err := (&Middleware{}).Middlewares(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := status.Names()
+	found := 0
+	for _, d := range descs {
+		props, _ := d.ConfigSchema["properties"].(map[string]any)
+		field, ok := props["statuses"].(map[string]any)
+		if !ok {
+			continue
+		}
+		found++
+		items, _ := field["items"].(map[string]any)
+		raw, _ := items["enum"].([]any)
+		got := make([]status.Name, 0, len(raw))
+		for _, v := range raw {
+			name, _ := v.(string)
+			got = append(got, status.Name(name))
+		}
+		if !slices.Equal(slices.Sorted(slices.Values(got)), slices.Sorted(slices.Values(want))) {
+			t.Errorf("%s.statuses enum = %v, want the canonical set %v", d.Name, got, want)
+		}
+	}
+	if found == 0 {
+		t.Error("no middleware exposes a statuses field; drop this test or restore the enum tag")
 	}
 }

--- a/go/plugins/middleware/retry.go
+++ b/go/plugins/middleware/retry.go
@@ -72,20 +72,20 @@ var sleepFunc = func(ctx context.Context, d time.Duration) error {
 //	)
 type Retry struct {
 	// MaxRetries is the maximum number of retry attempts. Defaults to 3.
-	MaxRetries int `json:"maxRetries,omitempty"`
+	MaxRetries int `json:"maxRetries,omitempty" jsonschema_description:"Maximum number of retry attempts. Defaults to 3."`
 	// Statuses is the set of status codes that trigger a retry for classified
 	// errors; unclassified errors are always retried regardless of this list.
 	// Defaults to [defaultRetryStatuses].
-	Statuses []status.Name `json:"statuses,omitempty"`
+	Statuses []status.Name `json:"statuses,omitempty" jsonschema_description:"Status codes that trigger a retry for classified errors. Unclassified errors are always retried regardless of this list. Defaults to UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, ABORTED and INTERNAL." jsonschema:"enum=OK,enum=CANCELLED,enum=UNKNOWN,enum=INVALID_ARGUMENT,enum=DEADLINE_EXCEEDED,enum=NOT_FOUND,enum=ALREADY_EXISTS,enum=PERMISSION_DENIED,enum=UNAUTHENTICATED,enum=RESOURCE_EXHAUSTED,enum=FAILED_PRECONDITION,enum=ABORTED,enum=OUT_OF_RANGE,enum=UNIMPLEMENTED,enum=INTERNAL,enum=UNAVAILABLE,enum=DATA_LOSS"`
 	// InitialDelayMs is the delay before the first retry, in milliseconds. Defaults to 1000.
-	InitialDelayMs int `json:"initialDelayMs,omitempty"`
+	InitialDelayMs int `json:"initialDelayMs,omitempty" jsonschema_description:"Delay before the first retry, in milliseconds. Defaults to 1000."`
 	// MaxDelayMs is the upper bound on retry delay, in milliseconds. Defaults to 60000.
-	MaxDelayMs int `json:"maxDelayMs,omitempty"`
+	MaxDelayMs int `json:"maxDelayMs,omitempty" jsonschema_description:"Upper bound on the retry delay, in milliseconds. Defaults to 60000."`
 	// BackoffFactor is the multiplier applied to the delay after each retry. Defaults to 2.
-	BackoffFactor float64 `json:"backoffFactor,omitempty"`
+	BackoffFactor float64 `json:"backoffFactor,omitempty" jsonschema_description:"Multiplier applied to the delay after each retry. Defaults to 2."`
 	// NoJitter disables random jitter on the delay. Jitter helps prevent
 	// thundering-herd problems when many clients retry simultaneously.
-	NoJitter bool `json:"noJitter,omitempty"`
+	NoJitter bool `json:"noJitter,omitempty" jsonschema_description:"Disables random jitter on the delay. Jitter helps prevent thundering-herd problems when many clients retry at the same time. Defaults to false."`
 }
 
 // Name implements [ai.Middleware].

--- a/go/plugins/middleware/skills.go
+++ b/go/plugins/middleware/skills.go
@@ -67,7 +67,7 @@ type Skills struct {
 	// SkillPaths lists directories that are scanned for skills. Each direct
 	// subdirectory containing a SKILL.md file is exposed as a skill.
 	// Defaults to []string{"skills"}.
-	SkillPaths []string `json:"skillPaths,omitempty"`
+	SkillPaths []string `json:"skillPaths,omitempty" jsonschema_description:"Directories that are scanned for skills. Each direct subdirectory containing a SKILL.md file is exposed as a skill. Defaults to the \"skills\" directory."`
 }
 
 // skillInfo records where a skill's SKILL.md lives and its description.

--- a/go/plugins/middleware/tool_approval.go
+++ b/go/plugins/middleware/tool_approval.go
@@ -51,7 +51,7 @@ type ToolApproval struct {
 	// AllowedTools is the list of tool names pre-approved to run without
 	// interruption. Tools not in this list trigger an interrupt. An empty
 	// list interrupts all tools.
-	AllowedTools []string `json:"allowedTools,omitempty"`
+	AllowedTools []string `json:"allowedTools,omitempty" jsonschema_description:"Tool names pre-approved to run without interruption. Any tool not in this list triggers an interrupt. An empty list interrupts every tool."`
 }
 
 // Name implements [ai.Middleware].


### PR DESCRIPTION
Every config field on the seven built-in middleware reached the Dev UI undescribed. The UI renders a field's description as the tooltip on the help icon beside its label, so none of them offered any explanation. Schema inference runs invopop/jsonschema without a comment map, so a Go doc comment never reaches the schema and only a struct tag does. JS carries the same text via `.describe()` on each zod field.

Descriptions use `jsonschema_description`, following the tool input schemas. `ModelRef` and `AgentRef` are described too, since they are the element types of the `models` and `agents` arrays.

Both `Statuses` fields now carry the canonical status set as an enum on their items, which the UI turns into a multi-select. The enum sits on the two struct tags rather than on a `JSONSchema` method on `status.Name`, because that type is also the `status` field of a serialized error: action output is validated against its inferred schema, so an enum there would reject an error arriving from another runtime with a status this build does not know. `RuntimeError.status` in the shared schema is a bare string for the same reason. Middleware config is never validated, so the enum is a UI hint only.

```go
// Added
status.Names() []Name  // canonical names in gRPC code order, derived from the existing table
```

`internal/schematest` guards both halves: every property in a published config schema needs a description ending in a period, and no `jsonschema` tag in a package's source may carry `description=`, so the comma truncation #6091 fixed cannot return. The second check covers the tool input schemas, which no descriptor exposes.
