### PR TITLE
fix(py): allow tools with only a ToolRunContext parameter

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -20,12 +20,12 @@ import inspect
 import json
 from collections.abc import Callable
 from contextvars import ContextVar
-from typing import Any, cast
+from typing import Any, cast, get_type_hints
 
 from opentelemetry import trace as trace_api
 from pydantic import BaseModel
 
-from genkit._core._action import Action, ActionKind, ActionRunContext
+from genkit._core._action import Action, ActionKind, ActionRunContext, _is_context_annotation
 from genkit._core._error import GenkitError, GenkitInterrupt
 from genkit._core._middleware import GenerateMiddlewareContext
 from genkit._core._registry import Registry
@@ -361,6 +361,12 @@ def _define_tool(
 
     input_spec = inspect.getfullargspec(func)
 
+    try:
+        resolved_annotations = get_type_hints(func)
+    except (NameError, TypeError, AttributeError):
+        resolved_annotations = input_spec.annotations
+    arg_types = [resolved_annotations.get(arg, Any) for arg in input_spec.args]
+
     async def tool_fn_wrapper(*args: Any) -> Any:  # noqa: ANN401 - arity dispatch; args/return follow registered tool
         # Record resumed metadata on the current span for observability.
         resumed_meta = _tool_resumed_metadata.get()
@@ -371,22 +377,27 @@ def _define_tool(
                     span.set_attribute('genkit:metadata:resumed', json.dumps(resumed_meta))
                 except Exception:
                     span.set_attribute('genkit:metadata:resumed', str(resumed_meta))
+        original_input = _tool_original_input.get()
+
+        def tool_run_context(action_ctx: ActionRunContext) -> ToolRunContext:
+            return ToolRunContext(
+                action_ctx,
+                resumed_metadata=resumed_meta,
+                original_input=original_input,
+            )
 
         # Dynamic dispatch by arity; payload types follow the registered tool (not expressible here).
         match len(input_spec.args):
             case 0:
                 return await func()
             case 1:
+                if _is_context_annotation(arg_types[0]):
+                    return await func(tool_run_context(cast(ActionRunContext, args[0])))
                 return await func(args[0])
             case 2:
-                original_input = _tool_original_input.get()
                 return await func(
                     args[0],
-                    ToolRunContext(
-                        cast(ActionRunContext, args[1]),
-                        resumed_metadata=resumed_meta,
-                        original_input=original_input,
-                    ),
+                    tool_run_context(cast(ActionRunContext, args[1])),
                 )
             case _:
                 raise ValueError('tool must have 0-2 args...')

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -242,6 +242,16 @@ def _first_action_arg_has_default(input_spec: inspect.FullArgSpec, n_action_args
     return len(defaults) >= n_action_args
 
 
+def _is_context_annotation(annotation: Any) -> bool:  # noqa: ANN401 - annotations are arbitrary types
+    """Return True when ``annotation`` is ActionRunContext or a subclass.
+
+    Context parameters (e.g. the tool-only ``ToolRunContext``) receive runtime
+    state rather than action input, so they must not be treated as input
+    types when inferring schemas or dispatching arguments.
+    """
+    return isinstance(annotation, type) and issubclass(annotation, ActionRunContext)
+
+
 # =============================================================================
 # Action key utilities
 # =============================================================================
@@ -446,6 +456,7 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         self._fn: Callable[..., Awaitable[OutputT]] = fn
         self._n_action_args: int = len(action_args)
         self._action_arg_names: list[str] = action_args
+        self._arg_types: list[Any] = arg_types
         # When True, calling the action without an input is legal because the
         # wrapped function will fall back to its own Python-level default.
         self._first_arg_optional: bool = _first_action_arg_has_default(input_spec, len(action_args))
@@ -628,7 +639,8 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         if len(action_args) > 2:
             raise TypeError(f'can only have up to 2 args: {action_args}')
 
-        if len(action_args) > 0:
+        has_input = len(action_args) > 0 and not _is_context_annotation(arg_types[0])
+        if has_input:
             type_adapter = TypeAdapter(arg_types[0])
             self._input_schema: dict[str, object] = type_adapter.json_schema()
             self._input_type: TypeAdapter[InputT] | None = cast(TypeAdapter[InputT], type_adapter)
@@ -819,6 +831,8 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
             case 1:
                 if omit_input:
                     return await self._fn()
+                if _is_context_annotation(self._arg_types[0]):
+                    return await self._fn(ctx)
                 return await self._fn(input)
             case 2:
                 if omit_input:

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -248,8 +248,19 @@ def _is_context_annotation(annotation: Any) -> bool:  # noqa: ANN401 - annotatio
     Context parameters (e.g. the tool-only ``ToolRunContext``) receive runtime
     state rather than action input, so they must not be treated as input
     types when inferring schemas or dispatching arguments.
+
+    String annotations are handled too: when a user module enables
+    ``from __future__ import annotations`` (or ``get_type_hints`` fails and we
+    fall back to raw annotations), the annotation arrives as the class name.
     """
-    return isinstance(annotation, type) and issubclass(annotation, ActionRunContext)
+    if isinstance(annotation, type) and issubclass(annotation, ActionRunContext):
+        return True
+    if isinstance(annotation, str):
+        return annotation in ('ActionRunContext', 'ToolRunContext') or annotation.endswith((
+            '.ActionRunContext',
+            '.ToolRunContext',
+        ))
+    return False
 
 
 # =============================================================================
@@ -829,10 +840,10 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
             case 0:
                 return await self._fn()
             case 1:
-                if omit_input:
-                    return await self._fn()
                 if _is_context_annotation(self._arg_types[0]):
                     return await self._fn(ctx)
+                if omit_input:
+                    return await self._fn()
                 return await self._fn(input)
             case 2:
                 if omit_input:

--- a/py/packages/genkit/tests/genkit/ai/_tools_test.py
+++ b/py/packages/genkit/tests/genkit/ai/_tools_test.py
@@ -349,3 +349,103 @@ async def test_run_tool_after_restart_pipes_generate_context() -> None:
     await run_tool_after_restart(tool=action, restart_trp=restart_trp, ctx=mw_ctx)
 
     assert seen == [{'auth_role': 'admin'}]
+
+
+@pytest.mark.asyncio
+async def test_tool_with_only_tool_run_context_param_is_valid() -> None:
+    """Tool with ``ToolRunContext`` as its sole parameter defines and executes.
+
+    Regression for #4492: the parameter must not be treated as the tool's input
+    type (previously crashed with ``PydanticSchemaGenerationError``), and the
+    tool must receive a ``ToolRunContext`` instead of the raw input at runtime.
+    """
+    ai = Genkit()
+    seen: list[ToolRunContext] = []
+
+    @ai.tool(name='ctx_only')
+    async def get_user(ctx: ToolRunContext) -> str:
+        seen.append(ctx)
+        raw_user = ctx.context.get('user')
+        user_id = 0
+        if isinstance(raw_user, dict):
+            user_id = int(raw_user.get('id', 0))
+        if user_id == 42:
+            return 'User is Arthur Dent, an intergalactic traveler.'
+        return 'User is Guest.'
+
+    action = await ai.registry.resolve_action(kind=ActionKind.TOOL, name='ctx_only')
+    assert action is not None
+    # No input schema is inferred for a context-only parameter.
+    assert action.input_schema == {}
+    assert action.input_type is None
+
+    resp = await action.run(input={}, context={'user': {'id': 42}})
+    assert resp.response == 'User is Arthur Dent, an intergalactic traveler.'
+    assert len(seen) == 1
+    assert isinstance(seen[0], ToolRunContext)
+    assert seen[0].context == {'user': {'id': 42}}
+    assert seen[0].resumed_metadata is None
+
+
+@pytest.mark.asyncio
+async def test_run_tool_after_restart_with_ctx_only_tool() -> None:
+    """Context-only tools get resume metadata: ``metadata.resumed`` surfaces as ``resumed_metadata``."""
+    ai = Genkit()
+    captured: list[tuple[dict | None, object | None]] = []
+
+    @ai.tool(name='ctx_only_restart')
+    async def check(ctx: ToolRunContext) -> str:
+        captured.append((ctx.resumed_metadata, ctx.original_input))
+        return 'done'
+
+    action = await ai.registry.resolve_action(kind=ActionKind.TOOL, name='ctx_only_restart')
+    assert action is not None
+
+    restart_trp = ToolRequestPart(
+        tool_request=ToolRequest(name='ctx_only_restart', ref='x', input={}),
+        metadata={'resumed': True, 'replacedInput': {'old': True}},
+    )
+    await run_tool_after_restart(tool=action, restart_trp=restart_trp)
+
+    assert len(captured) == 1
+    assert captured[0][0] == {}
+    assert captured[0][1] == {'old': True}
+
+
+@pytest.mark.asyncio
+async def test_tool_with_input_and_context_params_unaffected() -> None:
+    """``(input, ctx)`` tools keep receiving the input and a ``ToolRunContext``."""
+    ai = Genkit()
+    seen: list[tuple[dict, ToolRunContext]] = []
+
+    @ai.tool(name='inp_ctx')
+    async def echo(inp: dict, ctx: ToolRunContext) -> str:
+        seen.append((inp, ctx))
+        return 'echoed'
+
+    action = await ai.registry.resolve_action(kind=ActionKind.TOOL, name='inp_ctx')
+    assert action is not None
+    assert action.input_schema.get('type') == 'object'
+
+    resp = await action.run(input={'msg': 'hi'}, context={'auth': 'role'})
+    assert resp.response == 'echoed'
+    assert len(seen) == 1
+    assert seen[0][0] == {'msg': 'hi'}
+    assert isinstance(seen[0][1], ToolRunContext)
+    assert seen[0][1].context == {'auth': 'role'}
+
+
+@pytest.mark.asyncio
+async def test_tool_with_single_input_param_unaffected() -> None:
+    """A tool with a single input parameter keeps receiving the raw input."""
+    ai = Genkit()
+
+    @ai.tool(name='echo_input')
+    async def echo_input(x: dict) -> dict:
+        return x
+
+    action = await ai.registry.resolve_action(kind=ActionKind.TOOL, name='echo_input')
+    assert action is not None
+
+    resp = await action.run({'a': 1})
+    assert resp.response == {'a': 1}

--- a/py/packages/genkit/tests/genkit/ai/_tools_test.py
+++ b/py/packages/genkit/tests/genkit/ai/_tools_test.py
@@ -413,6 +413,33 @@ async def test_run_tool_after_restart_with_ctx_only_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tool_with_only_tool_run_context_param_with_default() -> None:
+    """A context-only tool whose param has a default still gets a ``ToolRunContext``.
+
+    Regression for the case where ``_first_arg_optional`` is True: without
+    explicit input the dispatch must pass the context, not call the tool with
+    no arguments (previously hit ``IndexError`` in the tool wrapper).
+    """
+    ai = Genkit()
+    seen: list[ToolRunContext] = []
+
+    @ai.tool(name='ctx_only_default')
+    async def get_user(ctx: ToolRunContext = None) -> str:  # noqa: ARG001
+        if ctx is not None:
+            seen.append(ctx)
+        return 'done'
+
+    action = await ai.registry.resolve_action(kind=ActionKind.TOOL, name='ctx_only_default')
+    assert action is not None
+
+    resp = await action.run(input=None, context={'user': {'id': 42}})
+    assert resp.response == 'done'
+    assert len(seen) == 1
+    assert isinstance(seen[0], ToolRunContext)
+    assert seen[0].context == {'user': {'id': 42}}
+
+
+@pytest.mark.asyncio
 async def test_tool_with_input_and_context_params_unaffected() -> None:
     """``(input, ctx)`` tools keep receiving the input and a ``ToolRunContext``."""
     ai = Genkit()

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -17,6 +17,7 @@ from genkit._core._action import (
     ActionKind,
     ActionRunContext,
     DapQualifiedName,
+    _is_context_annotation,
     create_action_key,
     get_current_context,
     parse_action_key,
@@ -25,6 +26,10 @@ from genkit._core._action import (
 )
 from genkit._core._error import GenkitError
 from genkit._core._model import OutputConfig
+
+
+class _ToolRunContextLike(ActionRunContext):
+    """Minimal ``ActionRunContext`` subclass for annotation recognition tests."""
 
 
 def test_action_enum_behaves_like_str() -> None:
@@ -435,3 +440,17 @@ async def test_action_coerces_dict_config_from_other_request_type() -> None:
     assert result.response == 'ok'
     assert isinstance(seen['config'], PluginCfg)
     assert seen['config'].temperature == 0.5
+
+
+def test_is_context_annotation_class_and_string_forms() -> None:
+    """``_is_context_annotation`` recognizes context classes and their string annotations."""
+    assert _is_context_annotation(ActionRunContext)
+    assert _is_context_annotation(_ToolRunContextLike)
+    assert _is_context_annotation('ActionRunContext')
+    assert _is_context_annotation('genkit._core._action.ActionRunContext')
+    assert _is_context_annotation('ToolRunContext')
+    assert _is_context_annotation('genkit._ai._tools.ToolRunContext')
+    assert not _is_context_annotation(str)
+    assert not _is_context_annotation('str')
+    assert not _is_context_annotation('NotARealContext')
+    assert not _is_context_annotation(None)


### PR DESCRIPTION
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] PR description contains enough context, bug link, code samples for new APIs
- [x] Tested (manually, unit tested, etc.)
- [x] Docs/readmes updated

## What

Fixes #4492 — a tool whose sole parameter is typed `ToolRunContext` previously crashed at definition time with `PydanticSchemaGenerationError`, and would have received the raw tool input instead of a context at runtime.

## Changes

- `_core/_action.py`
  - New `_is_context_annotation()` helper: `True` when an annotation is `ActionRunContext` or a subclass (e.g. `ToolRunContext`).
  - `_initialize_io_schemas` now skips `ActionRunContext`-typed parameters when inferring the input schema — a context-only parameter is no longer fed to `TypeAdapter(...)`. Context-only tools expose an empty input schema, matching zero-argument tools.
  - `Action._invoke` (1-arg dispatch) passes the run context rather than the input when the sole parameter is context-typed.
- `_ai/_tools.py`
  - The tool wrapper resolves the user function's annotations and dispatches on them: for a sole `ToolRunContext` parameter it constructs a proper `ToolRunContext` (with resume metadata / original input) before calling the tool.
  - `(input, ctx)` and single-input tools are unchanged.

## Repro

```python
from genkit import Genkit, ToolRunContext

ai = Genkit()

@ai.tool()
async def get_user_data(ctx: ToolRunContext) -> str:
    raw_user = ctx.context.get('user')
    ...
```

Before: `PydanticSchemaGenerationError` at definition time. After: defines and runs, receiving the context.

## Tests

- `tests/genkit/ai/_tools_test.py`: added 4 tests
  - context-only tool defines with empty input schema and receives a `ToolRunContext` with the correct context;
  - restart flow on a context-only tool surfaces resume metadata;
  - regression: `(input, ctx)` tools;
  - regression: single-input tools.
- `_tools_test.py`: 21 passed.
- `tests/genkit/ai` + `tests/genkit/core`: 847 passed. (Two collection errors are pre-existing and unrelated — `tests/specs/*.yaml` is missing from the repo; `already failing on main`.)
- Lint: `ruff format --preview`, `ruff check --preview --unsafe-fixes`, and `ty check` all pass on the changed files.

## Docs

N/A — internal behavior fix; API reference pages under `py/docs` are autogenerated.