### PR TITLE
feat(mcp): support remote headers

### DIFF
--- a/js/plugins/mcp/README.md
+++ b/js/plugins/mcp/README.md
@@ -74,7 +74,64 @@ The `createMcpHost` function initializes a `GenkitMcpHost` instance, which handl
             -   **`args`**: (optional, string[]) Array of string arguments to pass to the command.
             -   **`env`**: (optional, Record<string, string>) Key-value object of environment variables.
         -   **`url`**: (string) The URL of a remote server to connect to using the Streamable HTTP MCP transport.
+        -   **`headers`**: (optional, HeadersInit) Headers sent with every Streamable HTTP request.
+        -   **`requestInit`**: (optional, RequestInit) Additional Streamable HTTP request options.
+        -   **`authProvider`**: (optional, OAuthClientProvider) An MCP OAuth provider.
         -   **`transport`**: An existing MCP transport object for connecting to the server.
+
+
+### Authenticated remote servers
+
+Use `headers` for a fixed credential. Read secrets from the environment. This
+example connects Genkit to the Xquik API MCP server:
+
+```ts
+import { createMcpClient } from '@genkit-ai/mcp';
+
+const apiKey = process.env.XQUIK_API_KEY;
+if (!apiKey) throw new Error('XQUIK_API_KEY is required');
+
+const xquik = createMcpClient({
+  name: 'xquik',
+  mcpServer: {
+    url: 'https://xquik.com/mcp',
+    headers: { 'x-api-key': apiKey },
+  },
+});
+```
+
+Xquik is a third-party service. See its
+[MCP documentation](https://docs.xquik.com/mcp/overview) for authentication and
+available tools.
+
+Treat each client as one authorization context. Create and close a client per
+request when access tokens differ between users. Reuse the Genkit instance:
+
+```ts
+async function generateWithRemoteTools(accessToken: string, prompt: string) {
+  const client = createMcpClient({
+    name: 'remote',
+    mcpServer: {
+      url: 'https://example.com/mcp',
+      headers: { authorization: `Bearer ${accessToken}` },
+    },
+  });
+
+  try {
+    await client.ready();
+    return await ai.generate({
+      prompt,
+      tools: await client.getActiveTools(ai),
+    });
+  } finally {
+    await client.disable();
+  }
+}
+```
+
+Use `requestInit.headers` for advanced Fetch configuration. Top-level
+`headers` override duplicate names from `requestInit.headers`. Use
+`authProvider` when the server supports MCP OAuth.
 
 
 ## MCP Client (Single Server)

--- a/js/plugins/mcp/src/client/client.ts
+++ b/js/plugins/mcp/src/client/client.ts
@@ -63,6 +63,8 @@ export type McpStdioServerConfig = StdioServerParameters & {
 
 export type McpStreamableHttpConfig = {
   url: string;
+  /** Headers sent with every Streamable HTTP request. */
+  headers?: HeadersInit;
   command?: never;
   transport?: never;
 } & Omit<StreamableHTTPClientTransportOptions, 'sessionId'>;

--- a/js/plugins/mcp/src/util/transport.ts
+++ b/js/plugins/mcp/src/util/transport.ts
@@ -17,6 +17,15 @@
 import { McpServerConfig } from '../client/client.js';
 import type { StdioServerParameters, Transport } from '../client/index.js';
 
+function mergeHeaders(
+  requestHeaders: HeadersInit | undefined,
+  configHeaders: HeadersInit
+): Headers {
+  const headers = new Headers(requestHeaders);
+  new Headers(configHeaders).forEach((value, key) => headers.set(key, value));
+  return headers;
+}
+
 /**
  * Creates an MCP transport instance based on the provided server configuration.
  * It supports creating SSE, Stdio, or using a pre-configured custom transport.
@@ -39,13 +48,19 @@ export async function transportFrom(
   }
   // Handle SSE config
   if ('url' in config && config.url) {
-    const { url, ...httpConfig } = config;
+    const { headers, url, ...httpConfig } = config;
     const { StreamableHTTPClientTransport } = await import(
       '@modelcontextprotocol/sdk/client/streamableHttp.js'
     );
     return {
       transport: new StreamableHTTPClientTransport(new URL(url), {
         ...httpConfig,
+        requestInit: headers
+          ? {
+              ...httpConfig.requestInit,
+              headers: mergeHeaders(httpConfig.requestInit?.headers, headers),
+            }
+          : httpConfig.requestInit,
         sessionId,
       }),
       type: 'http',

--- a/js/plugins/mcp/src/util/transport.ts
+++ b/js/plugins/mcp/src/util/transport.ts
@@ -20,10 +20,12 @@ import type { StdioServerParameters, Transport } from '../client/index.js';
 function mergeHeaders(
   requestHeaders: HeadersInit | undefined,
   configHeaders: HeadersInit
-): Headers {
+): Record<string, string> {
   const headers = new Headers(requestHeaders);
   new Headers(configHeaders).forEach((value, key) => headers.set(key, value));
-  return headers;
+  const merged: Record<string, string> = {};
+  headers.forEach((value, key) => (merged[key] = value));
+  return merged;
 }
 
 /**

--- a/js/plugins/mcp/tests/transport_test.ts
+++ b/js/plugins/mcp/tests/transport_test.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import * as assert from 'assert';
+import express from 'express';
+import { genkit } from 'genkit';
+import getPort from 'get-port';
+import type { Server } from 'node:http';
+import { describe, it } from 'node:test';
+import { createMcpClient } from '../src/index.js';
+
+describe('Streamable HTTP transport', () => {
+  it('sends configured headers and overrides requestInit duplicates', async () => {
+    const receivedHeaders: express.Request['headers'][] = [];
+    const servers: McpServer[] = [];
+    const app = express();
+    app.use(express.json());
+    app.post('/mcp', async (request, response) => {
+      receivedHeaders.push(request.headers);
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+      });
+      const server = new McpServer({
+        name: 'test-server',
+        version: '1.0.0',
+      });
+      servers.push(server);
+      server.tool('test_tool', {}, async () => ({
+        content: [{ type: 'text', text: 'ok' }],
+      }));
+      await server.connect(transport);
+      await transport.handleRequest(request, response, request.body);
+    });
+    app.get('/mcp', (request, response) => {
+      receivedHeaders.push(request.headers);
+      response.status(405).end();
+    });
+    app.delete('/mcp', (request, response) => {
+      receivedHeaders.push(request.headers);
+      response.status(405).end();
+    });
+
+    const port = await getPort();
+    const httpServer = await new Promise<Server>((resolve) => {
+      const listener = app.listen(port, () => resolve(listener));
+    });
+    const ai = genkit({});
+    const client = createMcpClient({
+      name: 'authenticated-remote',
+      mcpServer: {
+        url: `http://localhost:${port}/mcp`,
+        requestInit: {
+          headers: {
+            authorization: 'Bearer stale',
+            'x-request-source': 'request-init',
+          },
+        },
+        headers: {
+          authorization: 'Bearer current',
+          'x-api-key': 'test-key',
+        },
+      },
+    });
+
+    try {
+      await client.ready();
+      const tools = await client.getActiveTools(ai);
+
+      assert.deepStrictEqual(
+        tools.map((tool) => tool.__action.name),
+        ['test-server/test_tool']
+      );
+      assert.ok(receivedHeaders.length >= 2);
+      for (const headers of receivedHeaders) {
+        assert.strictEqual(headers.authorization, 'Bearer current');
+        assert.strictEqual(headers['x-api-key'], 'test-key');
+        assert.strictEqual(headers['x-request-source'], 'request-init');
+      }
+    } finally {
+      await client.disable();
+      await Promise.all(servers.map((server) => server.close()));
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- accept top-level headers for Streamable HTTP MCP clients
- merge them with `requestInit.headers`, with top-level values taking precedence
- document fixed credentials and request-scoped authorization contexts
- add a remote Xquik API MCP example using its published endpoint

Fixes #3161.

## Context

Remote MCP servers often require an API key or bearer token. The underlying MCP
transport accepts Fetch options, but Genkit did not expose a direct `headers`
configuration. Applications also lacked guidance for tokens that vary by user.

This change keeps one Genkit instance while creating one MCP client per
authorization context. That prevents one user's credentials or transport state
from being shared with another user.

## Test coverage

- `pnpm format:check`
- `pnpm --dir js --filter @genkit-ai/mcp... test`
- `pnpm --dir js --filter @genkit-ai/mcp... build`
- read-only interoperability check against the public Xquik Docs MCP endpoint

The new transport test starts a local Streamable HTTP server. It verifies that
headers reach each request, existing Fetch headers survive, and top-level values
override duplicates.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Description includes context, the issue link, and new API examples
- [x] Tests pass
- [x] README updated
