### PR TITLE
fix(go/core): prefer completion over cancellation in bidi `Send`

### DIFF
--- a/go/core/bidi_action.go
+++ b/go/core/bidi_action.go
@@ -561,7 +561,7 @@ func (c *BidiConnection[In, Out, Stream]) Send(input In) (err error) {
 	}
 	select {
 	case <-c.ctx.Done():
-		return c.ctxErr()
+		return c.completedOrCtxErr()
 	default:
 	}
 
@@ -569,10 +569,27 @@ func (c *BidiConnection[In, Out, Stream]) Send(input In) (err error) {
 	case c.inputCh <- input:
 		return nil
 	case <-c.ctx.Done():
-		return c.ctxErr()
+		return c.completedOrCtxErr()
 	case <-c.doneCh:
 		return status.Errorf(ErrActionCompleted, "action has completed")
 	}
+}
+
+// completedOrCtxErr reports the reason a send cannot proceed, preferring
+// completion over cancellation the way [BidiConnection.Output] and
+// [BidiConnection.Receive] do. Completion closes doneCh and then releases the
+// connection context, so a context that reads as done may already be the
+// action's own teardown rather than an abort: a teardown landing between the
+// checks above, or racing the blocking select, must still surface as
+// [ErrActionCompleted] so the caller goes to Output for the real result
+// instead of reporting a cancellation that never happened.
+func (c *BidiConnection[In, Out, Stream]) completedOrCtxErr() error {
+	select {
+	case <-c.doneCh:
+		return status.Errorf(ErrActionCompleted, "action has completed")
+	default:
+	}
+	return c.ctxErr()
 }
 
 // Close signals that no more inputs will be sent. It does not terminate

--- a/go/core/bidi_action_test.go
+++ b/go/core/bidi_action_test.go
@@ -97,6 +97,66 @@ func TestSendPrefersCompletionOverTeardownCancellation(t *testing.T) {
 	}
 }
 
+// TestSendReportsAbortWhileActionRuns is the other half of that precedence:
+// completion wins only when the action has actually completed. An abort on a
+// session still running has no result to prefer, so Send must report the
+// cancellation. Without this, a helper that always answered
+// ErrActionCompleted would pass: callers like Agent.Run tolerate that error
+// and go to Output, so an abort would be swallowed and the invocation would
+// look like it finished.
+//
+// The action outlives the cancellation deliberately, keeping doneCh open so
+// there is no completion to race.
+func TestSendReportsAbortWhileActionRuns(t *testing.T) {
+	newSession := func(t *testing.T) (*BidiConnection[string, string, string], func()) {
+		t.Helper()
+		started, release := make(chan struct{}), make(chan struct{})
+		action := NewBidiActionOf(api.ActionTypeCustom, "blocks", nil,
+			func(ctx context.Context, _ struct{}, inCh <-chan string, outCh chan<- string) (string, error) {
+				close(started)
+				<-release
+				return "finished", nil
+			})
+		conn, err := action.Connect(context.Background(), struct{}{})
+		if err != nil {
+			t.Fatalf("Connect() error = %v", err)
+		}
+		<-started
+		return conn, func() { close(release) }
+	}
+
+	check := func(t *testing.T, err error) {
+		t.Helper()
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Send() error = %v, want the abort", err)
+		}
+		if errors.Is(err, ErrActionCompleted) {
+			t.Errorf("Send() error = %v, want an abort rather than completion: the action is still running", err)
+		}
+	}
+
+	t.Run("sent after the abort", func(t *testing.T) {
+		conn, finish := newSession(t)
+		defer finish()
+		conn.Cancel()
+		check(t, conn.Send("hi"))
+	})
+
+	t.Run("already blocked at the abort", func(t *testing.T) {
+		conn, finish := newSession(t)
+		defer finish()
+		// The action never reads, so the first input takes the only buffer
+		// slot and the second blocks in Send's select.
+		if err := conn.Send("first"); err != nil {
+			t.Fatalf("Send() error = %v, want the free buffer slot to take it", err)
+		}
+		sent := make(chan error, 1)
+		go func() { sent <- conn.Send("second") }()
+		conn.Cancel()
+		check(t, <-sent)
+	})
+}
+
 func TestBidiActionEcho(t *testing.T) {
 	ctx := context.Background()
 

--- a/go/core/bidi_action_test.go
+++ b/go/core/bidi_action_test.go
@@ -25,12 +25,77 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 )
+
+// TestSendPrefersCompletionOverTeardownCancellation pins Send's precedence
+// against the connection's own teardown. run closes doneCh and then releases
+// the connection context, so a context that reads as done is usually the
+// action finishing rather than an abort. Send tests the two in separate
+// selects, and a teardown landing between them used to surface as
+// context.Canceled: callers tolerate ErrActionCompleted and go to Output for
+// the outcome, but take a cancellation as the outcome, so the action's real
+// error was discarded.
+//
+// The window is a few instructions wide. This drives it under contention
+// rather than forcing it, with the gate piling the workers up so they are
+// descheduled around the call. A run that reproduces nothing still cannot
+// fail, and the fix makes the misreport impossible rather than rare.
+func TestSendPrefersCompletionOverTeardownCancellation(t *testing.T) {
+	const (
+		iterations = 500_000
+		workers    = 32
+	)
+
+	ctx := context.Background()
+	want := errors.New("action failed before reading input")
+	action := NewBidiActionOf(api.ActionTypeCustom, "failfast", nil,
+		func(ctx context.Context, _ struct{}, inCh <-chan string, outCh chan<- string) (string, error) {
+			return "", want
+		})
+
+	var (
+		gate       sync.Mutex
+		cancelled  atomic.Int64
+		lostResult atomic.Int64
+		wg         sync.WaitGroup
+	)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations / workers {
+				conn, err := action.Connect(ctx, struct{}{})
+				if err != nil {
+					t.Errorf("Connect() error = %v", err)
+					return
+				}
+				gate.Lock()
+				err = conn.Send("hi")
+				gate.Unlock()
+				if errors.Is(err, context.Canceled) {
+					cancelled.Add(1)
+				}
+				if _, err := conn.Output(); !errors.Is(err, want) {
+					lostResult.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if n := cancelled.Load(); n != 0 {
+		t.Errorf("Send reported cancellation on %d of %d completed invocations, want the action's completion", n, iterations)
+	}
+	if n := lostResult.Load(); n != 0 {
+		t.Errorf("Output lost the action's error on %d of %d invocations", n, iterations)
+	}
+}
 
 func TestBidiActionEcho(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
`BidiConnection.run` closes `doneCh` and then releases the connection context, so a context that reads as done is usually the action finishing rather than an abort. `Output` and `Receive` both account for that by re-checking `doneCh` inside their context arm. `Send` did not: it tested completion and cancellation in two separate selects, so a teardown landing between them returned `context.Canceled`, and its blocking select carried the same gap.

Callers tolerate `ErrActionCompleted` and go to `Output` for the outcome, but take a cancellation as the outcome. `exp.Agent.Run` is where it surfaced: an agent whose init is rejected fails before reading any input, so the caller saw `CANCELLED: context canceled` instead of the `FAILED_PRECONDITION` sitting on `Output`. That flaked `TestAgent_ResumeFromSessionID_PendingTipRejected`.

Both context arms now route through one helper that prefers completion. The window is a few instructions wide, so the test drives it under contention rather than forcing it, and reports 18 to 24 cancellations per run without the fix against none with it.
