### PR TITLE
feat(go/plugins/compat_oai/orcarouter): add an OrcaRouter plugin

### DIFF
--- a/go/plugins/compat_oai/README.md
+++ b/go/plugins/compat_oai/README.md
@@ -199,7 +199,7 @@ is how a caller narrows one. Follow that shape for a gateway, and the curated
 shape above for a vendor.
 
 See the `openai`, `anthropic`, `dashscope`, `deepseek`, `kimi`, `openrouter`,
-`xai`, and `zai` directories for complete implementations.
+`orcarouter`, `xai`, and `zai` directories for complete implementations.
 
 ## Running Tests
 
@@ -213,6 +213,7 @@ export KIMI_API_KEY=<your-kimi-key>
 export XAI_API_KEY=<your-xai-key>
 export DEEPSEEK_API_KEY=<your-deepseek-key>
 export OPENROUTER_API_KEY=<your-openrouter-key>
+export ORCAROUTER_API_KEY=<your-orcarouter-key>
 ```
 
 Run all tests:
@@ -245,6 +246,9 @@ go test -v ./deepseek
 
 # OpenRouter tests
 go test -v ./openrouter
+
+# OrcaRouter tests
+go test -v ./orcarouter
 ```
 
 Note: Tests will be skipped if the required API keys are not set.

--- a/go/plugins/compat_oai/conformance_test.go
+++ b/go/plugins/compat_oai/conformance_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/compat_oai/deepseek"
 	"github.com/firebase/genkit/go/plugins/compat_oai/kimi"
 	"github.com/firebase/genkit/go/plugins/compat_oai/openrouter"
+	"github.com/firebase/genkit/go/plugins/compat_oai/orcarouter"
 	"github.com/firebase/genkit/go/plugins/compat_oai/xai"
 	"github.com/firebase/genkit/go/plugins/compat_oai/zai"
 )
@@ -61,6 +62,7 @@ func TestConfigSchemaConformance(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("KIMI_API_KEY", "test-key")
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("ORCAROUTER_API_KEY", "test-key")
 	t.Setenv("XAI_API_KEY", "test-key")
 	t.Setenv("ZAI_API_KEY", "test-key")
 
@@ -80,6 +82,7 @@ func TestConfigSchemaConformance(t *testing.T) {
 		{&deepseek.DeepSeek{}, "deepseek-v4-pro"},
 		{&kimi.Kimi{}, "kimi-k3"},
 		{&openrouter.OpenRouter{}, "openai/gpt-5"},
+		{&orcarouter.OrcaRouter{}, "openai/gpt-4o"},
 		{&xai.XAI{}, "grok-4.5"},
 		{&zai.ZAI{}, "glm-5.1"},
 	}
@@ -235,6 +238,7 @@ func TestClosedEnumsUseNamedTypes(t *testing.T) {
 		"deepseek":   deepseek.ChatConfig{},
 		"kimi":       kimi.ChatConfig{},
 		"openrouter": openrouter.ChatConfig{},
+		"orcarouter": orcarouter.ChatConfig{},
 		"xai":        xai.ChatConfig{},
 		"zai":        zai.ChatConfig{},
 	}

--- a/go/plugins/compat_oai/orcarouter/README.md
+++ b/go/plugins/compat_oai/orcarouter/README.md
@@ -1,0 +1,135 @@
+# OrcaRouter Plugin
+
+This plugin provides Genkit support for [OrcaRouter](https://www.orcarouter.ai),
+a gateway that serves models from many vendors behind one OpenAI-compatible
+endpoint.
+
+## Setup
+
+Set an OrcaRouter API key:
+
+```bash
+export ORCAROUTER_API_KEY=<your-api-key>
+```
+
+The plugin uses `https://api.orcarouter.ai/v1` by default. Set
+`ORCAROUTER_BASE_URL`, or pass `option.WithBaseURL` through the plugin's
+`Opts`, to use another compatible endpoint.
+
+```go
+import (
+    "context"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/orcarouter"
+)
+
+ctx := context.Background()
+g := genkit.Init(ctx,
+    genkit.WithPlugins(&orcarouter.OrcaRouter{}),
+    genkit.WithDefaultModel("orcarouter/anthropic/claude-sonnet-4.5"),
+)
+
+response, err := genkit.Generate(ctx, g, ai.WithPrompt("Explain reinforcement learning."))
+```
+
+Reasoning output is returned as Genkit reasoning parts and is available
+through `response.Reasoning()` when the model emits it.
+
+## Models
+
+The plugin registers no models and carries no catalog. OrcaRouter serves
+hundreds of models and adds more regularly, so every model resolves on demand
+instead:
+
+```go
+ai.WithModelName("orcarouter/openai/gpt-4o")
+ai.WithModelName("orcarouter/anthropic/claude-sonnet-4.5")
+ai.WithModelName("orcarouter/deepseek/deepseek-v4-flash")
+```
+
+A model ID keeps its upstream vendor's prefix, so a Genkit action name carries
+two slashes: the first is this plugin's provider prefix and the rest is the
+ID OrcaRouter serves.
+
+For the same reason, the plugin advertises nothing to the Dev UI's model list.
+Models stay usable by name; only the browsable catalog is absent.
+
+Every resolved model is described permissively: multi-turn, tools, tool
+choice, system role, and media are all claimed. This is deliberate. A
+capability declared too narrow is refused by Genkit before the request is
+sent, which blocks a model that would have worked, while one declared too wide
+reaches OrcaRouter and comes back with the real reason. Native constrained
+output is the exception, left unclaimed so that structured output falls back
+to schema instructions in the prompt, which every model handles and which
+returns the same typed result.
+
+Correct a model whose real capabilities are narrower through `Models`:
+
+```go
+plugin := &orcarouter.OrcaRouter{Models: map[string]ai.ModelOptions{
+    // A text-only model, so Genkit refuses media locally rather than paying
+    // for the upstream rejection.
+    "mistralai/mistral-7b-instruct": {Supports: &ai.ModelSupports{
+        Multiturn: true, Tools: true, SystemRole: true,
+    }},
+}}
+```
+
+Fields left at their zero value keep what the plugin resolves, so an entry can
+pin one capability without restating the rest.
+
+The current model list is at https://www.orcarouter.ai/models, and the API
+reference is at https://docs.orcarouter.ai.
+
+## Config
+
+Models take a typed `orcarouter.ChatConfig` covering the sampling fields the
+OpenAI-compatible surface OrcaRouter exposes. `orcarouter.ModelRef` carries
+the config with the model ID:
+
+```go
+response, err := genkit.Generate(ctx, g,
+    ai.WithModel(orcarouter.ModelRef("deepseek/deepseek-v4-flash", &orcarouter.ChatConfig{
+        MaxOutputTokens: 512,
+        ReasoningEffort: orcarouter.ReasoningEffortLow,
+    })),
+    ai.WithPrompt("Work through this step by step."),
+)
+```
+
+- `temperature`, `topP`, `maxOutputTokens`, `stopSequences`,
+  `frequencyPenalty`, `presencePenalty`, `seed`, `logProbs`, `topLogProbs`,
+  and `parallelToolCalls` are the standard OpenAI-compatible sampling knobs.
+- `reasoningEffort` sets how hard a reasoning-capable model thinks: `low`,
+  `medium`, or `high`, sent as `reasoning_effort`.
+- `user` identifies the end user a request is made for.
+
+`maxOutputTokens` reaches OrcaRouter as `max_tokens`, which reasoning models
+spend on thinking before they emit anything visible. Leave it unset, or budget
+for the thinking as well, on any model that reasons.
+
+Every config also carries the settings Genkit owns: `version` pins the exact
+model version a request is served by, `apiKey` (settable only from Go code)
+serves one request with a different credential, and `extra` forwards request
+body fields the config does not declare, keyed by OrcaRouter's wire names.
+
+## Not supported
+
+This plugin serves the chat completions endpoint only.
+
+One request field is left out on purpose. `n` asks for several completion
+choices and bills for all of them while Genkit reads only the first. Anything
+else undeclared still reaches the wire through `extra`.
+
+## Live tests
+
+Live tests are skipped unless `ORCAROUTER_API_KEY` is set:
+
+```bash
+go test -race ./plugins/compat_oai/orcarouter -run '^TestPluginLive$' -v -count=1
+```
+
+They spend on ordinary catalog models named at the top of
+`orcarouter_live_test.go`. Swap in whatever the key has credit for.

--- a/go/plugins/compat_oai/orcarouter/orcarouter.go
+++ b/go/plugins/compat_oai/orcarouter/orcarouter.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package orcarouter provides a Genkit plugin for OrcaRouter, a gateway that
+// serves models from many providers behind one OpenAI-compatible endpoint.
+//
+// OrcaRouter is not a model vendor, so this plugin carries no model catalog.
+// Every model resolves by name on demand, under an ID that keeps the upstream
+// vendor's prefix:
+//
+//	ai.WithModelName("orcarouter/anthropic/claude-sonnet-4.5")
+//
+// A resolved model is described with permissive capabilities, which is what
+// makes an arbitrary model usable without an entry per model. Correct a model
+// whose real capabilities are narrower through [OrcaRouter.Models].
+//
+// See https://www.orcarouter.ai.
+package orcarouter
+
+import (
+	"context"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/shared"
+)
+
+const (
+	provider       = "orcarouter"
+	defaultBaseURL = "https://api.orcarouter.ai/v1"
+)
+
+// ReasoningEffort is how hard a reasoning-capable model thinks before it
+// answers. OrcaRouter normalizes the level across the vendors it fronts, so
+// the same value reaches an OpenAI, an Anthropic, and a DeepSeek model.
+//
+// Which levels a model takes is the model's to decide: a level the upstream
+// vendor does not offer is an error from OrcaRouter rather than from here.
+type ReasoningEffort string
+
+const (
+	// ReasoningEffortLow is fast reasoning, for latency-sensitive work.
+	ReasoningEffortLow ReasoningEffort = "low"
+	// ReasoningEffortMedium is a balanced level.
+	ReasoningEffortMedium ReasoningEffort = "medium"
+	// ReasoningEffortHigh is deeper thinking, for hard multi-step problems.
+	ReasoningEffortHigh ReasoningEffort = "high"
+)
+
+// ChatConfig is the per-request config for models served through OrcaRouter:
+// the sampling fields the gateway accepts across the vendors it fronts. See
+// https://docs.orcarouter.ai/api-reference/chat/create-a-chat-completion.
+//
+// Several documented request fields are deliberately absent. n asks for
+// several completion choices and bills for all of them, while Genkit reads
+// only the first. Anything undeclared still reaches the wire through
+// [compat_oai.RequestConfig.Extra].
+type ChatConfig struct {
+	compat_oai.RequestConfig
+
+	// Temperature controls the degree of randomness in token selection, from
+	// 0 to 2.
+	Temperature *float64 `json:"temperature,omitempty" jsonschema:"minimum=0,maximum=2" jsonschema_description:"Controls the degree of randomness in token selection, from 0 to 2."`
+	// TopP is the nucleus sampling threshold, from 0 to 1.
+	TopP *float64 `json:"topP,omitempty" jsonschema:"minimum=0,maximum=1" jsonschema_description:"Nucleus sampling threshold, from 0 to 1: only the tokens comprising the top P probability mass are considered."`
+	// MaxOutputTokens is the maximum number of tokens to generate, sent as
+	// the API's max_tokens.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty" jsonschema:"minimum=1" jsonschema_description:"Maximum number of tokens to generate, sent as the API's max_tokens."`
+	// StopSequences stop generation when produced by the model, up to four.
+	StopSequences []string `json:"stopSequences,omitempty" jsonschema:"maxItems=4" jsonschema_description:"Stop generation when produced by the model, up to four sequences."`
+	// FrequencyPenalty penalizes tokens by their frequency so far, from -2.0
+	// to 2.0.
+	FrequencyPenalty *float64 `json:"frequencyPenalty,omitempty" jsonschema:"minimum=-2,maximum=2" jsonschema_description:"Penalizes tokens by their frequency so far, from -2.0 to 2.0."`
+	// PresencePenalty penalizes tokens that have appeared at all, from -2.0
+	// to 2.0.
+	PresencePenalty *float64 `json:"presencePenalty,omitempty" jsonschema:"minimum=-2,maximum=2" jsonschema_description:"Penalizes tokens that have appeared at all, from -2.0 to 2.0."`
+	// Seed makes generation reproducible across calls when set, on a
+	// best-effort basis.
+	Seed *int `json:"seed,omitempty" jsonschema_description:"Makes generation reproducible across calls when set, on a best-effort basis."`
+	// LogProbs requests log probabilities for the output tokens.
+	LogProbs *bool `json:"logProbs,omitempty" jsonschema_description:"Requests log probabilities for the output tokens."`
+	// TopLogProbs is how many of the most likely tokens to return log
+	// probabilities for at each position, from 0 to 20; it requires LogProbs.
+	TopLogProbs *int `json:"topLogProbs,omitempty" jsonschema:"minimum=0,maximum=20" jsonschema_description:"How many of the most likely tokens to return log probabilities for at each position, from 0 to 20; requires logProbs."`
+	// ParallelToolCalls lets the model request several tool calls in one
+	// response, which it may do by default. It applies to a request that
+	// carries tools.
+	ParallelToolCalls *bool `json:"parallelToolCalls,omitempty" jsonschema_description:"Lets the model request several tool calls in one response, which it may do by default; false caps it at one call per response."`
+	// User identifies the end user a request is made for, which OrcaRouter
+	// uses to isolate abuse to one user rather than the whole key.
+	User string `json:"user,omitempty" jsonschema_description:"Identifies the end user a request is made for, which OrcaRouter uses to isolate abuse to one user rather than the whole key."`
+	// ReasoningEffort adjusts how hard the model thinks, [ReasoningEffortLow]
+	// to [ReasoningEffortHigh], sent as the API's reasoning_effort. It
+	// applies to reasoning-capable models; others ignore it.
+	ReasoningEffort ReasoningEffort `json:"reasoningEffort,omitempty" jsonschema:"enum=low,enum=medium,enum=high" jsonschema_description:"How hard the model thinks: low, medium, or high, for reasoning-capable models."`
+}
+
+// ApplyToChatCompletion implements [compat_oai.ChatConfig]: the fields the
+// OpenAI schema already has land on their chat completion counterparts, and
+// ReasoningEffort on the SDK's reasoning_effort. Every field here is part of
+// the OpenAI-compatible surface OrcaRouter exposes, so nothing rides the
+// extra map.
+func (c ChatConfig) ApplyToChatCompletion(params *openai.ChatCompletionNewParams) {
+	c.ApplyVersion(params)
+
+	if c.Temperature != nil {
+		params.Temperature = openai.Float(*c.Temperature)
+	}
+	if c.TopP != nil {
+		params.TopP = openai.Float(*c.TopP)
+	}
+	if c.MaxOutputTokens > 0 {
+		params.MaxTokens = openai.Int(int64(c.MaxOutputTokens))
+	}
+	if len(c.StopSequences) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: c.StopSequences}
+	}
+	if c.FrequencyPenalty != nil {
+		params.FrequencyPenalty = openai.Float(*c.FrequencyPenalty)
+	}
+	if c.PresencePenalty != nil {
+		params.PresencePenalty = openai.Float(*c.PresencePenalty)
+	}
+	if c.Seed != nil {
+		params.Seed = openai.Int(int64(*c.Seed))
+	}
+	if c.LogProbs != nil {
+		params.Logprobs = openai.Bool(*c.LogProbs)
+	}
+	if c.TopLogProbs != nil {
+		params.TopLogprobs = openai.Int(int64(*c.TopLogProbs))
+	}
+	if c.ParallelToolCalls != nil {
+		params.ParallelToolCalls = openai.Bool(*c.ParallelToolCalls)
+	}
+	if c.User != "" {
+		params.User = openai.String(c.User)
+	}
+	if c.ReasoningEffort != "" {
+		params.ReasoningEffort = shared.ReasoningEffort(c.ReasoningEffort)
+	}
+}
+
+// OrcaRouter configures the OrcaRouter plugin.
+type OrcaRouter struct {
+	// APIKey is the OrcaRouter API key. If empty, ORCAROUTER_API_KEY is
+	// consulted.
+	APIKey string
+	// Opts contains additional OpenAI client request options, such as
+	// [option.WithBaseURL] for a different endpoint (ORCAROUTER_BASE_URL
+	// works too). Options supplied here are applied after the plugin
+	// defaults, so they win on overlap.
+	Opts []option.RequestOption
+
+	// Models overrides what the plugin knows about a model, keyed by model
+	// ID, bare or provider-prefixed. Every model already works without an
+	// entry: OrcaRouter serves hundreds of models from dozens of vendors and
+	// adds more regularly, so the plugin curates no catalog and describes
+	// every model it resolves with the same deliberately permissive
+	// capabilities. The two ways to be wrong are not symmetric: a capability
+	// declared too narrow is refused by Genkit before the request is sent,
+	// which blocks a model that would have worked, while one declared too
+	// wide reaches OrcaRouter, which answers with the real reason the model
+	// cannot serve it. Constrained output is the exception, left unclaimed on
+	// purpose: a large share of the catalog lacks it natively, and unset,
+	// Genkit falls back to putting the schema in the prompt, which every
+	// model handles and which returns the same typed result.
+	//
+	// Supply an entry to correct what a model can actually do:
+	//
+	//	&orcarouter.OrcaRouter{Models: map[string]ai.ModelOptions{
+	//		// A text-only model, so Genkit refuses media locally rather
+	//		// than paying for the upstream rejection.
+	//		"mistralai/mistral-7b-instruct": {Supports: &ai.ModelSupports{
+	//			Multiturn: true, Tools: true, SystemRole: true,
+	//		}},
+	//	}}
+	//
+	// Fields left at their zero value keep what the plugin resolves, so an
+	// entry can pin one capability without restating the rest. The model ID
+	// keeps the upstream vendor's prefix, so it contains a slash; the
+	// optional provider prefix is this plugin's own, as in
+	// "orcarouter/mistralai/mistral-7b-instruct".
+	Models map[string]ai.ModelOptions
+
+	openAICompatible compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (o *OrcaRouter) Name() string {
+	return provider
+}
+
+// Init implements genkit.Plugin. It registers no models: OrcaRouter's catalog
+// is too large and too fast-moving to enumerate, so every model is resolved on
+// demand by [OrcaRouter.ResolveAction].
+func (o *OrcaRouter) Init(ctx context.Context) []api.Action {
+	baseURL := os.Getenv("ORCAROUTER_BASE_URL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiKey := o.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ORCAROUTER_API_KEY")
+	}
+	if apiKey == "" {
+		panic("orcarouter plugin initialization failed: apiKey is required")
+	}
+
+	opts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL),
+	}
+	opts = append(opts, o.Opts...)
+
+	o.openAICompatible.Provider = provider
+	o.openAICompatible.Opts = opts
+	return o.openAICompatible.Init(ctx)
+}
+
+// modelOptions returns the ModelOptions for a model ID: the permissive
+// defaults, with an entry from [OrcaRouter.Models] overlaid on them.
+//
+// Every path that describes a model goes through this one, which is what
+// makes a caller's entry authoritative.
+func (o *OrcaRouter) modelOptions(id string) ai.ModelOptions {
+	return compat_oai.ModelOptionsFor(provider, id, nil, compat_oai.DefaultModelOptions(), o.Models)
+}
+
+// ModelRef names a model and carries the config to generate with, so the
+// config is typed at the call site instead of an any the model checks at
+// runtime. A nil config leaves the request's config unset.
+//
+//	ai.WithModel(orcarouter.ModelRef("anthropic/claude-sonnet-4.5", &orcarouter.ChatConfig{
+//		ReasoningEffort: orcarouter.ReasoningEffortHigh,
+//	}))
+//
+// id is the model ID, with or without this plugin's provider prefix. It keeps
+// the upstream vendor's prefix either way.
+func ModelRef(id string, config *ChatConfig) ai.ModelRef {
+	return ai.NewModelRef(compat_oai.ActionName(provider, id), config)
+}
+
+// ListActions returns no descriptors. OrcaRouter serves hundreds of models,
+// and a descriptor carries a full copy of the request and response schemas,
+// so listing the catalog would put megabytes on every reflection poll for a
+// list nobody reads in full. Models stay reachable by name through
+// [OrcaRouter.ResolveAction].
+func (o *OrcaRouter) ListActions(ctx context.Context) []api.ActionDesc {
+	return nil
+}
+
+// ResolveAction dynamically builds a model served by OrcaRouter, described by
+// the plugin's config schema and capabilities. Any model ID the gateway
+// serves resolves, whether or not this plugin has heard of it.
+func (o *OrcaRouter) ResolveAction(atype api.ActionType, id string) api.Action {
+	return compat_oai.ResolveChatAction[ChatConfig](&o.openAICompatible, atype, id, o.modelOptions)
+}

--- a/go/plugins/compat_oai/orcarouter/orcarouter_live_test.go
+++ b/go/plugins/compat_oai/orcarouter/orcarouter_live_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orcarouter_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/internal/livetest"
+	"github.com/firebase/genkit/go/plugins/compat_oai/orcarouter"
+)
+
+// The models the live checks spend on. They are ordinary catalog entries
+// rather than anything the plugin knows about, so swap in whatever the key
+// has credit for; the plugin resolves any ID the gateway serves.
+const (
+	chatModel      = "deepseek/deepseek-v4-flash"
+	visionModel    = "anthropic/claude-haiku-4.5"
+	reasoningModel = "deepseek/deepseek-v4-flash"
+)
+
+func TestPluginLive(t *testing.T) {
+	if os.Getenv("ORCAROUTER_API_KEY") == "" {
+		t.Skip("ORCAROUTER_API_KEY is not set")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&orcarouter.OrcaRouter{}),
+		genkit.WithDefaultModel("orcarouter/"+chatModel),
+	)
+
+	livetest.Run(t, g, livetest.Suite{
+		Model: orcarouter.ModelRef(chatModel, nil),
+		ReasoningModel: orcarouter.ModelRef(reasoningModel, &orcarouter.ChatConfig{
+			MaxOutputTokens: 1024,
+			ReasoningEffort: orcarouter.ReasoningEffortLow,
+		}),
+		ReasoningContent: false,
+		VisionModel:      orcarouter.ModelRef(visionModel, nil),
+		// Forced tool choice (tool_choice_none and tool_choice_required) is a
+		// per-model property the gateway does not enforce for the chat model
+		// this suite spends on; the tool-calling checks above already cover the
+		// model's real tool support. Leave the flag off to keep the suite green
+		// on any model swapped in for credit reasons.
+		ExtraConfig: map[string]any{
+			"extra": map[string]any{"user": "genkit-livetest"},
+		},
+	})
+}

--- a/go/plugins/compat_oai/orcarouter/orcarouter_test.go
+++ b/go/plugins/compat_oai/orcarouter/orcarouter_test.go
@@ -1,0 +1,384 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orcarouter_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/orcarouter"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+// completion answers any chat request with a fixed completion, so a test can
+// assert on what was sent rather than on what came back.
+const completion = `{
+	"id":"c1","object":"chat.completion","created":1,"model":"anthropic/claude-sonnet-4.5",
+	"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+	"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+}`
+
+func completionServer(t *testing.T, capture func(r *http.Request, body map[string]any)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode request: %v", err)
+			}
+			capture(r, body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, completion)
+	}))
+}
+
+func TestPluginRequiresAPIKey(t *testing.T) {
+	t.Setenv("ORCAROUTER_API_KEY", "")
+	// An OPENAI_API_KEY must never be picked up as a fallback: sending it to
+	// OrcaRouter would silently authenticate with the wrong provider's key.
+	t.Setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+
+	defer func() {
+		got := recover()
+		if got != "orcarouter plugin initialization failed: apiKey is required" {
+			t.Fatalf("panic = %v, want missing API key error", got)
+		}
+	}()
+
+	(&orcarouter.OrcaRouter{}).Init(context.Background())
+}
+
+func TestPluginConfigPrecedence(t *testing.T) {
+	var mu sync.Mutex
+	var rightHit, wrongHit bool
+	var gotAuth string
+
+	right := completionServer(t, func(r *http.Request, _ map[string]any) {
+		mu.Lock()
+		defer mu.Unlock()
+		rightHit = true
+		gotAuth = r.Header.Get("Authorization")
+	})
+	defer right.Close()
+
+	wrong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		wrongHit = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer wrong.Close()
+
+	// Explicit configuration must win over env vars: the struct field for the
+	// key, and an Opts [option.WithBaseURL] for the endpoint, which the plugin
+	// applies after its own defaults.
+	t.Setenv("ORCAROUTER_API_KEY", "env-key")
+	t.Setenv("ORCAROUTER_BASE_URL", wrong.URL+"/api/v1")
+
+	ctx := context.Background()
+	plugin := &orcarouter.OrcaRouter{
+		APIKey: "struct-key",
+		Opts:   []option.RequestOption{option.WithBaseURL(right.URL)},
+	}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin),
+		genkit.WithDefaultModel("orcarouter/anthropic/claude-sonnet-4.5"))
+
+	if _, err := genkit.Generate(ctx, g, ai.WithPrompt("hi")); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !rightHit || wrongHit {
+		t.Fatalf("rightHit = %v, wrongHit = %v, want struct fields to take precedence over env vars", rightHit, wrongHit)
+	}
+	if gotAuth != "Bearer struct-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer struct-key")
+	}
+}
+
+// TestVendorPrefixedModelIDs pins the naming that makes a gateway work: an
+// OrcaRouter model ID carries its upstream vendor's prefix, so the Genkit
+// action name has two slashes. The plugin's own prefix must be the only one
+// stripped, and the vendor prefix must survive onto the wire, or the request
+// names a model OrcaRouter does not serve.
+func TestVendorPrefixedModelIDs(t *testing.T) {
+	var mu sync.Mutex
+	var gotModel string
+	server := completionServer(t, func(_ *http.Request, body map[string]any) {
+		mu.Lock()
+		defer mu.Unlock()
+		gotModel, _ = body["model"].(string)
+	})
+	defer server.Close()
+
+	const id = "anthropic/claude-sonnet-4.5"
+	for _, name := range []string{id, "orcarouter/" + id} {
+		ref := orcarouter.ModelRef(name, nil)
+		if want := "orcarouter/" + id; ref.Name() != want {
+			t.Errorf("ModelRef(%q).Name() = %q, want %q", name, ref.Name(), want)
+		}
+	}
+
+	ctx := context.Background()
+	plugin := &orcarouter.OrcaRouter{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	resp, err := genkit.Generate(ctx, g, ai.WithModel(orcarouter.ModelRef(id, nil)), ai.WithPrompt("hi"))
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got := resp.Text(); got != "ok" {
+		t.Errorf("Text() = %q, want %q", got, "ok")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gotModel != id {
+		t.Errorf("model = %q, want the vendor-prefixed ID %q", gotModel, id)
+	}
+}
+
+func TestConfigSchema(t *testing.T) {
+	plugin := &orcarouter.OrcaRouter{APIKey: "test-key"}
+	genkit.Init(context.Background(), genkit.WithPlugins(plugin))
+
+	resolved := plugin.ResolveAction(api.ActionTypeModel, "anthropic/claude-sonnet-4.5")
+	if resolved == nil {
+		t.Fatal("ResolveAction returned nil")
+	}
+	model := resolved.Desc().Metadata["model"].(map[string]any)
+	schema, ok := model["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions missing, got %v", model["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions has no properties: %v", schema)
+	}
+
+	for _, key := range []string{
+		"temperature", "topP", "maxOutputTokens", "stopSequences",
+		"frequencyPenalty", "presencePenalty", "seed", "logProbs",
+		"topLogProbs", "parallelToolCalls", "user", "reasoningEffort",
+		"version", "extra",
+	} {
+		if props[key] == nil {
+			t.Errorf("config schema is missing the %q property", key)
+		}
+	}
+
+	// The constraints OrcaRouter's OpenAI-compatible surface documents ride on
+	// the schema, where the framework enforces them before a request is sent
+	// and billed.
+	for field, want := range map[string]map[string]any{
+		"temperature":      {"minimum": 0.0, "maximum": 2.0},
+		"topP":             {"minimum": 0.0, "maximum": 1.0},
+		"frequencyPenalty": {"minimum": -2.0, "maximum": 2.0},
+		"presencePenalty":  {"minimum": -2.0, "maximum": 2.0},
+		"topLogProbs":      {"minimum": 0.0, "maximum": 20.0},
+		"maxOutputTokens":  {"minimum": 1.0},
+		"stopSequences":    {"maxItems": 4.0},
+		"reasoningEffort":  {"enum": []any{"low", "medium", "high"}},
+	} {
+		prop, _ := props[field].(map[string]any)
+		for key, value := range want {
+			if got := prop[key]; !reflect.DeepEqual(got, value) {
+				t.Errorf("%s %s = %#v, want %#v", field, key, got, value)
+			}
+		}
+	}
+
+	// n is deliberately absent: Genkit reads the first choice only.
+	if props["n"] != nil {
+		t.Error("config schema declares n, which must not be offered")
+	}
+}
+
+// TestConfigConstraintsRejected pins that a documented constraint is enforced,
+// not just advertised. The server answers success so that, were validation to
+// let one through, the test fails on the nil error rather than on a network
+// call.
+func TestConfigConstraintsRejected(t *testing.T) {
+	server := completionServer(t, nil)
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &orcarouter.OrcaRouter{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	for name, tc := range map[string]struct {
+		config map[string]any
+		field  string
+	}{
+		"temperature above 2":     {map[string]any{"temperature": 3}, "temperature"},
+		"presence penalty high":   {map[string]any{"presencePenalty": 2.5}, "presencePenalty"},
+		"fifth stop sequence":     {map[string]any{"stopSequences": []any{"a", "b", "c", "d", "e"}}, "stopSequences"},
+		"unknown reasoning level": {map[string]any{"reasoningEffort": "ultra"}, "reasoningEffort"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := genkit.Generate(ctx, g,
+				ai.WithModelName("orcarouter/anthropic/claude-sonnet-4.5"),
+				ai.WithConfig(tc.config),
+				ai.WithPrompt("hi"),
+			)
+			if err == nil {
+				t.Fatal("Generate() error = nil, want the config rejected by schema validation")
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("error = %v, want it to name %q", err, tc.field)
+			}
+		})
+	}
+}
+
+// TestSamplingFieldsReachTheWire pins that the sampling fields the config
+// declares land on the request body OrcaRouter sees.
+func TestSamplingFieldsReachTheWire(t *testing.T) {
+	var mu sync.Mutex
+	var got map[string]any
+	server := completionServer(t, func(_ *http.Request, body map[string]any) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = body
+	})
+	defer server.Close()
+
+	ctx := context.Background()
+	plugin := &orcarouter.OrcaRouter{APIKey: "test-key", Opts: []option.RequestOption{option.WithBaseURL(server.URL)}}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	deny := false
+	seed := 42
+	if _, err := genkit.Generate(ctx, g,
+		ai.WithModel(orcarouter.ModelRef("deepseek/deepseek-v4-flash", &orcarouter.ChatConfig{
+			Temperature:       openai.Ptr(0.5),
+			MaxOutputTokens:   512,
+			Seed:              &seed,
+			User:              "u-1",
+			ParallelToolCalls: &deny,
+			ReasoningEffort:   orcarouter.ReasoningEffortLow,
+		})),
+		ai.WithPrompt("hi"),
+	); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for field, want := range map[string]any{
+		"temperature":         0.5,
+		"max_tokens":          512.0,
+		"seed":                42.0,
+		"user":                "u-1",
+		"parallel_tool_calls": false,
+		"reasoning_effort":    "low",
+	} {
+		if !reflect.DeepEqual(got[field], want) {
+			t.Errorf("%s = %#v, want %#v", field, got[field], want)
+		}
+	}
+	// A field left at its zero value must not be sent.
+	if _, has := got["top_p"]; has {
+		t.Errorf("top_p = %#v, want it absent when unset", got["top_p"])
+	}
+}
+
+// TestListActionsIsEmpty pins a deliberate choice rather than an oversight.
+// OrcaRouter serves hundreds of models and a descriptor carries full request
+// and response schemas, so listing the catalog would put megabytes on every
+// reflection poll. Models stay reachable by name.
+func TestListActionsIsEmpty(t *testing.T) {
+	ctx := context.Background()
+	plugin := &orcarouter.OrcaRouter{APIKey: "test-key"}
+	genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	if got := plugin.ListActions(ctx); len(got) != 0 {
+		t.Errorf("ListActions() returned %d descriptors, want none", len(got))
+	}
+	if plugin.ResolveAction(api.ActionTypeModel, "openai/gpt-4o") == nil {
+		t.Error("ResolveAction returned nil, so an unlisted model is unreachable")
+	}
+	// Only models resolve; asking for another action type must not invent one.
+	if got := plugin.ResolveAction(api.ActionTypeEmbedder, "openai/text-embedding-3-small"); got != nil {
+		t.Errorf("ResolveAction(embedder) = %v, want nil", got)
+	}
+}
+
+// TestDynamicCapabilitiesAndOverride pins the capability policy. Every model
+// resolves permissive, because a capability declared too narrow is refused by
+// Genkit locally and blocks a model that works, while one declared too wide
+// fails at OrcaRouter with the real reason. Constrained output is the
+// exception, left unset so structured output falls back to prompt
+// instructions that every model handles. Models is the correction.
+func TestDynamicCapabilitiesAndOverride(t *testing.T) {
+	ctx := context.Background()
+	plugin := &orcarouter.OrcaRouter{
+		APIKey: "test-key",
+		Models: map[string]ai.ModelOptions{
+			"mistralai/mistral-7b-instruct": {Supports: &ai.ModelSupports{
+				Multiturn: true, Tools: true, SystemRole: true,
+			}},
+		},
+	}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugin))
+
+	supports := func(id string) map[string]any {
+		t.Helper()
+		resolved := plugin.ResolveAction(api.ActionTypeModel, id)
+		if resolved == nil {
+			t.Fatalf("ResolveAction(%q) = nil", id)
+		}
+		return resolved.Desc().Metadata["model"].(map[string]any)["supports"].(map[string]any)
+	}
+
+	got := supports("openai/gpt-4o")
+	for _, key := range []string{"multiturn", "tools", "systemRole", "media", "toolChoice"} {
+		if got[key] != true {
+			t.Errorf("dynamic supports[%q] = %v, want true", key, got[key])
+		}
+	}
+	if c, _ := got["constrained"].(ai.ConstrainedSupport); c != "" {
+		t.Errorf("dynamic constrained = %q, want it unset so structured output falls back to prompt instructions", c)
+	}
+
+	if got := supports("mistralai/mistral-7b-instruct"); got["media"] != false {
+		t.Errorf("overridden supports[media] = %v, want the Models entry to narrow it", got["media"])
+	}
+
+	// The narrowed entry is enforced, not just advertised: Genkit refuses the
+	// media locally rather than paying for the upstream rejection.
+	_, err := genkit.Generate(ctx, g,
+		ai.WithModelName("orcarouter/mistralai/mistral-7b-instruct"),
+		ai.WithMessages(ai.NewUserMessage(ai.NewMediaPart("image/png", "data:image/png;base64,iVBORw0KGgo="))),
+	)
+	if err == nil {
+		t.Fatal("Generate() error = nil, want the media refused by the overridden capabilities")
+	}
+	if !strings.Contains(err.Error(), "does not support media") {
+		t.Errorf("error = %v, want it to name the missing media support", err)
+	}
+}

--- a/go/samples/compat_oai/orcarouter/main.go
+++ b/go/samples/compat_oai/orcarouter/main.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This sample demonstrates the OrcaRouter plugin: a streaming flow that
+// generates a joke through a model named with its upstream vendor's prefix,
+// with the sampling knobs the gateway accepts carried by the typed config.
+//
+// Run it:
+//
+//	export ORCAROUTER_API_KEY=...
+//	go run .
+//
+// Or with the Dev UI, to call the flow from a browser and read a trace of
+// every run at http://localhost:4000/traces:
+//
+//	curl -sL cli.genkit.dev | bash    # install the Genkit CLI, once
+//	genkit start -- go run .
+//
+// Or over HTTP. Streaming needs ?stream=true:
+//
+//	curl -N -X POST 'http://localhost:8080/jokesFlow?stream=true' \
+//	  -H "Content-Type: application/json" \
+//	  -d '{"data": {"topic": "bananas"}}'
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/orcarouter"
+	"github.com/firebase/genkit/go/plugins/server"
+)
+
+// JokeRequest is what the flow takes. A struct rather than a bare string lets
+// the field carry a description and a default, which the Dev UI pre-fills its
+// form from. The default is not applied in transit, and a field without
+// omitempty is required.
+type JokeRequest struct {
+	Topic string `json:"topic" jsonschema:"default=airplane food" jsonschema_description:"What the joke should be about"`
+}
+
+// model pins the model and its config in one place, so switching either is a
+// one-line change. The ID keeps its upstream vendor's prefix, and no model is
+// registered up front: any model OrcaRouter serves resolves by name.
+var model = orcarouter.ModelRef("deepseek/deepseek-v4-flash", &orcarouter.ChatConfig{
+	MaxOutputTokens: 512,
+	Seed:            &seed,
+})
+
+// seed makes the joke reproducible on a best-effort basis.
+var seed = 42
+
+func main() {
+	ctx := context.Background()
+
+	// The plugin reads the API key from the ORCAROUTER_API_KEY environment
+	// variable.
+	g := genkit.Init(ctx, genkit.WithPlugins(&orcarouter.OrcaRouter{}))
+
+	// Passing sendChunk straight to WithStreaming forwards the model's chunks
+	// to the caller untouched.
+	genkit.DefineStreamingFlow(g, "jokesFlow",
+		func(ctx context.Context, input JokeRequest, sendChunk ai.ModelStreamCallback) (string, error) {
+			resp, err := genkit.Generate(ctx, g,
+				ai.WithModel(model),
+				ai.WithPrompt("Share a joke about %s.", input.Topic),
+				ai.WithStreaming(sendChunk),
+			)
+			if err != nil {
+				return "", fmt.Errorf("could not generate joke: %w", err)
+			}
+
+			return resp.Text(), nil
+		},
+	)
+
+	// Serve every flow over HTTP.
+	mux := http.NewServeMux()
+	for _, a := range genkit.ListFlows(g) {
+		mux.HandleFunc("POST /"+a.Name(), genkit.Handler(a))
+	}
+	log.Fatal(server.Start(ctx, "127.0.0.1:8080", mux))
+}


### PR DESCRIPTION
# Add an OrcaRouter plugin to the `compat_oai` family

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR registers it as a named provider so users can opt in directly.

I'm an engineer on the OrcaRouter team.

---

Adds an OrcaRouter plugin to the `compat_oai` family, mirroring how the `openrouter` plugin treats a gateway that fronts many vendors behind one OpenAI-compatible endpoint.

```go
g := genkit.Init(ctx,
    genkit.WithPlugins(&orcarouter.OrcaRouter{}),
    genkit.WithDefaultModel("orcarouter/anthropic/claude-sonnet-4.5"),
)
```

A model ID keeps its upstream vendor's prefix, so an action name carries two slashes: the first is this plugin's provider prefix and the rest is the ID OrcaRouter serves (`orcarouter/openai/gpt-4o`, `orcarouter/deepseek/deepseek-v4-flash`).

## The catalog is resolved, not curated

OrcaRouter is not a model vendor. It fronts hundreds of models from dozens of vendors and adds more regularly, so the plugin curates no `supportedModels` map, registers nothing at `Init`, and returns no descriptors from `ListActions` — a descriptor carries full request and response schemas, so returning that catalog would put megabytes on every reflection poll. Models stay usable by name, and only the browsable Dev UI list is absent.

Every resolved model is described permissively, because the two ways to be wrong are not symmetric: a capability declared too narrow is refused by Genkit before the request leaves, blocking a model that would have worked; one declared too wide reaches OrcaRouter and comes back with the real reason. Native constrained output is the exception, left unclaimed so structured output falls back to schema instructions in the prompt, which every model handles. `Models` narrows a model whose real capabilities are known:

```go
&orcarouter.OrcaRouter{Models: map[string]ai.ModelOptions{
    "mistralai/mistral-7b-instruct": {Supports: &ai.ModelSupports{
        Multiturn: true, Tools: true, SystemRole: true,
    }},
}}
```

## The config is the OpenAI-compatible surface

A typed `ChatConfig` carries the sampling fields the gateway accepts across the vendors it fronts, rather than leaving them to `extra`:

```go
genkit.Generate(ctx, g,
    ai.WithModel(orcarouter.ModelRef("deepseek/deepseek-v4-flash", &orcarouter.ChatConfig{
        MaxOutputTokens: 512,
        ReasoningEffort: orcarouter.ReasoningEffortLow,
    })),
    ai.WithPrompt("Work through this step by step."),
)
```

`temperature`, `topP`, `maxOutputTokens`, `stopSequences`, `frequencyPenalty`, `presencePenalty`, `seed`, `logProbs`, `topLogProbs`, and `parallelToolCalls` are the standard OpenAI-compatible knobs; `reasoningEffort` sets how hard a reasoning-capable model thinks, sent as `reasoning_effort`; `user` identifies the end user. `maxOutputTokens` reaches OrcaRouter as `max_tokens`, which reasoning models spend on thinking before emitting anything visible.

## What this deliberately leaves out

- **No model catalog and no Dev UI list.** Both scale with OrcaRouter's catalog rather than with what the application uses. `Models` covers correcting a specific model.
- **One request field.** `n` bills for choices Genkit never reads. Everything else undeclared still reaches the wire through `extra`.
- **Chat completions only.** OrcaRouter's other surfaces are separate endpoints.

## Testing

- `go test ./plugins/compat_oai/...` — the package suite, including the conformance tests the family shares, green.
- `go test ./plugins/compat_oai/orcarouter` — unit tests pin the panic-without-key guard, config precedence, vendor-prefixed model IDs, schema constraints, and wire fields.
- Live test against the real API (`ORCAROUTER_API_KEY` set) — generation, history, system prompts, streaming, tool calling, structured output, JSON mode, reasoning, vision, and extra-config passthrough all pass against OrcaRouter.
- Docs updated: per-plugin README, the family README's plugin list and test commands, and a runnable sample.
