### PR TITLE
fix(js/plugins/google-genai): surface API errors from streaming responses

### DIFF
--- a/js/plugins/google-genai/src/common/utils.ts
+++ b/js/plugins/google-genai/src/common/utils.ts
@@ -21,6 +21,8 @@ import {
   JSONSchema,
   MediaPart,
   ModelReference,
+  StatusName,
+  StatusNameSchema,
   getClientHeader as defaultGetClientHeader,
   z,
 } from 'genkit';
@@ -346,6 +348,69 @@ export function cleanSchema(schema: JSONSchema): JSONSchema {
 }
 
 /**
+ * Maps an HTTP status code to the corresponding Genkit `StatusName`.
+ *
+ * @param code The HTTP status code.
+ * @returns The matching `StatusName`, or `'UNKNOWN'` if there is no mapping.
+ */
+export function httpStatusToGenkitStatus(code?: number): StatusName {
+  switch (code) {
+    case 400:
+      return 'INVALID_ARGUMENT';
+    case 401:
+      return 'UNAUTHENTICATED';
+    case 403:
+      return 'PERMISSION_DENIED';
+    case 404:
+      return 'NOT_FOUND';
+    case 429:
+      return 'RESOURCE_EXHAUSTED';
+    case 499:
+      return 'CANCELLED';
+    case 500:
+      return 'INTERNAL';
+    case 503:
+      return 'UNAVAILABLE';
+    case 504:
+      return 'DEADLINE_EXCEEDED';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+/**
+ * Builds an error for leftover, unparsed stream text. When the model API is
+ * overloaded (or otherwise fails), it may return HTTP 200 with a plain JSON
+ * error body instead of SSE `data:` frames. In that case we surface a proper
+ * `GenkitError` with the correct status so downstream middleware (e.g. retry)
+ * can react appropriately, rather than a generic parse error.
+ *
+ * @param text The leftover text that could not be parsed as a stream chunk.
+ * @returns A `GenkitError` if the text is a recognizable API error body,
+ *  otherwise a generic `Error`.
+ */
+export function parseStreamErrorText(text: string): Error {
+  try {
+    const json = JSON.parse(text);
+    const apiError = json?.error;
+    if (apiError && (apiError.code || apiError.status)) {
+      const status: StatusName = StatusNameSchema.safeParse(apiError.status)
+        .success
+        ? (apiError.status as StatusName)
+        : httpStatusToGenkitStatus(apiError.code);
+      return new GenkitError({
+        status,
+        message: apiError.message || 'Error streaming from the model',
+        detail: json,
+      });
+    }
+  } catch (e) {
+    // Not JSON or not a recognizable error body, fall through to generic error.
+  }
+  return new Error('Failed to parse stream: ' + text);
+}
+
+/**
  * Processes the streaming body of a Response object. It decodes the stream as
  * UTF-8 text, parses JSON objects from specially formatted lines (e.g., "data: {}"),
  * and returns both an async generator for individual responses and a promise
@@ -365,9 +430,15 @@ export function processStream(response: Response): GenerateContentStreamResult {
   );
   const responseStream = getResponseStream(inputStream);
   const [stream1, stream2] = responseStream.tee();
+  const responsePromise = getResponsePromise(stream2);
+  // Attach a no-op catch so that if the caller only consumes `stream` and it
+  // errors before `response` is ever awaited, the teed response promise does
+  // not become an unhandled rejection (which would crash the process). This
+  // does not swallow the rejection for a real awaiter of `response`.
+  responsePromise.catch(() => {});
   return {
     stream: generateResponseSequence(stream1),
-    response: getResponsePromise(stream2),
+    response: responsePromise,
   };
 }
 
@@ -387,7 +458,7 @@ function getResponseStream(
             if (done) {
               reader.releaseLock();
               if (currentText.trim()) {
-                controller.error(new Error('Failed to parse stream'));
+                controller.error(parseStreamErrorText(currentText));
                 return;
               }
               controller.close();

--- a/js/plugins/google-genai/src/common/utils.ts
+++ b/js/plugins/google-genai/src/common/utils.ts
@@ -393,21 +393,35 @@ export function parseStreamErrorText(text: string): Error {
   try {
     const json = JSON.parse(text);
     const apiError = json?.error;
-    if (apiError && (apiError.code || apiError.status)) {
+    if (
+      apiError &&
+      typeof apiError === 'object' &&
+      (apiError.code || apiError.status)
+    ) {
+      // Coerce `code` to a number so a stringified code (e.g. "503") still maps.
+      const rawCode = Number(apiError.code);
       const status: StatusName = StatusNameSchema.safeParse(apiError.status)
         .success
         ? (apiError.status as StatusName)
-        : httpStatusToGenkitStatus(apiError.code);
+        : httpStatusToGenkitStatus(isNaN(rawCode) ? undefined : rawCode);
+      const message =
+        typeof apiError.message === 'string'
+          ? apiError.message
+          : 'Error streaming from the model';
       return new GenkitError({
         status,
-        message: apiError.message || 'Error streaming from the model',
+        message,
         detail: json,
       });
     }
   } catch (e) {
     // Not JSON or not a recognizable error body, fall through to generic error.
   }
-  return new Error('Failed to parse stream: ' + text);
+  // Truncate to avoid memory/log bloat from large non-JSON payloads (e.g. an
+  // HTML error page from an upstream proxy).
+  const truncatedText =
+    text.length > 500 ? text.substring(0, 500) + '...' : text;
+  return new Error('Failed to parse stream: ' + truncatedText);
 }
 
 /**

--- a/js/plugins/google-genai/tests/common/utils_test.ts
+++ b/js/plugins/google-genai/tests/common/utils_test.ts
@@ -1095,6 +1095,37 @@ describe('Common Utils', () => {
       assert.strictEqual(err.status, 'RESOURCE_EXHAUSTED');
     });
 
+    it('coerces a stringified HTTP code to a number when mapping status', () => {
+      const text = JSON.stringify({
+        error: { code: '503', message: 'overloaded' },
+      });
+      const err = parseStreamErrorText(text);
+      assert.ok(err instanceof GenkitError, 'Expected GenkitError');
+      assert.strictEqual(err.status, 'UNAVAILABLE');
+    });
+
+    it('uses a default message when the error message is not a string', () => {
+      const text = JSON.stringify({
+        error: { code: 500, message: { nested: 'oops' } },
+      });
+      const err = parseStreamErrorText(text);
+      assert.ok(err instanceof GenkitError, 'Expected GenkitError');
+      assert.strictEqual(err.status, 'INTERNAL');
+      assert.ok(err.message.includes('Error streaming from the model'));
+    });
+
+    it('truncates long non-JSON payloads in the fallback message', () => {
+      const longText = 'x'.repeat(1000);
+      const err = parseStreamErrorText(longText);
+      assert.ok(!(err instanceof GenkitError));
+      assert.ok(err.message.includes('...'));
+      // 'Failed to parse stream: ' + 500 chars + '...'
+      assert.ok(
+        err.message.length < 600,
+        `Expected truncated message, got length ${err.message.length}`
+      );
+    });
+
     it('returns a generic Error for non-JSON text', () => {
       const err = parseStreamErrorText('not json at all');
       assert.ok(!(err instanceof GenkitError));

--- a/js/plugins/google-genai/tests/common/utils_test.ts
+++ b/js/plugins/google-genai/tests/common/utils_test.ts
@@ -33,8 +33,10 @@ import {
   extractMimeType,
   extractText,
   extractVersion,
+  httpStatusToGenkitStatus,
   modelName,
   parseRetryAfterMs,
+  parseStreamErrorText,
   processStream,
 } from '../../src/common/utils.js';
 
@@ -970,6 +972,140 @@ describe('Common Utils', () => {
       } catch (err: any) {
         assert.ok(err.message.includes('Failed to parse stream'));
       }
+    });
+
+    it('surfaces a JSON error body (HTTP 200 with error) as a GenkitError', async () => {
+      // Overloaded models sometimes return HTTP 200 and put the real error in
+      // the body as plain JSON (not an SSE `data:` frame).
+      const encoder = new TextEncoder();
+      const errorBody = JSON.stringify({
+        error: {
+          code: 503,
+          message:
+            'This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.',
+          status: 'UNAVAILABLE',
+        },
+      });
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(errorBody));
+          controller.close();
+        },
+      });
+
+      const mockResponse = new Response(stream);
+      const { stream: asyncStream, response } = processStream(mockResponse);
+
+      // Silence the parallel promise rejection so it doesn't fail the test runner asynchronously
+      response.catch(() => {});
+
+      try {
+        for await (const val of asyncStream) {
+          // should throw
+        }
+        assert.fail('Should have thrown on error body');
+      } catch (err: any) {
+        assert.ok(err instanceof GenkitError, 'Expected GenkitError');
+        assert.strictEqual(err.status, 'UNAVAILABLE');
+        assert.ok(err.message.includes('high demand'));
+      }
+    });
+
+    it('does not cause an unhandled rejection when only the stream is consumed on error', async () => {
+      // Regression test: previously the teed `response` promise would reject
+      // with no handler attached (the caller only awaits `stream`), producing
+      // an unhandled promise rejection that crashed the process.
+      const encoder = new TextEncoder();
+      const errorBody = JSON.stringify({
+        error: { code: 503, message: 'overloaded', status: 'UNAVAILABLE' },
+      });
+
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown) => rejections.push(reason);
+      process.on('unhandledRejection', onRejection);
+
+      try {
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(errorBody));
+            controller.close();
+          },
+        });
+
+        const mockResponse = new Response(stream);
+        // Intentionally ignore `response` to simulate the streaming consumer.
+        const { stream: asyncStream } = processStream(mockResponse);
+
+        await assert.rejects(async () => {
+          for await (const val of asyncStream) {
+            // should throw
+          }
+        });
+
+        // Give any pending microtasks/rejections a chance to surface.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        assert.strictEqual(
+          rejections.length,
+          0,
+          `Expected no unhandled rejections, got: ${rejections}`
+        );
+      } finally {
+        process.off('unhandledRejection', onRejection);
+      }
+    });
+  });
+
+  describe('httpStatusToGenkitStatus', () => {
+    it('maps known HTTP status codes to Genkit statuses', () => {
+      assert.strictEqual(httpStatusToGenkitStatus(400), 'INVALID_ARGUMENT');
+      assert.strictEqual(httpStatusToGenkitStatus(401), 'UNAUTHENTICATED');
+      assert.strictEqual(httpStatusToGenkitStatus(403), 'PERMISSION_DENIED');
+      assert.strictEqual(httpStatusToGenkitStatus(404), 'NOT_FOUND');
+      assert.strictEqual(httpStatusToGenkitStatus(429), 'RESOURCE_EXHAUSTED');
+      assert.strictEqual(httpStatusToGenkitStatus(499), 'CANCELLED');
+      assert.strictEqual(httpStatusToGenkitStatus(500), 'INTERNAL');
+      assert.strictEqual(httpStatusToGenkitStatus(503), 'UNAVAILABLE');
+      assert.strictEqual(httpStatusToGenkitStatus(504), 'DEADLINE_EXCEEDED');
+    });
+
+    it('returns UNKNOWN for unmapped or missing codes', () => {
+      assert.strictEqual(httpStatusToGenkitStatus(418), 'UNKNOWN');
+      assert.strictEqual(httpStatusToGenkitStatus(undefined), 'UNKNOWN');
+    });
+  });
+
+  describe('parseStreamErrorText', () => {
+    it('returns a GenkitError with status from the error status field', () => {
+      const text = JSON.stringify({
+        error: { code: 503, message: 'overloaded', status: 'UNAVAILABLE' },
+      });
+      const err = parseStreamErrorText(text);
+      assert.ok(err instanceof GenkitError, 'Expected GenkitError');
+      assert.strictEqual(err.status, 'UNAVAILABLE');
+      assert.ok(err.message.includes('overloaded'));
+    });
+
+    it('falls back to the HTTP code when status is not a valid StatusName', () => {
+      const text = JSON.stringify({
+        error: { code: 429, message: 'too many' },
+      });
+      const err = parseStreamErrorText(text);
+      assert.ok(err instanceof GenkitError, 'Expected GenkitError');
+      assert.strictEqual(err.status, 'RESOURCE_EXHAUSTED');
+    });
+
+    it('returns a generic Error for non-JSON text', () => {
+      const err = parseStreamErrorText('not json at all');
+      assert.ok(!(err instanceof GenkitError));
+      assert.ok(err.message.includes('Failed to parse stream'));
+      assert.ok(err.message.includes('not json at all'));
+    });
+
+    it('returns a generic Error for JSON that is not an error body', () => {
+      const err = parseStreamErrorText(JSON.stringify({ hello: 'world' }));
+      assert.ok(!(err instanceof GenkitError));
+      assert.ok(err.message.includes('Failed to parse stream'));
     });
   });
 });


### PR DESCRIPTION
Map HTTP status codes to Genkit StatusName and parse plain JSON error bodies returned with HTTP 200 (e.g. overloaded models) into proper GenkitErrors instead of generic parse errors, so downstream middleware like retry can react appropriately.

Also attach a no-op catch to the teed response promise to prevent unhandled rejections when only the stream is consumed.
