### PR TITLE
fix(go/plugins/compat_oai): stop forwarding OpenAI credentials to other providers

### DIFF
--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -126,6 +126,14 @@ A plugin whose config is the raw OpenAI request (the `openai` plugin, or a
 proxy for the real OpenAI API) uses `OpenAICompatible.NewModel` instead,
 which takes the SDK's `openai.ChatCompletionNewParams` as the model config.
 
+Authentication is the plugin's own to supply, in `OpenAICompatible.APIKey` or
+as a `WithAPIKey` in `Opts`. The OpenAI SDK reads `OPENAI_API_KEY`,
+`OPENAI_ORG_ID` and `OPENAI_PROJECT_ID` from the environment for every client
+it builds, and `Init` clears all three before applying what the plugin
+composes, so a plugin serving another provider never forwards OpenAI's
+identity to that provider's endpoint. A plugin that wants one of them, as the
+`openai` plugin does, reads it and sets it explicitly.
+
 A typed config can also carry a per-request API key (`RequestConfig.APIKey` /
 `EmbeddingConfig.APIKey`) that overrides the plugin's key for that request
 alone. The key is a client credential: it never serializes, so it stays out of

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -170,9 +170,17 @@ type OpenAICompatible struct {
 	// see https://github.com/openai/openai-go
 	client *openai.Client
 
-	// Opts contains request options for the OpenAI client.
-	// Required: Must include at least WithAPIKey for authentication.
+	// Opts contains request options for the OpenAI client, applied after
+	// APIKey and BaseURL so an option here wins over those fields.
+	// Required: authentication, either here via WithAPIKey or in APIKey.
 	// Optional: Can include other options like WithOrganization, WithBaseURL, etc.
+	//
+	// The OpenAI SDK reads OPENAI_API_KEY, OPENAI_ORG_ID, and OPENAI_PROJECT_ID
+	// from the environment for every client it builds. None of the three are
+	// inherited, so a plugin serving another provider cannot send OpenAI's
+	// identity to it: the key it authenticates with is the one configured
+	// here or in APIKey, and the organization and project headers are sent
+	// only if an option here sets them.
 	Opts []option.RequestOption
 
 	// Provider is a unique identifier for the plugin.
@@ -209,13 +217,17 @@ func (o *OpenAICompatible) Init(ctx context.Context) []api.Action {
 		panic("compat_oai.Init already called")
 	}
 
-	if o.APIKey != "" {
-		o.Opts = append([]option.RequestOption{option.WithAPIKey(o.APIKey)}, o.Opts...)
-	}
-
+	// The scrub goes first so everything below wins over it, and it is folded
+	// into Opts rather than passed to NewClient alone so the per-request
+	// clients clientForKey builds carry it too.
+	opts := clearInheritedOpenAIIdentity()
 	if o.BaseURL != "" {
-		o.Opts = append([]option.RequestOption{option.WithBaseURL(o.BaseURL)}, o.Opts...)
+		opts = append(opts, option.WithBaseURL(o.BaseURL))
 	}
+	if o.APIKey != "" {
+		opts = append(opts, option.WithAPIKey(o.APIKey))
+	}
+	o.Opts = append(opts, o.Opts...)
 
 	// create client
 	client := openai.NewClient(o.Opts...)
@@ -223,6 +235,31 @@ func (o *OpenAICompatible) Init(ctx context.Context) []api.Action {
 	o.initted = true
 
 	return []api.Action{}
+}
+
+// clearInheritedOpenAIIdentity returns the options that undo the OpenAI
+// credentials [openai.NewClient] reads from the environment. The SDK prepends
+// OPENAI_API_KEY, OPENAI_ORG_ID, and OPENAI_PROJECT_ID to the options of every
+// client it builds, so without this a plugin pointed at another vendor sends
+// OpenAI's identity to that vendor's endpoint: the organization and project
+// headers always, and the bearer token whenever the plugin configures no key
+// of its own. Nothing about the credentials says who they belong to, so the
+// receiving provider cannot reject them and the caller never learns they went
+// out.
+//
+// Each of the three is cleared twice over, because the option that sets one
+// writes both a field on the request config and a header, and setting an
+// empty value leaves the header in place rather than removing it.
+//
+// This is a scrub of what leaks in, not a ban: it applies before anything a
+// plugin composes, so a plugin that wants any of the three sets it and wins.
+// The openai plugin does exactly that, and is the only one that should.
+func clearInheritedOpenAIIdentity() []option.RequestOption {
+	return []option.RequestOption{
+		option.WithAPIKey(""), option.WithHeaderDel("Authorization"),
+		option.WithOrganization(""), option.WithHeaderDel("OpenAI-Organization"),
+		option.WithProject(""), option.WithHeaderDel("OpenAI-Project"),
+	}
 }
 
 // Name implements genkit.Plugin.

--- a/go/plugins/compat_oai/compat_oai_test.go
+++ b/go/plugins/compat_oai/compat_oai_test.go
@@ -53,6 +53,17 @@ func headerRecordingServer(t *testing.T) (url string, lastHeader func() http.Hea
 	}
 }
 
+// assertHeaderAbsent fails unless the header carries no values at all.
+// [http.Header.Get] cannot tell an absent header from one sent with an empty
+// value, and clearing the identity without a WithHeaderDel leaves exactly
+// that on the wire, so asserting on Get would pass either way.
+func assertHeaderAbsent(t *testing.T, header http.Header, name string) {
+	t.Helper()
+	if values := header.Values(name); len(values) != 0 {
+		t.Errorf("%s = %q, want the header dropped rather than blanked", name, values)
+	}
+}
+
 // generateOnce runs one request through an initialized plugin.
 func generateOnce(t *testing.T, o *OpenAICompatible) {
 	t.Helper()
@@ -102,15 +113,13 @@ func TestInitDropsInheritedOpenAIIdentity(t *testing.T) {
 			generateOnce(t, o)
 
 			got := lastHeader()
-			if auth := got.Get("Authorization"); auth != tt.wantAuth {
+			if tt.wantAuth == "" {
+				assertHeaderAbsent(t, got, "Authorization")
+			} else if auth := got.Get("Authorization"); auth != tt.wantAuth {
 				t.Errorf("Authorization = %q, want %q", auth, tt.wantAuth)
 			}
-			if org := got.Get("OpenAI-Organization"); org != "" {
-				t.Errorf("OpenAI-Organization = %q, want the inherited organization dropped", org)
-			}
-			if project := got.Get("OpenAI-Project"); project != "" {
-				t.Errorf("OpenAI-Project = %q, want the inherited project dropped", project)
-			}
+			assertHeaderAbsent(t, got, "OpenAI-Organization")
+			assertHeaderAbsent(t, got, "OpenAI-Project")
 		})
 	}
 }
@@ -173,10 +182,6 @@ func TestClientForKeyKeepsTheIdentityScrub(t *testing.T) {
 	if auth := got.Get("Authorization"); auth != "Bearer request-key" {
 		t.Errorf("Authorization = %q, want the per-request key", auth)
 	}
-	if org := got.Get("OpenAI-Organization"); org != "" {
-		t.Errorf("OpenAI-Organization = %q, want the inherited organization dropped", org)
-	}
-	if project := got.Get("OpenAI-Project"); project != "" {
-		t.Errorf("OpenAI-Project = %q, want the inherited project dropped", project)
-	}
+	assertHeaderAbsent(t, got, "OpenAI-Organization")
+	assertHeaderAbsent(t, got, "OpenAI-Project")
 }

--- a/go/plugins/compat_oai/compat_oai_test.go
+++ b/go/plugins/compat_oai/compat_oai_test.go
@@ -1,0 +1,182 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compat_oai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+// headerRecordingServer serves one chat completion and reports the headers of
+// the last request it answered.
+func headerRecordingServer(t *testing.T) (url string, lastHeader func() http.Header) {
+	t.Helper()
+	var mu sync.Mutex
+	var header http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		header = r.Header.Clone()
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"c1","object":"chat.completion","created":1,"model":"m",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`)
+	}))
+	t.Cleanup(server.Close)
+	return server.URL, func() http.Header {
+		mu.Lock()
+		defer mu.Unlock()
+		return header
+	}
+}
+
+// generateOnce runs one request through an initialized plugin.
+func generateOnce(t *testing.T, o *OpenAICompatible) {
+	t.Helper()
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+	genkit.RegisterAction(g, o.NewModel("m", ai.ModelOptions{}))
+	if _, err := genkit.Generate(ctx, g, ai.WithModelName(o.Provider+"/m"), ai.WithPrompt("hi")); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+}
+
+// TestInitDropsInheritedOpenAIIdentity pins the boundary the OpenAI SDK does
+// not draw for us: openai.NewClient prepends OPENAI_API_KEY, OPENAI_ORG_ID,
+// and OPENAI_PROJECT_ID to every client, so a plugin serving another provider
+// would forward OpenAI's identity to that provider's endpoint. None of the
+// three may reach the wire, whether the plugin configures a key of its own or
+// not, and the plugin's own key must survive the scrub.
+func TestInitDropsInheritedOpenAIIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   string
+		wantAuth string
+	}{
+		{
+			name:     "provider key wins",
+			apiKey:   "provider-key",
+			wantAuth: "Bearer provider-key",
+		},
+		{
+			// The plugins that panic on a missing key never get here; a
+			// plugin that instead authenticates out of Opts, or not at all,
+			// must send nothing rather than OpenAI's key.
+			name:     "no key sends none",
+			apiKey:   "",
+			wantAuth: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OPENAI_API_KEY", "sk-must-not-leak")
+			t.Setenv("OPENAI_ORG_ID", "org-must-not-leak")
+			t.Setenv("OPENAI_PROJECT_ID", "proj-must-not-leak")
+
+			url, lastHeader := headerRecordingServer(t)
+			o := &OpenAICompatible{Provider: "testprovider", APIKey: tt.apiKey, BaseURL: url}
+			o.Init(context.Background())
+			generateOnce(t, o)
+
+			got := lastHeader()
+			if auth := got.Get("Authorization"); auth != tt.wantAuth {
+				t.Errorf("Authorization = %q, want %q", auth, tt.wantAuth)
+			}
+			if org := got.Get("OpenAI-Organization"); org != "" {
+				t.Errorf("OpenAI-Organization = %q, want the inherited organization dropped", org)
+			}
+			if project := got.Get("OpenAI-Project"); project != "" {
+				t.Errorf("OpenAI-Project = %q, want the inherited project dropped", project)
+			}
+		})
+	}
+}
+
+// TestInitOptsOverrideTheIdentityScrub pins the scrub as a floor rather than a
+// ban: it applies before what the plugin composes, so a plugin that wants an
+// OpenAI-shaped header sets it and wins. This is how the openai plugin keeps
+// serving its own organization and project.
+func TestInitOptsOverrideTheIdentityScrub(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-must-not-leak")
+	t.Setenv("OPENAI_ORG_ID", "org-must-not-leak")
+	t.Setenv("OPENAI_PROJECT_ID", "proj-must-not-leak")
+
+	url, lastHeader := headerRecordingServer(t)
+	o := &OpenAICompatible{
+		Provider: "testprovider",
+		APIKey:   "provider-key",
+		BaseURL:  url,
+		Opts: []option.RequestOption{
+			option.WithOrganization("org-chosen"),
+			option.WithProject("proj-chosen"),
+		},
+	}
+	o.Init(context.Background())
+	generateOnce(t, o)
+
+	got := lastHeader()
+	if org := got.Get("OpenAI-Organization"); org != "org-chosen" {
+		t.Errorf("OpenAI-Organization = %q, want the configured organization", org)
+	}
+	if project := got.Get("OpenAI-Project"); project != "proj-chosen" {
+		t.Errorf("OpenAI-Project = %q, want the configured project", project)
+	}
+	if auth := got.Get("Authorization"); auth != "Bearer provider-key" {
+		t.Errorf("Authorization = %q, want the plugin's own key", auth)
+	}
+}
+
+// TestClientForKeyKeepsTheIdentityScrub pins the scrub on the second place a
+// client is built. A per-request key override clones the plugin's options, so
+// the scrub has to live in them rather than only in the client Init makes.
+func TestClientForKeyKeepsTheIdentityScrub(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-must-not-leak")
+	t.Setenv("OPENAI_ORG_ID", "org-must-not-leak")
+	t.Setenv("OPENAI_PROJECT_ID", "proj-must-not-leak")
+
+	url, lastHeader := headerRecordingServer(t)
+	o := &OpenAICompatible{Provider: "testprovider", APIKey: "provider-key", BaseURL: url}
+	o.Init(context.Background())
+
+	client := o.clientForKey("request-key")
+	if _, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+		Model:    "m",
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hi")},
+	}); err != nil {
+		t.Fatalf("Completions.New() error = %v", err)
+	}
+
+	got := lastHeader()
+	if auth := got.Get("Authorization"); auth != "Bearer request-key" {
+		t.Errorf("Authorization = %q, want the per-request key", auth)
+	}
+	if org := got.Get("OpenAI-Organization"); org != "" {
+		t.Errorf("OpenAI-Organization = %q, want the inherited organization dropped", org)
+	}
+	if project := got.Get("OpenAI-Project"); project != "" {
+		t.Errorf("OpenAI-Project = %q, want the inherited project dropped", project)
+	}
+}

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -272,8 +272,13 @@ type OpenAI struct {
 	// APIKey is the API key for the OpenAI API. If empty, the values of the environment variable "OPENAI_API_KEY" will be consulted.
 	// Request a key at https://platform.openai.com/api-keys
 	APIKey string
-	// Optional: Opts are additional options for the OpenAI client.
+	// Optional: Opts are additional options for the OpenAI client, applied
+	// last so an option here wins over what the plugin composes.
 	// Can include other options like WithOrganization, WithBaseURL, etc.
+	//
+	// The organization and project come from OPENAI_ORG_ID and
+	// OPENAI_PROJECT_ID when set; WithOrganization or WithProject here
+	// overrides them.
 	Opts []option.RequestOption
 
 	// Models overrides what the plugin knows about an OpenAI model, keyed by
@@ -320,13 +325,20 @@ func (o *OpenAI) Init(ctx context.Context) []api.Action {
 		panic("openai plugin initialization failed: apiKey is required")
 	}
 
-	// set the options
-	o.openAICompatible.Opts = []option.RequestOption{
-		option.WithAPIKey(apiKey),
+	// The base plugin does not inherit the identity the OpenAI SDK reads from
+	// the environment, so that no plugin serving another provider sends
+	// OpenAI's credentials to it. This plugin does serve OpenAI, so it applies
+	// that identity itself: the key resolved above, plus the organization and
+	// project, which keep the meaning the SDK gave them. Opts still come last
+	// and win.
+	opts := []option.RequestOption{option.WithAPIKey(apiKey)}
+	if org := os.Getenv("OPENAI_ORG_ID"); org != "" {
+		opts = append(opts, option.WithOrganization(org))
 	}
-	if len(o.Opts) > 0 {
-		o.openAICompatible.Opts = append(o.openAICompatible.Opts, o.Opts...)
+	if project := os.Getenv("OPENAI_PROJECT_ID"); project != "" {
+		opts = append(opts, option.WithProject(project))
 	}
+	o.openAICompatible.Opts = append(opts, o.Opts...)
 
 	o.openAICompatible.Provider = provider
 	actions := o.openAICompatible.Init(ctx)

--- a/go/plugins/compat_oai/openai/openai_test.go
+++ b/go/plugins/compat_oai/openai/openai_test.go
@@ -231,6 +231,72 @@ func TestEmbedderPerRequestAPIKey(t *testing.T) {
 	}
 }
 
+// TestInitSendsOpenAIEnvIdentity pins that this plugin, alone among the
+// compat_oai plugins, still speaks OpenAI's environment. The base plugin drops
+// the identity the SDK reads from OPENAI_API_KEY, OPENAI_ORG_ID, and
+// OPENAI_PROJECT_ID so no plugin serving another provider forwards it; this
+// plugin serves OpenAI, so it applies the same three itself and they must
+// reach the wire unchanged. Opts still override them.
+func TestInitSendsOpenAIEnvIdentity(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        []option.RequestOption
+		wantOrg     string
+		wantProject string
+	}{
+		{
+			name:        "from the environment",
+			wantOrg:     "org-from-env",
+			wantProject: "proj-from-env",
+		},
+		{
+			name: "opts win",
+			opts: []option.RequestOption{
+				option.WithOrganization("org-from-opts"),
+				option.WithProject("proj-from-opts"),
+			},
+			wantOrg:     "org-from-opts",
+			wantProject: "proj-from-opts",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var header http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				header = r.Header.Clone()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{
+					"id":"c1","object":"chat.completion","created":1,"model":"gpt-4o",
+					"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+					"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+				}`)
+			}))
+			defer server.Close()
+
+			t.Setenv("OPENAI_API_KEY", "plugin-key")
+			t.Setenv("OPENAI_ORG_ID", "org-from-env")
+			t.Setenv("OPENAI_PROJECT_ID", "proj-from-env")
+
+			opts := append([]option.RequestOption{option.WithBaseURL(server.URL)}, tt.opts...)
+			g := genkit.Init(context.Background(), genkit.WithPlugins(&OpenAI{Opts: opts}))
+			if _, err := genkit.Generate(context.Background(), g,
+				ai.WithModelName("openai/gpt-4o"), ai.WithPrompt("hi")); err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+
+			if got := header.Get("Authorization"); got != "Bearer plugin-key" {
+				t.Errorf("Authorization = %q, want the environment's key", got)
+			}
+			if got := header.Get("OpenAI-Organization"); got != tt.wantOrg {
+				t.Errorf("OpenAI-Organization = %q, want %q", got, tt.wantOrg)
+			}
+			if got := header.Get("OpenAI-Project"); got != tt.wantProject {
+				t.Errorf("OpenAI-Project = %q, want %q", got, tt.wantProject)
+			}
+		})
+	}
+}
+
 // TestEmbedderBase64EncodingFormat pins that the base64 encoding the config
 // advertises actually works: the API returns the vector as a base64 string of
 // little-endian float32s, which the plugin decodes.


### PR DESCRIPTION
`openai.NewClient` prepends `DefaultClientOptions()`, which reads `OPENAI_API_KEY`, `OPENAI_ORG_ID`, and `OPENAI_PROJECT_ID` from the environment. Every `compat_oai` plugin builds its client through it, so all of them forwarded OpenAI's identity to whatever endpoint they pointed at: with the two IDs set, a request to DeepSeek or xAI or any other sibling carried `Openai-Organization` and `Openai-Project` next to the correct provider key. `compat_oai/anthropic` applied `option.WithAPIKey` only when the key was non-empty, so with `ANTHROPIC_API_KEY` unset it sent `Authorization: Bearer $OPENAI_API_KEY` to Anthropic as well. The other siblings escaped that one only by panicking at Init on a missing key.

`OpenAICompatible.Init` now clears all three before applying anything the plugin composes. Each is cleared twice, because the option that sets one writes both a field on the request config and a header, and an empty value leaves the header behind rather than removing it:

```go
option.WithAPIKey(""), option.WithHeaderDel("Authorization"),
option.WithOrganization(""), option.WithHeaderDel("OpenAI-Organization"),
option.WithProject(""), option.WithHeaderDel("OpenAI-Project"),
```

The scrub is folded into `o.Opts` rather than passed to `NewClient` alone. There are two construction sites: `clientForKey` clones `o.Opts` for the per-request key override, so a scrub living only in `Init`'s client would leave that path leaking.

It is a floor, not a ban. Landing before the plugin's own options means a plugin that wants one of the three sets it and wins, which is how `openai` keeps its behavior: it reads `OPENAI_ORG_ID` and `OPENAI_PROJECT_ID` itself now, as it already did `OPENAI_API_KEY`. Nothing changes for it on the wire.

`vertexai/modelgarden` builds on the same base and was sending both headers to Vertex AI. Its oauth2 transport overwrites `Authorization`, so the key never leaked there.

**`OPENAI_BASE_URL` is left alone.** The SDK inherits it too, but every plugin sets a base URL that wins over it. Closing it at the base would make `OpenAICompatible.BaseURL` required, since `option.RequestOption` takes an openai-go-internal type and the base cannot see a base URL passed through `Opts`. That breaks third-party plugins and belongs in its own PR.
