### PR TITLE
fix(go/core): prefer a committed bidi result over the caller's cancellation

### DIFF
--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -3661,11 +3661,7 @@ func TestAgent_Detach_SuppressesChunksFromTheDetachedTurn(t *testing.T) {
 	// cannot finish before the turn has emitted. That is the ordering that
 	// used to leak chunks onto the wire.
 	reg := newTestRegistry(t)
-	store := &blockingSaveStore[testState]{
-		testInMemStore: newTestInMemStore[testState](),
-		entered:        make(chan struct{}),
-		release:        make(chan struct{}),
-	}
+	store := newBlockingSaveStore[testState]()
 
 	emitted := make(chan struct{})
 	af := DefineCustomAgent(reg, "detachSuppressesChunks",
@@ -3961,6 +3957,84 @@ func TestAgent_Detach_ClientDisconnectBeforeDetachCancels(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("fn did not exit after client cancel")
 	}
+}
+
+// TestAgent_Detach_CommitSurvivesClientDeadline is the other side of that
+// guard. Once the runtime reads the detach directive the invocation is
+// committed: the pending row is written on a context.WithoutCancel, the
+// background goroutines own the turn, and the snapshot ID handed back is the
+// only handle to the work. A client context that dies inside that window must
+// not turn the handoff into an error. It used to, because the bidi framework
+// adopted the connection context's cancel cause as the session's error
+// whenever the function itself reported none, and a delegating caller reads
+// that error as a failed launch: the sub-agent keeps running with nothing
+// tracking or aborting it.
+func TestAgent_Detach_CommitSurvivesClientDeadline(t *testing.T) {
+	reg := newTestRegistry(t)
+	store := newBlockingSaveStore[testState]()
+
+	// The turn outlives the handoff, so the pending row is the only write the
+	// gate below can catch. Released on every exit path: a failed assertion
+	// must not leave the turn (and the runtime goroutines behind it) parked
+	// for the rest of the run.
+	turnRelease := make(chan struct{})
+	releaseTurn := sync.OnceFunc(func() { close(turnRelease) })
+	t.Cleanup(releaseTurn)
+	af := DefineCustomAgent(reg, "detachDeadline",
+		func(ctx context.Context, resp Responder, sess *SessionRunner[testState]) (*AgentResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+				<-turnRelease
+				return nil, nil
+			})
+		},
+		WithSessionStore[testState](store),
+	)
+
+	// Cancelled with the cause a lapsed deadline carries: the cause is what
+	// the framework mistook for an abort of its own, and firing it on the
+	// gate pins it inside the commit window instead of guessing a wall-clock
+	// timeout against the directive read.
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	go func() {
+		<-store.entered
+		cancel(context.DeadlineExceeded)
+		close(store.release)
+	}()
+
+	input, err := json.Marshal(&AgentInput{Detach: true, Message: ai.NewUserTextMessage("go")})
+	if err != nil {
+		t.Fatalf("marshal input: %v", err)
+	}
+	// The one-shot JSON path, which is how a delegating caller launches a
+	// background sub-agent.
+	res, err := af.RunBidiJSON(ctx, input, nil, nil)
+	if err != nil {
+		t.Fatalf("RunBidiJSON: %v, want the detached output", err)
+	}
+	var out AgentOutput[testState]
+	if err := json.Unmarshal(res.Result, &out); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if out.FinishReason != AgentFinishReasonDetached {
+		t.Errorf("FinishReason = %q, want %q", out.FinishReason, AgentFinishReasonDetached)
+	}
+	if out.SnapshotID == "" {
+		t.Fatal("SnapshotID is empty, want the pending snapshot's ID")
+	}
+	// The gate is what puts the cancellation inside the commit window. If a
+	// future store write lands ahead of the pending row, the gate parks on
+	// that instead and this test would pass while covering nothing.
+	if cause := context.Cause(ctx); !errors.Is(cause, context.DeadlineExceeded) {
+		t.Errorf("caller context cause = %v, want the deadline to have lapsed during the handoff", cause)
+	}
+
+	// The handle is good: the background work runs on and finalizes the row
+	// the caller was handed.
+	releaseTurn()
+	waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusCompleted
+	})
 }
 
 func TestAgent_ResumeFromErrorSnapshot_Rejected(t *testing.T) {
@@ -6854,6 +6928,14 @@ type blockingSaveStore[State any] struct {
 	once    sync.Once
 }
 
+func newBlockingSaveStore[State any]() *blockingSaveStore[State] {
+	return &blockingSaveStore[State]{
+		testInMemStore: newTestInMemStore[State](),
+		entered:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+}
+
 func (s *blockingSaveStore[State]) SaveSnapshot(
 	ctx context.Context,
 	id string,
@@ -6875,11 +6957,7 @@ func TestAgent_Detach_WaitsForInFlightTurnSnapshot(t *testing.T) {
 	// permanently break resume-by-session-ID), and the conversation stays
 	// in one session.
 	reg := newTestRegistry(t)
-	store := &blockingSaveStore[testState]{
-		testInMemStore: newTestInMemStore[testState](),
-		entered:        make(chan struct{}),
-		release:        make(chan struct{}),
-	}
+	store := newBlockingSaveStore[testState]()
 	af := defineLastGoodTestAgent(reg, "detachMidWrite", WithSessionStore[testState](store))
 
 	conn, err := af.Connect(context.Background())

--- a/go/core/bidi_action.go
+++ b/go/core/bidi_action.go
@@ -437,16 +437,18 @@ type BidiConnection[In, Out, Stream any] struct {
 	output   Out
 	err      error
 	ctx      context.Context
-	cancel   context.CancelCauseFunc
+	cancelFn context.CancelCauseFunc
+	abortErr error // guarded by mu: why the framework poisoned the session; see cancel
 	mu       sync.Mutex
 	closed   bool
 }
 
 // newBidiConnection creates an idle connection whose context derives from ctx.
 // The caller must start exactly one [BidiConnection.run] goroutine to operate
-// it. The context carries a cancel cause so that an abort reason (e.g. an
-// invalid inbound chunk poisoning the session) survives to Send/Receive/Output
-// instead of flattening to context.Canceled.
+// it. The context carries a cancel cause so that an abort reason recorded by
+// [BidiConnection.cancel] (e.g. an invalid inbound chunk poisoning the
+// session) reaches a function selecting on the context, rather than flattening
+// to context.Canceled.
 func newBidiConnection[In, Out, Stream any](ctx context.Context) *BidiConnection[In, Out, Stream] {
 	ctx, cancel := context.WithCancelCause(ctx)
 	return &BidiConnection[In, Out, Stream]{
@@ -454,8 +456,35 @@ func newBidiConnection[In, Out, Stream any](ctx context.Context) *BidiConnection
 		streamCh: make(chan Stream, 1),
 		doneCh:   make(chan struct{}),
 		ctx:      ctx,
-		cancel:   cancel,
+		cancelFn: cancel,
 	}
+}
+
+// cancel aborts the session, cancelling the action's context. A non-nil err
+// records why the framework poisoned this connection (an invalid inbound
+// chunk, a failed stream marshal, a callback error), which makes it the
+// session's terminal error; the first one recorded wins, as with the context's
+// own cause. The reason is recorded here rather than read back off the
+// connection context, whose cause the caller's own cancellation also sets; see
+// [BidiConnection.run].
+//
+// A reason must say what failed. Aborting without one (teardown,
+// [BidiConnection.Cancel]) passes nil, and a bare context.Canceled is the same
+// statement: it says only that someone stopped waiting, so it cancels the
+// context without becoming the session's error.
+//
+// Recording happens before the context is cancelled, and must stay that way:
+// cancelling first would let the action wake, return, and settle in run
+// against an abort reason this call has not stored yet, losing it.
+func (c *BidiConnection[In, Out, Stream]) cancel(err error) {
+	if err != nil && !errors.Is(err, context.Canceled) {
+		c.mu.Lock()
+		if c.abortErr == nil {
+			c.abortErr = err
+		}
+		c.mu.Unlock()
+	}
+	c.cancelFn(err)
 }
 
 // ctxErr returns the reason the connection's context was cancelled, preferring
@@ -506,17 +535,23 @@ func (c *BidiConnection[In, Out, Stream]) run(name string, fn func(context.Conte
 		closingStream = false
 	}()
 	output, err := fn(c.ctx)
+	c.mu.Lock()
 	// An abort recorded a cause (invalid inbound chunk, failed stream
 	// marshal, callback error): that cause is the session's terminal error.
 	// It overrides a nil error from a function that never observed the
 	// cancellation and the bare Canceled it unwound with, but not a distinct
 	// error the function chose to report.
-	if cause := context.Cause(c.ctx); cause != nil && !errors.Is(cause, context.Canceled) {
-		if err == nil || errors.Is(err, context.Canceled) {
-			err = cause
-		}
+	//
+	// Only a recorded abort qualifies. A cause that reached the connection
+	// through the caller's context (a deadline, a custom cancel cause) says
+	// the caller stopped waiting, not that this session failed: a function
+	// that committed its result anyway must return it. Discarding the result
+	// would strand work the caller can no longer reach, such as the snapshot
+	// ID a detached agent invocation returns for background work that is
+	// already running.
+	if c.abortErr != nil && (err == nil || errors.Is(err, context.Canceled)) {
+		err = c.abortErr
 	}
-	c.mu.Lock()
 	c.output = output
 	c.err = err
 	c.mu.Unlock()
@@ -674,9 +709,10 @@ func (c *BidiConnection[In, Out, Stream]) Output() (Out, error) {
 }
 
 // Cancel aborts the session by cancelling the connection's context: the
-// action's context is cancelled, blocked Sends unblock, and Output reports
-// the cancellation error unless the action already completed. Safe to call
-// multiple times and after completion.
+// action's context is cancelled and blocked Sends unblock. Output reports the
+// cancellation only while the action is still running; once it has returned,
+// Output reports its result, including from an action that ignored the cancel
+// and finished anyway. Safe to call multiple times and after completion.
 func (c *BidiConnection[In, Out, Stream]) Cancel() {
 	c.cancel(nil)
 }

--- a/go/core/bidi_action_test.go
+++ b/go/core/bidi_action_test.go
@@ -157,6 +157,87 @@ func TestSendReportsAbortWhileActionRuns(t *testing.T) {
 	})
 }
 
+// TestBidiCompletionSurvivesParentCancelCause extends completion over
+// cancellation to the result itself. When the function reports no error of
+// its own, run adopts a cause recorded against the connection: that is how an
+// invalid inbound chunk or a failed stream callback becomes the session's
+// error even though the function ignored the cancellation and returned
+// cleanly. The override used to read the cause off the connection context,
+// which also carries whatever cancelled the caller's context, so a deadline
+// or a custom cause that fired while the function was committing its result
+// replaced a success with a cancellation error. A plain Canceled cause was
+// already excluded; a deadline and a custom cause now behave the same way.
+//
+// The lost result is not always work the caller can repeat. A detached agent
+// invocation persists its pending snapshot on a context.WithoutCancel and
+// returns the snapshot ID while background goroutines carry the work; drop
+// that output and the work keeps running with no handle to track or abort it.
+func TestBidiCompletionSurvivesParentCancelCause(t *testing.T) {
+	// Commits only once the caller's context is done, which is the window
+	// the override used to corrupt.
+	commitAfterDone := func(ctx context.Context, _ struct{}, inCh <-chan string, outCh chan<- string) (string, error) {
+		<-ctx.Done()
+		return "committed", nil
+	}
+	connect := func(t *testing.T, ctx context.Context, fn BidiFunc[string, string, string, struct{}]) *BidiConnection[string, string, string] {
+		t.Helper()
+		conn, err := NewBidiActionOf(api.ActionTypeCustom, "commits", nil, fn).Connect(ctx, struct{}{})
+		if err != nil {
+			t.Fatalf("Connect() error = %v", err)
+		}
+		return conn
+	}
+	wantCommitted := func(t *testing.T, conn *BidiConnection[string, string, string]) {
+		t.Helper()
+		<-conn.Done()
+		out, err := conn.Output()
+		if err != nil {
+			t.Errorf("Output() error = %v, want the committed result", err)
+		}
+		if out != "committed" {
+			t.Errorf("Output() = %q, want %q", out, "committed")
+		}
+	}
+
+	t.Run("parent deadline", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		wantCommitted(t, connect(t, ctx, commitAfterDone))
+	})
+
+	t.Run("parent cancel cause", func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(context.Background())
+		conn := connect(t, ctx, commitAfterDone)
+		cancel(errors.New("caller gave up"))
+		wantCommitted(t, conn)
+	})
+
+	// The contrast: a cause the framework recorded against this connection
+	// still becomes the session's error, and still does so when the caller's
+	// context was cancelled first. The context keeps only the first cause, so
+	// reading the abort off the context would have surfaced the caller's.
+	t.Run("recorded abort still wins", func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+		conn := connect(t, ctx,
+			func(ctx context.Context, _ struct{}, inCh <-chan string, outCh chan<- string) (string, error) {
+				for range inCh {
+				}
+				return "committed", nil
+			})
+		abort := errors.New("stream callback failed")
+		cancel(errors.New("caller gave up"))
+		conn.cancel(abort)
+		if err := conn.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+		<-conn.Done()
+		if _, err := conn.Output(); !errors.Is(err, abort) {
+			t.Errorf("Output() error = %v, want the recorded abort %v", err, abort)
+		}
+	})
+}
+
 func TestBidiActionEcho(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Extends the completion-over-cancellation doctrine of #6110 to the result itself. Found reviewing #6118 and #6119, where the fix did not belong.

`BidiConnection.run` adopted `context.Cause(c.ctx)` as the session's error whenever the action function reported none of its own. That cause has two sources, and only one is a failure of the session: an abort the framework recorded through `conn.cancel(err)` (invalid inbound chunk, failed stream marshal, failed stream callback), or a cancellation inherited from the caller. A bare `context.Canceled` was already excluded, so a plain `WithCancel` caller was unaffected; a deadline or a custom cause replaced a successful result with the caller's error.

That result is not always repeatable work. A detached agent invocation persists its pending snapshot on a `context.WithoutCancel`, hands the turn to background goroutines, and returns an `AgentOutput` carrying the snapshot ID. A caller deadline lapsing in that window turned the handoff into an error, `runJSONWithTelemetry` dropped the `Result`, and the delegating caller saw a failed launch while the sub-agent kept running untracked and unabortable.

The connection now records the framework's own reason in a mutex-guarded field before cancelling, and `run` adopts only that. A reason must say what failed, so teardown and `Cancel` record nothing, and a bare `context.Canceled` is treated the same way: it cancels the context without becoming the session's error. `ctxErr` is unchanged, so `Send` and `Receive` still report the first thing that stopped the connection.

`Output` is deliberately left alone: it still adopts the caller's cause when the context dies before the action settles, so a `Connect`-based caller can lose a committed result. The one-shot path escapes by waiting on the done channel, which is what makes the detach handoff safe.