### PR TITLE
fix(js/plugins/compat-oai): swap inverted 401/403 to Genkit status mapping

### DIFF
--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -723,10 +723,10 @@ export function openAIModelRunner(
             status = 'RESOURCE_EXHAUSTED';
             break;
           case 401:
-            status = 'PERMISSION_DENIED';
+            status = 'UNAUTHENTICATED';
             break;
           case 403:
-            status = 'UNAUTHENTICATED';
+            status = 'PERMISSION_DENIED';
             break;
           case 400:
             status = 'INVALID_ARGUMENT';

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -1939,7 +1939,7 @@ describe('openAIModelRunner', () => {
         })
       ).rejects.toThrow(
         expect.objectContaining({
-          status: 'PERMISSION_DENIED',
+          status: 'UNAUTHENTICATED',
           message: expect.stringContaining('Incorrect API key provided'),
         })
       );
@@ -1958,7 +1958,7 @@ describe('openAIModelRunner', () => {
         })
       ).rejects.toThrow(
         expect.objectContaining({
-          status: 'PERMISSION_DENIED',
+          status: 'UNAUTHENTICATED',
           message: expect.stringContaining('Incorrect API key provided'),
         })
       );
@@ -1976,6 +1976,26 @@ describe('openAIModelRunner', () => {
           {}
         ),
         expectedStatus: 'RESOURCE_EXHAUSTED',
+      },
+      {
+        name: '401',
+        error: new APIError(
+          401,
+          { error: { message: 'Incorrect API key provided' } },
+          '',
+          {}
+        ),
+        expectedStatus: 'UNAUTHENTICATED',
+      },
+      {
+        name: '403',
+        error: new APIError(
+          403,
+          { error: { message: 'Project does not have access' } },
+          '',
+          {}
+        ),
+        expectedStatus: 'PERMISSION_DENIED',
       },
       {
         name: '400',


### PR DESCRIPTION
Fixes #6150.

`openAIModelRunner`'s APIError mapping had 401 and 403 swapped: 401 Unauthorized (not authenticated) mapped to `PERMISSION_DENIED` and 403 Forbidden (authenticated, not allowed) to `UNAUTHENTICATED` - the reverse of their HTTP semantics.

Concrete effect: a bad or missing OpenAI API key (401) surfaced as `PERMISSION_DENIED`, which Genkit maps back to HTTP 403 at flow boundaries, pointing callers at permissions instead of credentials; any handler branching on `UNAUTHENTICATED` (e.g. to refresh credentials) never fired. Affects every provider built on `@genkit-ai/compat-oai` (openai, xai, deepseek).

Two-line swap plus tests: the two invalid-apiKey fake-server tests now expect `UNAUTHENTICATED`, and 401/403 rows are added to the error-mapping table.

Kept separate from the Responses API stack (#6002) since it changes observable error statuses on the existing Chat Completions path.
