### PR TITLE
chore(js): add @genkit-ai/anthropic to version bump and release scripts

### DIFF
--- a/js/scripts/bump_and_tag_js.sh
+++ b/js/scripts/bump_and_tag_js.sh
@@ -62,6 +62,7 @@ bump_version js/plugins/middleware @genkit-ai/middleware middleware-v
 bump_version js/plugins/fetch @genkit-ai/fetch fetch-v
 bump_version js/plugins/fastify @genkit-ai/fastify fastify-v
 bump_version js/plugins/vercel-ai @genkit-ai/vercel-ai vercel-ai-v
+bump_version js/plugins/anthropic @genkit-ai/anthropic anthropic-v
 
 echo TAGS "${TAGS[*]}"
 

--- a/scripts/release_main.sh
+++ b/scripts/release_main.sh
@@ -116,3 +116,7 @@ cd $CURRENT
 cd  js/plugins/google-genai
 pnpm publish --provenance=false --tag $RELEASE_TAG --publish-branch $RELEASE_BRANCH --registry https://wombat-dressing-room.appspot.com
 cd $CURRENT
+
+cd  js/plugins/anthropic
+pnpm publish --provenance=false --tag $RELEASE_TAG --publish-branch $RELEASE_BRANCH --registry https://wombat-dressing-room.appspot.com
+cd $CURRENT

--- a/scripts/release_main.sh
+++ b/scripts/release_main.sh
@@ -116,7 +116,3 @@ cd $CURRENT
 cd  js/plugins/google-genai
 pnpm publish --provenance=false --tag $RELEASE_TAG --publish-branch $RELEASE_BRANCH --registry https://wombat-dressing-room.appspot.com
 cd $CURRENT
-
-cd  js/plugins/anthropic
-pnpm publish --provenance=false --tag $RELEASE_TAG --publish-branch $RELEASE_BRANCH --registry https://wombat-dressing-room.appspot.com
-cd $CURRENT


### PR DESCRIPTION
Adds @genkit-ai/anthropic to bump_and_tag_js.sh and release_main.sh, mirroring 40bf58b79 (compat-oai). It is currently in neither, so npm is stuck at 0.3.0 (2026-05-28) while the framework is at 1.41.0, with Opus 4.8 (#5500), Fable 5 (#5530), Sonnet 5 (#5747) and lazy API key resolution (#4298) unreleased on main. Python's genkit-anthropic is already in publish_python.yml.

One call for you: stay 0.x bumping in lockstep, or graduate to 1.x alongside the other packages? The change works either way. One mechanical note on the second option: `npm version major` takes it to 1.0.0, not 1.42.0, so aligning with the framework version needs a one-off manual edit of package.json before the next bump run.
