### PR TITLE
fix(go): record each tool-loop turn's messages on its `generate` span

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -196,9 +196,10 @@ type ModelOptions struct {
 func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 	a := core.NewStreamingActionOf(api.ActionTypeUtil, "generate", nil,
 		func(ctx context.Context, actionOpts *GenerateActionOptions, cb ModelStreamCallback) (resp *ModelResponse, err error) {
-			// The request and response are recorded on the action's trace span;
-			// no need to duplicate them here.
-			return GenerateWithRequest(ctx, r, actionOpts, nil, cb)
+			// The action's own span records the request and response, and
+			// stands in for the first turn's: opening one would nest a
+			// duplicate "generate" span directly inside it.
+			return generateWithRequest(ctx, r, actionOpts, nil, cb, false /* spanTurnZero */)
 		})
 	a.Register(r)
 	return (*generateAction)(a)
@@ -320,6 +321,13 @@ func LookupModel(r api.Registry, name string) Model {
 
 // GenerateWithRequest is the central generation implementation for ai.Generate(), prompt.Execute(), and the GenerateAction direct call.
 func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActionOptions, mmws []ModelMiddleware, cb ModelStreamCallback) (*ModelResponse, error) {
+	return generateWithRequest(ctx, r, opts, mmws, cb, true /* spanTurnZero */)
+}
+
+// generateWithRequest runs the tool loop. spanTurnZero reports whether the
+// first turn opens its own "generate" span; the generate action passes false
+// because its own span already serves as that one.
+func generateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActionOptions, mmws []ModelMiddleware, cb ModelStreamCallback, spanTurnZero bool) (*ModelResponse, error) {
 	if opts.Model == "" {
 		if defaultModel, ok := r.LookupValue(api.DefaultModelKey).(string); ok && defaultModel != "" {
 			opts.Model = defaultModel
@@ -485,157 +493,168 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 	runTool := buildToolRunner(mws)
 
 	var generate func(context.Context, *ModelRequest, int, int) (*ModelResponse, error)
-	var runGenerate func(context.Context, *GenerateParams) (*ModelResponse, error)
 
-	runGenerate = func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
-		name := params.Options.StepName
+	runTurn := func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
+		req := params.Request
+		currentTurn := params.Iteration
+		messageIndex := params.MessageIndex
+		var wrappedCb ModelStreamCallback
+		currentRole := RoleModel
+		currentIndex := messageIndex
+
+		if cb != nil {
+			wrappedCb = func(ctx context.Context, chunk *ModelResponseChunk) error {
+				if chunk.Role != currentRole && chunk.Role != "" {
+					currentIndex++
+					currentRole = chunk.Role
+				}
+				chunk.Index = currentIndex
+				if chunk.Role == "" {
+					chunk.Role = RoleModel
+				}
+				chunk.formatHandler = streamingHandler
+				return cb(ctx, chunk)
+			}
+		}
+
+		// Resume on the first turn is handled here so that restarted tool
+		// execution is both wrapped by WrapGenerate and recorded under this
+		// turn's span (generate > tool > generate > model > tool).
+		if currentTurn == 0 && opts.Resume != nil && (len(opts.Resume.Respond) > 0 || len(opts.Resume.Restart) > 0) {
+			resumeOutput, err := handleResumeOption(ctx, r, opts, runTool)
+			if err != nil {
+				return nil, err
+			}
+
+			if resumeOutput.interruptedResponse != nil {
+				return nil, status.Errorf(status.ErrFailedPrecondition,
+					"One or more tools triggered an interrupt during a restarted execution.")
+			}
+
+			opts = resumeOutput.revisedRequest
+
+			if resumeOutput.toolMessage != nil && wrappedCb != nil {
+				if err := wrappedCb(ctx, &ModelResponseChunk{
+					Content: resumeOutput.toolMessage.Content,
+					Role:    RoleTool,
+				}); err != nil {
+					return nil, fmt.Errorf("streaming callback failed for resumed tool message: %w", err)
+				}
+			}
+
+			resumeReq := &ModelRequest{
+				Messages:   opts.Messages,
+				Config:     req.Config,
+				Docs:       req.Docs,
+				ToolChoice: req.ToolChoice,
+				Tools:      req.Tools,
+				Output:     req.Output,
+			}
+			return generate(ctx, resumeReq, currentTurn+1, currentIndex)
+		}
+
+		logger.Debug(ctx, "calling model", "model", opts.Model, "turn", currentTurn, "messages", len(req.Messages))
+		resp, err := fn(ctx, req, wrappedCb)
+		if err != nil {
+			return nil, err
+		}
+
+		// ToolRequests allocates a scan of the message, so only build the
+		// log arguments when a handler accepts debug records.
+		if logger.FromContext(ctx).Enabled(ctx, slog.LevelDebug) {
+			modelArgs := []any{"model", opts.Model, "turn", currentTurn, "finishReason", resp.FinishReason, "toolRequests", len(resp.ToolRequests())}
+			if resp.Usage != nil {
+				modelArgs = append(modelArgs, "inputTokens", resp.Usage.InputTokens, "outputTokens", resp.Usage.OutputTokens)
+			}
+			logger.Debug(ctx, "model responded", modelArgs...)
+		}
+
+		// Ensure all tool requests have unique refs for matching during resume.
+		ensureToolRequestRefs(resp.Message)
+
+		// If this is a long-running operation response, return it immediately without further processing
+		if bm != nil && resp.Operation != nil {
+			return resp, nil
+		}
+
+		if formatHandler != nil {
+			resp.formatHandler = streamingHandler
+			switch resp.FinishReason {
+			case FinishReasonBlocked, FinishReasonAborted, FinishReasonInterrupted, FinishReasonOther:
+				// A termination known to be abnormal carries no conforming
+				// output, and a schema error here would mask the
+				// FinishReason and FinishMessage the caller needs to
+				// handle it, so the response passes through as-is.
+				// FinishReasonUnknown is not in this set on purpose:
+				// plugins map unrecognized provider reasons to it, and
+				// ParseMessage is the only place the output schema is
+				// enforced, so skipping it on an unclassified reason would
+				// silently drop validation for output the model may well
+				// have completed.
+				logger.Warn(ctx, "model finished abnormally, skipping output parsing",
+					"model", opts.Model,
+					"finishReason", resp.FinishReason,
+					"finishMessage", resp.FinishMessage)
+			default:
+				// This is legacy behavior. New format handlers should implement ParseMessage as a passthrough.
+				resp.Message, err = formatHandler.ParseMessage(resp.Message)
+				if err != nil {
+					logger.Debug(ctx, "model output does not match the expected schema", "model", opts.Model, "error", err)
+					return nil, status.Errorf(status.ErrInvalidOutput, "model failed to generate output matching expected schema: %w", err)
+				}
+			}
+		}
+
+		if len(resp.ToolRequests()) == 0 || opts.ReturnToolRequests {
+			return resp, nil
+		}
+
+		if currentTurn+1 > maxTurns {
+			return nil, status.Errorf(ErrMaxTurnsExceeded, "exceeded maximum tool call iterations (%d)", maxTurns)
+		}
+
+		newReq, interruptMsg, err := handleToolRequests(ctx, r, req, resp, wrappedCb, currentIndex, runTool)
+		if err != nil {
+			return nil, err
+		}
+		if interruptMsg != nil {
+			logger.Debug(ctx, "generation paused by tool interrupts", "model", opts.Model, "turn", currentTurn)
+			resp.FinishReason = "interrupted"
+			resp.FinishMessage = "One or more tool calls resulted in interrupts."
+			resp.Message = interruptMsg
+			return resp, nil
+		}
+		if newReq == nil {
+			return resp, nil
+		}
+
+		return generate(ctx, newReq, currentTurn+1, currentIndex+1)
+	}
+
+	// runGenerate opens the turn's span around runTurn. The span records the
+	// messages this turn sends rather than the ones the call started with, and
+	// is built after the WrapGenerate hooks so it includes theirs.
+	runGenerate := func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
+		if params.Iteration == 0 && !spanTurnZero {
+			return runTurn(ctx, params)
+		}
+		name := opts.StepName
 		if name == "" {
 			name = "generate"
 		}
+		// No subtype, as in TypeScript: the type says it all, and a subtype
+		// would annotate the trace path as well.
 		spanMetadata := &tracing.SpanMetadata{
-			Name:    name,
-			Type:    "util",
-			Subtype: "util",
+			Name: name,
+			Type: "util",
 		}
+		spanInput := turnOptions(opts)
+		spanInput.Messages = params.Request.Messages
 
-		return tracing.RunInNewSpan(ctx, spanMetadata, params.Options, func(ctx context.Context, _ *GenerateActionOptions) (*ModelResponse, error) {
-			req := params.Request
-			currentTurn := params.Iteration
-			messageIndex := params.MessageIndex
-			var wrappedCb ModelStreamCallback
-			currentRole := RoleModel
-			currentIndex := messageIndex
-
-			if cb != nil {
-				wrappedCb = func(ctx context.Context, chunk *ModelResponseChunk) error {
-					if chunk.Role != currentRole && chunk.Role != "" {
-						currentIndex++
-						currentRole = chunk.Role
-					}
-					chunk.Index = currentIndex
-					if chunk.Role == "" {
-						chunk.Role = RoleModel
-					}
-					chunk.formatHandler = streamingHandler
-					return cb(ctx, chunk)
-				}
-			}
-
-			// Handle resume on the first iteration inside this span so that
-			// restarted tool execution is both wrapped by WrapGenerate (from
-			// the outer middleware chain) and recorded as a child of the
-			// current generate span (lifecycle: generate > tool > generate >
-			// model > tool).
-			if currentTurn == 0 && opts.Resume != nil && (len(opts.Resume.Respond) > 0 || len(opts.Resume.Restart) > 0) {
-				resumeOutput, err := handleResumeOption(ctx, r, opts, runTool)
-				if err != nil {
-					return nil, err
-				}
-
-				if resumeOutput.interruptedResponse != nil {
-					return nil, status.Errorf(status.ErrFailedPrecondition,
-						"One or more tools triggered an interrupt during a restarted execution.")
-				}
-
-				opts = resumeOutput.revisedRequest
-
-				if resumeOutput.toolMessage != nil && wrappedCb != nil {
-					if err := wrappedCb(ctx, &ModelResponseChunk{
-						Content: resumeOutput.toolMessage.Content,
-						Role:    RoleTool,
-					}); err != nil {
-						return nil, fmt.Errorf("streaming callback failed for resumed tool message: %w", err)
-					}
-				}
-
-				resumeReq := &ModelRequest{
-					Messages:   opts.Messages,
-					Config:     req.Config,
-					Docs:       req.Docs,
-					ToolChoice: req.ToolChoice,
-					Tools:      req.Tools,
-					Output:     req.Output,
-				}
-				return generate(ctx, resumeReq, currentTurn+1, currentIndex)
-			}
-
-			logger.Debug(ctx, "calling model", "model", opts.Model, "turn", currentTurn, "messages", len(req.Messages))
-			resp, err := fn(ctx, req, wrappedCb)
-			if err != nil {
-				return nil, err
-			}
-
-			// ToolRequests allocates a scan of the message, so only build the
-			// log arguments when a handler accepts debug records.
-			if logger.FromContext(ctx).Enabled(ctx, slog.LevelDebug) {
-				modelArgs := []any{"model", opts.Model, "turn", currentTurn, "finishReason", resp.FinishReason, "toolRequests", len(resp.ToolRequests())}
-				if resp.Usage != nil {
-					modelArgs = append(modelArgs, "inputTokens", resp.Usage.InputTokens, "outputTokens", resp.Usage.OutputTokens)
-				}
-				logger.Debug(ctx, "model responded", modelArgs...)
-			}
-
-			// Ensure all tool requests have unique refs for matching during resume.
-			ensureToolRequestRefs(resp.Message)
-
-			// If this is a long-running operation response, return it immediately without further processing
-			if bm != nil && resp.Operation != nil {
-				return resp, nil
-			}
-
-			if formatHandler != nil {
-				resp.formatHandler = streamingHandler
-				switch resp.FinishReason {
-				case FinishReasonBlocked, FinishReasonAborted, FinishReasonInterrupted, FinishReasonOther:
-					// A termination known to be abnormal carries no conforming
-					// output, and a schema error here would mask the
-					// FinishReason and FinishMessage the caller needs to
-					// handle it, so the response passes through as-is.
-					// FinishReasonUnknown is not in this set on purpose:
-					// plugins map unrecognized provider reasons to it, and
-					// ParseMessage is the only place the output schema is
-					// enforced, so skipping it on an unclassified reason would
-					// silently drop validation for output the model may well
-					// have completed.
-					logger.Warn(ctx, "model finished abnormally, skipping output parsing",
-						"model", opts.Model,
-						"finishReason", resp.FinishReason,
-						"finishMessage", resp.FinishMessage)
-				default:
-					// This is legacy behavior. New format handlers should implement ParseMessage as a passthrough.
-					resp.Message, err = formatHandler.ParseMessage(resp.Message)
-					if err != nil {
-						logger.Debug(ctx, "model output does not match the expected schema", "model", opts.Model, "error", err)
-						return nil, status.Errorf(status.ErrInvalidOutput, "model failed to generate output matching expected schema: %w", err)
-					}
-				}
-			}
-
-			if len(resp.ToolRequests()) == 0 || opts.ReturnToolRequests {
-				return resp, nil
-			}
-
-			if currentTurn+1 > maxTurns {
-				return nil, status.Errorf(ErrMaxTurnsExceeded, "exceeded maximum tool call iterations (%d)", maxTurns)
-			}
-
-			newReq, interruptMsg, err := handleToolRequests(ctx, r, req, resp, wrappedCb, currentIndex, runTool)
-			if err != nil {
-				return nil, err
-			}
-			if interruptMsg != nil {
-				logger.Debug(ctx, "generation paused by tool interrupts", "model", opts.Model, "turn", currentTurn)
-				resp.FinishReason = "interrupted"
-				resp.FinishMessage = "One or more tool calls resulted in interrupts."
-				resp.Message = interruptMsg
-				return resp, nil
-			}
-			if newReq == nil {
-				return resp, nil
-			}
-
-			return generate(ctx, newReq, currentTurn+1, currentIndex+1)
-		})
+		return tracing.RunInNewSpan(ctx, spanMetadata, spanInput,
+			func(ctx context.Context, _ *GenerateActionOptions) (*ModelResponse, error) {
+				return runTurn(ctx, params)
+			})
 	}
 
 	// Compose WrapGenerate hooks once; this chain is invoked for every
@@ -644,7 +663,9 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 
 	generate = func(ctx context.Context, req *ModelRequest, currentTurn int, messageIndex int) (*ModelResponse, error) {
 		return hookedGenerate(ctx, &GenerateParams{
-			Options:      opts,
+			// The hooks get their own copy of the options: a hook writing to
+			// it must reach neither the loop nor the turns after it.
+			Options:      turnOptions(opts),
 			Request:      req,
 			Iteration:    currentTurn,
 			MessageIndex: messageIndex,
@@ -667,6 +688,18 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 	logger.Debug(ctx, "generate request resolved", resolvedArgs...)
 
 	return generate(ctx, req, 0, 0)
+}
+
+// turnOptions returns a per-turn copy of opts for the WrapGenerate hooks and
+// the turn's span. Messages and Resume are the fields the loop reads back, so
+// the copy detaches both; everything else is shared.
+func turnOptions(opts *GenerateActionOptions) *GenerateActionOptions {
+	turn := *opts
+	if turn.Resume != nil {
+		resume := *turn.Resume
+		turn.Resume = &resume
+	}
+	return &turn
 }
 
 // middlewareNames returns the names of the resolved middleware in chain
@@ -1417,10 +1450,13 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 		}
 	}
 
-	newReq := req
+	// The next turn gets its own request value: appending to the current one
+	// would retroactively grow the request a WrapModel or WrapGenerate hook is
+	// still holding.
+	newReq := *req
 	newReq.Messages = append(slices.Clone(req.Messages), resp.Message, toolMsg)
 
-	return newReq, nil, nil
+	return &newReq, nil, nil
 }
 
 // Text returns the contents of the first candidate in a
@@ -2070,20 +2106,15 @@ func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateAc
 	}
 	revisedMessages := append(slices.Clone(messages), toolMessage)
 
+	// Copied rather than rebuilt field by field, so that a field added to
+	// GenerateActionOptions carries through a resume without being listed here.
+	revised := *genOpts
+	revised.Messages = revisedMessages
+	revised.Resume = nil // These directives have now been applied.
+
 	return &resumeOptionOutput{
-		revisedRequest: &GenerateActionOptions{
-			Model:              genOpts.Model,
-			Messages:           revisedMessages,
-			Tools:              genOpts.Tools,
-			MaxTurns:           genOpts.MaxTurns,
-			Config:             genOpts.Config,
-			ToolChoice:         genOpts.ToolChoice,
-			Docs:               genOpts.Docs,
-			ReturnToolRequests: genOpts.ReturnToolRequests,
-			Output:             genOpts.Output,
-			Use:                genOpts.Use,
-		},
-		toolMessage: toolMessage,
+		revisedRequest: &revised,
+		toolMessage:    toolMessage,
 	}, nil
 }
 

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -18,14 +18,17 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/registry"
 	test_utils "github.com/firebase/genkit/go/tests/utils"
@@ -3053,6 +3056,218 @@ func TestMediaParts(t *testing.T) {
 		var msg *Message
 		if parts := msg.MediaParts(); parts != nil {
 			t.Errorf("MediaParts() on nil message = %v, want nil", parts)
+		}
+	})
+}
+
+// generateSpanMessageCounts returns, sorted, the number of messages each
+// collected span named "generate" recorded as its input.
+func generateSpanMessageCounts(t *testing.T, c *spanCollector) []int {
+	t.Helper()
+	var counts []int
+	for _, s := range c.allByName("generate") {
+		input, ok := spanAttr(s, "genkit:input")
+		if !ok {
+			t.Errorf("generate span recorded no input")
+			continue
+		}
+		var decoded struct {
+			Messages []*Message `json:"messages"`
+		}
+		if err := json.Unmarshal([]byte(input), &decoded); err != nil {
+			t.Errorf("generate span input is not a request: %v", err)
+			continue
+		}
+		counts = append(counts, len(decoded.Messages))
+	}
+	slices.Sort(counts)
+	return counts
+}
+
+// TestGenerateSpanRecordsAccumulatedMessages checks that every tool-loop turn
+// opens a generate span recording the conversation as of that turn, not the
+// messages the call started with.
+func TestGenerateSpanRecordsAccumulatedMessages(t *testing.T) {
+	// Two tool calls and a final answer: three model calls in all, whose
+	// requests hold 1, 3, and 5 messages as each turn appends a model and a
+	// tool message. Through the action the counts are the same, since the
+	// action's own span stands in for the first turn's: a fourth count here
+	// would mean the two are duplicating each other.
+	const turns = 3
+	want := []int{1, 3, 5}
+
+	setup := func(t *testing.T) (api.Registry, *spanCollector) {
+		t.Helper()
+		r := newTestRegistry(t)
+		defineFakeModel(t, r, fakeModelConfig{
+			name:    "test/loopModel",
+			handler: loopingToolModel("myTool", turns-1),
+		})
+		defineTool(r, "myTool", "A test tool",
+			func(ctx *ToolContext, in map[string]any) (string, error) { return "ok", nil })
+		return r, collectSpans(t)
+	}
+
+	t.Run("through Generate", func(t *testing.T) {
+		r, spans := setup(t)
+
+		_, err := Generate(testCtx, r,
+			WithModelName("test/loopModel"),
+			WithPrompt("start"),
+			WithTools(LookupTool(r, "myTool")),
+		)
+		assertNoError(t, err)
+
+		if got := generateSpanMessageCounts(t, spans); !slices.Equal(got, want) {
+			t.Errorf("generate spans recorded %v messages, want %v", got, want)
+		}
+		// The loop's spans are annotated by type alone. A subtype would show
+		// up in their trace paths, and in every path built under them.
+		for _, s := range spans.allByName("generate") {
+			assertSpanAttr(t, s, "genkit:type", "util")
+			if got, ok := spanAttr(s, "genkit:metadata:subtype"); ok {
+				t.Errorf("generate span carries subtype %q, want none", got)
+			}
+		}
+	})
+
+	t.Run("through the generate action", func(t *testing.T) {
+		r, spans := setup(t)
+		action := DefineGenerateAction(testCtx, r)
+
+		_, err := action.Run(testCtx, &GenerateActionOptions{
+			Model:    "test/loopModel",
+			Messages: []*Message{NewUserTextMessage("start")},
+			Tools:    []string{"myTool"},
+		}, nil)
+		assertNoError(t, err)
+
+		if got := generateSpanMessageCounts(t, spans); !slices.Equal(got, want) {
+			t.Errorf("generate spans recorded %v messages, want %v", got, want)
+		}
+	})
+}
+
+// TestToolLoopLeavesEarlierRequestsAlone checks that each turn of the tool loop
+// works from its own request: middleware holds these, so reusing one would
+// retroactively add the next turn's messages to a request a hook read.
+func TestToolLoopLeavesEarlierRequestsAlone(t *testing.T) {
+	r := newTestRegistry(t)
+	var seen []*ModelRequest
+	defineFakeModel(t, r, fakeModelConfig{
+		name:    "test/loopModel",
+		handler: loopingToolModel("myTool", 2),
+	})
+	defineTool(r, "myTool", "A test tool",
+		func(ctx *ToolContext, in map[string]any) (string, error) { return "ok", nil })
+
+	recorder := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+		return &Hooks{
+			WrapModel: func(ctx context.Context, p *ModelParams, next ModelNext) (*ModelResponse, error) {
+				seen = append(seen, p.Request)
+				return next(ctx, p)
+			},
+		}, nil
+	})
+
+	_, err := Generate(testCtx, r,
+		WithModelName("test/loopModel"),
+		WithPrompt("start"),
+		WithTools(LookupTool(r, "myTool")),
+		WithUse(recorder),
+	)
+	assertNoError(t, err)
+
+	// One request per turn, each holding what the turn before it appended,
+	// still true once the whole loop has run.
+	want := []int{1, 3, 5}
+	if len(seen) != len(want) {
+		t.Fatalf("middleware saw %d requests, want %d", len(seen), len(want))
+	}
+	for i, n := range want {
+		if got := len(seen[i].Messages); got != n {
+			t.Errorf("request %d holds %d messages after the loop finished, want %d", i, got, n)
+		}
+	}
+}
+
+// interruptedForResume runs a generate that stops on a tool interrupt and
+// returns the registry, the tool, and the interrupted response, ready for a
+// resuming call.
+func interruptedForResume(t *testing.T) (api.Registry, Tool, *ModelResponse) {
+	t.Helper()
+	r := childRegistry(t)
+	tool := defineTool(r, "conditional", "A tool that interrupts on request",
+		func(ctx *ToolContext, in conditionalToolInput) (string, error) {
+			if in.Interrupt {
+				return "", ctx.Interrupt(&InterruptOptions{Metadata: map[string]any{"reason": "test"}})
+			}
+			return "processed: " + in.Value, nil
+		})
+	defineFakeModel(t, r, fakeModelConfig{
+		name:    "test/resumeModel",
+		handler: toolCallingModelHandler("conditional", map[string]any{"Value": "v", "Interrupt": true}, "done"),
+	})
+
+	res, err := Generate(testCtx, r, WithModelName("test/resumeModel"),
+		WithPrompt("go"), WithTools(tool))
+	assertNoError(t, err)
+	if res.FinishReason != "interrupted" {
+		t.Fatalf("setup: finish reason = %q, want %q", res.FinishReason, "interrupted")
+	}
+	return r, tool, res
+}
+
+// TestResumeCarriesOptionsForward checks the options the loop switches to once
+// a resumed call has replayed its tools. It reads them for the rest of the
+// call, so whatever the revised copy drops is lost from that point on.
+func TestResumeCarriesOptionsForward(t *testing.T) {
+	t.Run("keeps the caller's step name", func(t *testing.T) {
+		r, tool, res := interruptedForResume(t)
+		respond := tool.Respond(res.Message.Content[0], "answer", nil)
+		spans := collectSpans(t)
+
+		_, err := Generate(testCtx, r, WithModelName("test/resumeModel"),
+			WithMessages(res.History()...), WithTools(tool),
+			WithToolResponses(respond), WithStepName("myStep"))
+		assertNoError(t, err)
+
+		// Both turns are the caller's step, so neither may fall back to the default.
+		if got := len(spans.allByName("generate")); got != 0 {
+			t.Errorf("got %d spans named %q, want 0: every iteration is the named step", got, "generate")
+		}
+		if got := len(spans.allByName("myStep")); got != 2 {
+			t.Errorf("got %d spans named %q, want 2 (one per iteration)", got, "myStep")
+		}
+	})
+
+	t.Run("resume survives a hook writing to its options", func(t *testing.T) {
+		r, tool, res := interruptedForResume(t)
+		respond := tool.Respond(res.Message.Content[0], "answer", nil)
+
+		clobber := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+			return &Hooks{
+				WrapGenerate: func(ctx context.Context, p *GenerateParams, next GenerateNext) (*ModelResponse, error) {
+					if p.Options.Resume != nil {
+						p.Options.Resume.Respond = nil
+						p.Options.Resume.Restart = nil
+					}
+					return next(ctx, p)
+				},
+			}, nil
+		})
+
+		out, err := Generate(testCtx, r, WithModelName("test/resumeModel"),
+			WithMessages(res.History()...), WithTools(tool),
+			WithToolResponses(respond), WithUse(clobber))
+		assertNoError(t, err)
+
+		// The hook's writes land on its own copy, so the call resumes as usual.
+		if out.FinishReason == "interrupted" {
+			t.Error("call stayed interrupted: a hook's write to Options reached the loop")
+		}
+		if got := out.Text(); got != "done" {
+			t.Errorf("resumed response = %q, want %q", got, "done")
 		}
 	})
 }

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -49,9 +49,17 @@ type Hooks struct {
 
 // GenerateParams holds params for the WrapGenerate hook.
 type GenerateParams struct {
-	// Options is the original options passed to [Generate].
+	// Options is a per-turn copy of the options [Generate] was called with,
+	// for the settings Request does not carry: model name, turn limit, resume
+	// directives. Its Messages are the call's original ones; read
+	// Request.Messages for the conversation as of this turn. Treat it as
+	// read-only: the loop keeps its own copy, so writes here reach nothing.
+	// The copy is shallow, so values it points at are still shared.
 	Options *GenerateActionOptions
-	// Request is the current model request for this iteration, with accumulated messages.
+	// Request is the model request for this turn, with the messages
+	// accumulated so far. Replace it, or edit it in place, to change what the
+	// model receives. Each turn gets its own value, so an edit stays with this
+	// turn unless it lands on a message shared with the next.
 	Request *ModelRequest
 	// Iteration is the current tool-loop iteration (0-indexed).
 	Iteration int

--- a/go/ai/middleware_test.go
+++ b/go/ai/middleware_test.go
@@ -1284,3 +1284,48 @@ func TestMiddlewareHookLoggingDisabled(t *testing.T) {
 		t.Errorf("got %d log records with debug disabled, want 0", len(rec.records))
 	}
 }
+
+// TestWrapGenerateOptionsAreIsolatedPerIteration checks that a WrapGenerate
+// hook writing to its Options disturbs neither later turns nor their spans.
+func TestWrapGenerateOptionsAreIsolatedPerIteration(t *testing.T) {
+	r := newTestRegistry(t)
+	defineFakeModel(t, r, fakeModelConfig{
+		name:    "test/toolModel",
+		handler: toolCallingModelHandler("myTool", map[string]any{"value": "x"}, "done"),
+	})
+	var toolCalls int32
+	tool := defineCountingTool(t, r, "myTool", &toolCalls)
+	spans := collectSpans(t)
+
+	var seen []int
+	clobber := MiddlewareFunc(func(ctx context.Context) (*Hooks, error) {
+		return &Hooks{
+			WrapGenerate: func(ctx context.Context, p *GenerateParams, next GenerateNext) (*ModelResponse, error) {
+				seen = append(seen, len(p.Options.Messages))
+				p.Options.Messages = nil
+				p.Options.StepName = "clobbered"
+				return next(ctx, p)
+			},
+		}, nil
+	})
+
+	_, err := Generate(testCtx, r,
+		WithModelName("test/toolModel"),
+		WithPrompt("use it"),
+		WithTools(tool),
+		WithUse(clobber),
+	)
+	assertNoError(t, err)
+
+	// One tool call and a final answer; each turn sees the call's own message.
+	want := []int{1, 1}
+	if !slices.Equal(seen, want) {
+		t.Errorf("hook saw %v messages per iteration, want %v", seen, want)
+	}
+	if got := len(spans.allByName("clobbered")); got != 0 {
+		t.Errorf("got %d spans named %q, want 0: a hook's step name must not rename the loop's spans", got, "clobbered")
+	}
+	if got := len(spans.allByName("generate")); got != len(want) {
+		t.Errorf("got %d generate spans, want %d (one per iteration)", got, len(want))
+	}
+}

--- a/go/ai/testutil_test.go
+++ b/go/ai/testutil_test.go
@@ -90,6 +90,22 @@ func defineFakeModel(t *testing.T, r api.Registry, cfg fakeModelConfig) Model {
 	return defineModel(r, cfg.name, &ModelOptions{Supports: cfg.supports}, cfg.handler)
 }
 
+// loopingToolModel returns a handler that answers its first turns calls with a
+// tool request and the rest with text.
+func loopingToolModel(toolName string, turns int) func(context.Context, *ModelRequest, ModelStreamCallback) (*ModelResponse, error) {
+	call := 0
+	return func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+		call++
+		if call > turns {
+			return &ModelResponse{Request: req, Message: NewModelTextMessage("done")}, nil
+		}
+		return &ModelResponse{Request: req, Message: &Message{
+			Role:    RoleModel,
+			Content: []*Part{NewToolRequestPart(&ToolRequest{Name: toolName, Input: map[string]any{"n": call}})},
+		}}, nil
+	}
+}
+
 // echoModelHandler creates a handler that echoes back information about the request.
 // Useful for verifying that options are properly passed through.
 func echoModelHandler() func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {

--- a/go/core/tracing/tracing.go
+++ b/go/core/tracing/tracing.go
@@ -244,11 +244,11 @@ func RunInNewSpan[I, O any](
 		parentPath = parentSM.Path
 	}
 
-	// Build path with type annotations to maintain compatibility with TypeScript telemetry format
+	// Build path with type annotations to maintain compatibility with the
+	// TypeScript telemetry format: a flow is annotated by its subtype, every
+	// other span by its type, then its subtype when it has one.
 	if metadata.Subtype == "flow" {
 		sm.Path = buildAnnotatedPath(metadata.Name, parentPath, "flow")
-	} else if metadata.Subtype == "util" {
-		sm.Path = buildAnnotatedPath(metadata.Name, parentPath, "util")
 	} else {
 		sm.Path = buildAnnotatedPath(metadata.Name, parentPath, metadata.Type)
 		if metadata.Subtype != "" {

--- a/go/core/tracing/tracing_test.go
+++ b/go/core/tracing/tracing_test.go
@@ -379,6 +379,31 @@ func TestRunInNewSpanWithMetadata(t *testing.T) {
 			expectedPath:    "/{generate,t:action,s:model}",
 		},
 		{
+			name:     "Util span",
+			spanName: "generate",
+			isRoot:   true,
+			metadata: &SpanMetadata{
+				Name: "generate",
+				Type: "util", // A tool-loop turn: no subtype, so nothing follows the type.
+			},
+			expectedType:    "util",
+			expectedSubtype: "",
+			expectedPath:    "/{generate,t:util}",
+		},
+		{
+			name:     "Util action span",
+			spanName: "generate",
+			isRoot:   true,
+			metadata: &SpanMetadata{
+				Name:    "generate",
+				Type:    "action", // /util/generate is an action first,
+				Subtype: "util",   // so util is its subtype, not its type.
+			},
+			expectedType:    "action",
+			expectedSubtype: "util",
+			expectedPath:    "/{generate,t:action,s:util}",
+		},
+		{
 			name:     "Nil metadata",
 			spanName: "testSpan",
 			isRoot:   true,


### PR DESCRIPTION
Every turn of the tool loop opened a `generate` span recording the options as the call received them, so after N tool calls the span still showed the original messages while the model span nested directly inside it showed the accumulated ones. Each turn's span now records the messages that turn sent, built after the `WrapGenerate` hooks so it reflects theirs. JS already behaves this way: `generateHelper` records the per-turn request, and the loop rebuilds that request each turn.

Four further defects in the same path:

**The `generate` action nested a duplicate span.** The action's own span already covers turn 0, and the loop opened a second `generate` span inside it with the same name, input, and output. `generateWithRequest` now takes `spanTurnZero`, false from the action. JS gets this structurally, calling `generateActionImpl` at turn 0 and recursing through `generateHelper` after.

**Every turn shared one `*ModelRequest`.** `handleToolRequests` aliased the previous turn's value and reassigned its `Messages`, so a `WrapModel` or `WrapGenerate` hook holding a request watched later turns' messages appear in it. Model functions never saw this, since `normalizeConfig` copies the request before they run.

**A resume dropped `StepName`.** `handleResumeOption` rebuilt `GenerateActionOptions` from `GenerateActionOptions` by listing 11 of 13 fields, and the loop reads the result for the rest of the call, so `WithStepName` was lost from the resume onward and later spans fell back to `generate`. It now copies the struct and clears `Resume`, so the next field added does not go missing too.

**Util-type actions lost `t:action` in their trace paths.** `RunInNewSpan` rewrote any span whose *subtype* was `util` to `t:util`, which caught `/util/generate`, whose type is `action` and subtype `util`. JS annotates by type, with `flow` as the single special case, and its own googlecloud feature extractor matches `t:(flow|action|prompt|dotprompt|helper)`, so a `t:util` first segment resolves to `<unknown>` there. The branch is gone, and the loop's own span no longer sets a redundant `util` subtype, leaving its path unchanged.

`GenerateParams.Options` is now a per-turn copy rather than the loop's own pointer, which a hook could write to and rename every later span or clear `Resume` mid-call. Its godoc states the contract: read-only, `Messages` are the call's original ones, and `Request.Messages` is the conversation as of this turn.

One cost worth knowing: a generate span now carries the same messages as the model span inside it, so trace payload for a tool loop roughly doubles. JS has the same property, and removing the action's duplicate turn-0 span offsets part of it.
