### PR TITLE
fix(py): route Google families by prefix and fail closed on unroutable ids

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -155,8 +155,8 @@ def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
         - Veo name (``veo-``) → veo
         - 'gemini'/'gemma' in name (and not an embedding) → gemini
       Ids with no working generate path here (``imagegeneration@*``,
-      ``virtual-try-on-*``) are not categorized at all, so they are never
-      advertised or registered.
+      ``imagetext@*``, ``virtual-try-on-*``) are not categorized at all, so
+      they are never advertised or registered.
       Embedders are intentionally NOT discovered here. The Vertex catalog
       over-lists embedders that are published but not callable, so they
       are advertised from a curated list (``VERTEX_KNOWN_EMBEDDERS``) instead.
@@ -338,14 +338,19 @@ def _create_veo_background_action(
     prefix = f'{plugin_name}/'
     clean_name = name.removeprefix(prefix)
     full_name = f'{prefix}{clean_name}'
+    action_key = f'/background-model/{full_name}'
 
     async def _start(request: Any, ctx: Any) -> Any:  # noqa: ANN401
         veo = VeoModel(clean_name, client_getter())
-        return await veo.start(request, ctx)
+        op = await veo.start(request, ctx)
+        op.action = action_key
+        return op
 
     async def _check(op: Any, _ctx: Any) -> Any:  # noqa: ANN401
         veo = VeoModel(clean_name, client_getter())
-        return await veo.check(op)
+        updated = await veo.check(op)
+        updated.action = action_key
+        return updated
 
     info = veo_model_info(clean_name).model_dump(by_alias=True)
 
@@ -387,7 +392,10 @@ def _veo_background_action_metadata(name: str) -> ActionMetadata:
         input_json_schema=to_json_schema(ModelRequest),
         output_json_schema=to_json_schema(Operation),
         metadata={
-            'model': {**veo_model_info(local).model_dump(by_alias=True), 'customOptions': to_json_schema(VeoConfigSchema)},
+            'model': {
+                **veo_model_info(local).model_dump(by_alias=True),
+                'customOptions': to_json_schema(VeoConfigSchema),
+            },
             'type': 'background-model',
         },
     )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -61,6 +61,7 @@ import genkit_google_genai.constants as const
 from genkit import ModelInfo
 from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
+from genkit._core._typing import Operation
 from genkit.embedder import embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
 from genkit.model import BackgroundAction, model_action_metadata
@@ -77,6 +78,7 @@ from genkit_google_genai.evaluators import (
     VertexAIEvaluationMetricType,
     create_vertex_evaluators,
 )
+from genkit_google_genai.models._routing import is_unroutable_model_id
 from genkit_google_genai.models.embedder import (
     VERTEX_KNOWN_EMBEDDERS,
     Embedder,
@@ -94,6 +96,8 @@ from genkit_google_genai.models.imagen import (
     SUPPORTED_MODELS as IMAGE_SUPPORTED_MODELS,
     ImagenConfigSchema,
     ImagenModel,
+    is_imagen_model_name,
+    is_unsupported_image_model_name,
     vertexai_image_model_info,
 )
 from genkit_google_genai.models.veo import (
@@ -141,15 +145,18 @@ def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
     - Google AI populates each model's ``supported_actions`` field, so models
       are categorized by action:
         - 'embedContent' action → embedders
-        - 'predict' + 'imagen' in name → imagen
-        - 'generateVideos' or 'veo' in name → veo
+        - 'predict' + Imagen name (``imagen-``) → imagen
+        - 'generateVideos' or Veo name (``veo-``) → veo
         - 'generateContent' + 'gemini'/'gemma' in name → gemini
     - Vertex AI returns ``supported_actions = None`` for every publisher model,
       so categorizing by action would skip them all. The Vertex path instead
-      categorizes by model name (mirroring the JS plugin's ``listActions``):
-        - 'imagen' in name → imagen
-        - 'veo' in name → veo
+      categorizes by model name:
+        - Imagen name (``imagen-``) → imagen
+        - Veo name (``veo-``) → veo
         - 'gemini'/'gemma' in name (and not an embedding) → gemini
+      Ids with no working generate path here (``imagegeneration@*``,
+      ``virtual-try-on-*``) are not categorized at all, so they are never
+      advertised or registered.
       Embedders are intentionally NOT discovered here. The Vertex catalog
       over-lists embedders that are published but not callable, so they
       are advertised from a curated list (``VERTEX_KNOWN_EMBEDDERS``) instead.
@@ -192,9 +199,11 @@ def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
             lower_name = name.lower()
             if 'embedding' in lower_name:
                 continue
-            elif 'imagen' in lower_name:
+            elif is_unsupported_image_model_name(name):
+                continue
+            elif is_imagen_model_name(name):
                 models.imagen.append(name)
-            elif 'veo' in lower_name:
+            elif is_veo_model(name):
                 models.veo.append(name)
             elif 'gemini' in lower_name or 'gemma' in lower_name:
                 models.gemini.append(name)
@@ -207,12 +216,12 @@ def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
         if 'embedContent' in m.supported_actions:
             models.embedders.append(name)
 
-        # Imagen (Vertex mostly)
-        if 'predict' in m.supported_actions and 'imagen' in name.lower():
+        # Imagen (imagen- prefix, not a bare "image" substring)
+        if 'predict' in m.supported_actions and is_imagen_model_name(name):
             models.imagen.append(name)
 
         # Veo
-        if 'generateVideos' in m.supported_actions or 'veo' in name.lower():
+        if 'generateVideos' in m.supported_actions or is_veo_model(name):
             models.veo.append(name)
 
         # Gemini / Gemma
@@ -304,6 +313,84 @@ def _create_embedder_action(
     action.output_schema = action_metadata.output_json_schema  # type: ignore[invalid-assignment]
 
     return action
+
+
+def _create_veo_background_action(
+    name: str,
+    client_getter: Callable[[], genai.Client],
+    plugin_name: str,
+) -> BackgroundAction:
+    """Create the start/check action pair for a Veo video generation model.
+
+    Veo runs as a background operation: callers start a generation and poll
+    it, they never block a generate call on a multi-minute video render. Both
+    plugins therefore expose Veo only as BACKGROUND_MODEL + CHECK_OPERATION,
+    never as a blocking MODEL.
+
+    Args:
+        name: The namespaced name of the model.
+        client_getter: Function returning the loop-local Google GenAI client.
+        plugin_name: The name of the plugin (googleai or vertexai).
+
+    Returns:
+        BackgroundAction pairing the start and check actions.
+    """
+    prefix = f'{plugin_name}/'
+    clean_name = name.removeprefix(prefix)
+    full_name = f'{prefix}{clean_name}'
+
+    async def _start(request: Any, ctx: Any) -> Any:  # noqa: ANN401
+        veo = VeoModel(clean_name, client_getter())
+        return await veo.start(request, ctx)
+
+    async def _check(op: Any, _ctx: Any) -> Any:  # noqa: ANN401
+        veo = VeoModel(clean_name, client_getter())
+        return await veo.check(op)
+
+    info = veo_model_info(clean_name).model_dump(by_alias=True)
+
+    start_action = Action(
+        kind=ActionKind.BACKGROUND_MODEL,
+        name=full_name,
+        fn=_start,
+        metadata={
+            'model': {**info, 'customOptions': to_json_schema(VeoConfigSchema)},
+            'type': 'background-model',
+        },
+    )
+
+    check_action = Action(
+        kind=ActionKind.CHECK_OPERATION,
+        name=f'{full_name}/check',
+        fn=_check,
+        metadata={'type': 'check-operation'},
+    )
+
+    return BackgroundAction(
+        start_action=start_action,
+        check_action=check_action,
+        cancel_action=None,
+    )
+
+
+def _veo_background_action_metadata(name: str) -> ActionMetadata:
+    """Build list_actions metadata for a Veo model as a background model.
+
+    The kind advertised here has to match what resolve() will actually hand
+    back, otherwise the Dev UI and registry offer a generate model that does
+    not exist.
+    """
+    local = name.split('/')[-1]
+    return ActionMetadata(
+        action_type=ActionKind.BACKGROUND_MODEL,
+        name=name,
+        input_json_schema=to_json_schema(ModelRequest),
+        output_json_schema=to_json_schema(Operation),
+        metadata={
+            'model': {**veo_model_info(local).model_dump(by_alias=True), 'customOptions': to_json_schema(VeoConfigSchema)},
+            'type': 'background-model',
+        },
+    )
 
 
 class GoogleAI(Plugin):
@@ -415,11 +502,13 @@ class GoogleAI(Plugin):
         actions: list[Action] = []
         # Gemini Models
         for name in genai_models.gemini:
-            actions.append(self._resolve_model(googleai_name(name)))
+            if action := self._resolve_model(googleai_name(name)):
+                actions.append(action)
 
         # Imagen Models
         for name in genai_models.imagen:
-            actions.append(self._resolve_model(googleai_name(name)))
+            if action := self._resolve_model(googleai_name(name)):
+                actions.append(action)
 
         # Veo Models (background models)
         for name in genai_models.veo:
@@ -434,20 +523,15 @@ class GoogleAI(Plugin):
         return actions
 
     def _list_known_models(self) -> list[Action]:
-        """List known models as Action objects.
-
-        Deprecated: Used only for internal testing if needed, but 'init' should be source of truth.
-        Keeping for compatibility but redirecting to dynamic list logic if accessed directly?
-        The interface defines init(), this helper was internal.
-        """
-        # Re-use init logic synchronously? init is async.
-        # Let's implementation just mimic init logic but sync call to client.models.list is fine (it is iterator)
+        """List known Gemini and Imagen models as Action objects."""
         genai_models = _list_genai_models(self._runtime_client(), is_vertex=False)
         actions = []
         for name in genai_models.gemini:
-            actions.append(self._resolve_model(googleai_name(name)))
+            if action := self._resolve_model(googleai_name(name)):
+                actions.append(action)
         for name in genai_models.imagen:
-            actions.append(self._resolve_model(googleai_name(name)))
+            if action := self._resolve_model(googleai_name(name)):
+                actions.append(action)
         return actions
 
     def _list_known_veo_models(self) -> list[Action]:
@@ -516,59 +600,27 @@ class GoogleAI(Plugin):
         Returns:
             BackgroundAction for the Veo model.
         """
-        clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
+        return _create_veo_background_action(name, self._runtime_client, GOOGLEAI_PLUGIN_NAME)
 
-        # Create actions manually since we don't have registry access here
-
-        async def _start(request: Any, ctx: Any) -> Any:  # noqa: ANN401
-            veo = VeoModel(clean_name, self._runtime_client())
-            return await veo.start(request, ctx)
-
-        async def _check(op: Any, _ctx: Any) -> Any:  # noqa: ANN401
-            veo = VeoModel(clean_name, self._runtime_client())
-            return await veo.check(op)
-
-        # Prepare metadata matching model_action_metadata structure
-        info = veo_model_info(clean_name).model_dump(by_alias=True)
-        config_schema = VeoConfigSchema
-
-        start_action = Action(
-            kind=ActionKind.BACKGROUND_MODEL,
-            name=name,
-            fn=_start,
-            metadata={
-                'model': {**info, 'customOptions': to_json_schema(config_schema)},
-                'type': 'background-model',
-            },
-        )
-
-        check_action = Action(
-            kind=ActionKind.CHECK_OPERATION,
-            name=f'{name}/check',
-            fn=_check,
-            metadata={'type': 'check-operation'},
-        )
-
-        return BackgroundAction(
-            start_action=start_action,
-            check_action=check_action,
-            cancel_action=None,
-        )
-
-    def _resolve_model(self, name: str) -> Action:
+    def _resolve_model(self, name: str) -> Action | None:
         """Create an Action object for a Google AI model.
 
         Args:
             name: The namespaced name of the model.
 
         Returns:
-            Action object for the model.
+            Action object for the model, or None if this id has no generate
+            path here (Veo is background-only; retired/unimplemented image
+            ids fail closed instead of defaulting to Gemini).
         """
         # Extract local name (remove plugin prefix)
         clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
 
+        if is_unroutable_model_id(clean_name):
+            return None
+
         # Determine model type and create model metadata/config schema
-        if clean_name.lower().startswith('image'):
+        if is_imagen_model_name(clean_name):
             model_ref = vertexai_image_model_info(clean_name)
             IMAGE_SUPPORTED_MODELS[clean_name] = model_ref  # pyright: ignore[reportArgumentType]
             config_schema = ImagenConfigSchema
@@ -578,7 +630,7 @@ class GoogleAI(Plugin):
             config_schema = get_model_config_schema(clean_name)
 
         async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-            if clean_name.lower().startswith('image'):
+            if is_imagen_model_name(clean_name):
                 model = ImagenModel(clean_name, self._runtime_client())
             else:
                 model = GeminiModel(
@@ -645,13 +697,7 @@ class GoogleAI(Plugin):
             )
 
         for name in genai_models.veo:
-            actions_list.append(
-                model_action_metadata(
-                    name=googleai_name(name),
-                    info=veo_model_info(name).model_dump(by_alias=True),
-                    config_schema=VeoConfigSchema,
-                )
-            )
+            actions_list.append(_veo_background_action_metadata(googleai_name(name)))
 
         for name in genai_models.embedders:
             actions_list.append(
@@ -688,7 +734,7 @@ class VertexAI(Plugin):
         |---|---|---|
         | Gemini / Gemma | MODEL | ``vertexai/gemini-flash-latest`` |
         | Imagen | MODEL | ``vertexai/imagen-3.0-generate-002`` |
-        | Veo (Video) | MODEL | ``vertexai/veo-2.0-generate-001`` |
+        | Veo (Video) | BACKGROUND_MODEL | ``vertexai/veo-2.0-generate-001`` |
         | Embedders | EMBEDDER | ``vertexai/text-embedding-005`` |
 
     Example:
@@ -814,13 +860,18 @@ class VertexAI(Plugin):
         actions: list[Action] = []
 
         for name in genai_models.gemini:
-            actions.append(self._resolve_model(vertexai_name(name)))
+            if action := self._resolve_model(vertexai_name(name)):
+                actions.append(action)
 
         for name in genai_models.imagen:
-            actions.append(self._resolve_model(vertexai_name(name)))
+            if action := self._resolve_model(vertexai_name(name)):
+                actions.append(action)
 
+        # Veo Models (background models)
         for name in genai_models.veo:
-            actions.append(self._resolve_model(vertexai_name(name)))
+            bg_action = self._resolve_veo_model(vertexai_name(name))
+            actions.append(bg_action.start_action)
+            actions.append(bg_action.check_action)
 
         for name in VERTEX_KNOWN_EMBEDDERS:
             actions.append(self._resolve_embedder(vertexai_name(name)))
@@ -851,11 +902,21 @@ class VertexAI(Plugin):
         genai_models = _list_genai_models(self._runtime_client(), is_vertex=True)
         actions = []
         for name in genai_models.gemini:
-            actions.append(self._resolve_model(vertexai_name(name)))
+            if action := self._resolve_model(vertexai_name(name)):
+                actions.append(action)
         for name in genai_models.imagen:
-            actions.append(self._resolve_model(vertexai_name(name)))
+            if action := self._resolve_model(vertexai_name(name)):
+                actions.append(action)
+        return actions
+
+    def _list_known_veo_models(self) -> list[Action]:
+        """List known Veo models as background model Action objects."""
+        genai_models = _list_genai_models(self._runtime_client(), is_vertex=True)
+        actions = []
         for name in genai_models.veo:
-            actions.append(self._resolve_model(vertexai_name(name)))
+            bg_action = self._resolve_veo_model(vertexai_name(name))
+            actions.append(bg_action.start_action)
+            actions.append(bg_action.check_action)
         return actions
 
     def _list_known_embedders(self) -> list[Action]:
@@ -882,11 +943,41 @@ class VertexAI(Plugin):
         """
         if action_type == ActionKind.MODEL:
             return self._resolve_model(name)
+        elif action_type == ActionKind.BACKGROUND_MODEL:
+            # For Veo models, return the start action
+            prefix = VERTEXAI_PLUGIN_NAME + '/'
+            clean_name = name.replace(prefix, '') if name.startswith(prefix) else name
+            if is_veo_model(clean_name):
+                bg_action = self._resolve_veo_model(name)
+                return bg_action.start_action
+            return None
+        elif action_type == ActionKind.CHECK_OPERATION:
+            # Check action names are in format {model_name}/check
+            # Extract the model name and resolve if it's a Veo model
+            if name.endswith('/check'):
+                model_name = name[:-6]  # Remove '/check' suffix
+                prefix = VERTEXAI_PLUGIN_NAME + '/'
+                clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
+                if is_veo_model(clean_name):
+                    bg_action = self._resolve_veo_model(model_name)
+                    return bg_action.check_action
+            return None
         elif action_type == ActionKind.EMBEDDER:
             return self._resolve_embedder(name)
         elif action_type == ActionKind.EVALUATOR:
             return self._resolve_evaluator(name)
         return None
+
+    def _resolve_veo_model(self, name: str) -> BackgroundAction:
+        """Create a BackgroundAction for a Veo video generation model.
+
+        Args:
+            name: The namespaced name of the model.
+
+        Returns:
+            BackgroundAction for the Veo model.
+        """
+        return _create_veo_background_action(name, self._runtime_client, VERTEXAI_PLUGIN_NAME)
 
     def _resolve_evaluator(self, name: str) -> Action | None:
         """Create an Action object for a Vertex AI evaluator.
@@ -922,17 +1013,22 @@ class VertexAI(Plugin):
         )
         return actions[0] if actions else None
 
-    def _resolve_model(self, name: str) -> Action:
+    def _resolve_model(self, name: str) -> Action | None:
         """Create an Action object for a Vertex AI model.
 
         Args:
             name: The namespaced name of the model.
 
         Returns:
-            Action object for the model.
+            Action object for the model, or None if this id has no generate
+            path here (Veo is background-only; retired/unimplemented image
+            ids fail closed instead of defaulting to Gemini).
         """
         # Extract local name (remove plugin prefix)
         clean_name = name.replace(VERTEXAI_PLUGIN_NAME + '/', '') if name.startswith(VERTEXAI_PLUGIN_NAME) else name
+
+        if is_unroutable_model_id(clean_name):
+            return None
 
         # Determine model type and create model metadata/config schema.
         # Tuned Gemini endpoints (endpoints/ID or projects/.../endpoints/ID)
@@ -943,13 +1039,10 @@ class VertexAI(Plugin):
                 supports=google_model_info('gemini').supports,
             )
             config_schema = GeminiConfigSchema
-        elif clean_name.lower().startswith('image'):
+        elif is_imagen_model_name(clean_name):
             model_ref = vertexai_image_model_info(clean_name)
             IMAGE_SUPPORTED_MODELS[clean_name] = model_ref  # pyright: ignore[reportArgumentType]
             config_schema = ImagenConfigSchema
-        elif is_veo_model(clean_name):
-            model_ref = veo_model_info(clean_name)
-            config_schema = VeoConfigSchema
         else:
             model_ref = google_model_info(clean_name)
             SUPPORTED_MODELS[clean_name] = model_ref
@@ -963,10 +1056,8 @@ class VertexAI(Plugin):
                     client_kwargs=self._client_kwargs,
                     base_url_pinned=self._base_url_pinned,
                 )
-            elif clean_name.lower().startswith('image'):
+            elif is_imagen_model_name(clean_name):
                 model = ImagenModel(clean_name, self._runtime_client())
-            elif is_veo_model(clean_name):
-                model = VeoModel(clean_name, self._runtime_client())
             else:
                 model = GeminiModel(
                     clean_name,
@@ -1032,13 +1123,7 @@ class VertexAI(Plugin):
             )
 
         for name in genai_models.veo:
-            actions_list.append(
-                model_action_metadata(
-                    name=vertexai_name(name),
-                    info=veo_model_info(name).model_dump(by_alias=True),
-                    config_schema=VeoConfigSchema,
-                )
-            )
+            actions_list.append(_veo_background_action_metadata(vertexai_name(name)))
 
         for name in VERTEX_KNOWN_EMBEDDERS:
             actions_list.append(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -60,7 +60,9 @@ from google.genai.types import HttpOptions, HttpOptionsDict
 import genkit_google_genai.constants as const
 from genkit import ModelInfo
 from genkit._core._action import ActionRunContext
+from genkit._core._background import define_background_model
 from genkit._core._model import ModelRequest, ModelResponse
+from genkit._core._registry import Registry
 from genkit._core._typing import Operation
 from genkit.embedder import embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
@@ -338,43 +340,25 @@ def _create_veo_background_action(
     prefix = f'{plugin_name}/'
     clean_name = name.removeprefix(prefix)
     full_name = f'{prefix}{clean_name}'
-    action_key = f'/background-model/{full_name}'
 
-    async def _start(request: Any, ctx: Any) -> Any:  # noqa: ANN401
+    async def start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
         veo = VeoModel(clean_name, client_getter())
-        op = await veo.start(request, ctx)
-        op.action = action_key
-        return op
+        return await veo.start(request, ctx)
 
-    async def _check(op: Any, _ctx: Any) -> Any:  # noqa: ANN401
+    async def check(op: Operation) -> Operation:
         veo = VeoModel(clean_name, client_getter())
-        updated = await veo.check(op)
-        updated.action = action_key
-        return updated
+        return await veo.check(op)
 
-    info = veo_model_info(clean_name).model_dump(by_alias=True)
-
-    start_action = Action(
-        kind=ActionKind.BACKGROUND_MODEL,
+    # Same helper as ai.define_background_model: action key, latency, and
+    # the longRunning flag generate_operation checks.
+    return define_background_model(
+        registry=Registry(),
         name=full_name,
-        fn=_start,
-        metadata={
-            'model': {**info, 'customOptions': to_json_schema(VeoConfigSchema)},
-            'type': 'background-model',
-        },
-    )
-
-    check_action = Action(
-        kind=ActionKind.CHECK_OPERATION,
-        name=f'{full_name}/check',
-        fn=_check,
-        metadata={'type': 'check-operation'},
-    )
-
-    return BackgroundAction(
-        start_action=start_action,
-        check_action=check_action,
-        cancel_action=None,
+        start=start,
+        check=check,
+        info=veo_model_info(clean_name),
+        config_schema=VeoConfigSchema,
+        metadata={'type': 'background-model'},
     )
 
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_routing.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_routing.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bucket a model id by the config schema its action would validate.
+
+resolve(MODEL) and the family constructors share this table so a name
+that cannot run as a generate model never quietly becomes Gemini.
+"""
+
+from genkit_google_genai.models.gemini import (
+    is_gemma_model,
+    is_image_model,
+    is_tts_model,
+)
+from genkit_google_genai.models.imagen import (
+    is_imagen_model_name,
+    is_unsupported_image_model_name,
+)
+from genkit_google_genai.models.lyria import is_lyria_model
+from genkit_google_genai.models.veo import is_veo_model
+
+# Prefixes people paste from action keys, Dev UI traces, or another plugin's
+# samples. Stripping them first means the constructor decides the namespace,
+# so GoogleAI.gemini_model('vertexai/gemini-2.5-flash') cannot smuggle a
+# cross-plugin name into the ref.
+STRIP_PREFIXES = (
+    'background-model/',
+    'model/',
+    'models/',
+    'embedders/',
+    'googleai/',
+    'vertexai/',
+)
+
+
+def strip_ref_prefixes(name: str) -> str:
+    """Reduce a pasted name to the bare model id."""
+    local = str(name)
+    changed = True
+    while changed:
+        changed = False
+        for prefix in STRIP_PREFIXES:
+            if local.startswith(prefix):
+                local = local[len(prefix) :]
+                changed = True
+    return local
+
+
+def classify_family(local: str) -> str:
+    """Bucket a bare model id by the config schema its action would validate.
+
+    The embedding check runs first because embedder ids can carry a family
+    prefix (``gemini-embedding-001``) and must never mint a generate ref.
+    """
+    lower = local.lower()
+    if 'embedding' in lower:
+        return 'embedder'
+    if is_unsupported_image_model_name(lower):
+        return 'unsupported'
+    if is_veo_model(lower):
+        return 'veo'
+    if is_lyria_model(lower):
+        return 'lyria'
+    if lower.startswith(('deep-research-', 'antigravity-')):
+        return 'interactions'
+    if is_imagen_model_name(lower):
+        return 'imagen'
+    if is_tts_model(lower):
+        return 'tts'
+    if is_image_model(lower):
+        return 'image'
+    if is_gemma_model(lower):
+        return 'gemma'
+    if lower.startswith('gemini-'):
+        return 'gemini'
+    return 'unknown'
+
+
+def is_unroutable_model_id(name: str) -> bool:
+    """True for ids that resolve(MODEL) must refuse instead of defaulting to Gemini.
+
+    Same closed set the constructors enforce, so a name a constructor
+    refuses can never quietly become a Gemini action at resolve time.
+    """
+    return classify_family(strip_ref_prefixes(name)) in {
+        'embedder',
+        'unsupported',
+        'veo',
+        'lyria',
+        'interactions',
+    }

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_routing.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_routing.py
@@ -14,10 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Bucket a model id by the config schema its action would validate.
+"""Bucket a model id so resolve(MODEL) does not default it to Gemini.
 
-resolve(MODEL) and the family constructors share this table so a name
-that cannot run as a generate model never quietly becomes Gemini.
+Families with no generate path here resolve to nothing: Veo is
+background-only, embedders are a different action kind, and retired or
+unimplemented image ids must not fall through. Lyria, Deep Research, and
+Antigravity fail closed until those families have a generate action here.
 """
 
 from genkit_google_genai.models.gemini import (
@@ -45,6 +47,18 @@ STRIP_PREFIXES = (
     'vertexai/',
 )
 
+# Families with no MODEL generate path on this plugin. Constructor
+# refusal is a different table — TTS, native image, Gemma, and Imagen
+# still resolve as MODEL.
+UNROUTABLE_FAMILIES = frozenset({
+    'embedder',
+    'unsupported',
+    'veo',
+    'lyria',
+    'deep-research',
+    'antigravity',
+})
+
 
 def strip_ref_prefixes(name: str) -> str:
     """Reduce a pasted name to the bare model id."""
@@ -59,46 +73,38 @@ def strip_ref_prefixes(name: str) -> str:
     return local
 
 
-def classify_family(local: str) -> str:
-    """Bucket a bare model id by the config schema its action would validate.
+def classify_family(name: str) -> str:
+    """Bucket a model id by the last path segment.
 
     The embedding check runs first because embedder ids can carry a family
     prefix (``gemini-embedding-001``) and must never mint a generate ref.
     """
-    lower = local.lower()
-    if 'embedding' in lower:
+    leaf = name.split('/')[-1].lower()
+    if 'embedding' in leaf:
         return 'embedder'
-    if is_unsupported_image_model_name(lower):
+    if is_unsupported_image_model_name(leaf):
         return 'unsupported'
-    if is_veo_model(lower):
+    if is_veo_model(leaf):
         return 'veo'
-    if is_lyria_model(lower):
+    if is_lyria_model(leaf):
         return 'lyria'
-    if lower.startswith(('deep-research-', 'antigravity-')):
-        return 'interactions'
-    if is_imagen_model_name(lower):
+    if leaf.startswith('deep-research-'):
+        return 'deep-research'
+    if leaf.startswith('antigravity-'):
+        return 'antigravity'
+    if is_imagen_model_name(leaf):
         return 'imagen'
-    if is_tts_model(lower):
+    if is_tts_model(leaf):
         return 'tts'
-    if is_image_model(lower):
+    if is_image_model(leaf):
         return 'image'
-    if is_gemma_model(lower):
+    if is_gemma_model(leaf):
         return 'gemma'
-    if lower.startswith('gemini-'):
+    if leaf.startswith('gemini-'):
         return 'gemini'
     return 'unknown'
 
 
 def is_unroutable_model_id(name: str) -> bool:
-    """True for ids that resolve(MODEL) must refuse instead of defaulting to Gemini.
-
-    Same closed set the constructors enforce, so a name a constructor
-    refuses can never quietly become a Gemini action at resolve time.
-    """
-    return classify_family(strip_ref_prefixes(name)) in {
-        'embedder',
-        'unsupported',
-        'veo',
-        'lyria',
-        'interactions',
-    }
+    """True for ids that resolve(MODEL) must refuse instead of defaulting to Gemini."""
+    return classify_family(name) in UNROUTABLE_FAMILIES

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -872,13 +872,15 @@ def is_gemini_model(name: str) -> bool:
         >>> is_gemini_model('gemini-2.5-flash-preview-tts')
         False
     """
-    return name.startswith('gemini-') and not is_tts_model(name) and not is_image_model(name)
+    local = name.split('/')[-1].lower()
+    return local.startswith('gemini-') and not is_tts_model(local) and not is_image_model(local)
 
 
 def is_tts_model(name: str) -> bool:
-    """Check if the model is a text-to-speech (TTS) model.
+    """Check if the model is a Gemini text-to-speech (TTS) model.
 
-    TTS models output audio instead of text and use GeminiTtsConfigSchema.
+    TTS is a ``gemini-`` name that contains ``-tts``. Strip the plugin /
+    ``models/`` prefix first so ``googleai/gemini-…-tts`` still routes here.
 
     Args:
         name: The model name to check.
@@ -890,13 +892,16 @@ def is_tts_model(name: str) -> bool:
         >>> is_tts_model('gemini-2.5-flash-preview-tts')
         True
     """
-    return (name.startswith('gemini-') and name.endswith('-tts')) or 'tts' in name
+    local = name.split('/')[-1].lower()
+    return local.startswith('gemini-') and '-tts' in local
 
 
 def is_image_model(name: str) -> bool:
-    """Check if the model is a Gemini image generation model.
+    """Check if the model is a Gemini native image generation model.
 
-    Image models output images instead of text and use GeminiImageConfigSchema.
+    Native image is a ``gemini-`` name that contains ``-image``. Imagen
+    (``imagen-…``) is a different family — a bare ``image`` substring
+    would catch both.
 
     Args:
         name: The model name to check.
@@ -908,13 +913,15 @@ def is_image_model(name: str) -> bool:
         >>> is_image_model('gemini-2.0-flash-preview-image-generation')
         True
     """
-    return (name.startswith('gemini-') and '-image' in name) or 'image' in name
+    local = name.split('/')[-1].lower()
+    return local.startswith('gemini-') and '-image' in local
 
 
 def is_gemma_model(name: str) -> bool:
     """Check if the model is a Gemma open model.
 
-    Gemma models are Google's open-weight models with different configuration.
+    Gemma is the ``gemma-`` prefix on the local name after stripping the
+    plugin / ``models/`` prefix.
 
     Args:
         name: The model name to check.
@@ -926,7 +933,7 @@ def is_gemma_model(name: str) -> bool:
         >>> is_gemma_model('gemma-2-27b-it')
         True
     """
-    return name.startswith('gemma-')
+    return name.split('/')[-1].lower().startswith('gemma-')
 
 
 def is_tuned_gemini_name(name: str) -> bool:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
@@ -104,14 +104,14 @@ def is_imagen_model_name(name: str) -> bool:
 def is_unsupported_image_model_name(name: str) -> bool:
     """Return True for image ids that must not route anywhere.
 
-    ``imagegeneration@*`` (Imagen 1/2) was shut down by Google in June 2026,
-    and ``virtual-try-on-*`` needs a person+product image request shape this
-    plugin does not implement. Letting either fall through to the Gemini
-    default would answer with the wrong model, so callers treat these ids as
-    not-a-model instead.
+    ``imagegeneration@*`` and ``imagetext@*`` were shut down by Google in
+    June 2026, and ``virtual-try-on-*`` needs a person+product image request
+    shape this plugin does not implement. Letting any of those fall through
+    to the Gemini default would answer with the wrong model, so callers
+    treat these ids as not-a-model instead.
     """
     local = name.split('/')[-1].lower()
-    return local.startswith('imagegeneration@') or local.startswith('virtual-try-on-')
+    return local.startswith('imagegeneration@') or local.startswith('imagetext@') or local.startswith('virtual-try-on-')
 
 
 def vertexai_image_model_info(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
@@ -57,7 +57,6 @@ class ImagenVersion(StrEnum):
 
     IMAGEN3 = 'imagen-3.0-generate-002'
     IMAGEN3_FAST = 'imagen-3.0-fast-generate-001'
-    IMAGEN2 = 'imagegeneration@006'
 
 
 SUPPORTED_MODELS = {
@@ -81,16 +80,6 @@ SUPPORTED_MODELS = {
             output=['media'],
         ),
     ),
-    ImagenVersion.IMAGEN2: ModelInfo(
-        label='Vertex AI - Imagen2',
-        supports=Supports(
-            media=False,
-            multiturn=False,
-            tools=False,
-            system_role=True,
-            output=['media'],
-        ),
-    ),
 }
 
 DEFAULT_IMAGE_SUPPORT = Supports(
@@ -100,6 +89,29 @@ DEFAULT_IMAGE_SUPPORT = Supports(
     system_role=True,
     output=['media'],
 )
+
+
+def is_imagen_model_name(name: str) -> bool:
+    """Return True if ``name`` is an Imagen model.
+
+    Imagen ids start with ``imagen-`` on the local name after stripping the
+    plugin / ``models/`` prefix. Gemini native image (``gemini-…-image``) is
+    not Imagen.
+    """
+    return name.split('/')[-1].lower().startswith('imagen-')
+
+
+def is_unsupported_image_model_name(name: str) -> bool:
+    """Return True for image ids that must not route anywhere.
+
+    ``imagegeneration@*`` (Imagen 1/2) was shut down by Google in June 2026,
+    and ``virtual-try-on-*`` needs a person+product image request shape this
+    plugin does not implement. Letting either fall through to the Gemini
+    default would answer with the wrong model, so callers treat these ids as
+    not-a-model instead.
+    """
+    local = name.split('/')[-1].lower()
+    return local.startswith('imagegeneration@') or local.startswith('virtual-try-on-')
 
 
 def vertexai_image_model_info(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/lyria.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/lyria.py
@@ -56,7 +56,7 @@ def is_lyria_model(name: str) -> bool:
     Returns:
         True if this is a Lyria model name.
     """
-    return name.startswith('lyria-')
+    return name.split('/')[-1].lower().startswith('lyria-')
 
 
 class LyriaConfig(BaseModel):

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -19,9 +19,8 @@
 Veo is Google's video generation model that creates videos from text prompts.
 """
 
-import asyncio
 import sys
-from typing import Any, cast
+from typing import Any
 
 if sys.version_info < (3, 11):
     from strenum import StrEnum
@@ -33,19 +32,12 @@ from google.genai import types as genai_types
 from pydantic import BaseModel, ConfigDict, Field
 
 from genkit import (
-    Media,
-    MediaPart,
-    Message,
     ModelInfo,
     ModelRequest,
-    ModelResponse,
-    Part,
-    Role,
     Supports,
-    TextPart,
 )
 from genkit.model import Error, Operation
-from genkit.plugin_api import ActionRunContext, tracer
+from genkit.plugin_api import ActionRunContext
 
 
 class VeoVersion(StrEnum):
@@ -228,8 +220,8 @@ def _from_veo_operation(api_op: dict[str, Any]) -> Operation:
 class VeoModel:
     """Veo video generation model.
 
-    This class implements both the standard model interface (for Vertex AI)
-    and the background model pattern (for GoogleAI) for Veo video generation.
+    Veo runs as a background operation: callers start a generation and
+    poll it. There is no blocking generate path.
     """
 
     def __init__(self, version: str, client: genai.Client) -> None:
@@ -241,59 +233,6 @@ class VeoModel:
         """
         self._version = version
         self._client = client
-
-    def _build_prompt(self, request: ModelRequest) -> str:
-        """Build prompt request from Genkit request."""
-        prompt = []
-        for message in request.messages:
-            for part in message.content:
-                if isinstance(part.root, TextPart):
-                    prompt.append(part.root.text)
-                else:
-                    # TODO(#4363): Support image input if Veo supports it (e.g. for image-to-video)
-                    # For now, strict text text-to-video
-                    pass
-        return ' '.join(prompt)
-
-    async def generate(self, request: ModelRequest, _: ActionRunContext) -> ModelResponse:
-        """Handle a generation request (synchronous/blocking mode for Vertex AI).
-
-        Args:
-            request: The generation request.
-            _: action context
-
-        Returns:
-            The model's response.
-        """
-        if request.tools:
-            raise ValueError('Tools are not supported for this model.')
-
-        prompt = self._build_prompt(request)
-        config = self._get_config(request)
-
-        with tracer.start_as_current_span('generate_videos'):
-            operation = await self._client.aio.models.generate_videos(model=self._version, prompt=prompt, config=config)
-
-            # Handling LRO. Using cast(Any) to avoid strict type definition issues for operation.result()
-            op = cast(Any, operation)
-            if hasattr(op, 'result'):
-                # Check if result is a coroutine (awaitable) or direct value
-                res = op.result()
-                if asyncio.iscoroutine(res):
-                    response = await res
-                else:
-                    response = res
-            else:
-                response = op
-
-            content = self._contents_from_response(cast(genai_types.GenerateVideosResponse, response))
-
-        return ModelResponse(
-            message=Message(
-                content=content,
-                role=Role.MODEL,
-            )
-        )
 
     async def start(self, request: ModelRequest, ctx: ActionRunContext) -> Operation:
         """Start a video generation operation (background model pattern for GoogleAI).
@@ -354,30 +293,6 @@ class VeoModel:
             op_dict['response'] = response.response
 
         return _from_veo_operation(op_dict)
-
-    def _get_config(self, request: ModelRequest) -> genai_types.GenerateVideosConfigOrDict | None:
-        if not request.config:
-            return None
-        return cast(genai_types.GenerateVideosConfigOrDict, request.config)
-
-    def _contents_from_response(self, response: genai_types.GenerateVideosResponse) -> list[Part]:
-        content = []
-        if response.generated_videos:
-            for video in response.generated_videos:
-                # Video URI is typically in video.video.uri
-                if video.video and video.video.uri:
-                    uri = video.video.uri
-                    content.append(
-                        Part(
-                            root=MediaPart(
-                                media=Media(
-                                    url=uri,
-                                    content_type='video/mp4',
-                                )
-                            )
-                        )
-                    )
-        return content
 
     @property
     def metadata(self) -> dict:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -98,6 +98,7 @@ DEFAULT_VEO_SUPPORT = Supports(
     tools=False,
     system_role=True,
     output=['media'],
+    long_running=True,
 )
 
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -74,7 +74,7 @@ def is_veo_model(name: str) -> bool:
     Returns:
         True if this is a Veo model name.
     """
-    return name.lower().startswith('veo')
+    return name.split('/')[-1].lower().startswith('veo-')
 
 
 class VeoConfigSchema(BaseModel):

--- a/py/packages/genkit-google-genai/test/google_plugin_test.py
+++ b/py/packages/genkit-google-genai/test/google_plugin_test.py
@@ -731,17 +731,18 @@ async def test_vertexai_resolve_action_embedder(
             'gemini-pro-deluxe-max',
             False,
         ),
+        # A bare "image" prefix is not Imagen; only imagen- ids route there.
         (
             'vertexai/image-gemini-pro-deluxe-max',
             'vertexai/image-gemini-pro-deluxe-max',
             'image-gemini-pro-deluxe-max',
-            True,
+            False,
         ),
         (
             'image-gemini-pro-deluxe-max',
             'vertexai/image-gemini-pro-deluxe-max',
             'image-gemini-pro-deluxe-max',
-            True,
+            False,
         ),
         (
             'gemini-pro-deluxe-max-image',
@@ -997,9 +998,11 @@ async def test_vertexai_list_known_models(vertexai_plugin_instance: VertexAI) ->
     action3 = next(a for a in result if a.name == vertexai_name('imagen-3.0-generate-001'))
     assert action3 is not None
 
-    # Verify Veo
-    action4 = next(a for a in result if a.name == vertexai_name('veo-2.0-generate-001'))
-    assert action4 is not None
+    # Veo is background-only, so it is not a known generate MODEL.
+    assert not any(a.name == vertexai_name('veo-2.0-generate-001') for a in result)
+
+    veo_actions = vertexai_plugin_instance._list_known_veo_models()
+    assert {a.kind for a in veo_actions} == {ActionKind.BACKGROUND_MODEL, ActionKind.CHECK_OPERATION}
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-google-genai/test/models/family_name_test.py
+++ b/py/packages/genkit-google-genai/test/models/family_name_test.py
@@ -17,7 +17,7 @@
 """Family name checks for Google model routing."""
 
 import pytest
-from genkit_google_genai.models._routing import is_unroutable_model_id
+from genkit_google_genai.models._routing import classify_family, is_unroutable_model_id
 from genkit_google_genai.models.gemini import (
     is_gemini_model,
     is_gemma_model,
@@ -58,6 +58,8 @@ def test_is_imagen_model_name(name: str, expected: bool) -> None:
         ('imagegeneration@006', True),
         ('imagegeneration@005', True),
         ('vertexai/imagegeneration@006', True),
+        ('imagetext@001', True),
+        ('vertexai/imagetext@001', True),
         ('virtual-try-on-001', True),
         ('vertexai/virtual-try-on-001', True),
         ('imagen-3.0-generate-002', False),
@@ -170,14 +172,38 @@ def test_is_lyria_model(name: str, expected: bool) -> None:
         'antigravity-code-1',
         'gemini-embedding-001',
         'imagegeneration@006',
+        'imagetext@001',
         'virtual-try-on-001',
         'veo-3.0-generate-001',
         'googleai/lyria-002',
+        'models/deep-research-pro-preview',
+        'googleai/deep-research-pro-preview',
+        'publishers/google/models/deep-research-pro-preview',
+        'publishers/google/models/antigravity-preview-05-2026',
+        'publishers/google/models/imagetext@001',
     ],
 )
 def test_unroutable_ids_fail_closed(name: str) -> None:
     """Ids with no generate path here must not default to Gemini."""
     assert is_unroutable_model_id(name) is True
+
+
+@pytest.mark.parametrize(
+    ('name', 'family'),
+    [
+        ('deep-research-pro-preview', 'deep-research'),
+        ('models/deep-research-pro-preview', 'deep-research'),
+        ('googleai/deep-research-pro-preview', 'deep-research'),
+        ('publishers/google/models/deep-research-pro-preview', 'deep-research'),
+        ('antigravity-preview-05-2026', 'antigravity'),
+        ('publishers/google/models/antigravity-preview-05-2026', 'antigravity'),
+        ('lyria-002', 'lyria'),
+        ('imagetext@001', 'unsupported'),
+    ],
+)
+def test_classify_family_uses_leaf_name(name: str, family: str) -> None:
+    """Deep Research and Antigravity are separate buckets, keyed off the leaf."""
+    assert classify_family(name) == family
 
 
 @pytest.mark.parametrize(

--- a/py/packages/genkit-google-genai/test/models/family_name_test.py
+++ b/py/packages/genkit-google-genai/test/models/family_name_test.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family name checks for Google model routing."""
+
+import pytest
+from genkit_google_genai.models._routing import is_unroutable_model_id
+from genkit_google_genai.models.gemini import (
+    is_gemini_model,
+    is_gemma_model,
+    is_image_model,
+    is_tts_model,
+)
+from genkit_google_genai.models.imagen import (
+    is_imagen_model_name,
+    is_unsupported_image_model_name,
+)
+from genkit_google_genai.models.lyria import is_lyria_model
+from genkit_google_genai.models.veo import is_veo_model
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('imagen-3.0-generate-002', True),
+        ('IMAGEN-3.0-generate-002', True),
+        ('googleai/imagen-3.0-generate-002', True),
+        ('vertexai/imagen-3.0-generate-002', True),
+        ('models/imagen-3.0-generate-002', True),
+        ('gemini-2.5-flash-image', False),
+        ('gemini-2.5-flash-image-preview', False),
+        ('imagegeneration@006', False),
+        ('virtual-try-on-001', False),
+        ('veo-3.0-generate-001', False),
+    ],
+)
+def test_is_imagen_model_name(name: str, expected: bool) -> None:
+    """Imagen is the ``imagen-`` prefix only, on both plugins."""
+    assert is_imagen_model_name(name) is expected
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('imagegeneration@006', True),
+        ('imagegeneration@005', True),
+        ('vertexai/imagegeneration@006', True),
+        ('virtual-try-on-001', True),
+        ('vertexai/virtual-try-on-001', True),
+        ('imagen-3.0-generate-002', False),
+        ('gemini-2.5-flash-image', False),
+        ('gemini-2.5-flash', False),
+    ],
+)
+def test_is_unsupported_image_model_name(name: str, expected: bool) -> None:
+    """Retired / unimplemented image ids fail closed instead of routing to Gemini."""
+    assert is_unsupported_image_model_name(name) is expected
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('gemini-2.5-flash-preview-tts', True),
+        ('GEMINI-2.5-FLASH-PREVIEW-TTS', True),
+        ('googleai/gemini-2.5-pro-preview-tts', True),
+        ('gemini-2.5-flash', False),
+        ('gemini-2.5-flash-image', False),
+    ],
+)
+def test_is_tts_model(name: str, expected: bool) -> None:
+    """TTS is ``gemini-`` plus ``-tts`` on the local name."""
+    assert is_tts_model(name) is expected
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('gemini-2.5-flash-image', True),
+        ('GEMINI-2.5-FLASH-IMAGE', True),
+        ('gemini-2.0-flash-preview-image-generation', True),
+        ('googleai/gemini-3-pro-image-preview', True),
+        ('imagen-3.0-generate-002', False),
+        ('gemini-2.5-flash', False),
+        ('gemini-2.5-flash-preview-tts', False),
+    ],
+)
+def test_is_image_model(name: str, expected: bool) -> None:
+    """Gemini native image is ``gemini-`` plus ``-image``."""
+    assert is_image_model(name) is expected
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('gemma-2-27b-it', True),
+        ('GEMMA-3-12B-IT', True),
+        ('googleai/gemma-3-12b-it', True),
+        ('gemini-2.5-flash', False),
+    ],
+)
+def test_is_gemma_model(name: str, expected: bool) -> None:
+    """Gemma is the ``gemma-`` prefix on the local name."""
+    assert is_gemma_model(name) is expected
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('gemini-2.0-flash-001', True),
+        ('GEMINI-2.0-FLASH-001', True),
+        ('googleai/gemini-2.5-flash', True),
+        ('gemini-2.5-flash-preview-tts', False),
+        ('gemini-2.5-flash-image', False),
+        ('gemma-2-27b-it', False),
+    ],
+)
+def test_is_gemini_model(name: str, expected: bool) -> None:
+    """Standard Gemini excludes TTS and native image variants."""
+    assert is_gemini_model(name) is expected
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('veo-3.0-generate-001', True),
+        ('googleai/veo-3.1-generate-preview', True),
+        ('VEO-2.0-generate-001', True),
+        ('gemini-2.0-flash', False),
+        ('devotional-hymn', False),
+    ],
+)
+def test_is_veo_model_local_and_namespaced(name: str, expected: bool) -> None:
+    """Veo is the ``veo-`` prefix after stripping a namespace."""
+    assert is_veo_model(name) is expected
+
+
+@pytest.mark.parametrize(
+    ('name', 'expected'),
+    [
+        ('lyria-002', True),
+        ('LYRIA-002', True),
+        ('vertexai/lyria-002', True),
+        ('gemini-2.5-flash', False),
+    ],
+)
+def test_is_lyria_model(name: str, expected: bool) -> None:
+    """Lyria is the ``lyria-`` prefix on the local name."""
+    assert is_lyria_model(name) is expected
+
+
+@pytest.mark.parametrize(
+    'name',
+    [
+        'lyria-002',
+        'LYRIA-002',
+        'deep-research-pro-preview',
+        'antigravity-code-1',
+        'gemini-embedding-001',
+        'imagegeneration@006',
+        'virtual-try-on-001',
+        'veo-3.0-generate-001',
+        'googleai/lyria-002',
+    ],
+)
+def test_unroutable_ids_fail_closed(name: str) -> None:
+    """Ids with no generate path here must not default to Gemini."""
+    assert is_unroutable_model_id(name) is True
+
+
+@pytest.mark.parametrize(
+    'name',
+    [
+        'gemini-2.5-flash',
+        'GEMINI-2.5-FLASH-PREVIEW-TTS',
+        'imagen-3.0-generate-002',
+        'gemma-3-12b-it',
+    ],
+)
+def test_routable_ids_are_not_unroutable(name: str) -> None:
+    """Generate families still resolve as MODEL."""
+    assert is_unroutable_model_id(name) is False

--- a/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
+++ b/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
@@ -20,6 +20,7 @@ import asyncio
 import os
 import queue
 import threading
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -40,8 +41,17 @@ from genkit_google_genai.google import (
     googleai_name,
     vertexai_name,
 )
+from genkit_google_genai.models.gemini import GeminiImageConfigSchema
+from genkit_google_genai.models.imagen import ImagenConfigSchema
 
 from genkit import ActionKind
+from genkit.plugin_api import Action, to_json_schema
+
+
+def _custom_options(action: Action) -> object:
+    """Return the advertised config schema from an action's model metadata."""
+    model_meta = cast('dict[str, object]', action.metadata['model'])
+    return model_meta['customOptions']
 
 
 def test_googleai_name() -> None:
@@ -182,6 +192,21 @@ async def test_googleai_resolve_imagen_model(mock_list_models: MagicMock, mock_c
     assert action is not None
     assert action.kind == ActionKind.MODEL
     assert action.name == 'googleai/imagen-3.0-generate-002'
+    assert _custom_options(action) == to_json_schema(ImagenConfigSchema)
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_googleai_resolve_gemini_image_is_not_imagen(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
+    """Native Gemini image models must not route through Imagen."""
+    mock_list_models.return_value = GenaiModels()
+
+    plugin = GoogleAI(api_key='test-key')
+    action = await plugin.resolve(ActionKind.MODEL, 'googleai/gemini-2.5-flash-image')
+
+    assert action is not None
+    assert _custom_options(action) == to_json_schema(GeminiImageConfigSchema)
 
 
 @patch('genkit_google_genai.google.genai.client.Client')
@@ -259,6 +284,129 @@ async def test_vertexai_resolve_model(mock_list_models: MagicMock, mock_client: 
     assert action is not None
     assert action.kind == ActionKind.MODEL
     assert action.name == 'vertexai/gemini-2.0-flash'
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'model_id',
+    ['virtual-try-on-001', 'imagegeneration@006', 'lyria-002', 'deep-research-pro-preview', 'gemini-embedding-001'],
+)
+async def test_vertexai_unroutable_ids_fail_closed(
+    mock_list_models: MagicMock, mock_client: MagicMock, model_id: str
+) -> None:
+    """Ids with no generate path here resolve to nothing, not to Gemini."""
+    mock_list_models.return_value = GenaiModels()
+
+    plugin = VertexAI(project='test-project')
+    action = await plugin.resolve(ActionKind.MODEL, f'vertexai/{model_id}')
+
+    assert action is None
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'model_id',
+    ['virtual-try-on-001', 'imagegeneration@006', 'lyria-002', 'deep-research-pro-preview', 'gemini-embedding-001'],
+)
+async def test_googleai_unroutable_ids_fail_closed(
+    mock_list_models: MagicMock, mock_client: MagicMock, model_id: str
+) -> None:
+    """Ids with no generate path here resolve to nothing, not to Gemini."""
+    mock_list_models.return_value = GenaiModels()
+
+    plugin = GoogleAI(api_key='test-key')
+    action = await plugin.resolve(ActionKind.MODEL, f'googleai/{model_id}')
+
+    assert action is None
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_googleai_resolve_veo_as_model_returns_none(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
+    """Veo is background-only; resolving it as MODEL must not build a Gemini action."""
+    mock_list_models.return_value = GenaiModels()
+
+    plugin = GoogleAI(api_key='test-key')
+    action = await plugin.resolve(ActionKind.MODEL, 'googleai/veo-3.0-generate-001')
+
+    assert action is None
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_vertexai_resolve_veo_as_model_returns_none(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
+    """Veo is background-only; resolving it as MODEL must not build a Gemini action."""
+    mock_list_models.return_value = GenaiModels()
+
+    plugin = VertexAI(project='test-project')
+    action = await plugin.resolve(ActionKind.MODEL, 'vertexai/veo-3.0-generate-001')
+
+    assert action is None
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_vertexai_resolve_veo_background_model(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
+    """Vertex Veo resolves as a background model with a check action."""
+    mock_list_models.return_value = GenaiModels()
+
+    plugin = VertexAI(project='test-project')
+    start = await plugin.resolve(ActionKind.BACKGROUND_MODEL, 'vertexai/veo-3.0-generate-001')
+    check = await plugin.resolve(ActionKind.CHECK_OPERATION, 'vertexai/veo-3.0-generate-001/check')
+
+    assert start is not None
+    assert start.kind == ActionKind.BACKGROUND_MODEL
+    assert start.name == 'vertexai/veo-3.0-generate-001'
+    assert check is not None
+    assert check.kind == ActionKind.CHECK_OPERATION
+    assert check.name == 'vertexai/veo-3.0-generate-001/check'
+
+
+@patch('genkit_google_genai.google.create_vertex_evaluators')
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_vertexai_init_registers_veo_as_background(
+    mock_list_models: MagicMock, mock_client: MagicMock, mock_evaluators: MagicMock
+) -> None:
+    """Vertex init registers Veo start/check, never a blocking MODEL action."""
+    models = GenaiModels()
+    models.veo = ['veo-3.0-generate-001']
+    mock_list_models.return_value = models
+    mock_evaluators.return_value = []
+
+    plugin = VertexAI(project='test-project')
+    actions = await plugin.init()
+
+    veo_actions = [a for a in actions if 'veo' in a.name]
+    assert {a.kind for a in veo_actions} == {ActionKind.BACKGROUND_MODEL, ActionKind.CHECK_OPERATION}
+    assert not any(a.kind == ActionKind.MODEL for a in veo_actions)
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_list_actions_advertises_veo_as_background(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
+    """Both plugins list Veo with the kind that resolve() actually serves."""
+    models = GenaiModels()
+    models.veo = ['veo-3.0-generate-001']
+    mock_list_models.return_value = models
+
+    googleai_actions = await GoogleAI(api_key='test-key').list_actions()
+    vertexai_actions = await VertexAI(project='test-project').list_actions()
+
+    for actions, plugin_name in ((googleai_actions, 'googleai'), (vertexai_actions, 'vertexai')):
+        veo_entries = [a for a in actions if 'veo' in a.name]
+        assert len(veo_entries) == 1
+        assert veo_entries[0].name == f'{plugin_name}/veo-3.0-generate-001'
+        assert veo_entries[0].action_type == ActionKind.BACKGROUND_MODEL
 
 
 @patch('genkit_google_genai.google.genai.client.Client')

--- a/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
+++ b/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
@@ -21,7 +21,7 @@ import os
 import queue
 import threading
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from genkit_google_genai import (
@@ -38,13 +38,16 @@ from genkit_google_genai.google import (
     GOOGLEAI_PLUGIN_NAME,
     VERTEXAI_PLUGIN_NAME,
     GenaiModels,
+    _list_genai_models,
     googleai_name,
     vertexai_name,
 )
 from genkit_google_genai.models.gemini import GeminiImageConfigSchema
 from genkit_google_genai.models.imagen import ImagenConfigSchema
+from genkit_google_genai.models.veo import VeoModel
 
-from genkit import ActionKind
+from genkit import ActionKind, Message, ModelRequest, Part, Role, TextPart
+from genkit.model import Operation
 from genkit.plugin_api import Action, to_json_schema
 
 
@@ -291,7 +294,16 @@ async def test_vertexai_resolve_model(mock_list_models: MagicMock, mock_client: 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     'model_id',
-    ['virtual-try-on-001', 'imagegeneration@006', 'lyria-002', 'deep-research-pro-preview', 'gemini-embedding-001'],
+    [
+        'virtual-try-on-001',
+        'imagegeneration@006',
+        'imagetext@001',
+        'lyria-002',
+        'deep-research-pro-preview',
+        'gemini-embedding-001',
+        'models/deep-research-pro-preview',
+        'publishers/google/models/deep-research-pro-preview',
+    ],
 )
 async def test_vertexai_unroutable_ids_fail_closed(
     mock_list_models: MagicMock, mock_client: MagicMock, model_id: str
@@ -310,7 +322,16 @@ async def test_vertexai_unroutable_ids_fail_closed(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     'model_id',
-    ['virtual-try-on-001', 'imagegeneration@006', 'lyria-002', 'deep-research-pro-preview', 'gemini-embedding-001'],
+    [
+        'virtual-try-on-001',
+        'imagegeneration@006',
+        'imagetext@001',
+        'lyria-002',
+        'deep-research-pro-preview',
+        'gemini-embedding-001',
+        'models/deep-research-pro-preview',
+        'publishers/google/models/deep-research-pro-preview',
+    ],
 )
 async def test_googleai_unroutable_ids_fail_closed(
     mock_list_models: MagicMock, mock_client: MagicMock, model_id: str
@@ -407,6 +428,54 @@ async def test_list_actions_advertises_veo_as_background(mock_list_models: Magic
         assert len(veo_entries) == 1
         assert veo_entries[0].name == f'{plugin_name}/veo-3.0-generate-001'
         assert veo_entries[0].action_type == ActionKind.BACKGROUND_MODEL
+
+
+def test_list_genai_models_vertex_skips_substring_veo_and_retired_image() -> None:
+    """Discovery buckets on the ``veo-`` prefix, not a ``veo`` substring."""
+
+    def _model(name: str) -> MagicMock:
+        item = MagicMock()
+        item.name = name
+        item.supported_actions = None
+        item.description = ''
+        return item
+
+    client = MagicMock()
+    client.models.list.return_value = [
+        _model('publishers/google/models/gemini-2.5-flash'),
+        _model('publishers/google/models/veo-3.0-generate-001'),
+        _model('publishers/google/models/braveo-lab'),
+        _model('publishers/google/models/imagegeneration@006'),
+        _model('publishers/google/models/virtual-try-on-001'),
+        _model('publishers/google/models/imagetext@001'),
+    ]
+    catalog = _list_genai_models(client, is_vertex=True)
+    assert catalog.veo == ['veo-3.0-generate-001']
+    assert catalog.imagen == []
+    assert 'imagetext@001' not in catalog.gemini
+    assert 'braveo-lab' not in catalog.gemini
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_veo_start_stamps_background_action_key(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
+    """Start and check stamp ``/background-model/{name}`` so a later check can resolve."""
+    mock_list_models.return_value = GenaiModels()
+    plugin = VertexAI(project='test-project')
+    start = await plugin.resolve(ActionKind.BACKGROUND_MODEL, 'vertexai/veo-3.0-generate-001')
+    check = await plugin.resolve(ActionKind.CHECK_OPERATION, 'vertexai/veo-3.0-generate-001/check')
+    assert start is not None
+    assert check is not None
+
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='a clip'))])])
+    with patch.object(VeoModel, 'start', new=AsyncMock(return_value=Operation(id='ops/1'))):
+        started = await start.run(request)
+    assert started.response.action == '/background-model/vertexai/veo-3.0-generate-001'
+
+    with patch.object(VeoModel, 'check', new=AsyncMock(return_value=Operation(id='ops/1'))):
+        checked = await check.run(Operation(id='ops/1'))
+    assert checked.response.action == '/background-model/vertexai/veo-3.0-generate-001'
 
 
 @patch('genkit_google_genai.google.genai.client.Client')

--- a/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
+++ b/py/packages/genkit-google-genai/tests/google_genai_plugin_test.py
@@ -385,6 +385,9 @@ async def test_vertexai_resolve_veo_background_model(mock_list_models: MagicMock
     assert start is not None
     assert start.kind == ActionKind.BACKGROUND_MODEL
     assert start.name == 'vertexai/veo-3.0-generate-001'
+    model_meta = cast('dict[str, object]', start.metadata['model'])
+    supports = cast('dict[str, object]', model_meta['supports'])
+    assert supports['longRunning'] is True
     assert check is not None
     assert check.kind == ActionKind.CHECK_OPERATION
     assert check.name == 'vertexai/veo-3.0-generate-001/check'

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -47,6 +47,14 @@ class TestIsVeoModel:
         """Non-Veo model names are rejected."""
         assert is_veo_model('gemini-2.0-flash') is False
 
+    def test_namespaced_veo_model(self) -> None:
+        """Plugin prefixes are stripped before the ``veo-`` check."""
+        assert is_veo_model('googleai/veo-3.0-generate-001') is True
+
+    def test_substring_veo_is_rejected(self) -> None:
+        """A bare ``veo`` substring is not enough; the id has to start with ``veo-``."""
+        assert is_veo_model('devotional-hymn') is False
+
 
 class TestVeoVersion:
     """Tests for VeoVersion enum convenience constants."""

--- a/py/packages/genkit-google-genai/tests/vertexai_location_test.py
+++ b/py/packages/genkit-google-genai/tests/vertexai_location_test.py
@@ -648,6 +648,7 @@ class TestPluginModelWiring:
         """The model action constructs GeminiModel with the plugin's kwargs."""
         plugin = _vertex_plugin(location='us')
         action = plugin._resolve_model('vertexai/gemini-2.5-flash')
+        assert action is not None
         with patch('genkit_google_genai.google.GeminiModel') as mock_model:
             mock_model.return_value.generate = AsyncMock(return_value=MagicMock())
             await action._fn(_text_request(), MagicMock())
@@ -663,6 +664,7 @@ class TestPluginModelWiring:
         with patch('genkit_google_genai.google.genai.client.Client'):
             plugin = GoogleAI(api_key='k')
         action = plugin._resolve_model('googleai/gemini-2.5-flash')
+        assert action is not None
         with patch('genkit_google_genai.google.GeminiModel') as mock_model:
             mock_model.return_value.generate = AsyncMock(return_value=MagicMock())
             await action._fn(_text_request(), MagicMock())

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -233,6 +233,16 @@ def define_background_model(
     if info:
         model_options.update(info.model_dump(by_alias=True, exclude_none=True))
 
+    # generate_operation looks at this flag. A background model is a
+    # poll-handle model, so the flag is set on registration.
+    supports = model_options.get('supports')
+    if not isinstance(supports, dict):
+        supports = {}
+    else:
+        supports = dict(supports)
+    supports['longRunning'] = True
+    model_options['supports'] = supports
+
     # Precedence: explicit label argument > info.label > fallback to model name
     label = label or model_options.get('label') or name
     model_options['label'] = label

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -1809,6 +1809,7 @@ def test_define_background_model_with_info(setup_test: SetupFixture) -> None:
         'supports': {
             'multiturn': True,
             'systemRole': True,
+            'longRunning': True,
         },
     }
 


### PR DESCRIPTION

## Summary
- Family routing keys off the local name after the plugin prefix, so a `gemini-*-image` id stays on Gemini native image and never hits the Imagen path.
- Ids with no generate path here resolve to nothing instead of falling through to Gemini: `imagegeneration@*` (shut down June 2026), `virtual-try-on-*` (predict shape not implemented), Veo (background-only on both plugins), Lyria, Interactions (`deep-research-*` / `antigravity-*`), and embedders.
- Vertex no longer registers Veo as a blocking MODEL. Both plugins advertise Veo as `BACKGROUND_MODEL` + check, matching what `resolve()` actually serves.
- Veo start/check now go through `define_background_model` (not a hand-built `Action` pair). That helper stamps `supports.longRunning=True`, so `generate_operation('…/veo-…')` does not die after lookup finds the background action.
- `DEFAULT_VEO_SUPPORT` also sets `long_running=True`, so `list_actions` / `veo_model_info` match the registered action.
- Drop `imagegeneration@006` from the Imagen catalog enum.