### PR TITLE
feat(skills): add plugin gap analysis skill

### DIFF
--- a/skills/plugin-gap-analysis/SKILL.md
+++ b/skills/plugin-gap-analysis/SKILL.md
@@ -10,8 +10,9 @@ target language and the same plugin in a reference language, then **verify every
 handing it over**. Output is Markdown; a human reviews it before anything is filed.
 
 **Roughly half of an unverified first pass needs rework** - some rows factually wrong, more of
-them right about the fact and wrong about the detail or the consequence. Phase 6 is therefore not
-optional, and a list that has not been through it must be labelled as unverified.
+them right about the fact and wrong about the detail or the consequence. Run phase 6 whenever you
+can delegate; when you cannot, label the list unverified in the required wording rather than
+implying it was checked.
 
 ## Arguments
 
@@ -29,12 +30,11 @@ Python comparison, say it is out of scope and why rather than auditing a moving 
 Default: **JS is the reference, Go is the target** - JS is the reference implementation and Go
 plugins have had less focused attention.
 
-**Verify direction per plugin before scoping, and distrust any inherited verdict.** Every run so
-far has come out two-way. An early anthropic run was recorded as one-way with the target behind
-on nearly everything; an independent re-run of the same plugin found the target leading on
-catalog handling and plugin surface, with a third of all rows pointing at the *reference* -
-including two of its strongest correctness findings. The stale verdict measurably primed the
-second auditor in the wrong direction until the evidence overrode it.
+**Verify direction per plugin before scoping, and distrust any inherited verdict.** A recorded
+verdict for a plugin has twice been overturned by an independent re-run of that same plugin, and in
+both cases the auditor reported that the stale verdict primed them before they had read any code.
+Per-plugin verdicts are therefore kept out of this file - see `references/prior-findings.md`, after
+your own tally is written.
 
 Do dimension group 0 first, tally which side leads per group, and state the verdict at the top of
 the report. Where the target leads half the groups, this is a convergence, not a catch-up - and a
@@ -44,8 +44,9 @@ direction as an output of the audit, never an input to it.
 Record reverse-direction gaps in the same flat list either way. The goal is experience parity,
 not a one-way feature checklist.
 
-**Do not read LOC as depth.** google-genai was 13137 JS to 3916 Go, but most of the difference
-was three model families and an agents layer Go does not serve, not depth on the shared path.
+**Do not read LOC as depth**, and do not let a headline ratio set your expectations. A large
+difference is usually families and layers one side does not serve at all, not depth on the shared
+path - dimension 0.6 tells you how to subtract those before choosing where to go deep.
 
 ## Non-goals
 
@@ -95,14 +96,22 @@ Confidence is `confirmed` (read both sides), `needs-repro` (plausible from the c
 E2E reproduction first) or `not-audited` (deferred, say why). Never report `needs-repro` as
 fact.
 
-**6. Adversarially verify every row. Mandatory.** Follow `references/verification.md`. Split
-the rows across several independent checkers with **fresh context**, each given the claims
-alone and told to *refute* them. Reconcile the verdicts: rewrite wrong rows, tighten imprecise
-ones, and keep a `corrected` marker plus a sentence saying what the original got wrong, so the
-trail is auditable rather than quietly rewritten. Expect severity to move in both directions.
+**6. Adversarially verify every row.** Follow `references/verification.md`. Split the rows across
+several independent checkers with **fresh context**, each given the claims alone and told to
+*refute* them. Reconcile the verdicts: rewrite wrong rows, tighten imprecise ones, and keep a
+`corrected` marker plus a sentence saying what the original got wrong, so the trail is auditable
+rather than quietly rewritten. Expect severity to move in both directions.
+
+**If you cannot delegate, you cannot do this phase** - say so rather than claiming it. Use the
+unverified header from the output template, and spend the time re-deriving the reverse-direction
+rows from scratch, since those fail most often. Do not downgrade the phase to self-review and
+present the result as verified. The `corrected` machinery above applies only once this phase has
+run; ignore it otherwise.
 
 **7. Sweep for work already in flight.** Before anything is filed, check open PRs - see
-`references/in-flight.md`. Expect a meaningful share of rows to be covered already; one trial run
+`references/in-flight.md`. **This is a single-agent step**: it needs only `gh` and a shell, so run it
+even when phase 6 is out of reach. One run skipped it on the assumption it needed delegation and lost
+the second-highest-yield hour of the audit. Expect a meaningful share of rows to be covered already; one trial run
 found a PR containing the exact fix for a row the audit had recorded as an open bug. Also flag PRs
 that are a *sequencing hazard* for a row rather than a fix for it.
 
@@ -147,6 +156,13 @@ and rows covered by an open PR should not be filed at all.
   several plugins; note when a fix lands in more than one place. In JS, a plugin serving two
   backends from sibling trees can drift from *itself* - measure the overlap before calling it
   duplication, and defer it to its own same-language run.
+- **Separate framework findings from plugin findings.** A defect whose fix lands in the framework
+  rather than the plugin needs saying so explicitly, or it gets filed against one plugin and fixed
+  in one plugin's options while every other caller keeps the bug. `references/locators.md` lists the
+  hops where this happens.
+- **A missing family is one row, but a missing *prerequisite* is its own row.** When a family is
+  absent and the thing blocking it lives in a different tree - a framework hook, a shared transport
+  layer - split it out, because it survives the family landing and is owned by someone else.
 - **Watch for rows that recur across plugins.** Recurring rows are cross-plugin decisions; say
   so, so they are not filed as per-plugin issues.
 - **Keep distinct decisions distinct.** Do not fold a locally-fixable defect into a broad
@@ -174,23 +190,21 @@ These recur. File them once, at the API-design level, not per plugin.
    staleness: verification showed the reference already resolves unknown IDs and lists from the
    live models API, so the override is a user escape hatch, not a freshness mechanism.
 
-## Prior runs
+## What prior runs taught, without the spoilers
 
-- `anthropic` (JS -> Go), 2026-08-18. Recorded at the time as one-way with the target behind.
-  **Superseded - see the re-run below.**
-- `google-genai` (JS <-> Go), same date. Direction came out two-way, which is what forced dimension
-  group 0 and the direction-check step.
-- **Verification pass over both.** Wrong rows pointed at the *reference* far more often than the
-  target, so reverse-direction claims are the least reliable output of a first pass. Severity moved
-  substantially in both directions, and the verifiers surfaced better bugs than the audit had -
-  including a target-side raw-response field that serialised to empty stubs, breaking response
-  inspection entirely.
-- **Independent re-run of `anthropic`**, 2026-08-19, by an auditor given only this skill and no
-  prior findings. Reached **two-way, net reference ahead** - overturning the earlier verdict - and
-  found several defects both earlier passes missed: an untyped-config union that silently drops a
-  field, server-side tools unreachable from JSON config, a reference that curates three retired
-  model IDs, and a reference that advertises constrained generation then hard-fails it on its own
-  default surface. Two of the three errors this skill's traps were written to prevent did not recur;
-  the third did, and produced the SDK-environment-defaults trap in `verification.md`. Most of its
-  strongest rows came from compiling probes against the pinned SDK rather than reading it, which is
-  why that is now a rule.
+Per-plugin verdicts and specific findings live in `references/prior-findings.md`, unread until your
+list is written. What generalises:
+
+- Every plugin audited so far came out **two-way**, and two recorded verdicts were later overturned
+  by an independent re-run of the same plugin. Direction is an output.
+- Wrong rows point at the **reference** far more often than the target. Reverse-direction claims are
+  the least reliable output of a first pass, and absence claims about the reference are where they
+  fail - it has more escape hatches and more places to look.
+- The strongest rows in every run came from **probing the SDK by running it**, not from reading. A
+  probe that *disproves* an expected defect is worth as much as one that finds a real one.
+- Verifying the **consequence** rather than the fact repeatedly moved severity in both directions,
+  and killed several rows outright.
+- **Test-coverage gaps predict where the bugs are.** In two plugins, the untested conversion path
+  was the path carrying most of the correctness rows.
+- The open-PR sweep covered a meaningful share of rows every time it was run, and titles misled in
+  both plugins. Filter by files touched.

--- a/skills/plugin-gap-analysis/SKILL.md
+++ b/skills/plugin-gap-analysis/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: plugin-gap-analysis
+description: Audit a Genkit provider plugin in one language against its reference implementation in another, adversarially verify every finding, and produce a flat, reviewable Markdown gap list. Use when asked to gap-analyse a plugin, compare Go and JS plugin parity, find what a plugin is missing, or prepare child issues under a plugin parity epic.
+---
+
+# Plugin gap analysis
+
+Produce a **flat, severity-tagged Markdown list of gaps** between a provider plugin in a
+target language and the same plugin in a reference language, then **verify every row before
+handing it over**. Output is Markdown; a human reviews it before anything is filed.
+
+**Roughly half of an unverified first pass needs rework** - some rows factually wrong, more of
+them right about the fact and wrong about the detail or the consequence. Phase 6 is therefore not
+optional, and a list that has not been through it must be labelled as unverified.
+
+## Arguments
+
+- `plugin` (required): `anthropic`, `google-genai`, `compat-oai`, ...
+- `target` (default `go`), `reference` (default `js`)
+
+## Scope
+
+**JS and Go only. Python is out of scope** - it is mid-migration to a separate `genkit-python`
+repo, so a parity claim against what is in this repo would be stale on arrival. If asked for a
+Python comparison, say it is out of scope and why rather than auditing a moving target.
+
+## Direction
+
+Default: **JS is the reference, Go is the target** - JS is the reference implementation and Go
+plugins have had less focused attention.
+
+**Verify direction per plugin before scoping.** The anthropic audit came out one-way, Go behind
+on nearly everything. The google-genai audit came out two-way: Go led on config surface,
+README, samples, transport options and error metadata, while JS led on model-family coverage.
+Do dimension group 0 first, tally which side leads per group, and state the verdict at the top
+of the report. Where the target leads half the groups, this is a convergence, not a catch-up -
+and a workplan that says "bring the target up to the reference" will *remove* capability.
+
+Record reverse-direction gaps in the same flat list either way. The goal is experience parity,
+not a one-way feature checklist.
+
+**Do not read LOC as depth.** google-genai was 13137 JS to 3916 Go, but most of the difference
+was three model families and an agents layer Go does not serve, not depth on the shared path.
+
+## Non-goals
+
+Do not propose designs, do not fix anything, do not file issues without being asked. Do not
+compare against the provider's upstream API - the reference implementation is the baseline. If
+a gap looks like it needs a redesign rather than a fix, tag it and say so; that is a signal to
+stop, not to keep going.
+
+## Workflow
+
+**1. Pin the commit.** Record the SHA you are auditing and use it for every citation. Also
+record the **pinned SDK version on each side** (`go/go.mod`, the installed
+`node_modules/.../package.json`). Version skew masquerades as a plugin bug - see the SDK-skew
+trap in `references/verification.md`.
+
+**2. Locate both plugins.** See `references/locators.md`. Layouts differ per language and per
+plugin, and a plugin may have more than one entry point in a language (Go serves Claude from
+`go/plugins/anthropic`, `go/plugins/compat_oai/anthropic` and `go/plugins/vertexai/modelgarden`).
+Name every entry point found and say which you audited.
+
+**Never conclude "the other language has no plugin for this" from one directory listing**, and
+never from an on-disk listing alone - confirm the path is tracked at your pinned commit. The same
+family is named differently per language (`compat-oai` in JS, `compat_oai` in Go) and may be
+modelled differently on each side.
+
+**3. Walk `references/dimensions.md` in order.** It is the frozen checklist. **Group 0
+(coverage) comes first and is not optional** - it decides both scope and direction. For each
+dimension, read the reference side, read the target side, record a row or record nothing. Do
+not improvise the dimension list; if the plugin forces a question the checklist does not cover,
+answer it *and* append the dimension to the checklist file.
+
+**4. Cite everything, and make citations resolvable.** Every row needs at least one `path:line`
+on the side that has the feature, preferably both. Paths are repo-relative from the root.
+Confirm each cited path exists at the pinned commit - one that does not is a signal, usually an
+untracked directory or a file introduced by an unmerged PR.
+
+**5. Tag severity and confidence.** Number rows with a per-section prefix (`ANT-1`, `GGA-1`,
+`DEC-1`) so a row survives being pasted into an issue on its own.
+
+| Tag | Meaning |
+|-----|---------|
+| **X** | Correctness bug - a valid provider response or a documented config fails |
+| **T** | Table stakes - a feature or config surface users reasonably expect |
+| **C** | Consistency / experience - naming, docs, samples, ergonomics, thin-but-working |
+
+Confidence is `confirmed` (read both sides), `needs-repro` (plausible from the code, wants an
+E2E reproduction first) or `not-audited` (deferred, say why). Never report `needs-repro` as
+fact.
+
+**6. Adversarially verify every row. Mandatory.** Follow `references/verification.md`. Split
+the rows across several independent checkers with **fresh context**, each given the claims
+alone and told to *refute* them. Reconcile the verdicts: rewrite wrong rows, tighten imprecise
+ones, and keep a `corrected` marker plus a sentence saying what the original got wrong, so the
+trail is auditable rather than quietly rewritten. Expect severity to move in both directions.
+
+**7. Sweep for work already in flight.** Before anything is filed, check open PRs - see
+`references/in-flight.md`. Expect a meaningful share of rows to be covered already; one trial run
+found a PR containing the exact fix for a row the audit had recorded as an open bug. Also flag PRs
+that are a *sequencing hazard* for a row rather than a fix for it.
+
+**8. Emit Markdown: flat list, then buckets, then in-flight.** Format in
+`references/output-template.md`. The flat list is what the reviewer validates; buckets are for
+scoping afterwards. Do not curate, merge or drop rows to make the list shorter - a reviewer can
+strike a row, but cannot recover one you never wrote.
+
+**9. Stop.** Hand the list over. Filing child issues is a separate, explicitly requested step,
+and rows covered by an open PR should not be filed at all.
+
+## Rules that keep runs comparable
+
+- **Read the code, not the README.** A README claim is a docs dimension, not evidence of a
+  feature. Several rows came from a config description advertising a capability the response
+  path could not handle.
+- **`grep` for absence, cite for presence** - and treat every absence claim as suspect until
+  you have ruled out the escape hatches in `references/verification.md`. Absence claims were
+  the single largest source of wrong rows. Say which command you ran.
+- **Diff catalogs both ways.** Curated model lists drift independently; neither side is
+  reliably a superset.
+- **Exhaustive switches are gap sites.** For every `switch` over provider block types, stop
+  reasons or part types, list the cases each side handles and diff them. A missing case in a
+  `default: return error` branch is an **X**, not a **C**.
+- **Verify the consequence, not just the fact.** "So the request fails" must be traced to the
+  point of failure. One row correctly identified a hardcoded flag but claimed a failure that
+  could not occur, because no failed tool could reach that code path.
+- **A missing family is one row.** Do not expand it into a row per config field it would have
+  had.
+- **Folding a restricted family into the generic one is an X - but check both sides do not do
+  it.** A restricted family inheriting generic capabilities advertises what the model lacks;
+  that is only a *parity* gap if the reference handles it correctly.
+- **Shared code changes the blast radius.** In Go, `go/plugins/internal/<provider>` is shared by
+  several plugins; note when a fix lands in more than one place. In JS, a plugin serving two
+  backends from sibling trees can drift from *itself* - measure the overlap before calling it
+  duplication, and defer it to its own same-language run.
+- **Watch for rows that recur across plugins.** Recurring rows are cross-plugin decisions; say
+  so, so they are not filed as per-plugin issues.
+- **Keep distinct decisions distinct.** Do not fold a locally-fixable defect into a broad
+  design decision because they touch the same code. One run wrongly folded an SDK-specific
+  type-mapping bug into the config-provenance decision; the other plugin did not share the
+  problem at all.
+- **Out-of-repo dimensions get flagged, not skipped.** Doc-site pages are not in this repo -
+  emit a row saying so rather than silently dropping the dimension.
+
+## Cross-plugin decisions found so far
+
+These recur. File them once, at the API-design level, not per plugin.
+
+1. **Config schema provenance** - curated schema with Genkit-flavoured names (JS) vs the
+   provider SDK's own struct, reflected and annotated (Go). Decides the entire user-facing
+   config vocabulary. Note the evidence cuts both ways: the reference's hand-curated schemas
+   were themselves found to reject values the provider accepts, which is the drift cost
+   curation incurs.
+2. **Per-request auth** - the reference supports a request-level API key and deferred plugin
+   auth; Go resolves the key once at init. Verification found these are *two* asks - multi-tenant
+   key routing and startup ordering - sharing one blocker, plus a third context-carried-secret
+   mechanism for background-model check and cancel.
+3. **Per-model capability override** - Go's `Models`/`Embedders` maps let a caller describe a
+   model newer than the plugin; JS has no equivalent. Do not claim this causes catalog
+   staleness: verification showed the reference already resolves unknown IDs and lists from the
+   live models API, so the override is a user escape hatch, not a freshness mechanism.
+
+## Prior runs
+
+- `anthropic` (JS -> Go), 2026-08-18 at `ccfe1093d`. Direction one-way as expected. Corrected one
+  seed item that had already landed. Several correctness rows were missing cases in
+  response-conversion switches.
+- `google-genai` (JS <-> Go), same commit. **Direction came out two-way**, which is what forced
+  dimension group 0 and the direction-check step.
+- **Verification pass over both.** Wrong rows pointed at the *reference* far more often than the
+  target, so reverse-direction claims are the least reliable output of a first pass. Severity moved
+  substantially in both directions, and the verifiers surfaced better bugs than the audit had -
+  including a target-side `raw` response field that serialised to an empty object, breaking
+  response inspection entirely.

--- a/skills/plugin-gap-analysis/SKILL.md
+++ b/skills/plugin-gap-analysis/SKILL.md
@@ -29,12 +29,17 @@ Python comparison, say it is out of scope and why rather than auditing a moving 
 Default: **JS is the reference, Go is the target** - JS is the reference implementation and Go
 plugins have had less focused attention.
 
-**Verify direction per plugin before scoping.** The anthropic audit came out one-way, Go behind
-on nearly everything. The google-genai audit came out two-way: Go led on config surface,
-README, samples, transport options and error metadata, while JS led on model-family coverage.
-Do dimension group 0 first, tally which side leads per group, and state the verdict at the top
-of the report. Where the target leads half the groups, this is a convergence, not a catch-up -
-and a workplan that says "bring the target up to the reference" will *remove* capability.
+**Verify direction per plugin before scoping, and distrust any inherited verdict.** Every run so
+far has come out two-way. An early anthropic run was recorded as one-way with the target behind
+on nearly everything; an independent re-run of the same plugin found the target leading on
+catalog handling and plugin surface, with a third of all rows pointing at the *reference* -
+including two of its strongest correctness findings. The stale verdict measurably primed the
+second auditor in the wrong direction until the evidence overrode it.
+
+Do dimension group 0 first, tally which side leads per group, and state the verdict at the top of
+the report. Where the target leads half the groups, this is a convergence, not a catch-up - and a
+workplan that says "bring the target up to the reference" will *remove* capability. Treat the
+direction as an output of the audit, never an input to it.
 
 Record reverse-direction gaps in the same flat list either way. The goal is experience parity,
 not a one-way feature checklist.
@@ -114,6 +119,14 @@ and rows covered by an open PR should not be filed at all.
 - **Read the code, not the README.** A README claim is a docs dimension, not evidence of a
   feature. Several rows came from a config description advertising a capability the response
   path could not handle.
+- **Probe the SDK by running it, do not only read it.** This is the highest-yield hour in the
+  audit and reading alone will not find these. Compile a throwaway program against the pinned SDK
+  and print what actually happens: marshal a config fragment, unmarshal it into the params struct,
+  re-marshal, and diff. Reflected-config plugins in particular hide defects that no amount of
+  source reading reveals - an inline union whose discriminator does not round-trip drops the field
+  silently, and a response field that looks populated can serialise to empty stubs. In one run four
+  of the strongest rows, three of them correctness bugs, came only from probes of this kind.
+  Enumerate the SDK's union variants too, and diff them against the cases the plugin handles.
 - **`grep` for absence, cite for presence** - and treat every absence claim as suspect until
   you have ruled out the escape hatches in `references/verification.md`. Absence claims were
   the single largest source of wrong rows. Say which command you ran.
@@ -163,13 +176,21 @@ These recur. File them once, at the API-design level, not per plugin.
 
 ## Prior runs
 
-- `anthropic` (JS -> Go), 2026-08-18 at `ccfe1093d`. Direction one-way as expected. Corrected one
-  seed item that had already landed. Several correctness rows were missing cases in
-  response-conversion switches.
-- `google-genai` (JS <-> Go), same commit. **Direction came out two-way**, which is what forced
-  dimension group 0 and the direction-check step.
+- `anthropic` (JS -> Go), 2026-08-18. Recorded at the time as one-way with the target behind.
+  **Superseded - see the re-run below.**
+- `google-genai` (JS <-> Go), same date. Direction came out two-way, which is what forced dimension
+  group 0 and the direction-check step.
 - **Verification pass over both.** Wrong rows pointed at the *reference* far more often than the
   target, so reverse-direction claims are the least reliable output of a first pass. Severity moved
   substantially in both directions, and the verifiers surfaced better bugs than the audit had -
-  including a target-side `raw` response field that serialised to an empty object, breaking
-  response inspection entirely.
+  including a target-side raw-response field that serialised to empty stubs, breaking response
+  inspection entirely.
+- **Independent re-run of `anthropic`**, 2026-08-19, by an auditor given only this skill and no
+  prior findings. Reached **two-way, net reference ahead** - overturning the earlier verdict - and
+  found several defects both earlier passes missed: an untyped-config union that silently drops a
+  field, server-side tools unreachable from JSON config, a reference that curates three retired
+  model IDs, and a reference that advertises constrained generation then hard-fails it on its own
+  default surface. Two of the three errors this skill's traps were written to prevent did not recur;
+  the third did, and produced the SDK-environment-defaults trap in `verification.md`. Most of its
+  strongest rows came from compiling probes against the pinned SDK rather than reading it, which is
+  why that is now a rule.

--- a/skills/plugin-gap-analysis/references/dimensions.md
+++ b/skills/plugin-gap-analysis/references/dimensions.md
@@ -3,9 +3,9 @@
 The frozen checklist. Walk it in order, once per plugin. Every dimension produces either a
 row in the gap list or nothing.
 
-Extracted from the anthropic JS -> Go run and corrected by the google-genai replay
-(2026-08-18). Append to it when a plugin forces a question these do not cover; never silently
-skip one.
+Each dimension is a **question**, deliberately not an answer - prior findings live in the appendix
+at the end so an auditor can choose whether to be primed by them. Append to the checklist when a
+plugin forces a question these do not cover; never silently skip one.
 
 ## Group 0. Coverage - do this first
 
@@ -56,11 +56,12 @@ these dimensions is a two-way convergence, not a catch-up.
 | C2 | Genkit-common coverage | maxOutputTokens, temperature, topK, topP, stopSequences, version - present, absent, or renamed on each side. |
 | C3 | Provider-specific coverage | Field by field, for every provider config field the reference exposes. |
 | C4 | Validation | Refinements, ranges, mutual exclusions, integer-vs-float constraints, and where they are enforced (plugin vs provider API). |
-| C5 | Managed fields | Fields a Genkit primitive owns (messages, system, model, output format, function tools). Whether setting one is rejected with a pointer to the right option, silently overwritten, or silently dropped. |
+| C5 | Managed-field protection | Which fields a Genkit primitive owns (messages, system, model, output format, function tools), and what happens when config supplies one anyway - rejected with the option to use instead, silently overwritten, or silently dropped. Check the ordering: config spread *after* the framework builds the request body can clobber messages, model, system or tools with no error. |
 | C6 | Dev UI presentation | Field descriptions, hidden fields, and reflection artefacts leaking into the schema. |
-| C7 | Schema type mapping | For reflected schemas: how SDK wrapper types are mapped to JSON Schema primitives, and what happens to a wrapper type the mapping does not name. Matching on `reflect.Type.Name()` string literals degrades silently on an SDK rename; comparing against `reflect.TypeOf(...)` fails at compile time instead. Check whether sibling plugins share the problem before generalising it - one did not, because its SDK uses plain pointer scalars with nothing to remap. |
-| C8 | Passthrough behaviour | Whether the schema rejects unknown keys or spreads them into the wire request, and *where* it spreads them. This decides whether a field absent from the schema is genuinely unreachable: a nested-config passthrough will not reach a field the provider places at the request root. The most common cause of a false "unreachable" row. |
-| C9 | Backend-conditional fields | Fields the SDK accepts on one backend and hard-errors on for another. Where one description map serves both backends, check the descriptions carry the caveat - otherwise a user reads documentation for a field that cannot work. |
+| C7 | Schema type mapping | For reflected schemas: how SDK wrapper types become JSON Schema primitives, and what happens to a wrapper type the mapping does not name. How is the mapping keyed, and would an SDK rename fail loudly or degrade silently? Check whether sibling plugins share whatever you find before generalising it. |
+| C8 | Passthrough behaviour | Whether the schema rejects unknown keys or spreads them into the wire request, and *where* it spreads them. This decides whether a field absent from the schema is genuinely unreachable, and it cuts both ways: passthrough can also let config silently overwrite what a Genkit primitive built. |
+| C9 | Backend-conditional fields | Fields the SDK accepts on one backend and hard-errors on for another. Where one description map serves several backends, check the descriptions carry the caveat. |
+| C10 | Config deserialization path | How an untyped config (`map[string]any`, JSON from the Dev UI or an HTTP transport) becomes the typed config the model function receives, and **whether the typed and untyped paths behave identically**. Probe it by running it - see the SDK-probing rule in SKILL.md. A discriminated union that does not round-trip drops the field with no error, which makes the bug invisible to typed callers and to source reading, and reachable only through the Dev UI. Establish this early: every other config row depends on it. |
 
 ## D. Request conversion
 
@@ -103,7 +104,7 @@ Only applies when group 0.1 found a background-model or check-operation action.
 
 | # | Dimension | What to compare |
 |---|-----------|-----------------|
-| F1 | Status classification | Per HTTP code. Check provider-specific codes (e.g. 529) individually - a generic `>= 500 -> Internal` fallback misclassifies them. |
+| F1 | Status classification | Per HTTP code, on both sides. Provider-specific codes need checking individually rather than assuming the general mapping covers them. Follow the classification helper wherever it leads: the code table may live in the framework, outside any plugin directory. |
 | F2 | Retry metadata | Whether `retry-after` (both delay-seconds and HTTP-date forms) reaches the caller. |
 | F3 | Caller-fault vs server-fault | Whether a bad request is classified so retry middleware does not reissue it. |
 | F4 | Message quality | Whether the error names the option to use instead. |
@@ -124,3 +125,39 @@ Only applies when group 0.1 found a background-model or check-operation action.
 | H1 | Unit coverage | Which of the dimensions above have a test on each side. |
 | H2 | Live tests | Presence, and what they cover. |
 | H3 | Conformance tests | Whether the plugin participates in the shared conformance suite. |
+
+---
+
+# Appendix: known findings from prior runs
+
+**Spoilers. Skip this section while auditing** if you want an independent result, and read it
+afterwards as a completeness check.
+
+The dimensions above are deliberately phrased as questions. Earlier drafts embedded the answers
+from prior runs, and an independent auditor reported that this stopped some rows from being real
+derivations - it confirmed conclusions it had been handed. The findings still have value as a
+coverage check, so they live here instead, separated from the checklist.
+
+Treat every entry as dated and possibly closed. Verify against the current commit before reusing.
+
+- **C7** - a Go plugin keyed its SDK wrapper-type remap on `reflect.Type.Name()` string literals,
+  which degrades silently on an SDK rename rather than failing at build time. A sibling plugin did
+  not share the problem, because its SDK uses plain pointer scalars with nothing to remap.
+- **C8** - a reference-side schema ending `.passthrough()` spread unknown keys into the nested
+  config object, so a field the provider places at the *request root* stayed unreachable while two
+  sibling fields did not. The same passthrough let config overwrite messages, model, system and
+  tools after the framework had built them.
+- **C10** - an inline union discriminator (`{"type":"adaptive"}`) failed to round-trip through
+  `map[string]any` into the SDK params struct, so the field vanished with no error on the untyped
+  path while the typed path worked. Reachable only through the Dev UI and invisible to source
+  reading.
+- **E1** - a Go response switch handled three of the SDK's twelve content-block variants and
+  returned an error for the rest, so a safety-redacted thinking block failed the whole request.
+- **E4** - a Go plugin assigned the SDK's field-presence bookkeeping struct to the raw response
+  field, which serialises to empty stubs; the intended value was the SDK's raw-JSON accessor.
+- **F1** - a provider's overload code (529) fell through a generic `>= 500 -> Internal` branch in
+  the framework's code table, landing the one retryable condition in the wrong retry class.
+- **G1/G2** - a target README asserted a capability that two correctness rows showed did not work
+  end-to-end. README claims are a docs dimension, never evidence of a feature.
+- **H1** - the language with no unit test for its response-conversion path was the language whose
+  response path carried five separate defects. Test-coverage gaps predict where the bugs are.

--- a/skills/plugin-gap-analysis/references/dimensions.md
+++ b/skills/plugin-gap-analysis/references/dimensions.md
@@ -1,0 +1,126 @@
+# Gap analysis dimensions
+
+The frozen checklist. Walk it in order, once per plugin. Every dimension produces either a
+row in the gap list or nothing.
+
+Extracted from the anthropic JS -> Go run and corrected by the google-genai replay
+(2026-08-18). Append to it when a plugin forces a question these do not cover; never silently
+skip one.
+
+## Group 0. Coverage - do this first
+
+Coverage decides scope. Running it late means auditing the shared path in depth while a whole
+model family is missing. It also decides direction: a plugin where the target is ahead on half
+these dimensions is a two-way convergence, not a catch-up.
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| 0.1 | Action types served | model, background-model, check-operation, embedder, and anything else. Diff the sets. |
+| 0.2 | Model families | Text/multimodal, TTS, image generation, video, music, research/agent, and each provider-specific family. A family absent on one side is one row, not thirty. |
+| 0.3 | Family-specific config and capabilities | Whether each family gets its own schema and capability set, or is folded into the generic one. Folding a restricted family (e.g. Gemma) into the general one makes the plugin advertise capabilities the model does not have - that is an **X**. |
+| 0.4 | Backend variants | Whether one plugin serves several backends (dev API vs enterprise), and how. Shared implementation with per-backend model lists vs duplicated per-backend trees. Duplicated trees drift from *each other* - a same-language parity audit worth its own run. |
+| 0.5 | Non-model plugin features | Context caching, code execution, batching, operation polling, file upload - features that are not a config field on a model action. |
+| 0.6 | Direction check | Tally which side leads per group. State the verdict at the top of the report. Do not assume the reference language leads. |
+| 0.7 | Pinned SDK versions | Record the provider SDK version each side pins (`go/go.mod`, the installed JS package). Skew is common and it reattributes gaps: one row blamed the target for a stale enum when the reference was rejecting a value its own newer SDK accepts. Any row citing an SDK capability must name the version. |
+| 0.8 | Pending dependency bumps | Check for an open dependency-bump PR against either SDK. A large version jump can invalidate a row's conclusion or trigger a fragility the audit only flagged as theoretical. |
+
+## A. Plugin surface and entry points
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| A1 | Entry points | Every place the provider is served from in each language. More than one is common. |
+| A2 | Plugin options | Field-by-field: what can be configured at construction time. |
+| A3 | Auth resolution | Order of precedence across request config, plugin option, env vars. Whether request-level keys exist. Whether auth can be deferred to request time. Whether a missing key panics, throws, or defers. |
+| A4 | Client escape hatch | Base URL override, custom transport/fetch, request options, middleware, timeouts, retries, extra headers, credentials objects. This is also how alternative routing (Bedrock, Vertex, Express Mode, a proxy) is reached - absence blocks whole deployment modes. Note whether supplying a custom client silently drops default instrumentation. |
+| A5 | Model reference helper | Name, signature, and config type of the "name a model and carry config" helper. |
+| A6 | Per-model capability override | Whether a caller can correct or extend what the plugin believes about a model, e.g. one released after the plugin version. |
+| A7 | Deprecated surface | Legacy define/lookup APIs present on one side only. Cleanup candidates, not parity gaps - tag **C** and say so. |
+| A8 | Debug and compatibility valves | Raw-request tracing toggles, legacy-format switches, and anything else that exists to unblock a user on an older deployment. Easy to miss because they are not features. |
+
+## B. Model catalog
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| B1 | Curated model list | Diff the ID sets **both ways**. Neither side is reliably a superset. |
+| B2 | Declared capabilities | Per model: multiturn, tools, toolChoice, media, systemRole, output formats, constrained generation. Diff the flags, not just their presence. |
+| B3 | Stage, versions, label | Dev UI surfaces all three; one side often sets none. |
+| B4 | Dynamic listing | Whether the plugin lists models from the API, whether results are cached and for how long, and how a discovery failure is reported. |
+| B5 | Dynamic fallback | What an unknown/undeclared model resolves to, and what it claims to support. |
+| B6 | Name normalisation | Provider-prefix trimming, date-suffix stripping, alias handling. A mismatch here means the curated list silently never matches. |
+
+## C. Config schema
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| C1 | Schema provenance | Curated (hand-written, Genkit-flavoured names) vs reflected from the provider SDK struct (raw provider names). This decides the whole user-facing config vocabulary and is usually the largest single row in the report. |
+| C2 | Genkit-common coverage | maxOutputTokens, temperature, topK, topP, stopSequences, version - present, absent, or renamed on each side. |
+| C3 | Provider-specific coverage | Field by field, for every provider config field the reference exposes. |
+| C4 | Validation | Refinements, ranges, mutual exclusions, integer-vs-float constraints, and where they are enforced (plugin vs provider API). |
+| C5 | Managed fields | Fields a Genkit primitive owns (messages, system, model, output format, function tools). Whether setting one is rejected with a pointer to the right option, silently overwritten, or silently dropped. |
+| C6 | Dev UI presentation | Field descriptions, hidden fields, and reflection artefacts leaking into the schema. |
+| C7 | Schema type mapping | For reflected schemas: how SDK wrapper types are mapped to JSON Schema primitives, and what happens to a wrapper type the mapping does not name. Matching on `reflect.Type.Name()` string literals degrades silently on an SDK rename; comparing against `reflect.TypeOf(...)` fails at compile time instead. Check whether sibling plugins share the problem before generalising it - one did not, because its SDK uses plain pointer scalars with nothing to remap. |
+| C8 | Passthrough behaviour | Whether the schema rejects unknown keys or spreads them into the wire request, and *where* it spreads them. This decides whether a field absent from the schema is genuinely unreachable: a nested-config passthrough will not reach a field the provider places at the request root. The most common cause of a false "unreachable" row. |
+| C9 | Backend-conditional fields | Fields the SDK accepts on one backend and hard-errors on for another. Where one description map serves both backends, check the descriptions carry the caveat - otherwise a user reads documentation for a field that cannot work. |
+
+## D. Request conversion
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| D1 | Role mapping | Including tool roles, and how a tool-result message is re-roled. |
+| D2 | System messages | Where they are extracted from, whether non-text content is rejected, whether an empty system block can be sent. |
+| D3 | Part types accepted | text, media, data, toolRequest, toolResponse, reasoning, custom. Diff the accepted set. |
+| D4 | Media sources | base64, remote URL, provider file ID. Accepted content types per source. A base64-only implementation silently inlines bytes the other side would send as a URL. |
+| D5 | Tool definitions | Name validation, empty-schema defaulting, strict mode, schema rewriting, per-provider carve-outs. |
+| D6 | Tool choice | Mapping of each Genkit tool-choice value, and whether an unset value clobbers a config-provided one. |
+| D7 | Structured output | Native constrained path vs prompt-instruction fallback, which models it is enabled for, and schema rewriting applied. |
+| D8 | Provider extras | Caching directives, citations/documents, server-side tools, beta feature flags, multipart tool results. |
+| D9 | Concurrency safety | Whether a shared/hoisted config can be mutated by a request (slice aliasing, in-place appends). |
+
+## E. Response conversion
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| E1 | Content block coverage | Enumerate every block type the provider can return and diff which side handles each. A block landing in a `default:` error branch is an **X**. |
+| E2 | Stop reason mapping | Every provider stop reason, and what an unmapped one becomes. |
+| E3 | Usage fields | Input, output, cached-read, cache-creation, reasoning/thoughts tokens. |
+| E4 | Raw passthrough | Whether the raw provider response and/or a `custom` field is populated. |
+| E5 | Streaming coverage | Which events produce chunks, chunk shape, whether non-text blocks stream at all, and whether signatures/metadata that only arrive on a separate event are captured. |
+| E6 | Stream termination | What happens when a stream ends without a terminal event. |
+
+## E'. Long-running actions
+
+Only applies when group 0.1 found a background-model or check-operation action.
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| E'1 | Start/check split | Whether both actions exist and whether one registration serves both keys. |
+| E'2 | Operation polling | How an operation handle is represented, and how a not-yet-done operation is reported. |
+| E'3 | Result retrieval | Output shape per backend - a URI to fetch vs inline bytes is a real user-visible divergence. |
+| E'4 | Failure and filtering | How a provider-side rejection mid-operation surfaces. |
+| E'5 | Batching | Request-splitting limits per backend and per model, for embedders and any other batched action. Absence means a large request fails at the API instead of being chunked. |
+
+## F. Errors
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| F1 | Status classification | Per HTTP code. Check provider-specific codes (e.g. 529) individually - a generic `>= 500 -> Internal` fallback misclassifies them. |
+| F2 | Retry metadata | Whether `retry-after` (both delay-seconds and HTTP-date forms) reaches the caller. |
+| F3 | Caller-fault vs server-fault | Whether a bad request is classified so retry middleware does not reissue it. |
+| F4 | Message quality | Whether the error names the option to use instead. |
+
+## G. Docs and DX
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| G1 | README sections | Diff the heading lists, not the word counts. |
+| G2 | Samples and testapps | Which features each sample actually exercises. |
+| G3 | Exported helpers | Public helper functions and types available to users on each side. |
+| G4 | Doc-site page | **Not in this repo.** Emit a row noting it must be tracked in the docs repo. |
+
+## H. Tests
+
+| # | Dimension | What to compare |
+|---|-----------|-----------------|
+| H1 | Unit coverage | Which of the dimensions above have a test on each side. |
+| H2 | Live tests | Presence, and what they cover. |
+| H3 | Conformance tests | Whether the plugin participates in the shared conformance suite. |

--- a/skills/plugin-gap-analysis/references/dimensions.md
+++ b/skills/plugin-gap-analysis/references/dimensions.md
@@ -3,9 +3,10 @@
 The frozen checklist. Walk it in order, once per plugin. Every dimension produces either a
 row in the gap list or nothing.
 
-Each dimension is a **question**, deliberately not an answer - prior findings live in the appendix
-at the end so an auditor can choose whether to be primed by them. Append to the checklist when a
-plugin forces a question these do not cover; never silently skip one.
+Each dimension is a **question**, deliberately not an answer. Prior findings live in
+`prior-findings.md`, which you should not open until your list is written - two independent runs
+reported that handed-over conclusions stopped rows from being real derivations. Append to the
+checklist when a plugin forces a question these do not cover; never silently skip one.
 
 ## Group 0. Coverage - do this first
 
@@ -20,9 +21,11 @@ these dimensions is a two-way convergence, not a catch-up.
 | 0.3 | Family-specific config and capabilities | Whether each family gets its own schema and capability set, or is folded into the generic one. Folding a restricted family (e.g. Gemma) into the general one makes the plugin advertise capabilities the model does not have - that is an **X**. |
 | 0.4 | Backend variants | Whether one plugin serves several backends (dev API vs enterprise), and how. Shared implementation with per-backend model lists vs duplicated per-backend trees. Duplicated trees drift from *each other* - a same-language parity audit worth its own run. |
 | 0.5 | Non-model plugin features | Context caching, code execution, batching, operation polling, file upload - features that are not a config field on a model action. |
-| 0.6 | Direction check | Tally which side leads per group. State the verdict at the top of the report. Do not assume the reference language leads. |
-| 0.7 | Pinned SDK versions | Record the provider SDK version each side pins (`go/go.mod`, the installed JS package). Skew is common and it reattributes gaps: one row blamed the target for a stale enum when the reference was rejecting a value its own newer SDK accepts. Any row citing an SDK capability must name the version. |
-| 0.8 | Pending dependency bumps | Check for an open dependency-bump PR against either SDK. A large version jump can invalidate a row's conclusion or trigger a fragility the audit only flagged as theoretical. |
+| 0.6 | Effort budget | Where LOC differs sharply, compute LOC per family on both sides and subtract the families the target does not serve *before* deciding where to go deep. Without this the shared path is invisible behind a headline ratio, and a run can spend its first third discovering that a 9000-line gap is three absent families. |
+| 0.7 | Direction check | Tally which side leads per group. State the verdict at the top of the report. Do not assume the reference language leads. |
+| 0.8 | Client provenance | Does each side wrap a vendored provider SDK, or hand-roll its own HTTP client? One of each is a real configuration, and it reframes several dimensions below - A4's escape hatches, C1's provenance, C7's type mapping and F1's classification all become "who wrote the client" questions. A hand-rolled client also has no SDK environment defaults to fall back on, which changes whether an absence claim is correct. |
+| 0.9 | Pinned SDK versions | Record the provider SDK version each side pins (`go/go.mod`, the installed JS package). Skew is common and it reattributes gaps: one row blamed the target for a stale enum when the reference was rejecting a value its own newer SDK accepts. Any row citing an SDK capability must name the version. |
+| 0.10 | Pending dependency bumps | Check for an open dependency-bump PR against either SDK. A large version jump can invalidate a row's conclusion or trigger a fragility the audit only flagged as theoretical. |
 
 ## A. Plugin surface and entry points
 
@@ -32,9 +35,9 @@ these dimensions is a two-way convergence, not a catch-up.
 | A2 | Plugin options | Field-by-field: what can be configured at construction time. |
 | A3 | Auth resolution | Order of precedence across request config, plugin option, env vars. Whether request-level keys exist. Whether auth can be deferred to request time. Whether a missing key panics, throws, or defers. |
 | A4 | Client escape hatch | Base URL override, custom transport/fetch, request options, middleware, timeouts, retries, extra headers, credentials objects. This is also how alternative routing (Bedrock, Vertex, Express Mode, a proxy) is reached - absence blocks whole deployment modes. Note whether supplying a custom client silently drops default instrumentation. |
-| A5 | Model reference helper | Name, signature, and config type of the "name a model and carry config" helper. |
-| A6 | Per-model capability override | Whether a caller can correct or extend what the plugin believes about a model, e.g. one released after the plugin version. |
-| A7 | Deprecated surface | Legacy define/lookup APIs present on one side only. Cleanup candidates, not parity gaps - tag **C** and say so. |
+| A5 | SDK defaults and environment variables | Before recording any client option as unreachable, check whether the provider SDK reads it from the environment or defaults it itself. A plugin that never passes a base URL may still honour a `*_BASE_URL` variable because the SDK constructor defaults from it. Two separate runs got this wrong on the same row. Scope the grep to plugin code to find what the *plugin* does, then check the SDK for what the user actually gets. |
+| A6 | Model reference helper | Name, signature, and config type of the "name a model and carry config" helper. |
+| A7 | Per-model capability override | Whether a caller can correct or extend what the plugin believes about a model, e.g. one released after the plugin version. |
 | A8 | Debug and compatibility valves | Raw-request tracing toggles, legacy-format switches, and anything else that exists to unblock a user on an older deployment. Easy to miss because they are not features. |
 
 ## B. Model catalog
@@ -125,39 +128,3 @@ Only applies when group 0.1 found a background-model or check-operation action.
 | H1 | Unit coverage | Which of the dimensions above have a test on each side. |
 | H2 | Live tests | Presence, and what they cover. |
 | H3 | Conformance tests | Whether the plugin participates in the shared conformance suite. |
-
----
-
-# Appendix: known findings from prior runs
-
-**Spoilers. Skip this section while auditing** if you want an independent result, and read it
-afterwards as a completeness check.
-
-The dimensions above are deliberately phrased as questions. Earlier drafts embedded the answers
-from prior runs, and an independent auditor reported that this stopped some rows from being real
-derivations - it confirmed conclusions it had been handed. The findings still have value as a
-coverage check, so they live here instead, separated from the checklist.
-
-Treat every entry as dated and possibly closed. Verify against the current commit before reusing.
-
-- **C7** - a Go plugin keyed its SDK wrapper-type remap on `reflect.Type.Name()` string literals,
-  which degrades silently on an SDK rename rather than failing at build time. A sibling plugin did
-  not share the problem, because its SDK uses plain pointer scalars with nothing to remap.
-- **C8** - a reference-side schema ending `.passthrough()` spread unknown keys into the nested
-  config object, so a field the provider places at the *request root* stayed unreachable while two
-  sibling fields did not. The same passthrough let config overwrite messages, model, system and
-  tools after the framework had built them.
-- **C10** - an inline union discriminator (`{"type":"adaptive"}`) failed to round-trip through
-  `map[string]any` into the SDK params struct, so the field vanished with no error on the untyped
-  path while the typed path worked. Reachable only through the Dev UI and invisible to source
-  reading.
-- **E1** - a Go response switch handled three of the SDK's twelve content-block variants and
-  returned an error for the rest, so a safety-redacted thinking block failed the whole request.
-- **E4** - a Go plugin assigned the SDK's field-presence bookkeeping struct to the raw response
-  field, which serialises to empty stubs; the intended value was the SDK's raw-JSON accessor.
-- **F1** - a provider's overload code (529) fell through a generic `>= 500 -> Internal` branch in
-  the framework's code table, landing the one retryable condition in the wrong retry class.
-- **G1/G2** - a target README asserted a capability that two correctness rows showed did not work
-  end-to-end. README claims are a docs dimension, never evidence of a feature.
-- **H1** - the language with no unit test for its response-conversion path was the language whose
-  response path carried five separate defects. Test-coverage gaps predict where the bugs are.

--- a/skills/plugin-gap-analysis/references/in-flight.md
+++ b/skills/plugin-gap-analysis/references/in-flight.md
@@ -1,0 +1,61 @@
+# Sweeping for work already in flight
+
+Run after verification, before anything is filed. **Expect a meaningful share of rows to be
+covered already** - in one trial run, a PR in review contained the exact fix for a row the audit
+had recorded as an open bug. Filing those as child issues duplicates work that needs a rebase and
+a review, not a ticket.
+
+## How to sweep
+
+PRs go to the public upstream (`genkit-ai/genkit`), not the private mirror - check `git remote -v`
+and target upstream explicitly.
+
+```
+gh pr list --repo <upstream> --state open --limit 250 \
+  --json number,title,author,isDraft,updatedAt,files
+```
+
+Filter by **files touched**, not title. Titles miss things and mislead: one PR titled as a
+Python change carried diffs to the Go plugin, and one titled "polish X support" created X from
+nothing. Match paths against the plugin directories from `locators.md`.
+
+Then, for each row with no title-level match, check whether *any* open PR touches the specific
+file the row cites. That is what establishes "nothing in flight" credibly:
+
+> Only four open PRs touch `<the cited file>` and none address these.
+
+Keyword-search bodies for the row's subject too, but expect mostly noise - a handful of terms
+produced a couple of real hits and a lot of unrelated matches.
+
+## What to record per covered row
+
+Row ID, PR number, author, state, and **what the PR does not cover**. Partial coverage is the
+common case:
+
+- a PR adding one model of a family, where the row is about the family
+- a PR fixing one direction of a two-way row
+- a PR solving the row with a *different API shape* than the reference uses, which converts the
+  remainder from missing work into a design decision
+- a draft covering half of a two-part row
+
+Also record merge state. Every feature PR in the first sweep was conflicted against main and
+months stale, which turned the workplan's "coordinate with in-flight infra PRs" from a
+forward-looking risk into a present blocker - and made an already-approved, merely-conflicted PR
+the cheapest available win.
+
+## Two categories beyond simple coverage
+
+**Sequencing hazards.** A PR that is not a fix for a row but will *trigger* it. A pending
+dependency bump jumped an SDK 39 minor versions, which is exactly the silent-breakage scenario
+one row described, with no test guarding it - and would also invalidate two other rows'
+conclusions. Emit as its own row with a `risk` tag and state the ordering.
+
+**Provenance to confirm.** Where a PR's description implies a baseline the audit could not find,
+say so and name who to ask rather than assuming either way. Do not treat the row as covered
+until it is resolved.
+
+## Noise to discount explicitly
+
+A stale branch shows diffs for work already merged at your commit. Check whether the diff's
+"new" lines are already present at the audited SHA before treating it as an overlap, and say in
+the report that you discounted it - otherwise the next reader re-investigates it.

--- a/skills/plugin-gap-analysis/references/locators.md
+++ b/skills/plugin-gap-analysis/references/locators.md
@@ -1,7 +1,7 @@
 # Where plugins live
 
-Layouts differ per language and per plugin. Verify with `ls` before reading - this table goes
-stale.
+Layouts differ per language and per plugin, and these tables go stale. Confirm everything against
+the tracked tree at your pinned commit, not against `ls` - see below.
 
 ## Scope: JS and Go only
 
@@ -70,28 +70,15 @@ Known cases for Claude in Go: `go/plugins/anthropic`,
 `go/plugins/compat_oai/anthropic`, `go/plugins/vertexai/modelgarden/anthropic.go`.
 The first and third share `go/plugins/internal/anthropic`, so a fix there lands in both.
 
-## File-role map
+## Do not assume a file layout
 
-Repo-relative, so a citation copied out of here resolves without guessing. `<plugin>` is the
-directory name from the table above; `<provider>` is the Go shared-package name.
+There was a file-role map here - which file holds the config schema, the catalog, the conversion
+layer - and it was wrong for the second plugin anyone audited, which keeps its whole implementation
+in the plugin package with no shared internal directory. A table that is wrong for the plugin in
+front of you, and carries a disclaimer saying it might be, is worse than no table: it invites a
+citation to a path that does not exist.
 
-| Role | JS | Go |
-|------|----|----|
-| Plugin entry, options, init | `js/plugins/<plugin>/src/index.ts` | `go/plugins/<plugin>/<plugin>.go` |
-| Config schema and types | `js/plugins/<plugin>/src/types.ts` | reflected from the SDK params struct in `go/plugins/internal/<provider>/<provider>.go`; presentation in `go/plugins/internal/<provider>/config_overrides.go` |
-| Model catalog, capabilities | `js/plugins/<plugin>/src/models.ts` | `go/plugins/<plugin>/models.go` |
-| Dynamic listing | `js/plugins/<plugin>/src/list.ts` | `ListActions` in `go/plugins/<plugin>/<plugin>.go`, `listModels` in `go/plugins/<plugin>/models.go` |
-| Request/response conversion | `js/plugins/<plugin>/src/runner/**` | `go/plugins/internal/<provider>/<provider>.go` |
-| Error classification | inline in `js/plugins/<plugin>/src/models.ts` | `go/plugins/<plugin>/errors.go` or `go/plugins/internal/<provider>/errors.go` |
-| Model reference helper | `js/plugins/<plugin>/src/index.ts` (`.model()`) | `go/plugins/<plugin>/refs.go` (`ModelRef`) |
-| Tests | `js/plugins/<plugin>/tests/*_test.ts` | `go/plugins/<plugin>/*_test.go`, `*_live_test.go` |
-| Samples | `js/testapps/<plugin>` | `go/samples/<plugin>` |
-
-**This is the single-family shape.** A plugin serving several model families splits these roles
-per family instead - google-genai has no `src/models.ts` or `src/types.ts` at the plugin root, and
-its catalog and config schemas live per family under `src/googleai/` and `src/vertexai/` with
-shared conversion in `src/common/`. Locate the roles before citing them rather than assuming this
-table's filenames exist.
+Two `git ls-tree` calls replace it. Locate the roles in the plugin you are auditing.
 
 ## Not in this repo
 

--- a/skills/plugin-gap-analysis/references/locators.md
+++ b/skills/plugin-gap-analysis/references/locators.md
@@ -1,0 +1,93 @@
+# Where plugins live
+
+Layouts differ per language and per plugin. Verify with `ls` before reading - this table goes
+stale.
+
+## Scope: JS and Go only
+
+**Python is out of scope.** It is mid-migration to a separate `genkit-python` repo, so anything
+Python-shaped in this repo is in flux and a parity claim against it would be stale on arrival.
+Do not audit it, do not cite it, and do not file a row for a plugin "missing" in Python.
+
+If a caller asks for a Python comparison, say it is out of scope and why, rather than producing
+a list against a moving target.
+
+## Confirm paths against the tracked tree, not the filesystem
+
+Verify every path you cite is tracked at your pinned commit. An on-disk listing is not evidence:
+directories exist in working copies that are not in the repo at all.
+
+```
+git cat-file -e <sha>:<path>     # exists?
+git cat-file -t <sha>:<path>     # blob or tree?
+```
+
+A path that fails is one of three things, each meaning something different: an untracked local
+directory (drop the citation), a file created by an unmerged PR (a signal the row is already
+being worked on - see `in-flight.md`), or a typo.
+
+One tracked path that is easy to get wrong: the CLI and tooling live at **`genkit-tools/`** in
+the repo root, not under `js/`.
+
+## Per plugin
+
+| plugin | JS | Go |
+|--------|----|----|
+| anthropic | `js/plugins/anthropic` | `go/plugins/anthropic` + shared `go/plugins/internal/anthropic` |
+| google-genai | `js/plugins/google-genai` (sibling `src/googleai/` and `src/vertexai/` trees over a shared `src/common/`) | `go/plugins/googlegenai` (one package, `GoogleAI` and `VertexAI` structs) |
+| openai / compat-oai | `js/plugins/compat-oai` | `go/plugins/compat_oai` (+ `openai`, `xai`, `zai`, `kimi`, `deepseek`, `dashscope`, `anthropic` sub-plugins) |
+
+Legacy plugins overlap the modern ones and are separate packages: `js/plugins/vertexai` (which
+is where JS serves Vertex-hosted Claude, via `src/modelgarden/`) and `go/plugins/vertexai`
+(`modelgarden`, `vectorsearch`). A row about a "missing" backend often lives in one of these.
+
+Note the naming: JS uses kebab-case directories, Go uses no separator or an underscore. Names do
+not line up across the two either - the OpenAI-compatible family is `compat-oai` in JS and
+`compat_oai` in Go, and the two are not the same shape, since Go factors sub-providers into
+separate sub-packages. Establish what each language actually models before diffing
+feature-by-feature.
+
+A plugin present in only one language is an inventory fact worth stating, not a gap to file
+against the other.
+
+## Additional entry points
+
+A provider is often served from more than one place. Find them before auditing:
+
+```
+find . -maxdepth 5 -type d -iname "*<provider>*" \
+  -not -path "*/node_modules/*" -not -path "./.claude/*"
+```
+
+Known cases for Claude in Go: `go/plugins/anthropic`,
+`go/plugins/compat_oai/anthropic`, `go/plugins/vertexai/modelgarden/anthropic.go`.
+The first and third share `go/plugins/internal/anthropic`, so a fix there lands in both.
+
+## File-role map
+
+Repo-relative, so a citation copied out of here resolves without guessing. `<plugin>` is the
+directory name from the table above; `<provider>` is the Go shared-package name.
+
+| Role | JS | Go |
+|------|----|----|
+| Plugin entry, options, init | `js/plugins/<plugin>/src/index.ts` | `go/plugins/<plugin>/<plugin>.go` |
+| Config schema and types | `js/plugins/<plugin>/src/types.ts` | reflected from the SDK params struct in `go/plugins/internal/<provider>/<provider>.go`; presentation in `go/plugins/internal/<provider>/config_overrides.go` |
+| Model catalog, capabilities | `js/plugins/<plugin>/src/models.ts` | `go/plugins/<plugin>/models.go` |
+| Dynamic listing | `js/plugins/<plugin>/src/list.ts` | `ListActions` in `go/plugins/<plugin>/<plugin>.go`, `listModels` in `go/plugins/<plugin>/models.go` |
+| Request/response conversion | `js/plugins/<plugin>/src/runner/**` | `go/plugins/internal/<provider>/<provider>.go` |
+| Error classification | inline in `js/plugins/<plugin>/src/models.ts` | `go/plugins/<plugin>/errors.go` or `go/plugins/internal/<provider>/errors.go` |
+| Model reference helper | `js/plugins/<plugin>/src/index.ts` (`.model()`) | `go/plugins/<plugin>/refs.go` (`ModelRef`) |
+| Tests | `js/plugins/<plugin>/tests/*_test.ts` | `go/plugins/<plugin>/*_test.go`, `*_live_test.go` |
+| Samples | `js/testapps/<plugin>` | `go/samples/<plugin>` |
+
+**This is the single-family shape.** A plugin serving several model families splits these roles
+per family instead - google-genai has no `src/models.ts` or `src/types.ts` at the plugin root, and
+its catalog and config schemas live per family under `src/googleai/` and `src/vertexai/` with
+shared conversion in `src/common/`. Locate the roles before citing them rather than assuming this
+table's filenames exist.
+
+## Not in this repo
+
+Doc-site pages. `docs/` here holds only internal specs (`model-spec.md`,
+`reflection-v2-protocol.md`, `agents-conformance-testing.md`). Doc-site parity is tracked in
+the docs repo.

--- a/skills/plugin-gap-analysis/references/locators.md
+++ b/skills/plugin-gap-analysis/references/locators.md
@@ -29,6 +29,13 @@ being worked on - see `in-flight.md`), or a typo.
 One tracked path that is easy to get wrong: the CLI and tooling live at **`genkit-tools/`** in
 the repo root, not under `js/`.
 
+**Several roles a plugin appears to own actually live in the framework**, and a row is invisible
+until you follow the call out of the plugin tree. Known hops: the HTTP-status-to-Genkit-status code
+table (`go/core/status`), untyped-config deserialization (`go/ai/config.go` into
+`go/internal/base/json.go`), media-part URI handling (`go/plugins/internal/uri`), and the response
+and finish-reason types (`go/ai/gen.go`). A defect in any of these surfaces as a plugin bug and
+fixes in the shared ones land across every plugin that calls them.
+
 ## Per plugin
 
 | plugin | JS | Go |

--- a/skills/plugin-gap-analysis/references/output-template.md
+++ b/skills/plugin-gap-analysis/references/output-template.md
@@ -17,7 +17,8 @@ Then **one of the two headers below**, never neither.
 > tag and say what the original got wrong. <Which direction the wrong rows pointed, so the reader
 > knows which half of the list is least settled.>
 
-*If phase 6 did not run* - required wording, at the top, before any row:
+*If phase 6 did not run* - required wording, at the top, before any row. Write the rows first and
+backfill `<n>`:
 
 > **THIS LIST IS UNVERIFIED.** Phase 6 (adversarial verification) <and phase 7 (the open-PR
 > sweep)> did not run. Roughly half of an unverified first pass needs rework, and wrong rows skew
@@ -33,6 +34,11 @@ Severity: **X** = correctness bug (a valid provider response or documented confi
 **T** = table stakes; **C** = consistency/experience.
 Confidence: **confirmed** = both sides read; **needs-repro** = plausible from code, wants an E2E
 reproduction before filing; **not-audited** = deferred.
+
+Add `reverse-direction` to the tag of any row where the *reference* is the side that is missing
+something, and `corrected` to any row a verification pass rewrote. Prose is not enough: a reader
+scanning for "what do we fix in the target" should not have to read every row's evidence to find
+out which way it points.
 
 ## <plugin>: <reference> to <target>
 
@@ -55,7 +61,7 @@ there was none**; do not emit the heading with a disclaimer.
 <Reference behaviour with `path:line`. Target behaviour with `path:line`, or the exact grep that
 shows absence. Consequence for the user.>
 
-**ANT-2. <One-line claim.>**  `[X, confirmed, corrected]`
+**ANT-2. <One-line claim.>**  `[X, confirmed, reverse-direction]`
 
 <Originally stated as "<the wrong claim>". <What is actually true, with evidence.>>
 
@@ -66,6 +72,11 @@ shows absence. Consequence for the user.>
 - **API shape decisions (T/C):** row IDs — design decisions, not independent tickets.
 - **<reference>-side gaps (reverse direction):** row IDs — the reference is not a superset.
 - **Docs and samples (C):** row IDs.
+- **Framework, not plugin (fix once, lands everywhere):** row IDs, with the file each fix belongs
+  in. Without this bucket a reader files the row against one plugin and the fix lands in one
+  plugin's options while every other caller keeps the bug.
+- **Dissolved / recorded as no-gap:** row IDs — rows a check killed, kept so the question is not
+  re-asked. A negative finding earned by probing is worth as much as a positive one.
 
 ### Not audited
 
@@ -108,7 +119,7 @@ decisions distinct — do not fold a locally-fixable defect in because it touche
 - Absence is evidenced by a named grep, not by assertion.
 - A row whose fix is a design decision goes in the flat list *and* the design bucket, so it is
   not filed as an ordinary child issue by mistake.
-- Reverse-direction gaps stay in the same flat list, tagged in the text as reverse-direction.
+- Reverse-direction gaps stay in the same flat list, carrying `reverse-direction` in the tag.
   They are real parity gaps; they just point the other way.
 - A row that verification dissolved stays in the list, restated as "no gap here, and why".
   Deleting it invites the next run to re-file it.

--- a/skills/plugin-gap-analysis/references/output-template.md
+++ b/skills/plugin-gap-analysis/references/output-template.md
@@ -8,11 +8,26 @@ issue on its own: `ANT-`, `GGA-`, `DEC-` for decisions, `IF-` for in-flight item
 
 Audited <date> at `<commit>`. SDK versions pinned: <target> `<ver>`, <reference> `<ver>`.
 
-Every row was re-checked against the code by <N> independent reviewers working from the claims
-alone: <n> confirmed as written, <n> corrected for detail or consequence, <n> found factually
-wrong, <n> previously unresolved now resolved. Rows whose original claim was wrong or materially
-understated carry `corrected` in their tag and say what the original got wrong. <Which direction
-the wrong rows pointed, so the reader knows which half of the list is least settled.>
+Then **one of the two headers below**, never neither.
+
+*If phase 6 ran:*
+
+> Every row was re-checked against the code by <N> independent reviewers working from the claims
+> alone. Rows whose original claim was wrong or materially understated carry `corrected` in their
+> tag and say what the original got wrong. <Which direction the wrong rows pointed, so the reader
+> knows which half of the list is least settled.>
+
+*If phase 6 did not run* - required wording, at the top, before any row:
+
+> **THIS LIST IS UNVERIFIED.** Phase 6 (adversarial verification) <and phase 7 (the open-PR
+> sweep)> did not run. Roughly half of an unverified first pass needs rework, and wrong rows skew
+> toward claims about the reference implementation - of which this list contains <n>. Treat every
+> row as a hypothesis with evidence attached, not a finding. Nothing here should be filed as an
+> issue until the missing phases run.
+
+Do **not** respond to being unable to verify by shortening the list to only the rows you are
+confident about. Keep everything and label harder - a reviewer can strike a row, but cannot
+recover one that was never written.
 
 Severity: **X** = correctness bug (a valid provider response or documented config fails);
 **T** = table stakes; **C** = consistency/experience.
@@ -25,6 +40,10 @@ Reference: `<ref path>` (<LOC>). Target: `<target paths>` (<LOC>). <Direction ve
 two-way, say so before the rows, because it changes scoping.>
 
 ### Corrections to the seed list
+
+Only when the caller supplied known gaps to check. A "seed list" is whatever the requester already
+believes is broken - from a meeting, an epic, or an earlier audit. **Omit this section entirely if
+there was none**; do not emit the heading with a disclaimer.
 
 - ~~"<seed claim>"~~ — **not a gap.** <evidence with `path:line`>. What is actually missing is
   <ROW-ID>.
@@ -99,5 +118,10 @@ decisions distinct — do not fold a locally-fixable defect in because it touche
 - Paths are repo-relative from the root, so a citation resolves without guessing. Where the
   output will be read alongside the repo, link them at the pinned commit rather than the
   default branch — line anchors drift.
-- Recount every counting claim (lines, sections, samples, catalog members) rather than
-  reasoning from an earlier count. They are the fastest way for a reviewer to lose trust.
+- Recount every counting claim (lines, sections, samples, catalog members) rather than reasoning
+  from an earlier count. They are the fastest way for a reviewer to lose trust. Check which
+  spelling a file uses before counting it - counting `test(` in a suite written with `it(` undercounts
+  by a factor.
+- Where a defect is severe on one code path and harmless on another, tag it by its worst reachable
+  path and state the condition in the evidence. A config bug that only bites through the Dev UI is
+  still a correctness bug.

--- a/skills/plugin-gap-analysis/references/output-template.md
+++ b/skills/plugin-gap-analysis/references/output-template.md
@@ -1,0 +1,103 @@
+# Output template
+
+Markdown. Row IDs carry a per-section prefix so a single row survives being pasted into an
+issue on its own: `ANT-`, `GGA-`, `DEC-` for decisions, `IF-` for in-flight items.
+
+```markdown
+# Plugin gap audit
+
+Audited <date> at `<commit>`. SDK versions pinned: <target> `<ver>`, <reference> `<ver>`.
+
+Every row was re-checked against the code by <N> independent reviewers working from the claims
+alone: <n> confirmed as written, <n> corrected for detail or consequence, <n> found factually
+wrong, <n> previously unresolved now resolved. Rows whose original claim was wrong or materially
+understated carry `corrected` in their tag and say what the original got wrong. <Which direction
+the wrong rows pointed, so the reader knows which half of the list is least settled.>
+
+Severity: **X** = correctness bug (a valid provider response or documented config fails);
+**T** = table stakes; **C** = consistency/experience.
+Confidence: **confirmed** = both sides read; **needs-repro** = plausible from code, wants an E2E
+reproduction before filing; **not-audited** = deferred.
+
+## <plugin>: <reference> to <target>
+
+Reference: `<ref path>` (<LOC>). Target: `<target paths>` (<LOC>). <Direction verdict — and if
+two-way, say so before the rows, because it changes scoping.>
+
+### Corrections to the seed list
+
+- ~~"<seed claim>"~~ — **not a gap.** <evidence with `path:line`>. What is actually missing is
+  <ROW-ID>.
+
+### Gaps
+
+**ANT-1. <One-line claim.>**  `[T, confirmed]`
+
+<Reference behaviour with `path:line`. Target behaviour with `path:line`, or the exact grep that
+shows absence. Consequence for the user.>
+
+**ANT-2. <One-line claim.>**  `[X, confirmed, corrected]`
+
+<Originally stated as "<the wrong claim>". <What is actually true, with evidence.>>
+
+### Buckets
+
+- **Missing features (T):** row IDs — one-line theme.
+- **Correctness bugs (X):** row IDs — one-line theme.
+- **API shape decisions (T/C):** row IDs — design decisions, not independent tickets.
+- **<reference>-side gaps (reverse direction):** row IDs — the reference is not a superset.
+- **Docs and samples (C):** row IDs.
+
+### Not audited
+
+<Entry points found but not audited; languages out of scope.>
+
+## Cross-plugin decisions
+
+**DEC-1. <Decision.>**  `[decision]`
+
+<The choice, the row IDs it came from, and which rows stop being gaps under each option. Keep
+decisions distinct — do not fold a locally-fixable defect in because it touches the same code.>
+
+## Work already in flight
+
+<Coverage table: Row | PR | Author | State and scope — including what each PR does *not* cover.>
+
+**IF-1. <Sequencing hazard.>**  `[risk]`
+
+<The PR, the row it triggers, and the required ordering.>
+
+**IF-2. <Provenance to confirm.>**  `[open question]`
+
+<What is unclear, and who to ask.>
+
+### Rows with nothing in flight
+
+- <Group>: row IDs. <The grep evidence that establishes it.>
+
+### Adjacent PRs worth watching
+
+- #NNNN (author) title — adjacent to <row IDs>.
+- Discount #NNNN: <why it is a stale branch rather than a real overlap>.
+```
+
+## Row rules
+
+- One gap per row. Do not merge related gaps to shorten the list.
+- Bold the claim, then evidence, then consequence. A reviewer reads the bold text first and
+  only drops into the evidence for rows they doubt.
+- Absence is evidenced by a named grep, not by assertion.
+- A row whose fix is a design decision goes in the flat list *and* the design bucket, so it is
+  not filed as an ordinary child issue by mistake.
+- Reverse-direction gaps stay in the same flat list, tagged in the text as reverse-direction.
+  They are real parity gaps; they just point the other way.
+- A row that verification dissolved stays in the list, restated as "no gap here, and why".
+  Deleting it invites the next run to re-file it.
+- `corrected` rows open with what the original claim got wrong. The audit trail is the point;
+  a reviewer who spot-checks one corrected row should be able to see the correction was
+  deliberate.
+- Paths are repo-relative from the root, so a citation resolves without guessing. Where the
+  output will be read alongside the repo, link them at the pinned commit rather than the
+  default branch — line anchors drift.
+- Recount every counting claim (lines, sections, samples, catalog members) rather than
+  reasoning from an earlier count. They are the fastest way for a reviewer to lose trust.

--- a/skills/plugin-gap-analysis/references/prior-findings.md
+++ b/skills/plugin-gap-analysis/references/prior-findings.md
@@ -1,0 +1,55 @@
+# Prior findings
+
+**Spoilers. Do not open this file while auditing.** It exists so that findings
+from earlier runs are not lost, and so they are not sitting in the checklist priming the next
+auditor. Read it after your list is written, as a completeness check.
+
+An independent re-run reported that findings embedded in the checklist stopped some rows from being
+real derivations - it confirmed conclusions it had been handed. Two separate runs also flagged that
+per-plugin verdicts elsewhere in the skill primed them before they read any code. Everything of that
+kind belongs here.
+
+Treat every entry as dated and possibly closed. Verify against the current commit before reusing.
+
+- **C7** - a Go plugin keyed its SDK wrapper-type remap on `reflect.Type.Name()` string literals,
+  which degrades silently on an SDK rename rather than failing at build time. A sibling plugin did
+  not share the problem, because its SDK uses plain pointer scalars with nothing to remap.
+- **C8** - a reference-side schema ending `.passthrough()` spread unknown keys into the nested
+  config object, so a field the provider places at the *request root* stayed unreachable while two
+  sibling fields did not. The same passthrough let config overwrite messages, model, system and
+  tools after the framework had built them.
+- **C10** - an inline union discriminator (`{"type":"adaptive"}`) failed to round-trip through
+  `map[string]any` into the SDK params struct, so the field vanished with no error on the untyped
+  path while the typed path worked. Reachable only through the Dev UI and invisible to source
+  reading.
+- **E1** - a Go response switch handled three of the SDK's twelve content-block variants and
+  returned an error for the rest, so a safety-redacted thinking block failed the whole request.
+- **E4** - a Go plugin assigned the SDK's field-presence bookkeeping struct to the raw response
+  field, which serialises to empty stubs; the intended value was the SDK's raw-JSON accessor.
+- **F1** - a provider's overload code (529) fell through a generic `>= 500 -> Internal` branch in
+  the framework's code table, landing the one retryable condition in the wrong retry class.
+- **G1/G2** - a target README asserted a capability that two correctness rows showed did not work
+  end-to-end. README claims are a docs dimension, never evidence of a feature.
+- **H1** - the language with no unit test for its response-conversion path was the language whose
+  response path carried five separate defects. Test-coverage gaps predict where the bugs are.
+
+## Per-plugin run history
+
+- `anthropic` (JS -> Go), 2026-08-18. Recorded at the time as one-way with the target behind.
+  **Superseded - see the re-run below.**
+- `google-genai` (JS <-> Go), same date. Direction came out two-way, which is what forced dimension
+  group 0 and the direction-check step.
+- **Verification pass over both.** Wrong rows pointed at the *reference* far more often than the
+  target, so reverse-direction claims are the least reliable output of a first pass. Severity moved
+  substantially in both directions, and the verifiers surfaced better bugs than the audit had -
+  including a target-side raw-response field that serialised to empty stubs, breaking response
+  inspection entirely.
+- **Independent re-run of `anthropic`**, 2026-08-19, by an auditor given only this skill and no
+  prior findings. Reached **two-way, net reference ahead** - overturning the earlier verdict - and
+  found several defects both earlier passes missed: an untyped-config union that silently drops a
+  field, server-side tools unreachable from JSON config, a reference that curates three retired
+  model IDs, and a reference that advertises constrained generation then hard-fails it on its own
+  default surface. Two of the three errors this skill's traps were written to prevent did not recur;
+  the third did, and produced the SDK-environment-defaults trap in `verification.md`. Most of its
+  strongest rows came from compiling probes against the pinned SDK rather than reading it, which is
+  why that is now a rule.

--- a/skills/plugin-gap-analysis/references/verification.md
+++ b/skills/plugin-gap-analysis/references/verification.md
@@ -1,0 +1,95 @@
+# Adversarial verification
+
+Mandatory phase. **Roughly half of an unverified first pass needs rework** - some rows factually
+wrong, more of them right about the fact and wrong about the detail or the consequence. Skipping
+this ships a list a reviewer will lose confidence in on the first row they check.
+
+**Wrong rows skew heavily toward the reference implementation.** Claims that the *reference* is
+missing something failed far more often than claims about the target, because the reference tends
+to have more escape hatches and more places to look. Weight the checking accordingly.
+
+## How to run it
+
+Split the rows across **several checkers with fresh context**, each covering a bounded range
+(15-25 rows). Fresh context is the point - a checker that helped write the rows will confirm its
+own reasoning. Give each checker the claims *as text*, including the cited `path:line`, and tell
+it to **refute**.
+
+Bias the split so reverse-direction rows are concentrated and explicitly flagged as the least
+reliable, and warn the checker that the audit's author may have been over-eager to find them.
+Name the specific escape hatches to check (below) - a checker told only "be skeptical" re-runs
+the same greps and reaches the same wrong answer.
+
+## Verdict taxonomy
+
+| Verdict | Meaning |
+|---|---|
+| `CONFIRMED` | Accurate as stated, both sides read |
+| `WRONG` | Factually false. Must say what is actually true |
+| `IMPRECISE` | Directionally right, but detail, line number or consequence is off. Must say precisely how |
+| `UNVERIFIABLE` | Cannot be determined from the repo. Must say what is missing |
+
+Require: open every cited line rather than trusting it; re-run every claimed grep; cite own
+`file:line` evidence. A cited line that is off but where the claim holds elsewhere in the file
+is `IMPRECISE` with the correct location, not `WRONG`.
+
+Ask each checker for two extra sections: **where the audit understated a problem**, and **any
+additional bug noticed while checking**. Both were high-yield - the verifiers surfaced better
+bugs than the audit itself.
+
+## Traps that produced the wrong rows
+
+Every one of these caused at least one wrong or imprecise row. Check them by name.
+
+**Passthrough and untyped escape hatches.** A schema ending `.passthrough()` that spreads
+unknown keys into the wire request means a field absent from the schema may still be reachable.
+Two "unreachable in the reference" rows were wrong for this reason. Check *where* the provider
+places the field: one sibling field was genuinely unreachable because it sits at the request
+root while passthrough only reaches the nested config object. The distinction is the row.
+
+**Sibling backend directories.** A plugin serving two backends from sibling trees needs both
+searched. One row asserted a transport option was missing when it existed on one backend and
+not the other - and the row had the direction backwards.
+
+**Second package location, and on-disk vs tracked.** Searching one plugin directory produced a
+"no plugin in this language" claim that was false. Worse, a directory present on disk was
+entirely untracked at the pinned commit, so a path cited from a local listing did not exist in
+the repo at all. Always confirm with the version-control tree, not `ls`.
+
+**SDK version skew.** The two languages pin different SDK versions. One row blamed the target
+for a stale enum description when the real defect was the *reference* rejecting a value its own
+newer SDK accepts. Record both pinned versions and attribute the gap to the right side. Check
+whether a pending dependency bump would change the row's conclusion.
+
+**Files that do not exist yet.** A path cited from an open PR's branch will not resolve at the
+audited commit. That is a signal the row is already being worked on, not a broken citation.
+
+**Deprecated fields.** One row reported a field as unpopulated on the target; the field was
+deprecated on both sides, and the real defect was in its replacement, which serialised to an
+empty object. Check whether the field you are comparing is the one that still matters.
+
+**Consequences that do not follow.** "So the request fails" needs tracing. One row correctly
+identified a hardcoded error flag but its stated consequence was impossible, because the
+framework aborts before that code path can see a failed tool. Downgrade to a latent wart.
+
+**Both sides doing the wrong thing.** A capability mismatch is only a *parity* gap if the
+reference gets it right. One correctness row dissolved because both implementations advertised
+the same wrong capability set - and the genuine divergence was elsewhere in the same file.
+
+**Counting claims.** Line counts, section counts, sample counts and catalog membership were all
+wrong somewhere. They are trivially checkable and therefore the fastest way for a reviewer to
+lose trust. Recount rather than reasoning from an earlier count.
+
+## Reconciling
+
+- Rewrite `WRONG` rows around whatever the verifier found instead; if there is no gap, say so
+  plainly and keep the row so the question is not re-asked.
+- Fold `IMPRECISE` corrections into the evidence text.
+- Mark every changed row `corrected` in its tag and open its evidence with one sentence on what
+  the original got wrong. Silent rewriting destroys the audit trail.
+- Re-derive severity afterwards; it moves in both directions. In the last run, four rows were
+  promoted to correctness bugs and one demoted to a latent wart.
+- Promote verifier-found bugs to full rows with their own IDs.
+- Re-check the buckets and any cross-references - they go stale when severity moves.
+- State the verification tally at the top of the report, including which direction the wrong
+  rows pointed.

--- a/skills/plugin-gap-analysis/references/verification.md
+++ b/skills/plugin-gap-analysis/references/verification.md
@@ -51,6 +51,14 @@ root while passthrough only reaches the nested config object. The distinction is
 searched. One row asserted a transport option was missing when it existed on one backend and
 not the other - and the row had the direction backwards.
 
+**The SDK's own defaults and environment variables.** Before claiming a client option is
+unreachable, check whether the provider SDK reads it from the environment or defaults it itself.
+A plugin that never passes `baseURL` may still honour a `*_BASE_URL` env var because the SDK
+constructor defaults from it - so "no way to reach a proxy" is wrong even though the grep over
+plugin source returns nothing. Two separate runs made this exact error on the same row. Scope the
+search to plugin code to find what the *plugin* does, then check the SDK for what the user
+actually gets.
+
 **Second package location, and on-disk vs tracked.** Searching one plugin directory produced a
 "no plugin in this language" claim that was false. Worse, a directory present on disk was
 entirely untracked at the pinned commit, so a path cited from a local listing did not exist in

--- a/skills/plugin-gap-analysis/references/verification.md
+++ b/skills/plugin-gap-analysis/references/verification.md
@@ -37,6 +37,44 @@ Ask each checker for two extra sections: **where the audit understated a problem
 additional bug noticed while checking**. Both were high-yield - the verifiers surfaced better
 bugs than the audit itself.
 
+## Probe recipes
+
+The SDK-probing rule in SKILL.md is the highest-yield instruction in this skill, and every run so
+far had to rediscover how to satisfy it from a read-only repo. Both recipes go in a **uniquely named
+scratch directory outside the repo** - a shared scratchpad may already hold another run's `main.go`,
+which breaks the build confusingly.
+
+**Go.** Write a scratch module pinning the same version the repo pins, and resolve offline from the
+module cache so no network is needed:
+
+```
+mkdir -p /tmp/probe-<plugin>-<something-unique> && cd $_
+cat > go.mod <<'EOF'
+module probe
+go 1.24
+require <module> <version-from-go.mod>
+EOF
+# copy the matching require+sum lines out of the repo's go.mod / go.sum, then:
+GOFLAGS=-mod=mod GOPROXY=off go run .
+```
+
+Three probes pay for themselves every time:
+
+1. **Round-trip diff.** Marshal a Dev-UI-shaped JSON config, unmarshal into the params struct,
+   re-marshal, diff the keys. Dropped keys are silent defects. A clean result is a finding worth
+   recording too, so the next run does not re-ask.
+2. **Field enumeration.** Reflect over the params struct and print every field and type. This is how
+   you get the real list to diff a plugin's handled cases against - union variants, content-block
+   kinds, stop reasons - instead of trusting a switch to be exhaustive.
+3. **Response serialisation.** Populate a response struct and marshal what the plugin assigns to its
+   raw/custom field. A field that looks correct in source can serialise to empty stubs.
+
+**JS.** The curated-schema side deserves the same treatment and has not had it - all probes so far
+were Go, which is why several reference-side rows stayed `needs-repro` when an hour with `node`
+would have settled them. The analogue: import the schema, `safeParse` a config fragment, build the
+request body the runner would build, and diff against what you expected. Also worth executing rather
+than reading: whether a schema converter emits the construct you think it does for a given input.
+
 ## Traps that produced the wrong rows
 
 Every one of these caused at least one wrong or imprecise row. Check them by name.


### PR DESCRIPTION
Adds an agent skill for auditing a provider plugin in one language against its reference implementation in another. Written for the JS/Go parity work, re-runnable per plugin.

The reusable part is `references/dimensions.md`: ~45 dimensions across 10 groups. The expensive step in a parity audit is deciding what to compare, so freezing that makes runs mechanical and comparable. Coverage and direction come first, because they decide scope — one trial run came out one-way, the other two-way with Go ahead on config surface, docs and transport options.

Two phases are required rather than optional, both because trial runs showed they change the answer:

- **Adversarial verification** (`references/verification.md`). Independent reviewers re-checked 54 findings and found 6 wrong, 19 imprecise. Five of the six wrong ones pointed at the reference, not the target.
- **Open-PR sweep** (`references/in-flight.md`). 8 of 54 findings already had an open PR, one containing the exact fix for a finding recorded as an open bug.

Scope is JS and Go; Python is excluded while it migrates to a separate repo. Output is Markdown. The skill stops at a reviewed list — it does not file issues, propose designs, or change code.

## Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
