### PR TITLE
feat(py): typed family ref constructors on GoogleAI and VertexAI

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
@@ -85,10 +85,15 @@ from genkit_google_genai.models.gemini import (
     GeminiConfigSchema,
     GeminiImageConfigSchema,
     GeminiTtsConfigSchema,
+    GemmaConfigSchema,
     GoogleAIGeminiVersion,
+    KnownGemini,
+    KnownGeminiImage,
+    KnownGeminiTts,
+    KnownGemma,
     VertexAIGeminiVersion,
 )
-from genkit_google_genai.models.imagen import ImagenVersion
+from genkit_google_genai.models.imagen import ImagenConfigSchema, ImagenVersion, KnownImagen
 from genkit_google_genai.models.lyria import LyriaConfig, LyriaVersion
 from genkit_google_genai.models.veo import VeoConfig, VeoVersion
 
@@ -108,9 +113,16 @@ __all__ = [
     'GeminiEmbeddingModels',
     'GeminiImageConfigSchema',
     'GeminiTtsConfigSchema',
+    'GemmaConfigSchema',
     'GoogleAI',
     'GoogleAIGeminiVersion',
+    'ImagenConfigSchema',
     'ImagenVersion',
+    'KnownGemini',
+    'KnownGeminiImage',
+    'KnownGeminiTts',
+    'KnownGemma',
+    'KnownImagen',
     'LyriaConfig',
     'LyriaVersion',
     'VeoConfig',

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -63,9 +63,9 @@ import genkit_google_genai.constants as const
 from genkit import ModelInfo
 from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
-from genkit.embedder import embedder_action_metadata
+from genkit.embedder import EmbedderRef, embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
-from genkit.model import BackgroundAction, Operation, model_action_metadata
+from genkit.model import BackgroundAction, ModelRef, Operation, model_action_metadata
 from genkit.plugin_api import (
     GENKIT_CLIENT_HEADER,
     Action,
@@ -78,6 +78,10 @@ from genkit.plugin_api import (
 from genkit_google_genai.evaluators import (
     VertexAIEvaluationMetricType,
     create_vertex_evaluators,
+)
+from genkit_google_genai.models._model_refs import (
+    family_embedder_ref,
+    family_model_ref,
 )
 from genkit_google_genai.models._routing import is_unroutable_model_id
 from genkit_google_genai.models.embedder import (
@@ -92,6 +96,10 @@ from genkit_google_genai.models.gemini import (
     GeminiModel,
     GeminiTtsConfigSchema,
     GemmaConfigSchema,
+    KnownGemini,
+    KnownGeminiImage,
+    KnownGeminiTts,
+    KnownGemma,
     get_model_config_schema,
     google_model_info,
     is_gemma_model,
@@ -103,6 +111,7 @@ from genkit_google_genai.models.imagen import (
     SUPPORTED_MODELS as IMAGE_SUPPORTED_MODELS,
     ImagenConfigSchema,
     ImagenModel,
+    KnownImagen,
     is_imagen_model_name,
     is_unsupported_image_model_name,
     vertexai_image_model_info,
@@ -409,6 +418,108 @@ def _create_veo_background_action(
     )
 
 
+class GoogleFamilyRefs:
+    """Typed ref constructors shared by GoogleAI and VertexAI.
+
+    One constructor per config family, because the function name is what
+    picks the return type. Each constructor strips pasted prefixes, stamps
+    this plugin's namespace, and refuses ids whose runtime action validates
+    a different schema.
+    """
+
+    name: str  # plugin namespace ('googleai' or 'vertexai')
+
+    @classmethod
+    def gemini_model(
+        cls, name: KnownGemini | str, *, config: GeminiConfigSchema | None = None
+    ) -> ModelRef[GeminiConfigSchema]:
+        """Typed ref for a Gemini text model, e.g. ``GoogleAI.gemini_model('gemini-2.5-flash')``.
+
+        Unknown ids are allowed so a brand-new Gemini release works before
+        this plugin learns its name; ids from other families are refused.
+        """
+        return family_model_ref(
+            name,
+            namespace=cls.name,
+            plugin_class=cls.__name__,
+            family='gemini',
+            method='gemini_model',
+            config_schema=GeminiConfigSchema,
+            config=config,
+        )
+
+    @classmethod
+    def gemini_tts_model(
+        cls, name: KnownGeminiTts | str, *, config: GeminiTtsConfigSchema | None = None
+    ) -> ModelRef[GeminiTtsConfigSchema]:
+        """Typed ref for a Gemini TTS model (``gemini-…-tts``)."""
+        return family_model_ref(
+            name,
+            namespace=cls.name,
+            plugin_class=cls.__name__,
+            family='tts',
+            method='gemini_tts_model',
+            config_schema=GeminiTtsConfigSchema,
+            config=config,
+        )
+
+    @classmethod
+    def gemini_image_model(
+        cls, name: KnownGeminiImage | str, *, config: GeminiImageConfigSchema | None = None
+    ) -> ModelRef[GeminiImageConfigSchema]:
+        """Typed ref for a Gemini native-image model (``gemini-…-image``)."""
+        return family_model_ref(
+            name,
+            namespace=cls.name,
+            plugin_class=cls.__name__,
+            family='image',
+            method='gemini_image_model',
+            config_schema=GeminiImageConfigSchema,
+            config=config,
+        )
+
+    @classmethod
+    def gemma_model(
+        cls, name: KnownGemma | str, *, config: GemmaConfigSchema | None = None
+    ) -> ModelRef[GemmaConfigSchema]:
+        """Typed ref for a Gemma open model (``gemma-…``)."""
+        return family_model_ref(
+            name,
+            namespace=cls.name,
+            plugin_class=cls.__name__,
+            family='gemma',
+            method='gemma_model',
+            config_schema=GemmaConfigSchema,
+            config=config,
+        )
+
+    @classmethod
+    def imagen_model(
+        cls, name: KnownImagen | str, *, config: ImagenConfigSchema | None = None
+    ) -> ModelRef[ImagenConfigSchema]:
+        """Typed ref for an Imagen model (``imagen-…``)."""
+        return family_model_ref(
+            name,
+            namespace=cls.name,
+            plugin_class=cls.__name__,
+            family='imagen',
+            method='imagen_model',
+            config_schema=ImagenConfigSchema,
+            config=config,
+        )
+
+    @classmethod
+    def embedding(
+        cls, name: str, *, config: dict[str, object] | None = None, version: str | None = None
+    ) -> EmbedderRef:
+        """EmbedderRef for ``ai.embed()``, e.g. ``GoogleAI.embedding('gemini-embedding-001')``.
+
+        Returns an EmbedderRef, not a ModelRef: an embedder id must never
+        end up in ``generate(model=...)``.
+        """
+        return family_embedder_ref(name, namespace=cls.name, plugin_class=cls.__name__, config=config, version=version)
+
+
 def _veo_background_action_metadata(name: str) -> ActionMetadata:
     """Build list_actions metadata for a Veo model as a background model.
 
@@ -432,7 +543,7 @@ def _veo_background_action_metadata(name: str) -> ActionMetadata:
     )
 
 
-class GoogleAI(Plugin):
+class GoogleAI(GoogleFamilyRefs, Plugin):
     """GoogleAI plugin for Genkit with dynamic model discovery.
 
     This plugin provides access to Google AI models (Gemini, embedders, Veo)
@@ -649,8 +760,9 @@ class GoogleAI(Plugin):
 
         Returns:
             Action object for the model, or None if this id has no generate
-            path here (Veo is background-only; retired/unimplemented image
-            ids fail closed instead of defaulting to Gemini).
+            path here (Veo runs as a background model, embedders are
+            EMBEDDER actions, and retired/unimplemented ids fail closed
+            instead of defaulting to Gemini).
         """
         # Extract local name (remove plugin prefix)
         clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
@@ -761,7 +873,7 @@ class GoogleAI(Plugin):
         return actions_list
 
 
-class VertexAI(Plugin):
+class VertexAI(GoogleFamilyRefs, Plugin):
     """Vertex AI plugin for Genkit with dynamic model discovery.
 
     This plugin provides access to Google Cloud Vertex AI models including
@@ -1068,8 +1180,9 @@ class VertexAI(Plugin):
 
         Returns:
             Action object for the model, or None if this id has no generate
-            path here (Veo is background-only; retired/unimplemented image
-            ids fail closed instead of defaulting to Gemini).
+            path here (Veo runs as a background model, embedders are
+            EMBEDDER actions, and retired/unimplemented ids fail closed
+            instead of defaulting to Gemini).
         """
         # Extract local name (remove plugin prefix)
         clean_name = name.replace(VERTEXAI_PLUGIN_NAME + '/', '') if name.startswith(VERTEXAI_PLUGIN_NAME) else name

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
@@ -52,7 +52,7 @@ def wrong_family_error(*, plugin_class: str, method: str, family: str, local: st
         hint = f"'{local}' is an embedder; use {plugin_class}.embedding()."
     elif actual == 'veo':
         hint = f"'{local}' is a Veo video model; it runs as a background model and has no ref constructor."
-    elif actual in ('lyria', 'interactions'):
+    elif actual in ('lyria', 'deep-research', 'antigravity'):
         hint = f"'{local}' has no ref constructor in this plugin."
     elif actual == 'unsupported':
         hint = f"'{local}' is not a supported model."

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared machinery for the typed family ref constructors.
+
+Each plugin class exposes one constructor per config family
+(``gemini_model``, ``imagen_model``, ...). The return type is the contract:
+``ModelRef[GeminiConfigSchema]`` tells generate-time code exactly which
+config is legal, so a constructor must refuse ids whose runtime action
+would validate a different schema — otherwise the ref lies and the wrong
+config sails through until the API rejects it.
+"""
+
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from genkit import GenkitError
+from genkit.embedder import EmbedderRef
+from genkit.model import ModelRef, model_ref
+from genkit_google_genai.models._routing import classify_family, strip_ref_prefixes
+
+ConfigT = TypeVar('ConfigT', bound=BaseModel)
+
+# Families with a constructor, for "use X instead" error hints.
+FAMILY_METHOD = {
+    'gemini': 'gemini_model',
+    'tts': 'gemini_tts_model',
+    'image': 'gemini_image_model',
+    'gemma': 'gemma_model',
+    'imagen': 'imagen_model',
+    'embedder': 'embedding',
+}
+
+
+def wrong_family_error(*, plugin_class: str, method: str, family: str, local: str, actual: str) -> GenkitError:
+    """Build the INVALID_ARGUMENT error naming the id and the way out."""
+    if actual == 'embedder':
+        hint = f"'{local}' is an embedder; use {plugin_class}.embedding()."
+    elif actual == 'veo':
+        hint = f"'{local}' is a Veo video model; it runs as a background model and has no ref constructor."
+    elif actual in ('lyria', 'interactions'):
+        hint = f"'{local}' has no ref constructor in this plugin."
+    elif actual == 'unsupported':
+        hint = f"'{local}' is not a supported model."
+    elif actual in FAMILY_METHOD:
+        hint = f"'{local}' is not a {family} model; use {plugin_class}.{FAMILY_METHOD[actual]}()."
+    else:
+        hint = f"'{local}' is not a {family} model."
+    return GenkitError(status='INVALID_ARGUMENT', message=f'{plugin_class}.{method}: {hint}')
+
+
+def family_model_ref(
+    name: str,
+    *,
+    namespace: str,
+    plugin_class: str,
+    family: str,
+    method: str,
+    config_schema: type[ConfigT],
+    config: ConfigT | None,
+) -> ModelRef[ConfigT]:
+    """Strip, gate against the closed family set, then stamp this plugin's namespace."""
+    local = strip_ref_prefixes(str(name))
+    if not local:
+        raise GenkitError(status='INVALID_ARGUMENT', message=f'{plugin_class}.{method}: model name is required.')
+    actual = classify_family(local)
+    # Unknown ids stay usable through gemini_model so a brand-new Gemini
+    # release works before this plugin learns its name. Every other family
+    # method takes only its own ids.
+    allowed = actual == family or (family == 'gemini' and actual == 'unknown')
+    if not allowed:
+        raise wrong_family_error(plugin_class=plugin_class, method=method, family=family, local=local, actual=actual)
+    return model_ref(local, config_schema=config_schema, namespace=namespace, config=config)
+
+
+def family_embedder_ref(
+    name: str,
+    *,
+    namespace: str,
+    plugin_class: str,
+    config: dict[str, object] | None,
+    version: str | None,
+) -> EmbedderRef:
+    """Strip, gate, and build an EmbedderRef for ai.embed().
+
+    This deliberately returns an EmbedderRef, not a ModelRef: an embedder id
+    must never end up in generate(model=...).
+    """
+    local = strip_ref_prefixes(str(name))
+    if not local:
+        raise GenkitError(status='INVALID_ARGUMENT', message=f'{plugin_class}.embedding: embedder name is required.')
+    actual = classify_family(local)
+    if actual not in ('embedder', 'unknown'):
+        raise wrong_family_error(
+            plugin_class=plugin_class, method='embedding', family='embedder', local=local, actual=actual
+        )
+    return EmbedderRef(name=f'{namespace}/{local}', config=config, version=version)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/_model_refs.py
@@ -74,7 +74,11 @@ def family_model_ref(
     config: ConfigT | None,
 ) -> ModelRef[ConfigT]:
     """Strip, gate against the closed family set, then stamp this plugin's namespace."""
-    local = strip_ref_prefixes(str(name))
+    # str(None) is 'None', and gemini_model allows unknown ids, so a
+    # non-string would mint a real-looking ref instead of failing here.
+    if not isinstance(name, str):
+        raise GenkitError(status='INVALID_ARGUMENT', message=f'{plugin_class}.{method}: model name must be a string.')
+    local = strip_ref_prefixes(name)
     if not local:
         raise GenkitError(status='INVALID_ARGUMENT', message=f'{plugin_class}.{method}: model name is required.')
     actual = classify_family(local)
@@ -100,7 +104,11 @@ def family_embedder_ref(
     This deliberately returns an EmbedderRef, not a ModelRef: an embedder id
     must never end up in generate(model=...).
     """
-    local = strip_ref_prefixes(str(name))
+    if not isinstance(name, str):
+        raise GenkitError(
+            status='INVALID_ARGUMENT', message=f'{plugin_class}.embedding: embedder name must be a string.'
+        )
+    local = strip_ref_prefixes(name)
     if not local:
         raise GenkitError(status='INVALID_ARGUMENT', message=f'{plugin_class}.embedding: embedder name is required.')
     actual = classify_family(local)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -31,6 +31,7 @@ from google.genai import types as genai_types
 from genkit import DocumentPart, Embedding, EmbedRequest, EmbedResponse
 from genkit._core._typing import DocumentData, MediaPart, TextPart
 from genkit.embedder import EmbedderOptions, EmbedderSupports
+from genkit_google_genai.models._routing import strip_ref_prefixes
 from genkit_google_genai.models.utils import PartConverter
 
 
@@ -171,12 +172,13 @@ class Embedder:
                 'Embed request input is empty: provide at least one document with content '
                 '(for example input: [{"content": [{"text": "your text here"}]}]).'
             )
-        if self._is_multimodal():
-            return await self._generate_multimodal(request)
+        model = self._embed_model(request)
+        if self._is_multimodal(model):
+            return await self._generate_multimodal(request, model)
         contents = await self._build_contents(request)
         config = self._genkit_to_googleai_cfg(request)
         response = await self._client.aio.models.embed_content(
-            model=self._version,
+            model=model,
             contents=cast(genai_types.ContentListUnion, contents),
             config=config,
         )
@@ -184,7 +186,14 @@ class Embedder:
         embeddings = [Embedding(embedding=em.values or []) for em in (response.embeddings or [])]
         return EmbedResponse(embeddings=embeddings)
 
-    def _is_multimodal(self) -> bool:
+    def _embed_model(self, request: EmbedRequest) -> str:
+        """API model id: options.version overlays the action's registered id."""
+        overlay = (request.options or {}).get('version')
+        if overlay:
+            return strip_ref_prefixes(str(overlay))
+        return str(self._version)
+
+    def _is_multimodal(self, model: str) -> bool:
         """Whether this embedder uses the Vertex multimodal ``:predict`` API.
 
         The google-genai ``embed_content`` API only accepts text on Vertex (it
@@ -192,9 +201,9 @@ class Embedder:
         ``predict`` endpoint with structured ``{text, image, video}`` instances
         instead. This mirrors the JS plugin's vertexai embedder.
         """
-        return 'multimodalembedding' in str(self._version).lower()
+        return 'multimodalembedding' in model.lower()
 
-    async def _generate_multimodal(self, request: EmbedRequest) -> EmbedResponse:
+    async def _generate_multimodal(self, request: EmbedRequest, model: str) -> EmbedResponse:
         """Embed text/image/video via the Vertex multimodal ``:predict`` endpoint.
 
         ``multimodalembedding@001`` accepts only one instance per ``:predict``
@@ -204,13 +213,14 @@ class Embedder:
 
         Args:
             request: Genkit embed request.
+            model: API model id (action id, or options.version overlay).
 
         Returns:
             EmbedResponse
         """
         if not self._is_vertex:
             raise ValueError(
-                f'{self._version} embedding is only available on Vertex AI; '
+                f'{model} embedding is only available on Vertex AI; '
                 'it is not supported by the Gemini Developer API. Use the VertexAI plugin instead.'
             )
         if len(request.input) > 1:
@@ -237,7 +247,7 @@ class Embedder:
             )
         http_response = await api_client.async_request(
             http_method='post',
-            path=f'publishers/google/models/{self._version}:predict',
+            path=f'publishers/google/models/{model}:predict',
             request_dict=payload,
         )
         body = json.loads(http_response.body) if http_response.body else {}

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -36,7 +36,7 @@ else:
     from enum import StrEnum
 
 from functools import cached_property
-from typing import Annotated, Any, Any as JsonAny, cast
+from typing import Annotated, Any, Any as JsonAny, Literal, TypeAlias, cast
 
 from google import genai
 from google.auth import default as google_auth_default
@@ -818,6 +818,50 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMMA_3N_E4B_IT = 'gemma-3n-e4b-it'
 
 
+# Quote autocomplete needs a Literal. The version enums above and the
+# ``_add_model`` names below are the catalog; a test requires each family
+# Literal to equal that catalog filtered by family.
+KnownGemini: TypeAlias = Literal[
+    'gemini-2.5-flash',
+    'gemini-2.5-pro',
+    'gemini-2.5-flash-lite',
+    'gemini-flash-latest',
+    'gemini-pro-latest',
+    'gemini-3-flash-preview',
+    'gemini-3-pro-preview',
+    'gemini-3.1-flash-lite',
+    'gemini-3.1-flash-lite-preview',
+    'gemini-3.1-pro-preview',
+    'gemini-3.1-pro-preview-customtools',
+    'gemini-3.5-flash',
+    'gemini-3.6-flash',
+    'gemini-3.7-flash',
+    'gemini-2.5-flash-preview-04-17',
+    'gemini-2.5-pro-exp-03-25',
+    'gemini-2.5-pro-preview-03-25',
+    'gemini-2.5-pro-preview-05-06',
+]
+KnownGeminiTts: TypeAlias = Literal[
+    'gemini-2.5-flash-preview-tts',
+    'gemini-2.5-pro-preview-tts',
+]
+KnownGeminiImage: TypeAlias = Literal[
+    'gemini-2.5-flash-image',
+    'gemini-2.5-flash-image-preview',
+    'gemini-3-pro-image',
+    'gemini-3-pro-image-preview',
+    'gemini-3.1-flash-image',
+    'gemini-3.1-flash-image-preview',
+]
+KnownGemma: TypeAlias = Literal[
+    'gemma-3-1b-it',
+    'gemma-3-4b-it',
+    'gemma-3-12b-it',
+    'gemma-3-27b-it',
+    'gemma-3n-e4b-it',
+]
+
+
 SUPPORTED_MODELS = {}
 
 
@@ -849,6 +893,10 @@ _add_model(GEMINI_3_1_FLASH_IMAGE_PREVIEW, ['gemini-3.1-flash-image-preview'])
 _add_model(GEMINI_3_PRO_IMAGE_PREVIEW, ['gemini-3-pro-image-preview'])
 _add_model(GEMINI_2_5_FLASH_IMAGE_PREVIEW, ['gemini-2.5-flash-image-preview'])
 _add_model(GEMINI_2_5_FLASH_IMAGE, ['gemini-2.5-flash-image'])
+
+# Frozen at import so quote-autocomplete tests do not see ids that
+# resolve() writes into SUPPORTED_MODELS later.
+GEMINI_CATALOG_IDS = frozenset(SUPPORTED_MODELS)
 
 
 DEFAULT_SUPPORTS_MODEL = Supports(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
@@ -26,7 +26,7 @@ else:
 
 import json
 from functools import cached_property
-from typing import Any
+from typing import Any, Literal, TypeAlias
 
 from google import genai
 from google.genai import types as genai_types
@@ -63,6 +63,14 @@ class ImagenVersion(StrEnum):
 
     IMAGEN3 = 'imagen-3.0-generate-002'
     IMAGEN3_FAST = 'imagen-3.0-fast-generate-001'
+
+
+# Quote autocomplete needs a Literal. The enum above is the catalog; a test
+# requires these members and the enum values to be the same set.
+KnownImagen: TypeAlias = Literal[
+    'imagen-3.0-generate-002',
+    'imagen-3.0-fast-generate-001',
+]
 
 
 SUPPORTED_MODELS = {

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -68,6 +68,26 @@ async def test_embedding(mocker: MockerFixture, version: GeminiEmbeddingModels) 
 
 
 @pytest.mark.asyncio
+async def test_options_version_is_the_api_model(mocker: MockerFixture) -> None:
+    """options.version overlays the action id as the model sent to embed_content."""
+    request_text = 'request text'
+    embedding_values = [0.1, 0.2]
+    request = EmbedRequest(
+        input=[Document.from_text(request_text)],
+        options={'version': 'vertexai/text-embedding-005'},
+    )
+    api_response = genai.types.EmbedContentResponse(embeddings=[genai.types.ContentEmbedding(values=embedding_values)])
+    googleai_client_mock = mocker.AsyncMock()
+    googleai_client_mock.aio.models.embed_content.return_value = api_response
+
+    embedder = Embedder('text-embedding-004', googleai_client_mock)
+    await embedder.generate(request)
+
+    googleai_client_mock.aio.models.embed_content.assert_called_once()
+    assert googleai_client_mock.aio.models.embed_content.call_args.kwargs['model'] == 'text-embedding-005'
+
+
+@pytest.mark.asyncio
 async def test_embedding_forwards_media_parts(mocker: MockerFixture) -> None:
     """Multimodal docs forward media parts to the client alongside the text."""
     text = 'a photo'

--- a/py/packages/genkit-google-genai/test/models/model_refs_test.py
+++ b/py/packages/genkit-google-genai/test/models/model_refs_test.py
@@ -184,8 +184,12 @@ class TestClosedRejectSet:
             GoogleAI.gemini_model('gemini-embedding-001')
         with pytest.raises(GenkitError, match=r'background model and has no ref constructor'):
             GoogleAI.gemini_model('veo-3.0-generate-001')
-        with pytest.raises(GenkitError, match=r'has no ref constructor'):
+        with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
             GoogleAI.gemini_model('lyria-002')
+        with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
+            GoogleAI.gemini_model('deep-research-pro-preview')
+        with pytest.raises(GenkitError, match=r'has no ref constructor in this plugin'):
+            GoogleAI.gemini_model('antigravity-code-1')
         with pytest.raises(GenkitError, match=r'is not a supported model'):
             GoogleAI.gemini_model('imagegeneration@006')
         with pytest.raises(GenkitError, match=r'is not a supported model'):
@@ -217,9 +221,9 @@ class TestEmbeddingConstructor:
 
     def test_embedding_strips_and_prefixes(self) -> None:
         """Pasted embedder prefixes are stripped before namespacing."""
-        ref = VertexAI.embedding('embedders/googleai/text-embedding-005', version='005')
-        assert ref.name == 'vertexai/text-embedding-005'
-        assert ref.version == '005'
+        ref = VertexAI.embedding('embedders/googleai/text-embedding-004', version='text-embedding-005')
+        assert ref.name == 'vertexai/text-embedding-004'
+        assert ref.version == 'text-embedding-005'
 
     def test_embedding_rejects_generate_models(self) -> None:
         """Generate-model ids cannot mint an EmbedderRef."""

--- a/py/packages/genkit-google-genai/test/models/model_refs_test.py
+++ b/py/packages/genkit-google-genai/test/models/model_refs_test.py
@@ -91,9 +91,10 @@ class TestHappyPaths:
         ref = GoogleAI.gemini_model('gemini-2.5-flash', config=config)
         assert ref.config == config
 
-    def test_unknown_id_allowed_on_gemini_model_only(self) -> None:
+    def test_unknown_id_allowed_on_gemini_model_and_embedding(self) -> None:
         """A brand-new release must work before this plugin learns its name."""
         assert GoogleAI.gemini_model('totally-new-model').name == 'googleai/totally-new-model'
+        assert GoogleAI.embedding('totally-new-embedder').name == 'googleai/totally-new-embedder'
 
         with pytest.raises(GenkitError):
             GoogleAI.imagen_model('totally-new-model')
@@ -122,6 +123,29 @@ class TestStripThenPrefix:
         with pytest.raises(GenkitError) as exc_info:
             GoogleAI.gemini_model('googleai/')
         assert exc_info.value.status == 'INVALID_ARGUMENT'
+        assert 'model name is required' in str(exc_info.value)
+
+        with pytest.raises(GenkitError) as exc_info:
+            GoogleAI.embedding('googleai/')
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+        assert 'embedder name is required' in str(exc_info.value)
+
+        with pytest.raises(GenkitError) as exc_info:
+            GoogleAI.embedding('')
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+        assert 'embedder name is required' in str(exc_info.value)
+
+    def test_non_string_name_is_rejected(self) -> None:
+        """A non-string must not become a name via str() (None → 'None')."""
+        with pytest.raises(GenkitError) as exc_info:
+            GoogleAI.gemini_model(None)  # type: ignore[arg-type]
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+        assert 'must be a string' in str(exc_info.value)
+
+        with pytest.raises(GenkitError) as exc_info:
+            GoogleAI.embedding(123)  # type: ignore[arg-type]
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+        assert 'must be a string' in str(exc_info.value)
 
 
 class TestClosedRejectSet:
@@ -158,6 +182,16 @@ class TestClosedRejectSet:
             VertexAI.imagen_model('gemini-2.5-flash')
         with pytest.raises(GenkitError, match=r'embedding'):
             GoogleAI.gemini_model('gemini-embedding-001')
+        with pytest.raises(GenkitError, match=r'background model and has no ref constructor'):
+            GoogleAI.gemini_model('veo-3.0-generate-001')
+        with pytest.raises(GenkitError, match=r'has no ref constructor'):
+            GoogleAI.gemini_model('lyria-002')
+        with pytest.raises(GenkitError, match=r'is not a supported model'):
+            GoogleAI.gemini_model('imagegeneration@006')
+        with pytest.raises(GenkitError, match=r'is not a supported model'):
+            GoogleAI.gemini_model('virtual-try-on-001')
+        with pytest.raises(GenkitError, match=r'is not a imagen model'):
+            GoogleAI.imagen_model('totally-new-model')
 
     def test_family_constructors_reject_other_families(self) -> None:
         """Non-gemini constructors take only their own family ids."""

--- a/py/packages/genkit-google-genai/test/models/model_refs_test.py
+++ b/py/packages/genkit-google-genai/test/models/model_refs_test.py
@@ -1,0 +1,223 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the typed family ref constructors on GoogleAI / VertexAI."""
+
+from collections.abc import Callable
+from enum import Enum
+from typing import get_args
+
+import pytest
+from genkit_google_genai import (
+    GoogleAI,
+    KnownGemini,
+    KnownGeminiImage,
+    KnownGeminiTts,
+    KnownGemma,
+    KnownImagen,
+    VertexAI,
+)
+from genkit_google_genai.models.gemini import (
+    GEMINI_CATALOG_IDS,
+    GeminiConfigSchema,
+    GeminiImageConfigSchema,
+    GeminiTtsConfigSchema,
+    GemmaConfigSchema,
+    GoogleAIGeminiVersion,
+    VertexAIGeminiVersion,
+    is_gemini_model,
+    is_gemma_model,
+    is_image_model,
+    is_tts_model,
+)
+from genkit_google_genai.models.imagen import (
+    ImagenConfigSchema,
+    ImagenVersion,
+    is_imagen_model_name,
+)
+
+from genkit import GenkitError
+from genkit.embedder import EmbedderRef
+from genkit.model import ModelRef
+
+
+class TestHappyPaths:
+    """Each constructor mints its family's typed ref under its own namespace."""
+
+    def test_gemini_model_both_plugins(self) -> None:
+        """Same constructor name works on both plugins, each stamping its namespace."""
+        googleai_ref = GoogleAI.gemini_model('gemini-2.5-flash')
+        vertexai_ref = VertexAI.gemini_model('gemini-2.5-flash')
+
+        assert isinstance(googleai_ref, ModelRef)
+        assert googleai_ref.name == 'googleai/gemini-2.5-flash'
+        assert googleai_ref.config_schema is GeminiConfigSchema
+        assert vertexai_ref.name == 'vertexai/gemini-2.5-flash'
+
+    def test_enum_names_still_work(self) -> None:
+        """The existing version enums remain valid constructor input."""
+        assert GoogleAI.gemini_model(GoogleAIGeminiVersion.GEMINI_2_5_FLASH).name == 'googleai/gemini-2.5-flash'
+        assert GoogleAI.imagen_model(ImagenVersion.IMAGEN3).name == 'googleai/imagen-3.0-generate-002'
+
+    def test_family_constructors_type_their_config(self) -> None:
+        """Each family constructor carries its own config schema."""
+        tts = GoogleAI.gemini_tts_model('gemini-2.5-flash-preview-tts')
+        image = VertexAI.gemini_image_model('gemini-2.5-flash-image')
+        gemma = GoogleAI.gemma_model('gemma-3-12b-it')
+        imagen = VertexAI.imagen_model('imagen-3.0-generate-002')
+
+        assert tts.config_schema is GeminiTtsConfigSchema
+        assert image.config_schema is GeminiImageConfigSchema
+        assert gemma.config_schema is GemmaConfigSchema
+        assert imagen.config_schema is ImagenConfigSchema
+        assert imagen.name == 'vertexai/imagen-3.0-generate-002'
+
+    def test_config_instance_rides_along(self) -> None:
+        """A default config passed at construction survives into the ref."""
+        config = GeminiConfigSchema(temperature=0.3)
+        ref = GoogleAI.gemini_model('gemini-2.5-flash', config=config)
+        assert ref.config == config
+
+    def test_unknown_id_allowed_on_gemini_model_only(self) -> None:
+        """A brand-new release must work before this plugin learns its name."""
+        assert GoogleAI.gemini_model('totally-new-model').name == 'googleai/totally-new-model'
+
+        with pytest.raises(GenkitError):
+            GoogleAI.imagen_model('totally-new-model')
+
+
+class TestStripThenPrefix:
+    """Pasted prefixes are stripped so the constructor decides the namespace."""
+
+    @pytest.mark.parametrize(
+        'pasted',
+        [
+            'googleai/gemini-2.5-flash',
+            'vertexai/gemini-2.5-flash',
+            'model/gemini-2.5-flash',
+            'models/gemini-2.5-flash',
+            'models/googleai/gemini-2.5-flash',
+        ],
+    )
+    def test_cross_plugin_paste_cannot_smuggle_namespace(self, pasted: str) -> None:
+        """Every pasted prefix form lands on this plugin, not the pasted one."""
+        assert GoogleAI.gemini_model(pasted).name == 'googleai/gemini-2.5-flash'
+        assert VertexAI.gemini_model(pasted).name == 'vertexai/gemini-2.5-flash'
+
+    def test_empty_after_strip_is_rejected(self) -> None:
+        """A bare prefix with no id left is an invalid argument."""
+        with pytest.raises(GenkitError) as exc_info:
+            GoogleAI.gemini_model('googleai/')
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+class TestClosedRejectSet:
+    """Ids whose action validates another schema must not mint this ref."""
+
+    @pytest.mark.parametrize(
+        'bad_id',
+        [
+            'veo-3.0-generate-001',  # background model, no ref constructor
+            'lyria-002',  # no constructor in this plugin
+            'googleai/lyria-002',  # prefix must not defeat the gate
+            'deep-research-pro-preview',  # Interactions API family
+            'antigravity-code-1',  # Interactions API family
+            'imagegeneration@006',  # retired June 2026
+            'virtual-try-on-001',  # predict shape not implemented
+            'gemini-embedding-001',  # embedder, not a generate model
+            'imagen-3.0-generate-002',  # wrong family: has its own constructor
+            'gemini-2.5-flash-preview-tts',  # wrong family: TTS
+            'gemini-2.5-flash-image',  # wrong family: native image
+            'gemma-3-12b-it',  # wrong family: Gemma
+        ],
+    )
+    def test_gemini_model_rejects(self, bad_id: str) -> None:
+        """gemini_model refuses every id whose action validates another schema."""
+        with pytest.raises(GenkitError) as exc_info:
+            GoogleAI.gemini_model(bad_id)
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+    def test_error_points_at_the_right_constructor(self) -> None:
+        """Rejections tell the caller which constructor to use instead."""
+        with pytest.raises(GenkitError, match=r'gemini_tts_model'):
+            GoogleAI.gemini_model('gemini-2.5-flash-preview-tts')
+        with pytest.raises(GenkitError, match=r'VertexAI\.gemini_model'):
+            VertexAI.imagen_model('gemini-2.5-flash')
+        with pytest.raises(GenkitError, match=r'embedding'):
+            GoogleAI.gemini_model('gemini-embedding-001')
+
+    def test_family_constructors_reject_other_families(self) -> None:
+        """Non-gemini constructors take only their own family ids."""
+        with pytest.raises(GenkitError):
+            GoogleAI.imagen_model('gemini-2.5-flash')
+        with pytest.raises(GenkitError):
+            GoogleAI.gemini_tts_model('gemini-2.5-flash')
+        with pytest.raises(GenkitError):
+            GoogleAI.gemma_model('gemini-2.5-flash')
+        with pytest.raises(GenkitError):
+            VertexAI.gemini_image_model('imagen-3.0-generate-002')
+
+
+class TestEmbeddingConstructor:
+    """embedding() returns an EmbedderRef so it can't be passed as a model."""
+
+    def test_embedding_ref(self) -> None:
+        """embedding() returns an EmbedderRef under this plugin namespace."""
+        ref = GoogleAI.embedding('gemini-embedding-001')
+        assert isinstance(ref, EmbedderRef)
+        assert not isinstance(ref, ModelRef)
+        assert ref.name == 'googleai/gemini-embedding-001'
+
+    def test_embedding_strips_and_prefixes(self) -> None:
+        """Pasted embedder prefixes are stripped before namespacing."""
+        ref = VertexAI.embedding('embedders/googleai/text-embedding-005', version='005')
+        assert ref.name == 'vertexai/text-embedding-005'
+        assert ref.version == '005'
+
+    def test_embedding_rejects_generate_models(self) -> None:
+        """Generate-model ids cannot mint an EmbedderRef."""
+        with pytest.raises(GenkitError, match=r'gemini_model'):
+            GoogleAI.embedding('gemini-2.5-flash')
+        with pytest.raises(GenkitError):
+            VertexAI.embedding('imagen-3.0-generate-002')
+
+
+def _enum_ids(*enums: type[Enum]) -> set[str]:
+    return {str(member.value) for enum in enums for member in enum}
+
+
+def _family_catalog(is_family: Callable[[str], bool]) -> set[str]:
+    """Version enums plus ``_add_model`` names for one family."""
+    enum_ids = _enum_ids(GoogleAIGeminiVersion, VertexAIGeminiVersion)
+    return {name for name in enum_ids | GEMINI_CATALOG_IDS if is_family(name)}
+
+
+class TestKnownIdLiterals:
+    """Constructor name types are string Literals so quotes autocomplete."""
+
+    def test_known_gemini_matches_catalog(self) -> None:
+        """Quote autocomplete and the text catalog are the same set of ids."""
+        known = set(get_args(KnownGemini))
+        assert known == _family_catalog(is_gemini_model)
+        assert not any(is_tts_model(value) or is_image_model(value) or is_gemma_model(value) for value in known)
+
+    def test_family_literals_match_their_catalog(self) -> None:
+        """Sibling constructors autocomplete exactly their catalog ids."""
+        assert set(get_args(KnownGeminiTts)) == _family_catalog(is_tts_model)
+        assert set(get_args(KnownGeminiImage)) == _family_catalog(is_image_model)
+        assert set(get_args(KnownGemma)) == _family_catalog(is_gemma_model)
+        assert set(get_args(KnownImagen)) == {str(member.value) for member in ImagenVersion}
+        assert all(is_imagen_model_name(value) for value in get_args(KnownImagen))


### PR DESCRIPTION
## Summary
- One classmethod per config family (`gemini_model`, `gemini_tts_model`, `gemini_image_model`, `gemma_model`, `imagen_model`, `embedding`) so the method name is what picks `ModelRef[T]` / `EmbedderRef`.
- Constructors strip prefixes (`model/`, `models/`, `googleai/`, `vertexai/`, …) and stamp this plugin's namespace. A pasted cross-plugin name cannot smuggle its namespace into the ref. The specific prefixes to strip are defined within each plugin.
- Ids whose runtime action validates a different schema are refused with a hint at the right constructor. Unknown ids stay usable through `gemini_model` / `embedding` so a new release works before this plugin learns its name.
- `GoogleAI.embedding()` / `VertexAI.embedding()` return an `EmbedderRef`. That is usable today: `ai.embed(embedder=GoogleAI.embedding('gemini-embedding-001'), content=…)`. Named `embedding` so `Plugin.embedder` still resolves an Action.
- `gemini_model()` and the other generate constructors are typed factories. `ai.generate(model=…)` is still `str` until #6074. Samples stay on string `model=`.


## Test plan
- [ ] `GoogleAI.gemini_model('gemini-2.5-flash').name == 'googleai/gemini-2.5-flash'` and the Vertex twin stamps `vertexai/`
- [ ] Pasted `vertexai/…`, `models/…`, `models/googleai/…` all land on the constructor's namespace
- [ ] `gemini_model` refuses Veo / Lyria / Interactions / embedder / TTS / image / Gemma / Imagen / retired image ids
- [ ] `GoogleAI.embedding('gemini-embedding-001')` is an `EmbedderRef`, not a `ModelRef`
- [ ] `await plugin.embedder('gemini-embedding-001')` is still an `Action`
- [ ] `KnownGemini` / TTS / image / Gemma / Imagen Literals match the import-time catalog (not ids `resolve()` writes later)