### PR TITLE
feat(go/samples): add tier A cases to dev-ui-qa

### DIFF
--- a/go/samples/dev-ui-qa/README.md
+++ b/go/samples/dev-ui-qa/README.md
@@ -29,8 +29,29 @@ with whatever subset you have:
 | `ANTHROPIC_API_KEY` (or `ANTHROPIC_AUTH_TOKEN`)    | anthropic        |
 
 The missing-key Init panic (ANT-52, GGA-48) is itself an audit case; to
-reproduce it, bypass the conditional init by constructing the plugin with no
-key in the environment.
+reproduce it, set `DEV_UI_QA_FORCE_PLUGINS=1`, which registers all three
+plugins unconditionally (see Tier A below).
+
+## Tier A repros (no API keys)
+
+Tier A covers everything that works keyless: local registrations only. With
+no credentials set, `genkit start -- go run .` logs one "skipping" line per
+plugin and the Dev UI should list Flows(4), Prompts(1), Tools(1),
+Retrievers(1), Models(0).
+
+| Check | Steps | Expect |
+| ----- | ----- | ------ |
+| Discovery | Open the Dev UI, check the sidebar counts | Flows `smoke`, `streamingCounter`, `loggingFlow`, `panicFlow`; prompt `qa-joke`; tool `shoutTool`; retriever `staticRetriever`; no models/embedders |
+| Streaming | Run `streamingCounter` with input `5` and "Stream response" checked | One chunk every 400ms, then final `streamed 5 chunks` |
+| Log streaming | Run `loggingFlow` with any string input; look for its log lines in the UI, then `curl http://127.0.0.1:4033/api/traces/<traceId>/logs` | Three records at INFO/WARN/ERROR, span-correlated, on the telemetry server; whether the UI renders them is the finding |
+| Trace spans | Open the trace for any run (`View trace`, or `/traces/<id>`) | Root flow span with Input, Output, and Attributes sections |
+| Flow panic | Run `panicFlow` with any input | Panic message `DEV_UI_QA_PANIC_MARKER: ...` in the terminal; record what the UI shows and whether the process survived |
+| Init panic | `DEV_UI_QA_FORCE_PLUGINS=1 genkit start -- go run .` with no keys | Go panic `Google AI requires setting GEMINI_API_KEY...` at Init; record what happens to the CLI and the Dev UI |
+
+Tool and retriever runs are direct: `shoutTool` uppercases its string input;
+`staticRetriever` substring-matches the query against a three-document corpus
+(try `{"content":[{"text":"dev ui"}]}`). `qa-joke` renders its template
+keyless but fails generation with "model is required" - also a useful row.
 
 ## Recording results
 

--- a/go/samples/dev-ui-qa/embedders.go
+++ b/go/samples/dev-ui-qa/embedders.go
@@ -36,9 +36,9 @@ func registerEmbedderCases(g *genkit.Genkit) {
 		"The Dev UI lets you run flows, tools, and retrievers locally.",
 		"Retrievers return ranked documents for a query.",
 	}
-	genkit.DefineRetriever(g, "staticRetriever",
+	genkit.DefineRetrieverAction(g, "staticRetriever",
 		&ai.RetrieverOptions{Label: "Static QA retriever"},
-		func(ctx context.Context, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error) {
+		func(ctx context.Context, req *ai.RetrieverRequest, _ struct{}) (*ai.RetrieverResponse, error) {
 			query := strings.ToLower(req.Query.Content[0].Text)
 			res := &ai.RetrieverResponse{}
 			for i, text := range corpus {

--- a/go/samples/dev-ui-qa/embedders.go
+++ b/go/samples/dev-ui-qa/embedders.go
@@ -14,14 +14,42 @@
 
 package main
 
-import "github.com/firebase/genkit/go/genkit"
+import (
+	"context"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+)
 
 // registerEmbedderCases covers the embedder rows of "Discovery and action
 // list" and "Model runner": cross-backend catalog leak (GGA-40), typo'd ID
 // resolving as a live embedder (GGA-60), and multimodal input hitting an SDK
-// refusal or process panic (GGA-32).
+// refusal or process panic (GGA-32). Also home for the local retriever used
+// by the retriever discovery row - it needs no plugin, so it works keyless.
 func registerEmbedderCases(g *genkit.Genkit) {
 	// TODO: embedder refs, including a deliberately misspelled ID and a
 	// multimodal input fixture.
-	_ = g
+
+	corpus := []string{
+		"Genkit is an open source framework for building AI-powered apps.",
+		"The Dev UI lets you run flows, tools, and retrievers locally.",
+		"Retrievers return ranked documents for a query.",
+	}
+	genkit.DefineRetriever(g, "staticRetriever",
+		&ai.RetrieverOptions{Label: "Static QA retriever"},
+		func(ctx context.Context, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error) {
+			query := strings.ToLower(req.Query.Content[0].Text)
+			res := &ai.RetrieverResponse{}
+			for i, text := range corpus {
+				if query == "" || strings.Contains(strings.ToLower(text), query) {
+					res.Documents = append(res.Documents, &ai.Document{
+						Content:  []*ai.Part{ai.NewTextPart(text)},
+						Metadata: map[string]any{"index": i},
+					})
+				}
+			}
+			return res, nil
+		},
+	)
 }

--- a/go/samples/dev-ui-qa/flows.go
+++ b/go/samples/dev-ui-qa/flows.go
@@ -14,7 +14,16 @@
 
 package main
 
-import "github.com/firebase/genkit/go/genkit"
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/logger"
+	"github.com/firebase/genkit/go/genkit"
+)
 
 // registerFlowAndToolCases covers the "Flows and tools" audit section:
 // streaming chunk rendering, classified provider errors on an error flow
@@ -23,7 +32,45 @@ import "github.com/firebase/genkit/go/genkit"
 // Also home for the trace cases of "Traces and logs": tool-loop spans,
 // thinking parts, raw request/response visibility (GGA-49).
 func registerFlowAndToolCases(g *genkit.Genkit) {
-	// TODO: streaming flow, error flow, interrupt tool, slash-named tool,
-	// code-execution flow.
-	_ = g
+	// Tier A: chunks must arrive in the UI one at a time, not as a single
+	// batch, so each is delayed enough to defeat buffering.
+	genkit.DefineStreamingFlow(g, "streamingCounter",
+		func(ctx context.Context, count int, sendChunk core.StreamCallback[string]) (string, error) {
+			if count <= 0 {
+				count = 5
+			}
+			for i := 1; i <= count; i++ {
+				if err := sendChunk(ctx, fmt.Sprintf("chunk %d of %d", i, count)); err != nil {
+					return "", err
+				}
+				time.Sleep(400 * time.Millisecond)
+			}
+			return fmt.Sprintf("streamed %d chunks", count), nil
+		},
+	)
+
+	// Tier A: exercises log streaming into the Dev UI (ccfe1093d) at each
+	// level the console handler forwards.
+	genkit.DefineFlow(g, "loggingFlow", func(ctx context.Context, input string) (string, error) {
+		log := logger.FromContext(ctx)
+		log.Info("loggingFlow info line", "input", input)
+		log.Warn("loggingFlow warn line", "hint", "this should render as a warning")
+		log.Error("loggingFlow error line", "code", "QA_TEST_ERROR")
+		return "logged 3 lines at info/warn/error", nil
+	})
+
+	// Tier A: tools appear as standalone actions in the Dev UI; no flow
+	// wraps this one on purpose.
+	genkit.DefineTool(g, "shoutTool", "Uppercases the input and appends an exclamation mark",
+		func(ctx *ai.ToolContext, input string) (string, error) {
+			out := ""
+			for _, r := range input {
+				if 'a' <= r && r <= 'z' {
+					r -= 'a' - 'A'
+				}
+				out += string(r)
+			}
+			return out + "!", nil
+		},
+	)
 }

--- a/go/samples/dev-ui-qa/flows.go
+++ b/go/samples/dev-ui-qa/flows.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
@@ -63,14 +64,7 @@ func registerFlowAndToolCases(g *genkit.Genkit) {
 	// wraps this one on purpose.
 	genkit.DefineTool(g, "shoutTool", "Uppercases the input and appends an exclamation mark",
 		func(ctx *ai.ToolContext, input string) (string, error) {
-			out := ""
-			for _, r := range input {
-				if 'a' <= r && r <= 'z' {
-					r -= 'a' - 'A'
-				}
-				out += string(r)
-			}
-			return out + "!", nil
+			return strings.ToUpper(input) + "!", nil
 		},
 	)
 }

--- a/go/samples/dev-ui-qa/lifecycle.go
+++ b/go/samples/dev-ui-qa/lifecycle.go
@@ -14,15 +14,20 @@
 
 package main
 
-import "github.com/firebase/genkit/go/genkit"
+import (
+	"context"
+
+	"github.com/firebase/genkit/go/genkit"
+)
 
 // registerLifecycleCases covers "Crash and lifecycle" and the failure rows of
 // "Discovery and action list": a flow that panics on demand (what the UI
 // shows, whether it reconnects; same class as GGA-1/GGA-32), silent
 // dynamic-listing failure (GGA-38), and the Init panic on missing auth
-// (ANT-52, GGA-48) - the last is exercised by unsetting keys, not by a
-// registration here.
+// (ANT-52, GGA-48) - the last is exercised by DEV_UI_QA_FORCE_PLUGINS=1 with
+// keys unset, not by a registration here.
 func registerLifecycleCases(g *genkit.Genkit) {
-	// TODO: panic flow, log-streaming exercise flow (ccfe1093d).
-	_ = g
+	genkit.DefineFlow(g, "panicFlow", func(ctx context.Context, input string) (string, error) {
+		panic("DEV_UI_QA_PANIC_MARKER: panicFlow panicked on purpose (input: " + input + ")")
+	})
 }

--- a/go/samples/dev-ui-qa/main.go
+++ b/go/samples/dev-ui-qa/main.go
@@ -43,23 +43,34 @@ func main() {
 	// QA than no surface. The panic itself is a lifecycle case; see
 	// lifecycle.go.
 	var plugins []api.Plugin
-	if os.Getenv("GEMINI_API_KEY") != "" || os.Getenv("GOOGLE_API_KEY") != "" {
-		plugins = append(plugins, &googlegenai.GoogleAI{})
-	} else {
-		log.Println("dev-ui-qa: GEMINI_API_KEY not set, skipping googleai")
+	force := os.Getenv("DEV_UI_QA_FORCE_PLUGINS") == "1"
+	if force {
+		// Escape hatch to demonstrate the missing-auth Init panic UX
+		// (ANT-52, GGA-48): register everything regardless of creds.
+		plugins = append(plugins, &googlegenai.GoogleAI{}, &googlegenai.VertexAI{}, &anthropic.Anthropic{})
 	}
-	if os.Getenv("GOOGLE_CLOUD_PROJECT") != "" && (os.Getenv("GOOGLE_CLOUD_LOCATION") != "" || os.Getenv("GOOGLE_CLOUD_REGION") != "") {
-		plugins = append(plugins, &googlegenai.VertexAI{})
-	} else {
-		log.Println("dev-ui-qa: GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_LOCATION/REGION not set, skipping vertexai")
-	}
-	if os.Getenv("ANTHROPIC_API_KEY") != "" || os.Getenv("ANTHROPIC_AUTH_TOKEN") != "" {
-		plugins = append(plugins, &anthropic.Anthropic{})
-	} else {
-		log.Println("dev-ui-qa: ANTHROPIC_API_KEY not set, skipping anthropic")
+	if !force {
+		if os.Getenv("GEMINI_API_KEY") != "" || os.Getenv("GOOGLE_API_KEY") != "" {
+			plugins = append(plugins, &googlegenai.GoogleAI{})
+		} else {
+			log.Println("dev-ui-qa: GEMINI_API_KEY not set, skipping googleai")
+		}
+		if os.Getenv("GOOGLE_CLOUD_PROJECT") != "" && (os.Getenv("GOOGLE_CLOUD_LOCATION") != "" || os.Getenv("GOOGLE_CLOUD_REGION") != "") {
+			plugins = append(plugins, &googlegenai.VertexAI{})
+		} else {
+			log.Println("dev-ui-qa: GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_LOCATION/REGION not set, skipping vertexai")
+		}
+		if os.Getenv("ANTHROPIC_API_KEY") != "" || os.Getenv("ANTHROPIC_AUTH_TOKEN") != "" {
+			plugins = append(plugins, &anthropic.Anthropic{})
+		} else {
+			log.Println("dev-ui-qa: ANTHROPIC_API_KEY not set, skipping anthropic")
+		}
 	}
 
-	g := genkit.Init(ctx, genkit.WithPlugins(plugins...))
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(plugins...),
+		genkit.WithPromptDir("prompts"),
+	)
 
 	genkit.DefineFlow(g, "smoke", func(ctx context.Context, input string) (string, error) {
 		return "ok: " + input, nil

--- a/go/samples/dev-ui-qa/prompts/qa-joke.prompt
+++ b/go/samples/dev-ui-qa/prompts/qa-joke.prompt
@@ -1,0 +1,8 @@
+---
+input:
+  schema:
+    topic?: string
+  default:
+    topic: airplane food
+---
+Share a short joke about {{topic}}.


### PR DESCRIPTION
Tier A ('no API key') cases for the dev-ui-qa testapp, added during the keyless Dev UI QA pass:

- `streamingCounter` - streaming flow with delayed chunks so progressive rendering is observable.
- `loggingFlow` - logs at info/warn/error via the context logger, exercising log streaming to the Dev UI.
- `shoutTool` - standalone tool (no wrapping flow) so tools appear as their own action type.
- `panicFlow` - panics with a distinctive marker to probe crash UX.
- `staticRetriever` - local retriever, no plugin needed.
- `qa-joke` dotprompt under `prompts/`.
- `DEV_UI_QA_FORCE_PLUGINS=1` escape hatch: registers all plugins regardless of creds, to demonstrate the missing-auth Init panic UX.

Pass results (summary): action discovery, streaming, and trace spans all pass; log streaming works Go-side but the Dev UI has no logs panel in CLI 1.41.0; a panicking flow is shown as a silent green success (net/http recovers the handler panic, span exported without error state); a plugin Init panic takes down the whole Dev UI via an unhandled rejection in the CLI's process manager.