### PR TITLE
feat(py): add Message.media as first-or-null

### DIFF
--- a/py/packages/genkit-amazon-bedrock/README.md
+++ b/py/packages/genkit-amazon-bedrock/README.md
@@ -299,7 +299,7 @@ response = await ai.generate(
     model='bedrock/stability.sd3-5-large-v1:0',
     prompt='A tabby cat asleep on a sunlit windowsill, watercolour.',
 )
-image = response.media[0].url  # data:image/png;base64,...
+image = response.media.url  # data:image/png;base64,...
 ```
 
 Declaring is optional here too. An undeclared ID in one of the two families

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -200,7 +200,7 @@ class ModelRef(Generic[ModelRefConfigT]):
 
 
 class Message(MessageData):
-    """Message wrapper with utility properties for text and tool requests."""
+    """Message wrapper with utility properties for text, media, and tool requests."""
 
     def __init__(
         self,
@@ -241,6 +241,11 @@ class Message(MessageData):
     def text(self) -> str:
         """All text parts concatenated into a single string."""
         return text_from_message(self)
+
+    @cached_property
+    def media(self) -> Media | None:
+        """First media part, or None."""
+        return first_media(self.content)
 
     @cached_property
     def tool_requests(self) -> list[ToolRequestPart]:
@@ -567,15 +572,11 @@ class ModelResponse(GenkitModel, Generic[OutputT]):
         return self.message.tool_requests
 
     @cached_property
-    def media(self) -> list[Media]:
-        """All media parts in the response message."""
+    def media(self) -> Media | None:
+        """First media part in the response message, or None."""
         if self.message is None:
-            return []
-        return [
-            part.root.media
-            for part in self.message.content
-            if isinstance(part.root, MediaPart) and part.root.media is not None
-        ]
+            return None
+        return self.message.media
 
     @cached_property
     def interrupts(self) -> list[ToolRequestPart]:
@@ -672,6 +673,14 @@ def text_from_message(msg: Message) -> str:
 def text_from_content(content: Sequence[Part | DocumentPart]) -> str:
     """Concatenate text from a list of parts."""
     return ''.join(str(p.root.text) for p in content if hasattr(p.root, 'text') and p.root.text is not None)
+
+
+def first_media(content: Sequence[Part | DocumentPart]) -> Media | None:
+    """The first media part, or None."""
+    for part in content:
+        if isinstance(part.root, MediaPart) and part.root.media is not None:
+            return part.root.media
+    return None
 
 
 def get_basic_usage_stats(input_: list[Message], response: Message) -> GenerationUsage:

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -15,6 +15,7 @@ from genkit._ai._model import text_from_content
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
     ActionMetadata,
+    DataPart,
     DocumentPart,
     Media,
     MediaPart,
@@ -44,6 +45,56 @@ def test_message_wrapper_text() -> None:
     )
 
     assert wrapper.text == 'hello world'
+
+
+def test_message_media_is_first_or_none() -> None:
+    """Test media property of Message: first part, or None."""
+    lone = Media(url='https://example.com/a.png', content_type='image/png')
+    msg = Message(
+        role='model',
+        content=[Part(root=MediaPart(media=lone))],
+    )
+    assert msg.media is lone
+    assert msg.media.url == 'https://example.com/a.png'
+    assert msg.text == ''
+
+    first = Media(url='https://example.com/first.jpg')
+    second = Media(url='https://example.com/second.jpg')
+    two = Message(
+        role='model',
+        content=[
+            Part(root=MediaPart(media=first)),
+            Part(root=MediaPart(media=second)),
+        ],
+    )
+    assert two.media is first
+    assert two.media.url == 'https://example.com/first.jpg'
+
+    text_only = Message(role='user', content=[Part(root=TextPart(text='hi'))])
+    assert text_only.media is None
+
+    data_only = Message(role='model', content=[Part(root=DataPart(data={'k': 1}))])
+    assert data_only.media is None
+
+
+def test_model_response_media_is_first_or_none() -> None:
+    """Test media property of ModelResponse: first part, or None."""
+    empty = ModelResponse(message=None)
+    assert empty.media is None
+
+    pic = Media(url='https://example.com/out.png', content_type='image/png')
+    extra = Media(url='https://example.com/extra.png')
+    resp = ModelResponse(
+        message=Message(
+            role='model',
+            content=[
+                Part(root=MediaPart(media=pic)),
+                Part(root=MediaPart(media=extra)),
+            ],
+        )
+    )
+    assert resp.media is pic
+    assert resp.media.url == 'https://example.com/out.png'
 
 
 def test_response_wrapper_text() -> None:

--- a/py/samples/amazon-bedrock-sample/src/main.py
+++ b/py/samples/amazon-bedrock-sample/src/main.py
@@ -658,14 +658,14 @@ async def generate_image(data: ImageInput) -> dict[str, object]:
         config={'aspect_ratio': data.aspect_ratio, 'output_format': data.output_format},
     )
     media = response.media
-    if not media:
+    if media is None:
         raise RuntimeError(f'Bedrock returned no images for {data.model}.')
-    url = media[0].url
+    url = media.url
     _, _, payload = url.partition(',')
     return {
         'model': data.model,
-        'images': len(media),
-        'content_type': media[0].content_type,
+        'images': 1,
+        'content_type': media.content_type,
         'approx_kilobytes': round(len(payload) * 3 / 4 / 1024),
         'data_url_preview': f'{url[:48]}...',
     }


### PR DESCRIPTION
## Summary
- Add `Message.media` on the Python `Message` type so callers can read the image on a message without scanning `content`. The accessor is the first media part, or `None` — same shape as JS (`message.media.url`).

  ```python
  msg.media          # Media | None
  msg.media.url      # works when present
  ```

- `AgentResponse.media` is already this (`first_media_of`). `Document.media` stays a list (JS `Document.media` is a list too).
- **Behavior change:** `ModelResponse.media` was a `list[Media]` (empty list when `message` is `None`). It is now first-or-null (`Media | None`) so `response.media.url` matches JS `GenerateResponse.media`. Anyone iterating `response.media` needs to scan `content` (or a future `media_parts`) instead.

Fixes #6097

## Test plan
- [x] Lone `MediaPart` → `message.media` is that `Media`, `message.text == ''`
- [x] Two media parts → first only
- [x] Text-only / data-only → `None`
- [x] `ModelResponse.media` is that first part when a message is present; `None` when `message` is `None`
- [x] `Document.media` remains a list
- [ ] CLA check