### PR TITLE
fix(go/core): name operation companions for the operation they perform

### DIFF
--- a/go/ai/background_model_test.go
+++ b/go/ai/background_model_test.go
@@ -99,7 +99,7 @@ func TestNewBackgroundModelInputSchema(t *testing.T) {
 		m.Register(r)
 		for _, key := range []string{
 			"/background-model/test/bgmodel",
-			"/check-operation/test/bgmodel",
+			"/check-operation/test/bgmodel/check",
 		} {
 			action := r.LookupAction(key)
 			if action == nil {

--- a/go/core/background_action.go
+++ b/go/core/background_action.go
@@ -122,6 +122,15 @@ type BackgroundActionOptions[In, Out any] struct {
 	Cancel CancelOpFunc[Out]
 }
 
+// checkOpName and cancelOpName return the registry names of a background
+// action's lifecycle companions: the action's own name followed by the
+// operation the companion performs, e.g. "googleai/veo-2/check". Both the
+// constructor and [LookupBackgroundAction] build the names this way, and
+// tooling that reaches a companion directly (the Dev UI polls and cancels
+// background tasks over the reflection API) expects the same shape.
+func checkOpName(name string) string  { return name + "/check" }
+func cancelOpName(name string) string { return name + "/cancel" }
+
 // NewBackgroundActionOf creates a new background action without
 // registering it. Register it with [BackgroundAction.Register].
 //
@@ -184,7 +193,7 @@ func NewBackgroundActionOf[In, Out any](
 		OutputSchema: opSchema,
 	}
 
-	checkAction := NewActionOf(api.ActionTypeCheckOperation, name, opOpts,
+	checkAction := NewActionOf(api.ActionTypeCheckOperation, checkOpName(name), opOpts,
 		func(ctx context.Context, op *Operation[Out]) (*Operation[Out], error) {
 			updatedOp, err := checkFn(ctx, op)
 			if err != nil {
@@ -196,7 +205,7 @@ func NewBackgroundActionOf[In, Out any](
 
 	var cancelAction *Action[*Operation[Out], *Operation[Out], struct{}]
 	if cancelFn != nil {
-		cancelAction = NewActionOf(api.ActionTypeCancelOperation, name, opOpts,
+		cancelAction = NewActionOf(api.ActionTypeCancelOperation, cancelOpName(name), opOpts,
 			func(ctx context.Context, op *Operation[Out]) (*Operation[Out], error) {
 				cancelledOp, err := cancelFn(ctx, op)
 				if err != nil {
@@ -253,12 +262,12 @@ func LookupBackgroundAction[In, Out any](r api.Registry, key string) *Background
 		return nil
 	}
 
-	checkAction := ResolveActionFor[*Operation[Out], *Operation[Out], struct{}](r, api.ActionTypeCheckOperation, name)
+	checkAction := ResolveActionFor[*Operation[Out], *Operation[Out], struct{}](r, api.ActionTypeCheckOperation, checkOpName(name))
 	if checkAction == nil {
 		return nil
 	}
 
-	cancelAction := ResolveActionFor[*Operation[Out], *Operation[Out], struct{}](r, api.ActionTypeCancelOperation, name)
+	cancelAction := ResolveActionFor[*Operation[Out], *Operation[Out], struct{}](r, api.ActionTypeCancelOperation, cancelOpName(name))
 
 	return &BackgroundAction[In, Out]{
 		action: startAction,

--- a/go/core/background_action_test.go
+++ b/go/core/background_action_test.go
@@ -277,13 +277,13 @@ func TestBackgroundActionRegister(t *testing.T) {
 		}
 
 		// Check check action
-		checkKey := api.KeyFromName(api.ActionTypeCheckOperation, "test/register")
+		checkKey := api.KeyFromName(api.ActionTypeCheckOperation, "test/register/check")
 		if r.LookupAction(checkKey) == nil {
 			t.Error("check action not registered")
 		}
 
 		// Check cancel action
-		cancelKey := api.KeyFromName(api.ActionTypeCancelOperation, "test/register")
+		cancelKey := api.KeyFromName(api.ActionTypeCancelOperation, "test/register/cancel")
 		if r.LookupAction(cancelKey) == nil {
 			t.Error("cancel action not registered")
 		}
@@ -302,7 +302,7 @@ func TestBackgroundActionRegister(t *testing.T) {
 		ba.Register(r)
 
 		// Cancel action should not be registered
-		cancelKey := api.KeyFromName(api.ActionTypeCancelOperation, "test/register-nocancel")
+		cancelKey := api.KeyFromName(api.ActionTypeCancelOperation, "test/register-nocancel/cancel")
 		if r.LookupAction(cancelKey) != nil {
 			t.Error("cancel action should not be registered")
 		}

--- a/go/plugins/googlegenai/actions.go
+++ b/go/plugins/googlegenai/actions.go
@@ -6,6 +6,7 @@ package googlegenai
 import (
 	"context"
 	"slices"
+	"strings"
 
 	"github.com/firebase/genkit/go/core/api"
 	"google.golang.org/genai"
@@ -79,10 +80,16 @@ func resolveAction(client *genai.Client, c catalog, atype api.ActionType, id str
 	// and check actions, so the same value resolves either key. The registry
 	// registers what we return and then looks up the key it was asked for.
 	case api.ActionTypeBackgroundModel, api.ActionTypeCheckOperation:
-		if mt != ModelTypeVeo {
+		// The check companion is named for the model plus the operation it
+		// performs, so resolve the model the companion belongs to.
+		modelID := id
+		if atype == api.ActionTypeCheckOperation {
+			modelID = strings.TrimSuffix(id, "/check")
+		}
+		if ClassifyModel(modelID) != ModelTypeVeo {
 			return nil
 		}
-		return newVeoModel(client, id, c.modelOptions(id))
+		return newVeoModel(client, modelID, c.modelOptions(modelID))
 	}
 
 	return nil

--- a/go/plugins/googlegenai/actions.go
+++ b/go/plugins/googlegenai/actions.go
@@ -77,11 +77,12 @@ func resolveAction(client *genai.Client, c catalog, atype api.ActionType, id str
 		return newModel(client, id, c.modelOptions(id))
 
 	// A background model is a bundle: registering it registers both its start
-	// and check actions, so the same value resolves either key. The registry
-	// registers what we return and then looks up the key it was asked for.
+	// and check actions. The registry registers what we return and then looks
+	// up the key it was asked for.
 	case api.ActionTypeBackgroundModel, api.ActionTypeCheckOperation:
-		// The check companion is named for the model plus the operation it
-		// performs, so resolve the model the companion belongs to.
+		// The two keys differ: start is the bare model, and the check companion
+		// is the model plus the operation it performs. Strip the suffix to get
+		// back the model the companion belongs to.
 		modelID := id
 		if atype == api.ActionTypeCheckOperation {
 			modelID = strings.TrimSuffix(id, "/check")

--- a/go/plugins/googlegenai/veo_test.go
+++ b/go/plugins/googlegenai/veo_test.go
@@ -428,6 +428,7 @@ func TestResolveVeoActions(t *testing.T) {
 	const modelName = "veo-3.0-generate-001"
 	startKey := api.KeyFromName(api.ActionTypeBackgroundModel, api.NewName(googleAIProvider, modelName))
 	checkKey := api.KeyFromName(api.ActionTypeCheckOperation, api.NewName(googleAIProvider, modelName+"/check"))
+	cancelKey := api.KeyFromName(api.ActionTypeCancelOperation, api.NewName(googleAIProvider, modelName+"/cancel"))
 
 	// Resolving either key yields the background model bundle, and registering
 	// it makes both the start and check actions resolvable.
@@ -455,6 +456,14 @@ func TestResolveVeoActions(t *testing.T) {
 					t.Errorf("action %q not registered", key)
 				}
 			}
+
+			// Veo passes no cancel function, so the bundle carries no cancel
+			// companion and resolveAction answers no cancel-operation key.
+			// Giving a googlegenai background model a cancel function has to
+			// teach the resolver that key as well; this is what catches it.
+			if r.LookupAction(cancelKey) != nil {
+				t.Errorf("action %q registered, so resolveAction must answer cancel-operation keys too", cancelKey)
+			}
 		})
 	}
 
@@ -471,8 +480,10 @@ func TestResolveVeoActions(t *testing.T) {
 	})
 
 	t.Run("non-veo models do not resolve as background models", func(t *testing.T) {
-		for _, id := range []string{"gemini-flash-latest", "gemini-flash-latest/check"} {
-			for _, atype := range []api.ActionType{api.ActionTypeBackgroundModel, api.ActionTypeCheckOperation} {
+		for _, id := range []string{"gemini-flash-latest", "gemini-flash-latest/check", "gemini-flash-latest/cancel"} {
+			for _, atype := range []api.ActionType{
+				api.ActionTypeBackgroundModel, api.ActionTypeCheckOperation, api.ActionTypeCancelOperation,
+			} {
 				if action := resolveAction(client, catalog{provider: googleAIProvider}, atype, id); action != nil {
 					t.Errorf("resolveAction(%s, %q) = %v, want nil", atype, id, action)
 				}

--- a/go/plugins/googlegenai/veo_test.go
+++ b/go/plugins/googlegenai/veo_test.go
@@ -427,21 +427,24 @@ func TestResolveVeoActions(t *testing.T) {
 
 	const modelName = "veo-3.0-generate-001"
 	startKey := api.KeyFromName(api.ActionTypeBackgroundModel, api.NewName(googleAIProvider, modelName))
-	checkKey := api.KeyFromName(api.ActionTypeCheckOperation, api.NewName(googleAIProvider, modelName))
+	checkKey := api.KeyFromName(api.ActionTypeCheckOperation, api.NewName(googleAIProvider, modelName+"/check"))
 
 	// Resolving either key yields the background model bundle, and registering
 	// it makes both the start and check actions resolvable.
 	for _, tc := range []struct {
 		name  string
 		atype api.ActionType
+		// id is what the registry hands the resolver: the bare model for the
+		// start action, the model plus its operation for the check companion.
+		id string
 	}{
-		{"resolved as background model", api.ActionTypeBackgroundModel},
-		{"resolved as check operation", api.ActionTypeCheckOperation},
+		{"resolved as background model", api.ActionTypeBackgroundModel, modelName},
+		{"resolved as check operation", api.ActionTypeCheckOperation, modelName + "/check"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			action := resolveAction(client, catalog{provider: googleAIProvider}, tc.atype, modelName)
+			action := resolveAction(client, catalog{provider: googleAIProvider}, tc.atype, tc.id)
 			if action == nil {
-				t.Fatalf("resolveAction(%s, %q) = nil", tc.atype, modelName)
+				t.Fatalf("resolveAction(%s, %q) = nil", tc.atype, tc.id)
 			}
 
 			r := registry.New()
@@ -468,9 +471,11 @@ func TestResolveVeoActions(t *testing.T) {
 	})
 
 	t.Run("non-veo models do not resolve as background models", func(t *testing.T) {
-		for _, atype := range []api.ActionType{api.ActionTypeBackgroundModel, api.ActionTypeCheckOperation} {
-			if action := resolveAction(client, catalog{provider: googleAIProvider}, atype, "gemini-flash-latest"); action != nil {
-				t.Errorf("resolveAction(%s, gemini-flash-latest) = %v, want nil", atype, action)
+		for _, id := range []string{"gemini-flash-latest", "gemini-flash-latest/check"} {
+			for _, atype := range []api.ActionType{api.ActionTypeBackgroundModel, api.ActionTypeCheckOperation} {
+				if action := resolveAction(client, catalog{provider: googleAIProvider}, atype, id); action != nil {
+					t.Errorf("resolveAction(%s, %q) = %v, want nil", atype, id, action)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
Fixes the keys a background action's lifecycle companions register under. Go named the check and cancel companions after the action itself, producing `/check-operation/{model}` and `/cancel-operation/{model}`. JS and Python both name them for the operation they perform, `{name}/check` and `{name}/cancel`, and the Dev UI builds that form, so its background-task panel got NOT_FOUND on every poll and every cancel against a Go background model.

Both companions now carry the suffix. `googlegenai` resolves the model its check companion belongs to, because dynamic resolution now hands the plugin `veo-3.0-generate-001/check`, a name `ClassifyModel` does not recognize.

`Operation.Action` still carries the start key, so anything round-tripping an operation through `LookupBackgroundAction` is unaffected. Only a hand-built check key changes, and those were already broken against the other two runtimes.
