### PR TITLE
feat(py): Anthropic.claude_model and OpenAI.gpt_model typed ref constructors

### DIFF
--- a/py/packages/genkit-anthropic/src/genkit_anthropic/__init__.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/__init__.py
@@ -58,6 +58,7 @@ from genkit_anthropic.config import (
     ToolChoice,
     ToolChoiceNone,
 )
+from genkit_anthropic.model_info import KnownClaude
 from genkit_anthropic.plugin import Anthropic, anthropic_name
 
 __all__ = [
@@ -65,6 +66,7 @@ __all__ = [
     'AnthropicConfig',
     'AutoToolChoice',
     'AnyToolChoice',
+    'KnownClaude',
     'OutputConfig',
     'RequestMetadata',
     'SpecificToolChoice',

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/model_info.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/model_info.py
@@ -16,6 +16,8 @@
 
 """Anthropic Models for Genkit."""
 
+from typing import Literal, TypeAlias, cast
+
 from genkit import (
     Constrained,
     ModelInfo,
@@ -179,7 +181,26 @@ CLAUDE_FABLE_5 = ModelInfo(
     ),
 )
 
-SUPPORTED_ANTHROPIC_MODELS: dict[str, ModelInfo] = {
+# Quote autocomplete needs a Literal. The catalog below is what you edit when
+# a Claude ships; a test requires these members and the dict keys to be the
+# same set, and the dict is typed so a new key that is not in the Literal
+# does not type-check.
+KnownClaude: TypeAlias = Literal[
+    'claude-sonnet-4',
+    'claude-opus-4',
+    'claude-sonnet-4-5',
+    'claude-sonnet-4-6',
+    'claude-sonnet-5',
+    'claude-haiku-4-5',
+    'claude-opus-4-1',
+    'claude-opus-4-5',
+    'claude-opus-4-6',
+    'claude-opus-4-7',
+    'claude-opus-4-8',
+    'claude-fable-5',
+]
+
+SUPPORTED_ANTHROPIC_MODELS: dict[KnownClaude, ModelInfo] = {
     'claude-sonnet-4': CLAUDE_SONNET_4,
     'claude-opus-4': CLAUDE_OPUS_4,
     'claude-sonnet-4-5': CLAUDE_SONNET_4_5,
@@ -212,10 +233,9 @@ def get_model_info(name: str) -> ModelInfo:
     Returns:
         Model information.
     """
-    return SUPPORTED_ANTHROPIC_MODELS.get(
-        name,
-        ModelInfo(
-            label=f'Anthropic - {name}',
-            supports=DEFAULT_SUPPORTS,
-        ),
+    if name in SUPPORTED_ANTHROPIC_MODELS:
+        return SUPPORTED_ANTHROPIC_MODELS[cast(KnownClaude, name)]
+    return ModelInfo(
+        label=f'Anthropic - {name}',
+        supports=DEFAULT_SUPPORTS,
     )

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -40,21 +40,13 @@ logger = structlog.get_logger(__name__)
 
 ANTHROPIC_PLUGIN_NAME = 'anthropic'
 
-# Prefixes people paste from action keys, Dev UI traces, or another plugin's
-# samples. Stripping them first means this constructor decides the namespace.
-_STRIP_PREFIXES = (
-    'background-model/',
-    'model/',
-    'models/',
-    'embedders/',
-    'googleai/',
-    'vertexai/',
-    f'{ANTHROPIC_PLUGIN_NAME}/',
-)
+# Only this plugin's namespace. A vertexai/ paste is a different name —
+# remapping it here would send the request to the Anthropic API.
+_STRIP_PREFIXES = (f'{ANTHROPIC_PLUGIN_NAME}/',)
 
 
 def _strip_ref_prefixes(name: str) -> str:
-    """Reduce a pasted name to the bare model id."""
+    """Peel this plugin's prefix so it is not stamped twice."""
     local = name
     changed = True
     while changed:

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -21,8 +21,8 @@ from typing import Any, Literal, cast
 import structlog
 from anthropic import AsyncAnthropic
 
-from genkit import ModelRequest, ModelResponse
-from genkit.model import model_action_metadata
+from genkit import GenkitError, ModelRequest, ModelResponse
+from genkit.model import ModelRef, model_action_metadata, model_ref
 from genkit.plugin_api import (
     Action,
     ActionKind,
@@ -33,7 +33,7 @@ from genkit.plugin_api import (
     to_json_schema,
 )
 from genkit_anthropic.config import AnthropicConfig
-from genkit_anthropic.model_info import SUPPORTED_ANTHROPIC_MODELS, get_model_info
+from genkit_anthropic.model_info import SUPPORTED_ANTHROPIC_MODELS, KnownClaude, get_model_info
 from genkit_anthropic.models import AnthropicModel
 
 logger = structlog.get_logger(__name__)
@@ -60,6 +60,21 @@ class Anthropic(Plugin):
     """
 
     name = ANTHROPIC_PLUGIN_NAME
+
+    @classmethod
+    def claude_model(
+        cls, name: KnownClaude | str, *, config: AnthropicConfig | None = None
+    ) -> ModelRef[AnthropicConfig]:
+        """Typed ref for a Claude model, e.g. ``Anthropic.claude_model('claude-sonnet-4-5')``.
+
+        Unknown ids are allowed so new Claude releases work before this
+        plugin learns their names; every Anthropic generate model takes
+        AnthropicConfig.
+        """
+        local = str(name).removeprefix(f'{ANTHROPIC_PLUGIN_NAME}/')
+        if not local:
+            raise GenkitError(status='INVALID_ARGUMENT', message='Anthropic.claude_model: model name is required.')
+        return model_ref(local, config_schema=AnthropicConfig, namespace=ANTHROPIC_PLUGIN_NAME, config=config)
 
     def __init__(
         self,
@@ -129,7 +144,7 @@ class Anthropic(Plugin):
 
         model_info = get_model_info(clean_name)
 
-        async def _generate(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        async def _generate(request: ModelRequest[AnthropicConfig], ctx: ActionRunContext) -> ModelResponse:
             model = AnthropicModel(
                 model_name=clean_name,
                 client=self._runtime_client(),

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -40,6 +40,31 @@ logger = structlog.get_logger(__name__)
 
 ANTHROPIC_PLUGIN_NAME = 'anthropic'
 
+# Prefixes people paste from action keys, Dev UI traces, or another plugin's
+# samples. Stripping them first means this constructor decides the namespace.
+_STRIP_PREFIXES = (
+    'background-model/',
+    'model/',
+    'models/',
+    'embedders/',
+    'googleai/',
+    'vertexai/',
+    f'{ANTHROPIC_PLUGIN_NAME}/',
+)
+
+
+def _strip_ref_prefixes(name: str) -> str:
+    """Reduce a pasted name to the bare model id."""
+    local = name
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _STRIP_PREFIXES:
+            if local.startswith(prefix):
+                local = local[len(prefix) :]
+                changed = True
+    return local
+
 
 def anthropic_name(name: str) -> str:
     """Get Anthropic model name.
@@ -71,7 +96,7 @@ class Anthropic(Plugin):
         plugin learns their names; every Anthropic generate model takes
         AnthropicConfig.
         """
-        local = str(name).removeprefix(f'{ANTHROPIC_PLUGIN_NAME}/')
+        local = _strip_ref_prefixes(str(name))
         if not local:
             raise GenkitError(status='INVALID_ARGUMENT', message='Anthropic.claude_model: model name is required.')
         return model_ref(local, config_schema=AnthropicConfig, namespace=ANTHROPIC_PLUGIN_NAME, config=config)

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -88,7 +88,11 @@ class Anthropic(Plugin):
         plugin learns their names; every Anthropic generate model takes
         AnthropicConfig.
         """
-        local = _strip_ref_prefixes(str(name))
+        # str(None) is 'None', and unknown ids are allowed, so a non-string
+        # would mint a real-looking ref instead of failing here.
+        if not isinstance(name, str):
+            raise GenkitError(status='INVALID_ARGUMENT', message='Anthropic.claude_model: model name must be a string.')
+        local = _strip_ref_prefixes(name)
         if not local:
             raise GenkitError(status='INVALID_ARGUMENT', message='Anthropic.claude_model: model name is required.')
         return model_ref(local, config_schema=AnthropicConfig, namespace=ANTHROPIC_PLUGIN_NAME, config=config)

--- a/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
@@ -24,7 +24,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from genkit_anthropic import Anthropic, anthropic_name
+from genkit_anthropic import Anthropic, AnthropicConfig, anthropic_name
 from genkit_anthropic.model_info import (
     SUPPORTED_ANTHROPIC_MODELS as SUPPORTED_MODELS,
     get_model_info,
@@ -34,7 +34,6 @@ from genkit import (
     ActionKind,
     Constrained,
     Message,
-    ModelConfig,
     ModelRequest,
     Part,
     Role,
@@ -448,7 +447,7 @@ def _create_sample_request() -> ModelRequest:
                 content=[Part(root=TextPart(text='Hello, how are you?'))],
             )
         ],
-        config=ModelConfig(),
+        config=AnthropicConfig(),
         tools=[
             ToolDefinition(
                 name='get_weather',

--- a/py/packages/genkit-anthropic/tests/model_refs_test.py
+++ b/py/packages/genkit-anthropic/tests/model_refs_test.py
@@ -41,20 +41,9 @@ def test_claude_model_strips_own_prefix() -> None:
     assert ref.name == 'anthropic/claude-sonnet-4-5'
 
 
-@pytest.mark.parametrize(
-    'pasted',
-    [
-        'anthropic/claude-sonnet-4-5',
-        'vertexai/claude-sonnet-4-5',
-        'googleai/claude-sonnet-4-5',
-        'model/claude-sonnet-4-5',
-        'models/claude-sonnet-4-5',
-        'models/anthropic/claude-sonnet-4-5',
-    ],
-)
-def test_claude_model_strips_pasted_prefixes(pasted: str) -> None:
-    """Every pasted prefix form lands on this plugin, not the pasted one."""
-    assert Anthropic.claude_model(pasted).name == 'anthropic/claude-sonnet-4-5'
+def test_claude_model_keeps_foreign_prefix() -> None:
+    """A Vertex Model Garden paste is a different name, not remapped onto Anthropic."""
+    assert Anthropic.claude_model('vertexai/claude-sonnet-4-5').name == 'anthropic/vertexai/claude-sonnet-4-5'
 
 
 def test_claude_model_carries_config() -> None:

--- a/py/packages/genkit-anthropic/tests/model_refs_test.py
+++ b/py/packages/genkit-anthropic/tests/model_refs_test.py
@@ -41,9 +41,20 @@ def test_claude_model_strips_own_prefix() -> None:
     assert ref.name == 'anthropic/claude-sonnet-4-5'
 
 
-def test_claude_model_keeps_foreign_prefix() -> None:
-    """A Vertex Model Garden paste is a different name, not remapped onto Anthropic."""
-    assert Anthropic.claude_model('vertexai/claude-sonnet-4-5').name == 'anthropic/vertexai/claude-sonnet-4-5'
+@pytest.mark.parametrize(
+    'pasted',
+    [
+        'anthropic/claude-sonnet-4-5',
+        'vertexai/claude-sonnet-4-5',
+        'googleai/claude-sonnet-4-5',
+        'model/claude-sonnet-4-5',
+        'models/claude-sonnet-4-5',
+        'models/anthropic/claude-sonnet-4-5',
+    ],
+)
+def test_claude_model_strips_pasted_prefixes(pasted: str) -> None:
+    """Every pasted prefix form lands on this plugin, not the pasted one."""
+    assert Anthropic.claude_model(pasted).name == 'anthropic/claude-sonnet-4-5'
 
 
 def test_claude_model_carries_config() -> None:

--- a/py/packages/genkit-anthropic/tests/model_refs_test.py
+++ b/py/packages/genkit-anthropic/tests/model_refs_test.py
@@ -65,6 +65,19 @@ def test_claude_model_requires_a_name() -> None:
     assert exc_info.value.status == 'INVALID_ARGUMENT'
 
 
+def test_claude_model_rejects_non_string_name() -> None:
+    """A non-string must not become a name via str() (None → 'None')."""
+    with pytest.raises(GenkitError) as exc_info:
+        Anthropic.claude_model(None)  # type: ignore[arg-type]
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'must be a string' in str(exc_info.value)
+
+    with pytest.raises(GenkitError) as exc_info:
+        Anthropic.claude_model(123)  # type: ignore[arg-type]
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'must be a string' in str(exc_info.value)
+
+
 def test_known_claude_matches_catalog() -> None:
     """Quote autocomplete and the catalog are the same set of ids."""
     assert set(get_args(KnownClaude)) == set(SUPPORTED_ANTHROPIC_MODELS)

--- a/py/packages/genkit-anthropic/tests/model_refs_test.py
+++ b/py/packages/genkit-anthropic/tests/model_refs_test.py
@@ -41,6 +41,11 @@ def test_claude_model_strips_own_prefix() -> None:
     assert ref.name == 'anthropic/claude-sonnet-4-5'
 
 
+def test_claude_model_keeps_foreign_prefix() -> None:
+    """A Vertex Model Garden paste is a different name, not remapped onto Anthropic."""
+    assert Anthropic.claude_model('vertexai/claude-sonnet-4-5').name == 'anthropic/vertexai/claude-sonnet-4-5'
+
+
 def test_claude_model_carries_config() -> None:
     """A default config passed at construction survives into the ref."""
     ref = Anthropic.claude_model('claude-sonnet-4-5', config=AnthropicConfig(max_output_tokens=256))

--- a/py/packages/genkit-anthropic/tests/model_refs_test.py
+++ b/py/packages/genkit-anthropic/tests/model_refs_test.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Anthropic.claude_model typed ref constructor."""
+
+from typing import get_args, get_type_hints
+
+import pytest
+from genkit_anthropic import Anthropic, AnthropicConfig, KnownClaude
+from genkit_anthropic.model_info import SUPPORTED_ANTHROPIC_MODELS
+
+from genkit import GenkitError
+from genkit.model import ModelRef
+
+
+def test_claude_model_prefixes_anthropic() -> None:
+    """claude_model namespaces the name and binds AnthropicConfig."""
+    ref = Anthropic.claude_model('claude-sonnet-4-5')
+
+    assert isinstance(ref, ModelRef)
+    assert ref.name == 'anthropic/claude-sonnet-4-5'
+    assert ref.config_schema is AnthropicConfig
+
+
+def test_claude_model_strips_own_prefix() -> None:
+    """An already-namespaced name is not double-prefixed."""
+    ref = Anthropic.claude_model('anthropic/claude-sonnet-4-5')
+    assert ref.name == 'anthropic/claude-sonnet-4-5'
+
+
+def test_claude_model_carries_config() -> None:
+    """A default config passed at construction survives into the ref."""
+    ref = Anthropic.claude_model('claude-sonnet-4-5', config=AnthropicConfig(max_output_tokens=256))
+    assert ref.config is not None
+    assert ref.config.max_output_tokens == 256
+
+
+def test_claude_model_allows_unknown_ids() -> None:
+    """A brand-new Claude release works before this plugin learns its name."""
+    assert Anthropic.claude_model('claude-next-99').name == 'anthropic/claude-next-99'
+
+
+def test_claude_model_requires_a_name() -> None:
+    """A bare prefix with no id left is an invalid argument."""
+    with pytest.raises(GenkitError) as exc_info:
+        Anthropic.claude_model('anthropic/')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+def test_known_claude_matches_catalog() -> None:
+    """Quote autocomplete and the catalog are the same set of ids."""
+    assert set(get_args(KnownClaude)) == set(SUPPORTED_ANTHROPIC_MODELS)
+
+
+def test_create_model_action_types_anthropic_config() -> None:
+    """Anthropic model actions opt into ModelRequest[AnthropicConfig]."""
+    plugin = Anthropic(api_key='test-key', models=['claude-sonnet-4'])
+    action = plugin._create_model_action('anthropic/claude-sonnet-4')
+
+    hints = get_type_hints(action._fn)  # noqa: SLF001
+    request_type = hints['request']
+    args = get_args(request_type) or (getattr(request_type, '__pydantic_generic_metadata__', {}) or {}).get('args')
+    assert args and args[0] is AnthropicConfig

--- a/py/packages/genkit-openai/src/genkit_openai/__init__.py
+++ b/py/packages/genkit-openai/src/genkit_openai/__init__.py
@@ -48,6 +48,7 @@ See Also:
     - OpenAI documentation: https://platform.openai.com/docs/
 """
 
+from .models.model_info import KnownGpt
 from .openai_plugin import OpenAI, openai_model
 from .typing import OpenAIConfig
 
@@ -57,4 +58,4 @@ def package_name() -> str:
     return 'genkit_openai'
 
 
-__all__ = ['OpenAI', 'OpenAIConfig', 'openai_model', 'package_name']
+__all__ = ['KnownGpt', 'OpenAI', 'OpenAIConfig', 'openai_model', 'package_name']

--- a/py/packages/genkit-openai/src/genkit_openai/models/handler.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/handler.py
@@ -16,7 +16,8 @@
 
 """OpenAI Compatible Model handlers for Genkit."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
+from typing import cast
 
 from openai import AsyncOpenAI
 
@@ -49,7 +50,7 @@ class OpenAIModelHandler:
         self._source = source
 
     @staticmethod
-    def _get_supported_models(source: PluginSource) -> dict[str, ModelInfo]:
+    def _get_supported_models(source: PluginSource) -> Mapping[str, ModelInfo]:
         """Returns the supported models based on the plugin source.
 
         Args:
@@ -61,7 +62,9 @@ class OpenAIModelHandler:
             with openai-compat models if source is model-garden.
 
         """
-        return SUPPORTED_OPENAI_COMPAT_MODELS if source == PluginSource.MODEL_GARDEN else SUPPORTED_OPENAI_MODELS
+        if source == PluginSource.MODEL_GARDEN:
+            return SUPPORTED_OPENAI_COMPAT_MODELS
+        return cast(Mapping[str, ModelInfo], SUPPORTED_OPENAI_MODELS)
 
     @classmethod
     def get_model_handler(

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -37,7 +37,7 @@ from genkit import (
     ToolDefinition,
 )
 from genkit.plugin_api import ActionRunContext
-from genkit_openai.models.model_info import SUPPORTED_OPENAI_MODELS
+from genkit_openai.models.model_info import SUPPORTED_OPENAI_MODELS, KnownGpt
 from genkit_openai.models.utils import (
     DictMessageAdapter,
     MessageAdapter,
@@ -167,7 +167,7 @@ class OpenAIModel:
                     },
                 }
 
-            model = SUPPORTED_OPENAI_MODELS[self._model]
+            model = SUPPORTED_OPENAI_MODELS[cast(KnownGpt, self._model)]
             if model.supports and model.supports.output and SupportedOutputFormat.JSON_MODE in model.supports.output:
                 return {'type': 'json_object'}
 

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -147,7 +147,9 @@ class OpenAIModel:
         Returns:
             A dictionary representing the response format, which may include:
             - 'type': 'json_schema' and a validated JSON Schema if a schema is provided.
-            - 'type': 'json_object' if the model supports JSON mode and no schema is provided.
+            - 'type': 'json_object' if the model supports JSON mode, or the id
+              is not in the catalog (fine-tune, dated snapshot), and no schema
+              is provided.
             - 'type': 'text' as the default fallback.
         """
         if request.output_format == 'json':
@@ -167,7 +169,11 @@ class OpenAIModel:
                     },
                 }
 
-            model = SUPPORTED_OPENAI_MODELS[cast(KnownGpt, self._model)]
+            model = SUPPORTED_OPENAI_MODELS.get(cast(KnownGpt, self._model))
+            # Unlisted chat ids still asked for JSON; send json_object and let
+            # the provider reject it if that model cannot do it.
+            if model is None:
+                return {'type': 'json_object'}
             if model.supports and model.supports.output and SupportedOutputFormat.JSON_MODE in model.supports.output:
                 return {'type': 'json_object'}
 

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -48,6 +48,35 @@ from genkit_openai.typing import OpenAIConfig, SupportedOutputFormat
 
 logger = structlog.get_logger(__name__)
 
+# Genkit common fields that are not chat.completions.create() kwargs.
+# stop_sequences is remapped to stop; the rest are peeled off.
+_GENKIT_ONLY = frozenset({'api_key', 'top_k', 'version', 'max_output_tokens', 'stop_sequences'})
+
+
+def _openai_create_kwargs(*, config: OpenAIConfig) -> dict[str, Any]:
+    """Kwargs for chat.completions.create().
+
+    Peel Genkit-only keys. ``stop_sequences`` becomes ``stop`` when ``stop``
+    was not set. Everything else on the config, including extras, goes out
+    under the Python field name. ``max_output_tokens`` is not mapped to
+    ``max_tokens`` — that knob is ``max_tokens`` / ``maxTokens``.
+    """
+    body: dict[str, Any] = {}
+    for name in type(config).model_fields:
+        if name in _GENKIT_ONLY:
+            continue
+        value = getattr(config, name)
+        if value is not None:
+            body[name] = value
+    extras = config.model_extra
+    if extras:
+        for name, value in extras.items():
+            if value is not None:
+                body[name] = value
+    if 'stop' not in body and config.stop_sequences is not None:
+        body['stop'] = config.stop_sequences
+    return body
+
 
 class OpenAIModel:
     """Handles OpenAI API interactions for the Genkit plugin."""
@@ -279,7 +308,10 @@ class OpenAIModel:
                 # pyrefly: ignore[bad-typed-dict-key] - response_format dict is valid for OpenAI API
                 openai_config['response_format'] = response_format
         if request.config:
-            openai_config.update(**request.config.model_dump(exclude_none=True))
+            config = (
+                request.config if isinstance(request.config, OpenAIConfig) else self.normalize_config(request.config)
+            )
+            openai_config.update(_openai_create_kwargs(config=config))
         return openai_config
 
     async def _generate(self, request: ModelRequest) -> ModelResponse:

--- a/py/packages/genkit-openai/src/genkit_openai/models/model.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model.py
@@ -49,7 +49,7 @@ from genkit_openai.typing import OpenAIConfig, SupportedOutputFormat
 logger = structlog.get_logger(__name__)
 
 # Genkit common fields that are not chat.completions.create() kwargs.
-# stop_sequences is remapped to stop; the rest are peeled off.
+# version becomes the wire model id; stop_sequences becomes stop.
 _GENKIT_ONLY = frozenset({'api_key', 'top_k', 'version', 'max_output_tokens', 'stop_sequences'})
 
 
@@ -57,9 +57,10 @@ def _openai_create_kwargs(*, config: OpenAIConfig) -> dict[str, Any]:
     """Kwargs for chat.completions.create().
 
     Peel Genkit-only keys. ``stop_sequences`` becomes ``stop`` when ``stop``
-    was not set. Everything else on the config, including extras, goes out
-    under the Python field name. ``max_output_tokens`` is not mapped to
-    ``max_tokens`` — that knob is ``max_tokens`` / ``maxTokens``.
+    was not set. ``version`` is peeled here and applied as ``model`` by the
+    caller when ``OpenAIConfig.model`` is unset. Everything else, including
+    extras, goes out under the Python field name. ``max_output_tokens`` is
+    not mapped to ``max_tokens`` — that knob is ``max_tokens`` / ``maxTokens``.
     """
     body: dict[str, Any] = {}
     for name in type(config).model_fields:
@@ -311,6 +312,8 @@ class OpenAIModel:
             config = (
                 request.config if isinstance(request.config, OpenAIConfig) else self.normalize_config(request.config)
             )
+            if config.version:
+                openai_config['model'] = config.version
             openai_config.update(_openai_create_kwargs(config=config))
         return openai_config
 
@@ -441,6 +444,7 @@ class OpenAIModel:
 
         if isinstance(config, (ModelConfig, ModelConfig)):
             return OpenAIConfig(
+                version=config.version,
                 temperature=config.temperature,
                 max_tokens=int(config.max_output_tokens) if config.max_output_tokens is not None else None,
                 top_p=config.top_p,

--- a/py/packages/genkit-openai/src/genkit_openai/models/model_info.py
+++ b/py/packages/genkit-openai/src/genkit_openai/models/model_info.py
@@ -18,6 +18,7 @@
 """OpenAI Compatible Models for Genkit."""
 
 import sys
+from typing import Literal, TypeAlias
 
 if sys.version_info < (3, 11):
     from strenum import StrEnum
@@ -92,8 +93,52 @@ GPT_OSS_MODEL_SUPPORTS = Supports(
 LLAMA_3_1 = 'meta/llama-3.1-405b-instruct-maas'
 LLAMA_3_2 = 'meta/llama-3.2-90b-vision-instruct-maas'
 
+# Quote autocomplete needs a Literal. The catalog below is what you edit when
+# a chat model ships; a test requires these members and the dict keys to be the
+# same set, and the dict is typed so a new key that is not in the Literal
+# does not type-check. Image, TTS, STT, and embedding ids live in other
+# catalogs — they do not take OpenAIConfig.
+KnownGpt: TypeAlias = Literal[
+    'gpt-4o',
+    'gpt-4o-2024-05-13',
+    'gpt-4o-mini',
+    'gpt-4o-mini-2024-07-18',
+    'gpt-4.5-preview',
+    'gpt-4.1',
+    'gpt-4.1-mini',
+    'gpt-4-turbo',
+    'gpt-4-turbo-2024-04-09',
+    'gpt-4-turbo-preview',
+    'gpt-4-0125-preview',
+    'gpt-4-1106-preview',
+    'gpt-4',
+    'gpt-4-0613',
+    'gpt-3.5-turbo',
+    'gpt-3.5-turbo-0125',
+    'gpt-3.5-turbo-1106',
+    'o1',
+    'o3',
+    'o3-mini',
+    'o3-pro',
+    'o4-mini',
+    'gpt-5',
+    'gpt-5-mini',
+    'gpt-5-nano',
+    'gpt-5-chat-latest',
+    'gpt-5.1',
+    'gpt-5.1-codex',
+    'gpt-5.1-codex-max',
+    'gpt-5.2',
+    'gpt-5.2-chat',
+    'gpt-5.2-pro',
+    'gpt-5.3-codex',
+    'gpt-oss-120b',
+    'gpt-oss-20b',
+]
+
+
 # Source: https://platform.openai.com/docs/models
-SUPPORTED_OPENAI_MODELS: dict[str, ModelInfo] = {
+SUPPORTED_OPENAI_MODELS: dict[KnownGpt, ModelInfo] = {
     # --- GPT-4o series ---
     'gpt-4o': ModelInfo(label='OpenAI - gpt-4o', supports=MULTIMODAL_MODEL_SUPPORTS),
     'gpt-4o-2024-05-13': ModelInfo(label='OpenAI - gpt-4o-2024-05-13', supports=MULTIMODAL_MODEL_SUPPORTS),

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -64,21 +64,13 @@ def open_ai_name(name: str) -> str:
     return f'openai/{name}'
 
 
-# Prefixes people paste from action keys, Dev UI traces, or another plugin's
-# samples. Stripping them first means this constructor decides the namespace.
-_STRIP_PREFIXES = (
-    'background-model/',
-    'model/',
-    'models/',
-    'embedders/',
-    'googleai/',
-    'vertexai/',
-    'openai/',
-)
+# Only this plugin's namespace. A vertexai/ or azure/ paste is a different
+# name — remapping it here would send the request to the OpenAI API.
+_STRIP_PREFIXES = ('openai/',)
 
 
 def _strip_ref_prefixes(name: str) -> str:
-    """Reduce a pasted name to the bare model id."""
+    """Peel this plugin's prefix so it is not stamped twice."""
     local = name
     changed = True
     while changed:

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -531,7 +531,7 @@ class OpenAI(Plugin):
                 actions.append(
                     model_action_metadata(
                         name=open_ai_name(name),
-                        config_schema=ModelConfig,
+                        config_schema=OpenAIConfig,
                         info={
                             'label': f'OpenAI - {name}',
                             'supports': Supports(

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -64,6 +64,32 @@ def open_ai_name(name: str) -> str:
     return f'openai/{name}'
 
 
+# Prefixes people paste from action keys, Dev UI traces, or another plugin's
+# samples. Stripping them first means this constructor decides the namespace.
+_STRIP_PREFIXES = (
+    'background-model/',
+    'model/',
+    'models/',
+    'embedders/',
+    'googleai/',
+    'vertexai/',
+    'openai/',
+)
+
+
+def _strip_ref_prefixes(name: str) -> str:
+    """Reduce a pasted name to the bare model id."""
+    local = name
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _STRIP_PREFIXES:
+            if local.startswith(prefix):
+                local = local[len(prefix) :]
+                changed = True
+    return local
+
+
 class _ModelType(enum.Enum):
     """Classification of OpenAI model types based on name patterns."""
 
@@ -208,7 +234,7 @@ class OpenAI(Plugin):
         request shapes, so binding OpenAIConfig to them would let chat-only
         keys like frequency_penalty ride into the wrong endpoint.
         """
-        local = str(name).removeprefix('openai/')
+        local = _strip_ref_prefixes(str(name))
         if not local:
             raise GenkitError(status='INVALID_ARGUMENT', message='OpenAI.gpt_model: model name is required.')
         model_type = _classify_model(local)

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -226,7 +226,11 @@ class OpenAI(Plugin):
         request shapes, so binding OpenAIConfig to them would let chat-only
         keys like frequency_penalty ride into the wrong endpoint.
         """
-        local = _strip_ref_prefixes(str(name))
+        # str(None) is 'None', and that classifies as chat, so a non-string
+        # would mint a real-looking ref instead of failing here.
+        if not isinstance(name, str):
+            raise GenkitError(status='INVALID_ARGUMENT', message='OpenAI.gpt_model: model name must be a string.')
+        local = _strip_ref_prefixes(name)
         if not local:
             raise GenkitError(status='INVALID_ARGUMENT', message='OpenAI.gpt_model: model name is required.')
         model_type = _classify_model(local)

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -23,9 +23,9 @@ from typing import Any, Literal, TypeAlias, cast
 from openai import AsyncOpenAI
 from openai.types import Model
 
-from genkit import Embedding, EmbedRequest, EmbedResponse, ModelInfo, ModelRequest, ModelResponse, Supports
+from genkit import Embedding, EmbedRequest, EmbedResponse, GenkitError, ModelInfo, ModelRequest, ModelResponse, Supports
 from genkit.embedder import EmbedderOptions, EmbedderSupports, embedder_action_metadata
-from genkit.model import ModelConfig, model_action_metadata
+from genkit.model import ModelConfig, ModelRef, model_action_metadata, model_ref
 from genkit.plugin_api import (
     Action,
     ActionKind,
@@ -48,7 +48,7 @@ from genkit_openai.models import (
     OpenAISTTModel,
     OpenAITTSModel,
 )
-from genkit_openai.models.model_info import get_default_openai_model_info
+from genkit_openai.models.model_info import KnownGpt, get_default_openai_model_info
 from genkit_openai.typing import OpenAIConfig
 
 
@@ -200,6 +200,27 @@ class OpenAI(Plugin):
 
     name = 'openai'
 
+    @classmethod
+    def gpt_model(cls, name: KnownGpt | str, *, config: OpenAIConfig | None = None) -> ModelRef[OpenAIConfig]:
+        """Typed ref for an OpenAI chat model, e.g. ``OpenAI.gpt_model('gpt-4o')``.
+
+        Chat only: image, TTS, STT, and embedding ids validate different
+        request shapes, so binding OpenAIConfig to them would let chat-only
+        keys like frequency_penalty ride into the wrong endpoint.
+        """
+        local = str(name).removeprefix('openai/')
+        if not local:
+            raise GenkitError(status='INVALID_ARGUMENT', message='OpenAI.gpt_model: model name is required.')
+        model_type = _classify_model(local)
+        if model_type != _ModelType.CHAT:
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=(
+                    f"OpenAI.gpt_model: '{local}' is a {model_type.value} model; only chat models take OpenAIConfig."
+                ),
+            )
+        return model_ref(local, config_schema=OpenAIConfig, namespace='openai', config=config)
+
     def __init__(self, **openai_params: Any) -> None:  # noqa: ANN401
         """Initializes the OpenAI plugin with the specified parameters.
 
@@ -254,7 +275,7 @@ class OpenAI(Plugin):
             is provided). The 'supports' key contains a dictionary representing
             the model's capabilities (e.g., tools, streaming).
         """
-        if model_supported := SUPPORTED_OPENAI_MODELS.get(name):
+        if model_supported := SUPPORTED_OPENAI_MODELS.get(cast(KnownGpt, name)):
             supports = (
                 model_supported.supports.model_dump(by_alias=True, exclude_none=True)
                 if model_supported.supports
@@ -316,7 +337,7 @@ class OpenAI(Plugin):
         # Create the model handler
         model_info = self.get_model_info(clean_name) or {}
 
-        async def _generate(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        async def _generate(request: ModelRequest[OpenAIConfig], ctx: ActionRunContext) -> ModelResponse:
             openai_model = OpenAIModelHandler(OpenAIModel(clean_name, self._runtime_client()))
             return await openai_model.generate(request, ctx)
 

--- a/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
+++ b/py/packages/genkit-openai/src/genkit_openai/openai_plugin.py
@@ -213,10 +213,17 @@ class OpenAI(Plugin):
             raise GenkitError(status='INVALID_ARGUMENT', message='OpenAI.gpt_model: model name is required.')
         model_type = _classify_model(local)
         if model_type != _ModelType.CHAT:
+            kind = {
+                _ModelType.EMBEDDER: 'an embedder',
+                _ModelType.IMAGE: 'an image model',
+                _ModelType.TTS: 'a tts model',
+                _ModelType.STT: 'an stt model',
+            }[model_type]
             raise GenkitError(
                 status='INVALID_ARGUMENT',
                 message=(
-                    f"OpenAI.gpt_model: '{local}' is a {model_type.value} model; only chat models take OpenAIConfig."
+                    f"OpenAI.gpt_model: '{local}' is {kind}; it does not take "
+                    f'OpenAIConfig. Pass it as a string (openai_model({local!r})).'
                 ),
             )
         return model_ref(local, config_schema=OpenAIConfig, namespace='openai', config=config)

--- a/py/packages/genkit-openai/src/genkit_openai/typing.py
+++ b/py/packages/genkit-openai/src/genkit_openai/typing.py
@@ -39,6 +39,7 @@ else:
     from enum import StrEnum
 
 from pydantic import ConfigDict, Field
+from pydantic.alias_generators import to_camel
 
 from genkit.model import ModelConfig
 
@@ -215,7 +216,10 @@ class OpenAIConfig(ModelConfig):
             See: https://platform.openai.com/docs/api-reference/chat/create#chat-create-web_search_options
     """
 
+    # Dev UI and reflection send camelCase (frequencyPenalty, maxOutputTokens).
+    # populate_by_name keeps the snake_case Python fields working too.
     model_config: ClassVar[ConfigDict] = ConfigDict(
+        alias_generator=to_camel,
         extra='allow',
         populate_by_name=True,
     )

--- a/py/packages/genkit-openai/src/genkit_openai/typing.py
+++ b/py/packages/genkit-openai/src/genkit_openai/typing.py
@@ -216,7 +216,9 @@ class OpenAIConfig(ModelConfig):
             See: https://platform.openai.com/docs/api-reference/chat/create#chat-create-web_search_options
     """
 
-    # Dev UI and reflection send camelCase (frequencyPenalty, maxOutputTokens).
+    # Dev UI and reflection send camelCase. frequencyPenalty binds and goes
+    # out as frequency_penalty. maxOutputTokens binds on the schema; it is
+    # not a create() kwarg (use max_tokens / maxTokens for a token cap).
     # populate_by_name keeps the snake_case Python fields working too.
     model_config: ClassVar[ConfigDict] = ConfigDict(
         alias_generator=to_camel,

--- a/py/packages/genkit-openai/tests/model_refs_test.py
+++ b/py/packages/genkit-openai/tests/model_refs_test.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the OpenAI.gpt_model typed ref constructor."""
+
+from typing import get_args, get_type_hints
+
+import pytest
+from genkit_openai import KnownGpt, OpenAI, OpenAIConfig, openai_model
+from genkit_openai.models.model_info import SUPPORTED_OPENAI_MODELS
+
+from genkit import GenkitError
+from genkit.model import ModelRef
+
+
+def test_openai_model_still_returns_str() -> None:
+    """openai_model stays a string helper, not a ModelRef."""
+    assert openai_model('gpt-4o') == 'openai/gpt-4o'
+    assert isinstance(openai_model('gpt-4o'), str)
+
+
+def test_gpt_model_returns_model_ref() -> None:
+    """gpt_model namespaces the name and binds OpenAIConfig."""
+    ref = OpenAI.gpt_model('gpt-4o')
+
+    assert isinstance(ref, ModelRef)
+    assert ref.name == 'openai/gpt-4o'
+    assert ref.config_schema is OpenAIConfig
+
+
+def test_gpt_model_strips_own_prefix() -> None:
+    """An already-namespaced name is not double-prefixed."""
+    assert OpenAI.gpt_model('openai/gpt-4o').name == 'openai/gpt-4o'
+
+
+@pytest.mark.parametrize(
+    'bad_id',
+    [
+        'gpt-image-1',  # image endpoint takes a different request shape
+        'dall-e-3',
+        'tts-1',
+        'whisper-1',
+        'gpt-4o-transcribe',
+        'text-embedding-3-small',  # embedders never take chat config
+    ],
+)
+def test_gpt_model_is_chat_only(bad_id: str) -> None:
+    """Non-chat ids are refused so chat-only keys can't hit the wrong endpoint."""
+    with pytest.raises(GenkitError) as exc_info:
+        OpenAI.gpt_model(bad_id)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+def test_gpt_model_requires_a_name() -> None:
+    """A bare prefix with no id left is an invalid argument."""
+    with pytest.raises(GenkitError) as exc_info:
+        OpenAI.gpt_model('openai/')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+def test_known_gpt_matches_catalog() -> None:
+    """Quote autocomplete and the chat catalog are the same set of ids."""
+    assert set(get_args(KnownGpt)) == set(SUPPORTED_OPENAI_MODELS)
+
+
+def test_create_model_action_types_openai_config() -> None:
+    """Chat actions opt into ModelRequest[OpenAIConfig]."""
+    plugin = OpenAI(api_key='test-key')
+    action = plugin._create_model_action('openai/gpt-4o')
+
+    hints = get_type_hints(action._fn)  # noqa: SLF001
+    request_type = hints['request']
+    args = get_args(request_type) or (getattr(request_type, '__pydantic_generic_metadata__', {}) or {}).get('args')
+    assert args and args[0] is OpenAIConfig

--- a/py/packages/genkit-openai/tests/model_refs_test.py
+++ b/py/packages/genkit-openai/tests/model_refs_test.py
@@ -17,9 +17,11 @@
 """Tests for the OpenAI.gpt_model typed ref constructor."""
 
 from typing import get_args, get_type_hints
+from unittest.mock import MagicMock
 
 import pytest
 from genkit_openai import KnownGpt, OpenAI, OpenAIConfig, openai_model
+from genkit_openai.models.model import OpenAIModel
 from genkit_openai.models.model_info import SUPPORTED_OPENAI_MODELS
 
 from genkit import GenkitError
@@ -116,17 +118,31 @@ def test_create_model_action_types_openai_config() -> None:
     assert args and args[0] is OpenAIConfig
 
 
-def test_create_model_action_accepts_camel_case_config() -> None:
-    """A reflection / Dev UI payload can set knobs in camelCase."""
+@pytest.mark.asyncio
+async def test_create_model_action_camel_case_lands_on_the_wire() -> None:
+    """Dev UI camelCase binds, then create() gets OpenAI snake_case names."""
     plugin = OpenAI(api_key='test-key')
     action = plugin._create_model_action('openai/gpt-4o')
     validated = action._validate_input(  # noqa: SLF001
         {
             'messages': [{'role': 'user', 'content': [{'text': 'hi'}]}],
-            'config': {'frequencyPenalty': 0.5, 'maxOutputTokens': 256},
+            'config': {
+                'frequencyPenalty': 0.5,
+                'maxOutputTokens': 256,
+                'stopSequences': ['END'],
+                'topP': 0.9,
+                'apiKey': 'should-not-leak',
+            },
         }
     )
     assert validated is not None
-    assert validated.config is not None
-    assert validated.config.frequency_penalty == 0.5
-    assert validated.config.max_output_tokens == 256
+    body = await OpenAIModel(model='gpt-4o', client=MagicMock())._get_openai_request_config(validated)
+    assert body['frequency_penalty'] == 0.5
+    assert body['top_p'] == 0.9
+    assert body['stop'] == ['END']
+    assert 'max_output_tokens' not in body
+    assert 'maxOutputTokens' not in body
+    assert 'frequencyPenalty' not in body
+    assert 'stop_sequences' not in body
+    assert 'api_key' not in body
+    assert 'apiKey' not in body

--- a/py/packages/genkit-openai/tests/model_refs_test.py
+++ b/py/packages/genkit-openai/tests/model_refs_test.py
@@ -102,6 +102,19 @@ def test_gpt_model_requires_a_name() -> None:
     assert exc_info.value.status == 'INVALID_ARGUMENT'
 
 
+def test_gpt_model_rejects_non_string_name() -> None:
+    """A non-string must not become a name via str() (None → 'None')."""
+    with pytest.raises(GenkitError) as exc_info:
+        OpenAI.gpt_model(None)  # type: ignore[arg-type]
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'must be a string' in str(exc_info.value)
+
+    with pytest.raises(GenkitError) as exc_info:
+        OpenAI.gpt_model(123)  # type: ignore[arg-type]
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'must be a string' in str(exc_info.value)
+
+
 def test_known_gpt_matches_catalog() -> None:
     """Quote autocomplete and the chat catalog are the same set of ids."""
     assert set(get_args(KnownGpt)) == set(SUPPORTED_OPENAI_MODELS)

--- a/py/packages/genkit-openai/tests/model_refs_test.py
+++ b/py/packages/genkit-openai/tests/model_refs_test.py
@@ -48,9 +48,24 @@ def test_gpt_model_strips_own_prefix() -> None:
     assert OpenAI.gpt_model('openai/gpt-4o').name == 'openai/gpt-4o'
 
 
-def test_gpt_model_keeps_foreign_prefix() -> None:
-    """A Vertex or Azure paste is a different name, not remapped onto OpenAI."""
-    assert OpenAI.gpt_model('vertexai/gpt-4o').name == 'openai/vertexai/gpt-4o'
+@pytest.mark.parametrize(
+    'pasted',
+    [
+        'openai/gpt-4o',
+        'vertexai/gpt-4o',
+        'googleai/gpt-4o',
+        'model/gpt-4o',
+        'models/gpt-4o',
+        'models/openai/gpt-4o',
+    ],
+)
+def test_gpt_model_strips_pasted_prefixes(pasted: str) -> None:
+    """Every pasted prefix form lands on this plugin, not the pasted one."""
+    assert OpenAI.gpt_model(pasted).name == 'openai/gpt-4o'
+
+
+def test_gpt_model_keeps_unlisted_foreign_prefix() -> None:
+    """Prefixes this loop does not know stay in the id (azure is not stripped)."""
     assert OpenAI.gpt_model('azure/gpt-4o').name == 'openai/azure/gpt-4o'
 
 

--- a/py/packages/genkit-openai/tests/model_refs_test.py
+++ b/py/packages/genkit-openai/tests/model_refs_test.py
@@ -46,12 +46,31 @@ def test_gpt_model_strips_own_prefix() -> None:
     assert OpenAI.gpt_model('openai/gpt-4o').name == 'openai/gpt-4o'
 
 
+def test_gpt_model_keeps_foreign_prefix() -> None:
+    """A Vertex or Azure paste is a different name, not remapped onto OpenAI."""
+    assert OpenAI.gpt_model('vertexai/gpt-4o').name == 'openai/vertexai/gpt-4o'
+    assert OpenAI.gpt_model('azure/gpt-4o').name == 'openai/azure/gpt-4o'
+
+
+def test_gpt_model_carries_config() -> None:
+    """A default config passed at construction survives into the ref."""
+    ref = OpenAI.gpt_model('gpt-4o', config=OpenAIConfig(temperature=0.2))
+    assert ref.config is not None
+    assert ref.config.temperature == 0.2
+
+
+def test_gpt_model_allows_unknown_chat_ids() -> None:
+    """A brand-new chat id works before this plugin learns its name."""
+    assert OpenAI.gpt_model('gpt-next-99').name == 'openai/gpt-next-99'
+
+
 @pytest.mark.parametrize(
     'bad_id',
     [
         'gpt-image-1',  # image endpoint takes a different request shape
         'dall-e-3',
         'tts-1',
+        'gpt-4o-mini-tts',  # catalog speech id that looks like a chat model
         'whisper-1',
         'gpt-4o-transcribe',
         'text-embedding-3-small',  # embedders never take chat config
@@ -62,6 +81,16 @@ def test_gpt_model_is_chat_only(bad_id: str) -> None:
     with pytest.raises(GenkitError) as exc_info:
         OpenAI.gpt_model(bad_id)
     assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+def test_gpt_model_reject_names_the_string_path() -> None:
+    """The error names the id and the plain-string way to still use it."""
+    with pytest.raises(GenkitError) as exc_info:
+        OpenAI.gpt_model('dall-e-3')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    message = str(exc_info.value)
+    assert 'an image model' in message
+    assert "openai_model('dall-e-3')" in message
 
 
 def test_gpt_model_requires_a_name() -> None:
@@ -85,3 +114,19 @@ def test_create_model_action_types_openai_config() -> None:
     request_type = hints['request']
     args = get_args(request_type) or (getattr(request_type, '__pydantic_generic_metadata__', {}) or {}).get('args')
     assert args and args[0] is OpenAIConfig
+
+
+def test_create_model_action_accepts_camel_case_config() -> None:
+    """A reflection / Dev UI payload can set knobs in camelCase."""
+    plugin = OpenAI(api_key='test-key')
+    action = plugin._create_model_action('openai/gpt-4o')
+    validated = action._validate_input(  # noqa: SLF001
+        {
+            'messages': [{'role': 'user', 'content': [{'text': 'hi'}]}],
+            'config': {'frequencyPenalty': 0.5, 'maxOutputTokens': 256},
+        }
+    )
+    assert validated is not None
+    assert validated.config is not None
+    assert validated.config.frequency_penalty == 0.5
+    assert validated.config.max_output_tokens == 256

--- a/py/packages/genkit-openai/tests/model_refs_test.py
+++ b/py/packages/genkit-openai/tests/model_refs_test.py
@@ -48,24 +48,9 @@ def test_gpt_model_strips_own_prefix() -> None:
     assert OpenAI.gpt_model('openai/gpt-4o').name == 'openai/gpt-4o'
 
 
-@pytest.mark.parametrize(
-    'pasted',
-    [
-        'openai/gpt-4o',
-        'vertexai/gpt-4o',
-        'googleai/gpt-4o',
-        'model/gpt-4o',
-        'models/gpt-4o',
-        'models/openai/gpt-4o',
-    ],
-)
-def test_gpt_model_strips_pasted_prefixes(pasted: str) -> None:
-    """Every pasted prefix form lands on this plugin, not the pasted one."""
-    assert OpenAI.gpt_model(pasted).name == 'openai/gpt-4o'
-
-
-def test_gpt_model_keeps_unlisted_foreign_prefix() -> None:
-    """Prefixes this loop does not know stay in the id (azure is not stripped)."""
+def test_gpt_model_keeps_foreign_prefix() -> None:
+    """A Vertex or Azure paste is a different name, not remapped onto OpenAI."""
+    assert OpenAI.gpt_model('vertexai/gpt-4o').name == 'openai/vertexai/gpt-4o'
     assert OpenAI.gpt_model('azure/gpt-4o').name == 'openai/azure/gpt-4o'
 
 

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -39,6 +39,16 @@ from genkit._core._model import OutputConfig
 from genkit.plugin_api import ActionRunContext
 
 
+def test_unknown_chat_id_json_mode_uses_json_object() -> None:
+    """An unlisted chat id that asked for JSON gets json_object, not a KeyError."""
+    model = OpenAIModel(model='my-custom-ft', client=MagicMock())
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+        output=OutputConfig(format='json'),
+    )
+    assert model._get_response_format(request) == {'type': 'json_object'}
+
+
 def test_get_messages(sample_request: ModelRequest) -> None:
     """Test _get_messages method.
 

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -77,6 +77,42 @@ async def test_get_openai_config(sample_request: ModelRequest) -> None:
     assert openai_config['model'] == 'gpt-4'
     assert 'messages' in openai_config
     assert isinstance(openai_config['messages'], list)
+    assert openai_config['top_p'] == 0.9
+    assert openai_config['temperature'] == 0.7
+    assert openai_config['stop'] == ['stop']
+    assert openai_config['max_tokens'] == 100
+    assert 'topP' not in openai_config
+    assert 'maxTokens' not in openai_config
+    assert 'max_output_tokens' not in openai_config
+
+
+@pytest.mark.asyncio
+async def test_get_openai_config_peels_genkit_keys_and_passes_the_rest() -> None:
+    """Genkit-only keys stay off create(); declared OpenAI fields and extras go out."""
+    model = OpenAIModel(model='gpt-4o', client=MagicMock())
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=OpenAIConfig.model_validate({
+            'temperature': 0.5,
+            'max_output_tokens': 128,
+            'stop_sequences': ['END'],
+            'api_key': 'secret',
+            'top_k': 8,
+            'version': 'ignored',
+            'prompt_cache_key': 'abc',
+            'some_new_openai_knob': 1,
+        }),
+    )
+    body = await model._get_openai_request_config(request)
+    assert body['temperature'] == 0.5
+    assert body['stop'] == ['END']
+    assert body['prompt_cache_key'] == 'abc'
+    assert body['some_new_openai_knob'] == 1
+    assert 'max_output_tokens' not in body
+    assert 'stop_sequences' not in body
+    assert 'api_key' not in body
+    assert 'top_k' not in body
+    assert 'version' not in body
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-openai/tests/openai_model_test.py
+++ b/py/packages/genkit-openai/tests/openai_model_test.py
@@ -98,7 +98,7 @@ async def test_get_openai_config_peels_genkit_keys_and_passes_the_rest() -> None
             'stop_sequences': ['END'],
             'api_key': 'secret',
             'top_k': 8,
-            'version': 'ignored',
+            'version': 'gpt-4o-2024-08-06',
             'prompt_cache_key': 'abc',
             'some_new_openai_knob': 1,
         }),
@@ -108,10 +108,24 @@ async def test_get_openai_config_peels_genkit_keys_and_passes_the_rest() -> None
     assert body['stop'] == ['END']
     assert body['prompt_cache_key'] == 'abc'
     assert body['some_new_openai_knob'] == 1
+    assert body['model'] == 'gpt-4o-2024-08-06'
     assert 'max_output_tokens' not in body
     assert 'stop_sequences' not in body
     assert 'api_key' not in body
     assert 'top_k' not in body
+    assert 'version' not in body
+
+
+@pytest.mark.asyncio
+async def test_get_openai_config_model_field_overrides_version() -> None:
+    """OpenAIConfig.model is the create() model id; it wins over version."""
+    model = OpenAIModel(model='gpt-4o', client=MagicMock())
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=OpenAIConfig(version='gpt-4o-2024-08-06', model='gpt-4.1'),
+    )
+    body = await model._get_openai_request_config(request)
+    assert body['model'] == 'gpt-4.1'
     assert 'version' not in body
 
 
@@ -222,6 +236,10 @@ async def test_generate(stream: bool, sample_request: ModelRequest) -> None:
         (
             ModelConfig(temperature=0.7),
             OpenAIConfig(temperature=0.7),
+        ),
+        (
+            ModelConfig(version='gpt-4o-2024-08-06'),
+            OpenAIConfig(version='gpt-4o-2024-08-06'),
         ),
         (
             None,

--- a/py/packages/genkit-openai/tests/openai_plugin_test.py
+++ b/py/packages/genkit-openai/tests/openai_plugin_test.py
@@ -96,6 +96,17 @@ async def test_openai_plugin_list_actions() -> None:
     assert actions[0].name == 'openai/gpt-4-0613'
     assert actions[-1].name == 'openai/text-embedding-ada-002'
 
+    chat = next(a for a in actions if a.name == 'openai/gpt-4')
+    assert chat.metadata is not None
+    chat_props = chat.metadata['model']['customOptions']['properties']
+    assert 'frequencyPenalty' in chat_props
+    assert 'maxTokens' in chat_props
+
+    embed = next(a for a in actions if a.name == 'openai/text-embedding-ada-002')
+    assert embed.metadata is not None
+    embed_options = embed.metadata.get('embedder', {}).get('customOptions')
+    assert embed_options is None or 'frequencyPenalty' not in (embed_options.get('properties') or {})
+
 
 @pytest.mark.asyncio
 async def test_openai_runtime_clients_are_loop_local() -> None:


### PR DESCRIPTION
## Summary
- `Anthropic.claude_model` namespaces the id and binds `AnthropicConfig`. Unknown ids are allowed; every Anthropic generate model takes that schema.
- `OpenAI.gpt_model` is chat-only. Image, TTS, STT, and embedding ids validate different request shapes, so binding `OpenAIConfig` would let chat-only keys like `frequency_penalty` ride into the wrong endpoint. Those ids raise `INVALID_ARGUMENT` and keep working as plain strings (`openai_model(...)`).
- Foreign prefixes (`vertexai/…`, `azure/…`) stay in the name. This constructor does not remap a Vertex or Azure paste onto Anthropic/OpenAI — that would hit the wrong API.
- Chat actions opt into `ModelRequest[OpenAIConfig]` / `ModelRequest[AnthropicConfig]`, so the **string** generate path validates plugin config today (`temperature: 3` is `INVALID_ARGUMENT`). `OpenAIConfig` accepts camelCase aliases so Dev UI / reflection knobs (`frequencyPenalty`, `maxOutputTokens`) land. `maxOutputTokens` is accepted; it is not mapped to `max_tokens`.
- Unlisted chat ids that ask for JSON (no schema) get `json_object`. The provider rejects the request if that model cannot do JSON mode.
- `KnownClaude` / `KnownGpt` are catalog Literals so quote autocomplete and the supported-model dict are the same set.
- `openai_model()` stays the string name helper.
- refs can be minted but all the end-user surfaces (generate, agent, prompt, Genkit() constructor) still want a string, until #6074 lands.